### PR TITLE
fix: report per-context session id in a2a/acp telemetry

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -26,6 +26,7 @@ from iac_code.a2a.types import (
 )
 from iac_code.services.agent_factory import AgentFactoryOptions, create_agent_runtime
 from iac_code.services.session_storage import SessionStorage
+from iac_code.services.telemetry import use_session_id
 
 logger = logging.getLogger(__name__)
 _CONTEXT_LOCK_ACQUIRE_TIMEOUT_SECONDS = 1
@@ -218,18 +219,19 @@ class IacCodeA2AExecutor(AgentExecutor):
                     context_id=context_id,
                     state=TaskState.TASK_STATE_WORKING,
                 )
-                async for event in runtime.agent_loop.run_streaming(prompt):
-                    text_chunk = await publish_stream_event(
-                        event_queue,
-                        task_id=task_id,
-                        context_id=context_id,
-                        event=event,
-                        artifact_store=self._artifact_store,
-                        permission_resolver=self._permission_resolver,
-                        auto_approve_permissions=self._auto_approve_permissions,
-                    )
-                    if text_chunk:
-                        task.output_text.append(text_chunk)
+                with use_session_id(ctx.session_id):
+                    async for event in runtime.agent_loop.run_streaming(prompt):
+                        text_chunk = await publish_stream_event(
+                            event_queue,
+                            task_id=task_id,
+                            context_id=context_id,
+                            event=event,
+                            artifact_store=self._artifact_store,
+                            permission_resolver=self._permission_resolver,
+                            auto_approve_permissions=self._auto_approve_permissions,
+                        )
+                        if text_chunk:
+                            task.output_text.append(text_chunk)
                 task.state = TASK_STATE_INPUT_REQUIRED
                 await self._publish_status(
                     event_queue,

--- a/src/iac_code/acp/session.py
+++ b/src/iac_code/acp/session.py
@@ -19,6 +19,7 @@ from iac_code.acp.state import TurnState
 from iac_code.acp.tools import ACPTerminalBashTool
 from iac_code.acp.types import ACPContentBlock
 from iac_code.agent.message import Message, TextBlock, ThinkingBlock, ToolResultBlock, ToolUseBlock
+from iac_code.services.telemetry import use_session_id
 from iac_code.state.app_state import lookup_permission, record_permission
 from iac_code.types.permissions import PermissionDecision
 from iac_code.types.stream_events import PermissionRequestEvent
@@ -315,15 +316,16 @@ class ACPSession:
                 context_snapshot=self._context_snapshot,
             )
             logger.debug("Prompt started, session_id=%s, turn_id=%s", self.id, turn_id)
-            async for event in self.agent_loop.run_streaming(prompt_text):
-                if isinstance(event, PermissionRequestEvent):
-                    allowed = await self._request_permission(event)
-                    if event.response_future is not None and not event.response_future.done():
-                        event.response_future.set_result(allowed)
-                    continue
+            with use_session_id(self.id):
+                async for event in self.agent_loop.run_streaming(prompt_text):
+                    if isinstance(event, PermissionRequestEvent):
+                        allowed = await self._request_permission(event)
+                        if event.response_future is not None and not event.response_future.done():
+                            event.response_future.set_result(allowed)
+                        continue
 
-                for update in converter.event_to_updates(event):
-                    await self._conn.session_update(session_id=self.id, update=update)
+                    for update in converter.event_to_updates(event):
+                        await self._conn.session_update(session_id=self.id, update=update)
 
         prompt_start = time.monotonic()
         self._current_task = asyncio.create_task(_run())

--- a/src/iac_code/services/telemetry/__init__.py
+++ b/src/iac_code/services/telemetry/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from iac_code.services.telemetry.client import TelemetryClient
+from iac_code.services.telemetry.identity import use_session_id
 
 __all__ = [
     "log_event",
@@ -17,6 +18,7 @@ __all__ = [
     "set_client",
     "get_session_id",
     "get_user_id",
+    "use_session_id",
 ]
 
 _client: TelemetryClient | None = None

--- a/src/iac_code/services/telemetry/identity.py
+++ b/src/iac_code/services/telemetry/identity.py
@@ -7,8 +7,11 @@ tenant.id  = iac_tenant_<user-defined>, from IAC_CODE_TENANT_ID
 
 from __future__ import annotations
 
+import contextvars
 import os
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from iac_code.config import _load_yaml, _save_yaml
@@ -19,6 +22,27 @@ TENANT_ID_PREFIX = "iac_tenant_"
 
 _USER_ID_KEY = "userID"
 _TENANT_ENV_VAR = "IAC_CODE_TENANT_ID"
+
+# Per-async-context override for session id. Set via use_session_id; when
+# present, Identity.get_session_id returns this instead of the process-level
+# value. Enables a2a/acp servers to report per-conversation session ids in
+# telemetry without rebuilding the OTel providers.
+_session_id_override: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "iac_code_telemetry_session_id_override", default=None
+)
+
+
+@contextmanager
+def use_session_id(session_id: str) -> Iterator[None]:
+    """Override the telemetry session id for the current async context."""
+    if not session_id:
+        raise ValueError("session_id must be a non-empty string")
+    value = session_id if session_id.startswith(SESSION_ID_PREFIX) else f"{SESSION_ID_PREFIX}{session_id}"
+    token = _session_id_override.set(value)
+    try:
+        yield
+    finally:
+        _session_id_override.reset(token)
 
 
 class Identity:
@@ -51,7 +75,14 @@ class Identity:
         return new_id
 
     def get_session_id(self) -> str:
-        """Return per-instance session.id; generate on first call."""
+        """Return per-instance session.id; generate on first call.
+
+        Honors an active ``use_session_id`` override so a2a/acp servers can
+        report per-context session ids without mutating process state.
+        """
+        override = _session_id_override.get()
+        if override is not None:
+            return override
         if self._session_id is None:
             self._session_id = f"{SESSION_ID_PREFIX}{uuid.uuid4()}"
         return self._session_id

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -457,6 +457,64 @@ async def test_independent_contexts_execute_concurrently(monkeypatch: pytest.Mon
 
 
 @pytest.mark.asyncio
+async def test_executor_overrides_telemetry_session_id_per_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Per-context conversation session_id must surface in telemetry while
+    run_streaming is executing, instead of the process-level bootstrap id."""
+    from iac_code.services.telemetry import bootstrap_telemetry, get_session_id, set_client
+    from iac_code.services.telemetry.identity import SESSION_ID_PREFIX
+
+    monkeypatch.setenv("DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    set_client(None)
+    bootstrap_telemetry(session_id="a2a-server-process")
+    try:
+        process_level = get_session_id()
+        assert process_level == f"{SESSION_ID_PREFIX}a2a-server-process"
+
+        observed: dict[str, str] = {}
+
+        class ObservingLoop:
+            def __init__(self, label: str) -> None:
+                self._label = label
+
+            async def run_streaming(self, prompt: str):
+                observed[self._label] = get_session_id()
+                yield TextDeltaEvent(text="ok")
+
+        def factory(options):
+            return FakeRuntime(
+                agent_loop=ObservingLoop(label=options.session_id),
+                session_id=options.session_id,
+            )
+
+        monkeypatch.setattr("iac_code.a2a.executor.create_agent_runtime", factory)
+
+        store = A2ATaskStore(metrics=NoOpA2AMetrics())
+        executor = IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus")
+
+        await executor.execute(
+            FakeRequestContext(task_id="task-1", context_id="ctx-1", metadata={"iac_code": {"cwd": str(tmp_path)}}),
+            FakeEventQueue(),
+        )
+        await executor.execute(
+            FakeRequestContext(task_id="task-2", context_id="ctx-2", metadata={"iac_code": {"cwd": str(tmp_path)}}),
+            FakeEventQueue(),
+        )
+
+        session_one = store._contexts["ctx-1"].session_id
+        session_two = store._contexts["ctx-2"].session_id
+        assert session_one != session_two
+        assert observed[session_one] == f"{SESSION_ID_PREFIX}{session_one}"
+        assert observed[session_two] == f"{SESSION_ID_PREFIX}{session_two}"
+        # And the per-context override does not leak back to the parent scope.
+        assert get_session_id() == process_level
+    finally:
+        set_client(None)
+
+
+@pytest.mark.asyncio
 async def test_executor_resumes_messages_after_restart(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     from iac_code.a2a.persistence import A2APersistenceStore
     from iac_code.agent.message import Message

--- a/tests/acp/test_sessions.py
+++ b/tests/acp/test_sessions.py
@@ -600,6 +600,43 @@ async def test_acp_prompt_flushes_telemetry_after_completion(monkeypatch: pytest
 
 
 @pytest.mark.asyncio
+async def test_acp_prompt_overrides_telemetry_session_id_per_session(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Two ACP sessions in the same process must report distinct session ids
+    in telemetry during their respective run_streaming calls."""
+    from iac_code.services.telemetry import bootstrap_telemetry, get_session_id, set_client
+    from iac_code.services.telemetry.identity import SESSION_ID_PREFIX
+
+    monkeypatch.setenv("DISABLE_TELEMETRY", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    set_client(None)
+    bootstrap_telemetry(session_id="acp-server-process")
+    try:
+        observed: dict[str, str] = {}
+
+        class _ObservingLoop:
+            def __init__(self, label: str) -> None:
+                self._label = label
+
+            async def run_streaming(self, prompt: str):
+                observed[self._label] = get_session_id()
+                yield TextDeltaEvent(text="ok")
+                yield MessageEndEvent(stop_reason="stop", usage=Usage())
+
+        conn = _RecordingFakeConn()
+        session_a = ACPSession("session-a", _ObservingLoop("a"), conn)
+        session_b = ACPSession("session-b", _ObservingLoop("b"), conn)
+
+        await session_a.prompt([acp.schema.TextContentBlock(type="text", text="hi-a")])
+        await session_b.prompt([acp.schema.TextContentBlock(type="text", text="hi-b")])
+
+        assert observed["a"] == f"{SESSION_ID_PREFIX}session-a"
+        assert observed["b"] == f"{SESSION_ID_PREFIX}session-b"
+        assert get_session_id() == f"{SESSION_ID_PREFIX}acp-server-process"
+    finally:
+        set_client(None)
+
+
+@pytest.mark.asyncio
 async def test_acp_prompt_flushes_telemetry_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
     flush_calls: list[int] = []
 

--- a/tests/test_services/test_telemetry/test_client.py
+++ b/tests/test_services/test_telemetry/test_client.py
@@ -152,3 +152,19 @@ def test_facade_delegates_to_singleton(tmp_path, monkeypatch):
         mock_client.flush.assert_called_once_with()
     finally:
         set_client(None)
+
+
+def test_use_session_id_facade_overrides_get_session_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from iac_code.services.telemetry import bootstrap_telemetry, get_session_id, set_client, use_session_id
+    from iac_code.services.telemetry.identity import SESSION_ID_PREFIX
+
+    set_client(None)
+    try:
+        bootstrap_telemetry(session_id="process-id")
+        assert get_session_id() == f"{SESSION_ID_PREFIX}process-id"
+        with use_session_id("per-context"):
+            assert get_session_id() == f"{SESSION_ID_PREFIX}per-context"
+        assert get_session_id() == f"{SESSION_ID_PREFIX}process-id"
+    finally:
+        set_client(None)

--- a/tests/test_services/test_telemetry/test_identity.py
+++ b/tests/test_services/test_telemetry/test_identity.py
@@ -117,3 +117,55 @@ def test_session_id_generated_when_not_injected(settings_path):
     session_id = Identity(settings_path).get_session_id()
     assert session_id.startswith(SESSION_ID_PREFIX)
     assert len(session_id) > len(SESSION_ID_PREFIX)
+
+
+def test_context_override_takes_precedence_over_process_session_id(settings_path):
+    from iac_code.services.telemetry.identity import use_session_id
+
+    identity = Identity(settings_path, session_id="process-level")
+    with use_session_id("per-context-call"):
+        assert identity.get_session_id() == f"{SESSION_ID_PREFIX}per-context-call"
+    # After the context manager exits, the process-level id is back.
+    assert identity.get_session_id() == f"{SESSION_ID_PREFIX}process-level"
+
+
+def test_context_override_prefix_idempotent(settings_path):
+    from iac_code.services.telemetry.identity import use_session_id
+
+    identity = Identity(settings_path, session_id="process-level")
+    already_prefixed = f"{SESSION_ID_PREFIX}explicit"
+    with use_session_id(already_prefixed):
+        # Caller may pass a value that already contains the prefix; we don't double it.
+        assert identity.get_session_id() == already_prefixed
+
+
+def test_context_override_isolated_between_async_tasks(settings_path):
+    import asyncio
+
+    from iac_code.services.telemetry.identity import use_session_id
+
+    identity = Identity(settings_path, session_id="process-level")
+
+    async def under_override(sid: str, started: asyncio.Event, release: asyncio.Event) -> str:
+        with use_session_id(sid):
+            started.set()
+            await release.wait()
+            return identity.get_session_id()
+
+    async def main() -> tuple[str, str, str]:
+        started_a = asyncio.Event()
+        started_b = asyncio.Event()
+        release = asyncio.Event()
+        task_a = asyncio.create_task(under_override("ctx-a", started_a, release))
+        task_b = asyncio.create_task(under_override("ctx-b", started_b, release))
+        await started_a.wait()
+        await started_b.wait()
+        # Outside any override, the parent task still sees the process-level id.
+        outside = identity.get_session_id()
+        release.set()
+        return outside, await task_a, await task_b
+
+    outside, a, b = asyncio.run(main())
+    assert outside == f"{SESSION_ID_PREFIX}process-level"
+    assert a == f"{SESSION_ID_PREFIX}ctx-a"
+    assert b == f"{SESSION_ID_PREFIX}ctx-b"


### PR DESCRIPTION
Telemetry's get_session_id() returned the process-level bootstrap id (iac_sess_a2a-server-<uuid>), so every A2A context and ACP session in one server process shared the same gen_ai.session.id in spans and the same name in fallback batches — multiple conversations looked like one session.

Add a contextvar-backed override in Identity plus a use_session_id() context manager, and wrap each run_streaming call in a2a/acp with the per-conversation session id. Process-level resource session.id stays the bootstrap value; headless/REPL paths are unaffected.