### PR TITLE
feat: support A2A thinking exposure

### DIFF
--- a/src/iac_code/a2a/agent_card.py
+++ b/src/iac_code/a2a/agent_card.py
@@ -18,10 +18,12 @@ from a2a.types import (
 from google.protobuf.json_format import ParseDict
 
 from iac_code import __version__
+from iac_code.a2a.exposure import format_a2a_exposure_types
 from iac_code.a2a.parts import supported_input_mime_types
 from iac_code.a2a.signing import sign_agent_card_dict
 
 IAC_CODE_ARTIFACT_METADATA_EXTENSION_URI = "urn:iac-code:a2a:artifact-metadata:v1"
+IAC_CODE_THINKING_EXPOSURE_EXTENSION_URI = "urn:iac-code:a2a:thinking-exposure:v1"
 
 
 def _base_url(host: str, port: int) -> str:
@@ -66,6 +68,7 @@ def build_agent_card(
     push_notifications: bool = False,
     supported_interfaces: list[dict[str, str]] | None = None,
     agent_extensions: Any = None,
+    thinking_exposure_types: Any = None,
 ) -> AgentCard:
     url = _base_url(host, port)
     description = "AI-powered Infrastructure as Code assistant for Alibaba Cloud ROS and Terraform workflows."
@@ -152,6 +155,19 @@ def build_agent_card(
             required=False,
         )
     )
+    if thinking_exposure_types is not None:
+        enabled_types = format_a2a_exposure_types(thinking_exposure_types)
+        if enabled_types:
+            extension = AgentExtension(
+                uri=IAC_CODE_THINKING_EXPOSURE_EXTENSION_URI,
+                description=(
+                    "Optional iac-code metadata namespace for selected thinking exposure signals. "
+                    "Raw thinking is emitted only when raw_thinking is enabled."
+                ),
+                required=False,
+            )
+            ParseDict({"enabledTypes": enabled_types}, extension.params)
+            card.capabilities.extensions.append(extension)
     for item in _iter_agent_extensions(agent_extensions):
         card.capabilities.extensions.append(_agent_extension_from_dict(item))
 

--- a/src/iac_code/a2a/app.py
+++ b/src/iac_code/a2a/app.py
@@ -166,6 +166,7 @@ def create_app(
     supported_interfaces: list[dict[str, str]] | None = None,
     agent_extensions: object | None = None,
     auto_approve_permissions: bool = False,
+    thinking_exposure: object | None = None,
 ) -> Starlette:
     from iac_code.a2a.transports.dispatcher import create_runtime_components
 
@@ -194,6 +195,7 @@ def create_app(
         supported_interfaces=supported_interfaces,
         agent_extensions=agent_extensions,
         auto_approve_permissions=auto_approve_permissions,
+        thinking_exposure=thinking_exposure,
     )
 
     @asynccontextmanager
@@ -287,6 +289,7 @@ def run_server(
     push_consumer_name: str | None = None,
     push_lease_timeout_ms: int = 300_000,
     auto_approve_permissions: bool = False,
+    thinking_exposure: object | None = None,
 ) -> None:
     from iac_code.a2a.transports.base import normalize_transport_name, validate_transport_for_platform
 
@@ -347,6 +350,7 @@ def run_server(
         "push_lease_timeout_ms": push_lease_timeout_ms,
         "supported_interfaces": supported_interfaces,
         "auto_approve_permissions": auto_approve_permissions,
+        "thinking_exposure": thinking_exposure,
     }
 
     if normalized_transport == "stdio":
@@ -444,6 +448,7 @@ def run_server(
             push_lease_timeout_ms=push_lease_timeout_ms,
             supported_interfaces=supported_interfaces,
             auto_approve_permissions=auto_approve_permissions,
+            thinking_exposure=thinking_exposure,
         )
 
     try:

--- a/src/iac_code/a2a/events.py
+++ b/src/iac_code/a2a/events.py
@@ -18,6 +18,7 @@ from a2a.types import (
 )
 from google.protobuf.json_format import ParseDict
 
+from iac_code.a2a.exposure import A2AExposureType, normalize_a2a_exposure_types
 from iac_code.types.stream_events import (
     ErrorEvent,
     MessageEndEvent,
@@ -170,7 +171,10 @@ async def publish_stream_event(
     artifact_store: Any | None = None,
     permission_resolver: A2APermissionResolver | None = None,
     auto_approve_permissions: bool = False,
+    exposure_types: Any = None,
 ) -> str | None:
+    enabled_exposure_types = normalize_a2a_exposure_types(exposure_types)
+
     if isinstance(event, TextDeltaEvent):
         if not event.text:
             return None
@@ -184,9 +188,20 @@ async def publish_stream_event(
         return event.text
 
     if isinstance(event, ThinkingDeltaEvent):
+        if A2AExposureType.RAW_THINKING not in enabled_exposure_types:
+            return None
+        await _enqueue_status(
+            event_queue,
+            task_id=task_id,
+            context_id=context_id,
+            state=TaskState.TASK_STATE_WORKING,
+            metadata={"iac_code": {"thinking": {"type": "raw_thinking", "text": _truncate(event.text)}}},
+        )
         return None
 
     if isinstance(event, ToolUseStartEvent):
+        if A2AExposureType.TOOL_TRACE not in enabled_exposure_types:
+            return None
         await _enqueue_status(
             event_queue,
             task_id=task_id,
@@ -197,6 +212,8 @@ async def publish_stream_event(
         return None
 
     if isinstance(event, ToolInputDeltaEvent):
+        if A2AExposureType.TOOL_TRACE not in enabled_exposure_types:
+            return None
         await _enqueue_status(
             event_queue,
             task_id=task_id,
@@ -215,6 +232,8 @@ async def publish_stream_event(
         return None
 
     if isinstance(event, ToolUseEndEvent):
+        if A2AExposureType.TOOL_TRACE not in enabled_exposure_types:
+            return None
         await _enqueue_status(
             event_queue,
             task_id=task_id,
@@ -235,6 +254,12 @@ async def publish_stream_event(
 
     if isinstance(event, ToolResultEvent):
         artifact_metadata = _extract_artifact_metadata(event.result, artifact_store)
+        if A2AExposureType.TOOL_TRACE not in enabled_exposure_types:
+            if artifact_metadata is not None:
+                await event_queue.enqueue_event(
+                    _artifact_update_event(task_id=task_id, context_id=context_id, metadata=artifact_metadata)
+                )
+            return None
         tool_metadata = {
             "status": "failed" if event.is_error else "completed",
             "toolUseId": event.tool_use_id,
@@ -262,6 +287,8 @@ async def publish_stream_event(
             approved = bool(await decision) if inspect.isawaitable(decision) else bool(decision)
         if event.response_future is not None and not event.response_future.done():
             event.response_future.set_result(approved)
+        if A2AExposureType.TOOL_TRACE not in enabled_exposure_types:
+            return None
         await _enqueue_status(
             event_queue,
             task_id=task_id,

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -15,6 +15,7 @@ from a2a.types import Message, Role, Task, TaskState, TaskStatus, TaskStatusUpda
 from google.protobuf.json_format import MessageToDict
 
 from iac_code.a2a.events import make_text_part, publish_stream_event
+from iac_code.a2a.exposure import normalize_a2a_exposure_types
 from iac_code.a2a.metrics import A2AMetrics, NoOpA2AMetrics
 from iac_code.a2a.parts import allowed_cwd_roots, is_relative_to, parts_to_prompt
 from iac_code.a2a.task_store import A2ATaskStore
@@ -62,6 +63,7 @@ class IacCodeA2AExecutor(AgentExecutor):
         push_notifier: Any | None = None,
         permission_resolver: A2APermissionResolver | None = None,
         auto_approve_permissions: bool = False,
+        thinking_exposure_types: Any = None,
     ) -> None:
         self._task_store = task_store
         self._model = model
@@ -70,6 +72,7 @@ class IacCodeA2AExecutor(AgentExecutor):
         self._push_notifier = push_notifier
         self._permission_resolver = permission_resolver
         self._auto_approve_permissions = auto_approve_permissions
+        self._thinking_exposure_types = normalize_a2a_exposure_types(thinking_exposure_types)
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
         task_id = context.task_id or "task-" + uuid.uuid4().hex[:12]
@@ -229,6 +232,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                             artifact_store=self._artifact_store,
                             permission_resolver=self._permission_resolver,
                             auto_approve_permissions=self._auto_approve_permissions,
+                            exposure_types=self._thinking_exposure_types,
                         )
                         if text_chunk:
                             task.output_text.append(text_chunk)

--- a/src/iac_code/a2a/exposure.py
+++ b/src/iac_code/a2a/exposure.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import Enum
+from typing import Any
+
+
+class A2AExposureType(str, Enum):
+    RAW_THINKING = "raw_thinking"
+    TOOL_TRACE = "tool_trace"
+
+
+_EXPOSURE_TYPE_ORDER = (
+    A2AExposureType.RAW_THINKING,
+    A2AExposureType.TOOL_TRACE,
+)
+_SUPPORTED_TYPE_NAMES = ", ".join(item.value.replace("_", "-") for item in _EXPOSURE_TYPE_ORDER)
+_DISABLED_ALIASES = frozenset({"", "none", "off", "false", "0"})
+_ALL_ALIASES = frozenset({"all", "*"})
+DEFAULT_A2A_EXPOSURE_TYPES = frozenset({A2AExposureType.TOOL_TRACE})
+
+
+def normalize_a2a_exposure_types(value: Any) -> frozenset[A2AExposureType]:
+    if value is None:
+        return DEFAULT_A2A_EXPOSURE_TYPES
+
+    tokens = list(_iter_exposure_tokens(value))
+    if not tokens:
+        return frozenset()
+    if any(token in _ALL_ALIASES for token in tokens):
+        return frozenset(_EXPOSURE_TYPE_ORDER)
+    tokens = [token for token in tokens if token not in _DISABLED_ALIASES]
+    return frozenset(_exposure_type_from_token(token) for token in tokens)
+
+
+def format_a2a_exposure_types(value: Any) -> list[str]:
+    enabled = normalize_a2a_exposure_types(value)
+    return [item.value for item in _EXPOSURE_TYPE_ORDER if item in enabled]
+
+
+def _iter_exposure_tokens(value: Any) -> Iterable[str]:
+    if isinstance(value, A2AExposureType):
+        yield value.value
+        return
+    if isinstance(value, str):
+        for item in value.replace(";", ",").split(","):
+            token = item.strip().lower().replace("-", "_")
+            if token:
+                yield token
+        return
+    if isinstance(value, Iterable) and not isinstance(value, dict):
+        for item in value:
+            yield from _iter_exposure_tokens(item)
+        return
+    raise ValueError(
+        f"A2A thinking exposure must be a string or list of strings. Supported values: {_SUPPORTED_TYPE_NAMES}."
+    )
+
+
+def _exposure_type_from_token(token: str) -> A2AExposureType:
+    try:
+        return A2AExposureType(token)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unsupported A2A thinking exposure type {token!r}. Supported values: {_SUPPORTED_TYPE_NAMES}."
+        ) from exc

--- a/src/iac_code/a2a/transports/dispatcher.py
+++ b/src/iac_code/a2a/transports/dispatcher.py
@@ -37,6 +37,7 @@ from iac_code.a2a.agent_card import build_agent_card, build_extended_agent_card
 from iac_code.a2a.app import normalize_v03_jsonrpc_version
 from iac_code.a2a.artifacts import A2AArtifactStore
 from iac_code.a2a.executor import IacCodeA2AExecutor
+from iac_code.a2a.exposure import normalize_a2a_exposure_types
 from iac_code.a2a.metrics import NoOpA2AMetrics
 from iac_code.a2a.persistence import A2APersistenceStore
 from iac_code.a2a.push import (
@@ -114,8 +115,10 @@ def create_runtime_components(
     supported_interfaces: list[dict[str, str]] | None = None,
     agent_extensions: object | None = None,
     auto_approve_permissions: bool = False,
+    thinking_exposure: object | None = None,
 ) -> A2ARuntimeComponents:
     metrics = NoOpA2AMetrics()
+    thinking_exposure_types = normalize_a2a_exposure_types(thinking_exposure)
     persistence = A2APersistenceStore(persistence_dir) if persistence_dir is not None else None
     artifact_store = A2AArtifactStore(artifact_dir) if artifact_dir is not None else None
     push_config_store = None
@@ -166,6 +169,7 @@ def create_runtime_components(
         metrics=metrics,
         artifact_store=artifact_store,
         auto_approve_permissions=auto_approve_permissions,
+        thinking_exposure_types=thinking_exposure_types,
     )
     card = build_agent_card(
         host=host,
@@ -179,6 +183,7 @@ def create_runtime_components(
         push_notifications=push_notifications,
         supported_interfaces=supported_interfaces,
         agent_extensions=agent_extensions,
+        thinking_exposure_types=thinking_exposure_types,
     )
     handler = IacCodeRequestHandler(
         agent_executor=executor,

--- a/src/iac_code/cli/main.py
+++ b/src/iac_code/cli/main.py
@@ -555,6 +555,11 @@ def a2a(
         help=_("A2A transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc, or redis-streams"),
     ),
     debug: bool = typer.Option(False, "--debug", "-d", help=_("Enable debug logging")),
+    thinking_exposure: list[str] | None = typer.Option(
+        None,
+        "--thinking-exposure",
+        help=_("Expose A2A thinking signal types; repeat for multiple. Values: raw-thinking, tool-trace."),
+    ),
 ) -> None:
     """Run iac-code as an A2A 1.0 server."""
     config = _load_a2a_config(config_path) if config_path else {}
@@ -587,6 +592,7 @@ def a2a(
     push_consumer_name = config.get("push_consumer_name", "")
     push_lease_timeout_ms = config.get("push_lease_timeout_ms", 300000)
     auto_approve_permissions = config.get("auto_approve_permissions", False)
+    thinking_exposure = _a2a_config_value(ctx, config, "thinking_exposure", thinking_exposure)
     model = load_saved_model() or DEFAULT_MODEL
     setup_logging(session_id="a2a-server", debug=debug)
     try:
@@ -721,8 +727,9 @@ def a2a(
             response_stream=response_stream,
             consumer_group=consumer_group,
             auto_approve_permissions=auto_approve_permissions,
+            thinking_exposure=thinking_exposure,
         )
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         exit_reason = "error"
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 20:30+0800\n"
+"POT-Creation-Date: 2026-05-29 09:47+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: de\n"
@@ -155,8 +155,8 @@ msgstr "iac-code als A2A-Client verwenden."
 msgid "YAML config file containing A2A client options"
 msgstr "YAML-Konfigurationsdatei mit A2A-Client-Optionen"
 
-#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1450
-#: src/iac_code/cli/main.py:1811 src/iac_code/cli/main.py:1850
+#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py:1818 src/iac_code/cli/main.py:1857
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -274,7 +274,15 @@ msgstr ""
 "A2A-Transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc oder "
 "redis-streams"
 
-#: src/iac_code/cli/main.py:602
+#: src/iac_code/cli/main.py:561
+msgid ""
+"Expose A2A thinking signal types; repeat for multiple. Values: raw-"
+"thinking, tool-trace."
+msgstr ""
+"Legt A2A-Thinking-Signaltypen offen; fuer mehrere Werte wiederholen. Werte: "
+"raw-thinking, tool-trace."
+
+#: src/iac_code/cli/main.py:608
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -282,228 +290,228 @@ msgstr ""
 "A2A-Server-Abhängigkeiten fehlen. Installieren mit: pip install 'iac-"
 "code[a2a]'"
 
-#: src/iac_code/cli/main.py:733
+#: src/iac_code/cli/main.py:740
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Sendet einen Prompt an einen A2A-JSON-RPC-Endpunkt."
 
-#: src/iac_code/cli/main.py:736 src/iac_code/cli/main.py:900
-#: src/iac_code/cli/main.py:953 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1063 src/iac_code/cli/main.py:1112
-#: src/iac_code/cli/main.py:1191 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1361
+#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:907
+#: src/iac_code/cli/main.py:960 src/iac_code/cli/main.py:1020
+#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1119
+#: src/iac_code/cli/main.py:1198 src/iac_code/cli/main.py:1255
+#: src/iac_code/cli/main.py:1311 src/iac_code/cli/main.py:1368
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL des A2A-JSON-RPC-Endpunkts"
 
-#: src/iac_code/cli/main.py:737 src/iac_code/cli/main.py:1406
+#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:1413
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Routen-Spezifikation: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:738
+#: src/iac_code/cli/main.py:745
 msgid "Named A2A route to call"
 msgstr "Aufzurufende benannte A2A-Route"
 
-#: src/iac_code/cli/main.py:739
+#: src/iac_code/cli/main.py:746
 msgid "Prompt to send"
 msgstr "Zu sendender Prompt"
 
-#: src/iac_code/cli/main.py:740
+#: src/iac_code/cli/main.py:747
 msgid "Working directory metadata to send with the request"
 msgstr "Arbeitsverzeichnis-Metadaten, die mit der Anfrage gesendet werden"
 
-#: src/iac_code/cli/main.py:741
+#: src/iac_code/cli/main.py:748
 msgid "A2A context ID to continue"
 msgstr "Fortzusetzende A2A-Kontext-ID"
 
-#: src/iac_code/cli/main.py:742 src/iac_code/cli/main.py:831
-#: src/iac_code/cli/main.py:903 src/iac_code/cli/main.py:960
-#: src/iac_code/cli/main.py:1015 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1119 src/iac_code/cli/main.py:1194
-#: src/iac_code/cli/main.py:1252 src/iac_code/cli/main.py:1307
-#: src/iac_code/cli/main.py:1362
+#: src/iac_code/cli/main.py:749 src/iac_code/cli/main.py:838
+#: src/iac_code/cli/main.py:910 src/iac_code/cli/main.py:967
+#: src/iac_code/cli/main.py:1022 src/iac_code/cli/main.py:1072
+#: src/iac_code/cli/main.py:1126 src/iac_code/cli/main.py:1201
+#: src/iac_code/cli/main.py:1259 src/iac_code/cli/main.py:1314
+#: src/iac_code/cli/main.py:1369
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Bearer-Token für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:832
-#: src/iac_code/cli/main.py:904 src/iac_code/cli/main.py:961
-#: src/iac_code/cli/main.py:1016 src/iac_code/cli/main.py:1066
-#: src/iac_code/cli/main.py:1120 src/iac_code/cli/main.py:1195
-#: src/iac_code/cli/main.py:1253 src/iac_code/cli/main.py:1308
-#: src/iac_code/cli/main.py:1363
+#: src/iac_code/cli/main.py:750 src/iac_code/cli/main.py:839
+#: src/iac_code/cli/main.py:911 src/iac_code/cli/main.py:968
+#: src/iac_code/cli/main.py:1023 src/iac_code/cli/main.py:1073
+#: src/iac_code/cli/main.py:1127 src/iac_code/cli/main.py:1202
+#: src/iac_code/cli/main.py:1260 src/iac_code/cli/main.py:1315
+#: src/iac_code/cli/main.py:1370
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Basic-Auth-Benutzername für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:833
-#: src/iac_code/cli/main.py:905 src/iac_code/cli/main.py:962
-#: src/iac_code/cli/main.py:1017 src/iac_code/cli/main.py:1067
-#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1196
-#: src/iac_code/cli/main.py:1254 src/iac_code/cli/main.py:1309
-#: src/iac_code/cli/main.py:1364
+#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:912 src/iac_code/cli/main.py:969
+#: src/iac_code/cli/main.py:1024 src/iac_code/cli/main.py:1074
+#: src/iac_code/cli/main.py:1128 src/iac_code/cli/main.py:1203
+#: src/iac_code/cli/main.py:1261 src/iac_code/cli/main.py:1316
+#: src/iac_code/cli/main.py:1371
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Basic-Auth-Passwort für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:745 src/iac_code/cli/main.py:834
-#: src/iac_code/cli/main.py:906 src/iac_code/cli/main.py:963
-#: src/iac_code/cli/main.py:1018 src/iac_code/cli/main.py:1068
-#: src/iac_code/cli/main.py:1122 src/iac_code/cli/main.py:1197
-#: src/iac_code/cli/main.py:1255 src/iac_code/cli/main.py:1310
-#: src/iac_code/cli/main.py:1365
+#: src/iac_code/cli/main.py:752 src/iac_code/cli/main.py:841
+#: src/iac_code/cli/main.py:913 src/iac_code/cli/main.py:970
+#: src/iac_code/cli/main.py:1025 src/iac_code/cli/main.py:1075
+#: src/iac_code/cli/main.py:1129 src/iac_code/cli/main.py:1204
+#: src/iac_code/cli/main.py:1262 src/iac_code/cli/main.py:1317
+#: src/iac_code/cli/main.py:1372
 msgid "API key for A2A HTTP requests"
 msgstr "API-Schlüssel für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:746 src/iac_code/cli/main.py:835
-#: src/iac_code/cli/main.py:907 src/iac_code/cli/main.py:964
-#: src/iac_code/cli/main.py:1019 src/iac_code/cli/main.py:1069
-#: src/iac_code/cli/main.py:1123 src/iac_code/cli/main.py:1198
-#: src/iac_code/cli/main.py:1256 src/iac_code/cli/main.py:1311
-#: src/iac_code/cli/main.py:1366
+#: src/iac_code/cli/main.py:753 src/iac_code/cli/main.py:842
+#: src/iac_code/cli/main.py:914 src/iac_code/cli/main.py:971
+#: src/iac_code/cli/main.py:1026 src/iac_code/cli/main.py:1076
+#: src/iac_code/cli/main.py:1130 src/iac_code/cli/main.py:1205
+#: src/iac_code/cli/main.py:1263 src/iac_code/cli/main.py:1318
+#: src/iac_code/cli/main.py:1373
 msgid "HTTP header name for A2A API key"
 msgstr "HTTP-Header-Name für den A2A-API-Schlüssel"
 
-#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:758 src/iac_code/cli/main.py:847
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Geheimnis zur Verifizierung der A2A Agent Card"
 
-#: src/iac_code/cli/main.py:756 src/iac_code/cli/main.py:845
+#: src/iac_code/cli/main.py:763 src/iac_code/cli/main.py:852
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "Remote-JWKS-URL zur Verifizierung der A2A Agent Card"
 
-#: src/iac_code/cli/main.py:762 src/iac_code/cli/main.py:851
+#: src/iac_code/cli/main.py:769 src/iac_code/cli/main.py:858
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Eine gültige A2A-Agent-Card-Signatur erfordern"
 
-#: src/iac_code/cli/main.py:764
+#: src/iac_code/cli/main.py:771
 msgid "A2A call timeout in seconds"
 msgstr "A2A-Aufruf-Timeout in Sekunden"
 
-#: src/iac_code/cli/main.py:765
+#: src/iac_code/cli/main.py:772
 msgid "Use A2A streaming message delivery"
 msgstr "A2A-Streaming-Nachrichtenübertragung verwenden"
 
-#: src/iac_code/cli/main.py:827
+#: src/iac_code/cli/main.py:834
 msgid "Discover an A2A Agent Card."
 msgstr "Eine A2A Agent Card entdecken."
 
-#: src/iac_code/cli/main.py:830
+#: src/iac_code/cli/main.py:837
 msgid "A2A agent base URL"
 msgstr "Basis-URL des A2A-Agenten"
 
-#: src/iac_code/cli/main.py:897
+#: src/iac_code/cli/main.py:904
 msgid "Get an A2A task."
 msgstr "Eine A2A-Aufgabe abrufen."
 
-#: src/iac_code/cli/main.py:901 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1064 src/iac_code/cli/main.py:1113
-#: src/iac_code/cli/main.py:1192 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1305
+#: src/iac_code/cli/main.py:908 src/iac_code/cli/main.py:1021
+#: src/iac_code/cli/main.py:1071 src/iac_code/cli/main.py:1120
+#: src/iac_code/cli/main.py:1199 src/iac_code/cli/main.py:1256
+#: src/iac_code/cli/main.py:1312
 msgid "A2A task ID"
 msgstr "A2A-Aufgaben-ID"
 
-#: src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py:909
 msgid "Maximum task history items to return"
 msgstr "Maximale Anzahl zurückzugebender Aufgabenverlaufselemente"
 
-#: src/iac_code/cli/main.py:950
+#: src/iac_code/cli/main.py:957
 msgid "List A2A tasks."
 msgstr "A2A-Aufgaben auflisten."
 
-#: src/iac_code/cli/main.py:954
+#: src/iac_code/cli/main.py:961
 msgid "Filter by A2A context ID"
 msgstr "Nach A2A-Kontext-ID filtern"
 
-#: src/iac_code/cli/main.py:955
+#: src/iac_code/cli/main.py:962
 msgid "Filter by A2A task state"
 msgstr "Nach A2A-Aufgabenzustand filtern"
 
-#: src/iac_code/cli/main.py:956
+#: src/iac_code/cli/main.py:963
 msgid "Maximum tasks to return"
 msgstr "Maximale Anzahl zurückzugebender Aufgaben"
 
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1251
+#: src/iac_code/cli/main.py:964 src/iac_code/cli/main.py:1258
 msgid "Pagination token"
 msgstr "Paginierungs-Token"
 
-#: src/iac_code/cli/main.py:958
+#: src/iac_code/cli/main.py:965
 msgid "Include task artifacts"
 msgstr "Aufgaben-Artefakte einschließen"
 
-#: src/iac_code/cli/main.py:959
+#: src/iac_code/cli/main.py:966
 msgid "Output format: table or json"
 msgstr "Ausgabeformat: table oder json"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py:1017
 msgid "Cancel an A2A task."
 msgstr "Eine A2A-Aufgabe abbrechen."
 
-#: src/iac_code/cli/main.py:1060
+#: src/iac_code/cli/main.py:1067
 msgid "Subscribe to an A2A task event stream."
 msgstr "A2A-Aufgaben-Ereignisstrom abonnieren."
 
-#: src/iac_code/cli/main.py:1109
+#: src/iac_code/cli/main.py:1116
 msgid "Create an A2A task push notification config."
 msgstr "Eine Push-Benachrichtigungskonfiguration für eine A2A-Aufgabe erstellen."
 
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1193
-#: src/iac_code/cli/main.py:1306
+#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1200
+#: src/iac_code/cli/main.py:1313
 msgid "Push config ID"
 msgstr "Push-Konfigurations-ID"
 
-#: src/iac_code/cli/main.py:1115
+#: src/iac_code/cli/main.py:1122
 msgid "Push callback URL"
 msgstr "Push-Callback-URL"
 
-#: src/iac_code/cli/main.py:1116
+#: src/iac_code/cli/main.py:1123
 msgid "Notification verification token"
 msgstr "Token zur Benachrichtigungsverifizierung"
 
-#: src/iac_code/cli/main.py:1117
+#: src/iac_code/cli/main.py:1124
 msgid "Callback authentication scheme"
 msgstr "Callback-Authentifizierungsschema"
 
-#: src/iac_code/cli/main.py:1118
+#: src/iac_code/cli/main.py:1125
 msgid "Callback authentication credentials"
 msgstr "Callback-Authentifizierungsanmeldeinformationen"
 
-#: src/iac_code/cli/main.py:1188
+#: src/iac_code/cli/main.py:1195
 msgid "Get an A2A task push notification config."
 msgstr "Eine Push-Benachrichtigungskonfiguration für eine A2A-Aufgabe abrufen."
 
-#: src/iac_code/cli/main.py:1245
+#: src/iac_code/cli/main.py:1252
 msgid "List A2A task push notification configs."
 msgstr "Push-Benachrichtigungskonfigurationen für A2A-Aufgaben auflisten."
 
-#: src/iac_code/cli/main.py:1250
+#: src/iac_code/cli/main.py:1257
 msgid "Maximum configs to return"
 msgstr "Maximale Anzahl zurückzugebender Konfigurationen"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py:1308
 msgid "Delete an A2A task push notification config."
 msgstr "Eine Push-Benachrichtigungskonfiguration für eine A2A-Aufgabe löschen."
 
-#: src/iac_code/cli/main.py:1358
+#: src/iac_code/cli/main.py:1365
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Eine authentifizierte erweiterte A2A Agent Card abrufen."
 
-#: src/iac_code/cli/main.py:1401
+#: src/iac_code/cli/main.py:1408
 msgid "Preview A2A route resolution."
 msgstr "Vorschau der A2A-Routenauflösung."
 
-#: src/iac_code/cli/main.py:1408
+#: src/iac_code/cli/main.py:1415
 msgid "Route name to resolve"
 msgstr "Aufzulösender Routenname"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py:1416
 msgid "Skill ID to resolve"
 msgstr "Aufzulösende Skill-ID"
 
-#: src/iac_code/cli/main.py:1410
+#: src/iac_code/cli/main.py:1417
 msgid "Prompt text used for tag/name route matching"
 msgstr "Prompt-Text für die Tag-/Namens-Routenübereinstimmung"
 
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py:1422
 msgid "Directory for persisted A2A routes"
 msgstr "Verzeichnis für persistierte A2A-Routen"
 
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py:1424
 msgid "Save the provided routes as a route snapshot"
 msgstr "Speichert die angegebenen Routen als Routen-Snapshot"
 
@@ -2109,4 +2117,3 @@ msgstr "  Option 2 - npmmirror (China-freundlicher Spiegel):"
 
 #~ msgid "Provider switched: {status}"
 #~ msgstr "Provider gewechselt: {status}"
-

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 20:30+0800\n"
+"POT-Creation-Date: 2026-05-29 09:47+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: es\n"
@@ -159,8 +159,8 @@ msgstr "Usa iac-code como cliente A2A."
 msgid "YAML config file containing A2A client options"
 msgstr "Archivo de configuración YAML con opciones del cliente A2A"
 
-#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1450
-#: src/iac_code/cli/main.py:1811 src/iac_code/cli/main.py:1850
+#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py:1818 src/iac_code/cli/main.py:1857
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -273,7 +273,15 @@ msgstr ""
 "Transporte A2A: http, stdio, unix, websocket, grpc, grpc-jsonrpc o redis-"
 "streams"
 
-#: src/iac_code/cli/main.py:602
+#: src/iac_code/cli/main.py:561
+msgid ""
+"Expose A2A thinking signal types; repeat for multiple. Values: raw-"
+"thinking, tool-trace."
+msgstr ""
+"Expone tipos de señal de thinking A2A; repite para varios. Valores: raw-"
+"thinking, tool-trace."
+
+#: src/iac_code/cli/main.py:608
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -281,230 +289,230 @@ msgstr ""
 "Faltan las dependencias del servidor A2A. Instálalas con: pip install "
 "'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:733
+#: src/iac_code/cli/main.py:740
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Envía un prompt a un endpoint JSON-RPC A2A."
 
-#: src/iac_code/cli/main.py:736 src/iac_code/cli/main.py:900
-#: src/iac_code/cli/main.py:953 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1063 src/iac_code/cli/main.py:1112
-#: src/iac_code/cli/main.py:1191 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1361
+#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:907
+#: src/iac_code/cli/main.py:960 src/iac_code/cli/main.py:1020
+#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1119
+#: src/iac_code/cli/main.py:1198 src/iac_code/cli/main.py:1255
+#: src/iac_code/cli/main.py:1311 src/iac_code/cli/main.py:1368
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL del endpoint JSON-RPC A2A"
 
-#: src/iac_code/cli/main.py:737 src/iac_code/cli/main.py:1406
+#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:1413
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Especificación de ruta: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:738
+#: src/iac_code/cli/main.py:745
 msgid "Named A2A route to call"
 msgstr "Ruta A2A con nombre a llamar"
 
-#: src/iac_code/cli/main.py:739
+#: src/iac_code/cli/main.py:746
 msgid "Prompt to send"
 msgstr "Prompt a enviar"
 
-#: src/iac_code/cli/main.py:740
+#: src/iac_code/cli/main.py:747
 msgid "Working directory metadata to send with the request"
 msgstr "Metadatos del directorio de trabajo a enviar con la solicitud"
 
-#: src/iac_code/cli/main.py:741
+#: src/iac_code/cli/main.py:748
 msgid "A2A context ID to continue"
 msgstr "ID de contexto A2A a continuar"
 
-#: src/iac_code/cli/main.py:742 src/iac_code/cli/main.py:831
-#: src/iac_code/cli/main.py:903 src/iac_code/cli/main.py:960
-#: src/iac_code/cli/main.py:1015 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1119 src/iac_code/cli/main.py:1194
-#: src/iac_code/cli/main.py:1252 src/iac_code/cli/main.py:1307
-#: src/iac_code/cli/main.py:1362
+#: src/iac_code/cli/main.py:749 src/iac_code/cli/main.py:838
+#: src/iac_code/cli/main.py:910 src/iac_code/cli/main.py:967
+#: src/iac_code/cli/main.py:1022 src/iac_code/cli/main.py:1072
+#: src/iac_code/cli/main.py:1126 src/iac_code/cli/main.py:1201
+#: src/iac_code/cli/main.py:1259 src/iac_code/cli/main.py:1314
+#: src/iac_code/cli/main.py:1369
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Token Bearer para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:832
-#: src/iac_code/cli/main.py:904 src/iac_code/cli/main.py:961
-#: src/iac_code/cli/main.py:1016 src/iac_code/cli/main.py:1066
-#: src/iac_code/cli/main.py:1120 src/iac_code/cli/main.py:1195
-#: src/iac_code/cli/main.py:1253 src/iac_code/cli/main.py:1308
-#: src/iac_code/cli/main.py:1363
+#: src/iac_code/cli/main.py:750 src/iac_code/cli/main.py:839
+#: src/iac_code/cli/main.py:911 src/iac_code/cli/main.py:968
+#: src/iac_code/cli/main.py:1023 src/iac_code/cli/main.py:1073
+#: src/iac_code/cli/main.py:1127 src/iac_code/cli/main.py:1202
+#: src/iac_code/cli/main.py:1260 src/iac_code/cli/main.py:1315
+#: src/iac_code/cli/main.py:1370
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Nombre de usuario de autenticación básica para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:833
-#: src/iac_code/cli/main.py:905 src/iac_code/cli/main.py:962
-#: src/iac_code/cli/main.py:1017 src/iac_code/cli/main.py:1067
-#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1196
-#: src/iac_code/cli/main.py:1254 src/iac_code/cli/main.py:1309
-#: src/iac_code/cli/main.py:1364
+#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:912 src/iac_code/cli/main.py:969
+#: src/iac_code/cli/main.py:1024 src/iac_code/cli/main.py:1074
+#: src/iac_code/cli/main.py:1128 src/iac_code/cli/main.py:1203
+#: src/iac_code/cli/main.py:1261 src/iac_code/cli/main.py:1316
+#: src/iac_code/cli/main.py:1371
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Contraseña de autenticación básica para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:745 src/iac_code/cli/main.py:834
-#: src/iac_code/cli/main.py:906 src/iac_code/cli/main.py:963
-#: src/iac_code/cli/main.py:1018 src/iac_code/cli/main.py:1068
-#: src/iac_code/cli/main.py:1122 src/iac_code/cli/main.py:1197
-#: src/iac_code/cli/main.py:1255 src/iac_code/cli/main.py:1310
-#: src/iac_code/cli/main.py:1365
+#: src/iac_code/cli/main.py:752 src/iac_code/cli/main.py:841
+#: src/iac_code/cli/main.py:913 src/iac_code/cli/main.py:970
+#: src/iac_code/cli/main.py:1025 src/iac_code/cli/main.py:1075
+#: src/iac_code/cli/main.py:1129 src/iac_code/cli/main.py:1204
+#: src/iac_code/cli/main.py:1262 src/iac_code/cli/main.py:1317
+#: src/iac_code/cli/main.py:1372
 msgid "API key for A2A HTTP requests"
 msgstr "Clave de API para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:746 src/iac_code/cli/main.py:835
-#: src/iac_code/cli/main.py:907 src/iac_code/cli/main.py:964
-#: src/iac_code/cli/main.py:1019 src/iac_code/cli/main.py:1069
-#: src/iac_code/cli/main.py:1123 src/iac_code/cli/main.py:1198
-#: src/iac_code/cli/main.py:1256 src/iac_code/cli/main.py:1311
-#: src/iac_code/cli/main.py:1366
+#: src/iac_code/cli/main.py:753 src/iac_code/cli/main.py:842
+#: src/iac_code/cli/main.py:914 src/iac_code/cli/main.py:971
+#: src/iac_code/cli/main.py:1026 src/iac_code/cli/main.py:1076
+#: src/iac_code/cli/main.py:1130 src/iac_code/cli/main.py:1205
+#: src/iac_code/cli/main.py:1263 src/iac_code/cli/main.py:1318
+#: src/iac_code/cli/main.py:1373
 msgid "HTTP header name for A2A API key"
 msgstr "Nombre del encabezado HTTP para la clave de API A2A"
 
-#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:758 src/iac_code/cli/main.py:847
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Secreto utilizado para verificar la A2A Agent Card"
 
-#: src/iac_code/cli/main.py:756 src/iac_code/cli/main.py:845
+#: src/iac_code/cli/main.py:763 src/iac_code/cli/main.py:852
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "URL JWKS remota utilizada para verificar la A2A Agent Card"
 
-#: src/iac_code/cli/main.py:762 src/iac_code/cli/main.py:851
+#: src/iac_code/cli/main.py:769 src/iac_code/cli/main.py:858
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Requerir una firma válida de A2A Agent Card"
 
-#: src/iac_code/cli/main.py:764
+#: src/iac_code/cli/main.py:771
 msgid "A2A call timeout in seconds"
 msgstr "Tiempo de espera de llamada A2A en segundos"
 
-#: src/iac_code/cli/main.py:765
+#: src/iac_code/cli/main.py:772
 msgid "Use A2A streaming message delivery"
 msgstr "Usar entrega de mensajes en streaming A2A"
 
-#: src/iac_code/cli/main.py:827
+#: src/iac_code/cli/main.py:834
 msgid "Discover an A2A Agent Card."
 msgstr "Descubre una A2A Agent Card."
 
-#: src/iac_code/cli/main.py:830
+#: src/iac_code/cli/main.py:837
 msgid "A2A agent base URL"
 msgstr "URL base del agente A2A"
 
-#: src/iac_code/cli/main.py:897
+#: src/iac_code/cli/main.py:904
 msgid "Get an A2A task."
 msgstr "Obtén una tarea A2A."
 
-#: src/iac_code/cli/main.py:901 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1064 src/iac_code/cli/main.py:1113
-#: src/iac_code/cli/main.py:1192 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1305
+#: src/iac_code/cli/main.py:908 src/iac_code/cli/main.py:1021
+#: src/iac_code/cli/main.py:1071 src/iac_code/cli/main.py:1120
+#: src/iac_code/cli/main.py:1199 src/iac_code/cli/main.py:1256
+#: src/iac_code/cli/main.py:1312
 msgid "A2A task ID"
 msgstr "ID de tarea A2A"
 
-#: src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py:909
 msgid "Maximum task history items to return"
 msgstr "Número máximo de elementos del historial de tareas a devolver"
 
-#: src/iac_code/cli/main.py:950
+#: src/iac_code/cli/main.py:957
 msgid "List A2A tasks."
 msgstr "Lista las tareas A2A."
 
-#: src/iac_code/cli/main.py:954
+#: src/iac_code/cli/main.py:961
 msgid "Filter by A2A context ID"
 msgstr "Filtrar por ID de contexto A2A"
 
-#: src/iac_code/cli/main.py:955
+#: src/iac_code/cli/main.py:962
 msgid "Filter by A2A task state"
 msgstr "Filtrar por estado de tarea A2A"
 
-#: src/iac_code/cli/main.py:956
+#: src/iac_code/cli/main.py:963
 msgid "Maximum tasks to return"
 msgstr "Número máximo de tareas a devolver"
 
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1251
+#: src/iac_code/cli/main.py:964 src/iac_code/cli/main.py:1258
 msgid "Pagination token"
 msgstr "Token de paginación"
 
-#: src/iac_code/cli/main.py:958
+#: src/iac_code/cli/main.py:965
 msgid "Include task artifacts"
 msgstr "Incluir artefactos de tarea"
 
-#: src/iac_code/cli/main.py:959
+#: src/iac_code/cli/main.py:966
 msgid "Output format: table or json"
 msgstr "Formato de salida: table o json"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py:1017
 msgid "Cancel an A2A task."
 msgstr "Cancela una tarea A2A."
 
-#: src/iac_code/cli/main.py:1060
+#: src/iac_code/cli/main.py:1067
 msgid "Subscribe to an A2A task event stream."
 msgstr "Suscríbete a un flujo de eventos de tarea A2A."
 
-#: src/iac_code/cli/main.py:1109
+#: src/iac_code/cli/main.py:1116
 msgid "Create an A2A task push notification config."
 msgstr "Crea una configuración de notificación push de tarea A2A."
 
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1193
-#: src/iac_code/cli/main.py:1306
+#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1200
+#: src/iac_code/cli/main.py:1313
 msgid "Push config ID"
 msgstr "ID de configuración push"
 
-#: src/iac_code/cli/main.py:1115
+#: src/iac_code/cli/main.py:1122
 msgid "Push callback URL"
 msgstr "URL de callback push"
 
-#: src/iac_code/cli/main.py:1116
+#: src/iac_code/cli/main.py:1123
 msgid "Notification verification token"
 msgstr "Token de verificación de notificación"
 
-#: src/iac_code/cli/main.py:1117
+#: src/iac_code/cli/main.py:1124
 msgid "Callback authentication scheme"
 msgstr "Esquema de autenticación de callback"
 
-#: src/iac_code/cli/main.py:1118
+#: src/iac_code/cli/main.py:1125
 msgid "Callback authentication credentials"
 msgstr "Credenciales de autenticación de callback"
 
-#: src/iac_code/cli/main.py:1188
+#: src/iac_code/cli/main.py:1195
 msgid "Get an A2A task push notification config."
 msgstr "Obtén una configuración de notificación push de tarea A2A."
 
-#: src/iac_code/cli/main.py:1245
+#: src/iac_code/cli/main.py:1252
 msgid "List A2A task push notification configs."
 msgstr "Lista las configuraciones de notificación push de tareas A2A."
 
-#: src/iac_code/cli/main.py:1250
+#: src/iac_code/cli/main.py:1257
 msgid "Maximum configs to return"
 msgstr "Número máximo de configuraciones a devolver"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py:1308
 msgid "Delete an A2A task push notification config."
 msgstr "Elimina una configuración de notificación push de tarea A2A."
 
-#: src/iac_code/cli/main.py:1358
+#: src/iac_code/cli/main.py:1365
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Obtén una A2A Agent Card extendida autenticada."
 
-#: src/iac_code/cli/main.py:1401
+#: src/iac_code/cli/main.py:1408
 msgid "Preview A2A route resolution."
 msgstr "Vista previa de la resolución de rutas A2A."
 
-#: src/iac_code/cli/main.py:1408
+#: src/iac_code/cli/main.py:1415
 msgid "Route name to resolve"
 msgstr "Nombre de ruta a resolver"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py:1416
 msgid "Skill ID to resolve"
 msgstr "ID de habilidad a resolver"
 
-#: src/iac_code/cli/main.py:1410
+#: src/iac_code/cli/main.py:1417
 msgid "Prompt text used for tag/name route matching"
 msgstr ""
 "Texto del prompt utilizado para la coincidencia de rutas por "
 "etiqueta/nombre"
 
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py:1422
 msgid "Directory for persisted A2A routes"
 msgstr "Directorio para rutas A2A persistentes"
 
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py:1424
 msgid "Save the provided routes as a route snapshot"
 msgstr "Guarda las rutas proporcionadas como una instantánea de rutas"
 
@@ -2117,4 +2125,3 @@ msgstr "  Opción 2 - npmmirror (espejo para China):"
 
 #~ msgid "Provider switched: {status}"
 #~ msgstr "Provider cambiado: {status}"
-

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 20:30+0800\n"
+"POT-Creation-Date: 2026-05-29 09:47+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: fr\n"
@@ -155,8 +155,8 @@ msgstr "Utilise iac-code comme client A2A."
 msgid "YAML config file containing A2A client options"
 msgstr "Fichier de configuration YAML contenant les options client A2A"
 
-#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1450
-#: src/iac_code/cli/main.py:1811 src/iac_code/cli/main.py:1850
+#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py:1818 src/iac_code/cli/main.py:1857
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -271,7 +271,15 @@ msgstr ""
 "Transport A2A : http, stdio, unix, websocket, grpc, grpc-jsonrpc ou "
 "redis-streams"
 
-#: src/iac_code/cli/main.py:602
+#: src/iac_code/cli/main.py:561
+msgid ""
+"Expose A2A thinking signal types; repeat for multiple. Values: raw-"
+"thinking, tool-trace."
+msgstr ""
+"Expose les types de signal de thinking A2A ; répétez pour en fournir "
+"plusieurs. Valeurs : raw-thinking, tool-trace."
+
+#: src/iac_code/cli/main.py:608
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -279,228 +287,228 @@ msgstr ""
 "Les dépendances du serveur A2A sont manquantes. Installez-les avec : pip "
 "install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:733
+#: src/iac_code/cli/main.py:740
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Envoie un prompt à un point de terminaison JSON-RPC A2A."
 
-#: src/iac_code/cli/main.py:736 src/iac_code/cli/main.py:900
-#: src/iac_code/cli/main.py:953 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1063 src/iac_code/cli/main.py:1112
-#: src/iac_code/cli/main.py:1191 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1361
+#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:907
+#: src/iac_code/cli/main.py:960 src/iac_code/cli/main.py:1020
+#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1119
+#: src/iac_code/cli/main.py:1198 src/iac_code/cli/main.py:1255
+#: src/iac_code/cli/main.py:1311 src/iac_code/cli/main.py:1368
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL du point de terminaison JSON-RPC A2A"
 
-#: src/iac_code/cli/main.py:737 src/iac_code/cli/main.py:1406
+#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:1413
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Spécification de route : name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:738
+#: src/iac_code/cli/main.py:745
 msgid "Named A2A route to call"
 msgstr "Route A2A nommée à appeler"
 
-#: src/iac_code/cli/main.py:739
+#: src/iac_code/cli/main.py:746
 msgid "Prompt to send"
 msgstr "Prompt à envoyer"
 
-#: src/iac_code/cli/main.py:740
+#: src/iac_code/cli/main.py:747
 msgid "Working directory metadata to send with the request"
 msgstr "Métadonnées du répertoire de travail à envoyer avec la requête"
 
-#: src/iac_code/cli/main.py:741
+#: src/iac_code/cli/main.py:748
 msgid "A2A context ID to continue"
 msgstr "ID de contexte A2A à poursuivre"
 
-#: src/iac_code/cli/main.py:742 src/iac_code/cli/main.py:831
-#: src/iac_code/cli/main.py:903 src/iac_code/cli/main.py:960
-#: src/iac_code/cli/main.py:1015 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1119 src/iac_code/cli/main.py:1194
-#: src/iac_code/cli/main.py:1252 src/iac_code/cli/main.py:1307
-#: src/iac_code/cli/main.py:1362
+#: src/iac_code/cli/main.py:749 src/iac_code/cli/main.py:838
+#: src/iac_code/cli/main.py:910 src/iac_code/cli/main.py:967
+#: src/iac_code/cli/main.py:1022 src/iac_code/cli/main.py:1072
+#: src/iac_code/cli/main.py:1126 src/iac_code/cli/main.py:1201
+#: src/iac_code/cli/main.py:1259 src/iac_code/cli/main.py:1314
+#: src/iac_code/cli/main.py:1369
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Jeton Bearer pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:832
-#: src/iac_code/cli/main.py:904 src/iac_code/cli/main.py:961
-#: src/iac_code/cli/main.py:1016 src/iac_code/cli/main.py:1066
-#: src/iac_code/cli/main.py:1120 src/iac_code/cli/main.py:1195
-#: src/iac_code/cli/main.py:1253 src/iac_code/cli/main.py:1308
-#: src/iac_code/cli/main.py:1363
+#: src/iac_code/cli/main.py:750 src/iac_code/cli/main.py:839
+#: src/iac_code/cli/main.py:911 src/iac_code/cli/main.py:968
+#: src/iac_code/cli/main.py:1023 src/iac_code/cli/main.py:1073
+#: src/iac_code/cli/main.py:1127 src/iac_code/cli/main.py:1202
+#: src/iac_code/cli/main.py:1260 src/iac_code/cli/main.py:1315
+#: src/iac_code/cli/main.py:1370
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Nom d'utilisateur d'authentification basique pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:833
-#: src/iac_code/cli/main.py:905 src/iac_code/cli/main.py:962
-#: src/iac_code/cli/main.py:1017 src/iac_code/cli/main.py:1067
-#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1196
-#: src/iac_code/cli/main.py:1254 src/iac_code/cli/main.py:1309
-#: src/iac_code/cli/main.py:1364
+#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:912 src/iac_code/cli/main.py:969
+#: src/iac_code/cli/main.py:1024 src/iac_code/cli/main.py:1074
+#: src/iac_code/cli/main.py:1128 src/iac_code/cli/main.py:1203
+#: src/iac_code/cli/main.py:1261 src/iac_code/cli/main.py:1316
+#: src/iac_code/cli/main.py:1371
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Mot de passe d'authentification basique pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:745 src/iac_code/cli/main.py:834
-#: src/iac_code/cli/main.py:906 src/iac_code/cli/main.py:963
-#: src/iac_code/cli/main.py:1018 src/iac_code/cli/main.py:1068
-#: src/iac_code/cli/main.py:1122 src/iac_code/cli/main.py:1197
-#: src/iac_code/cli/main.py:1255 src/iac_code/cli/main.py:1310
-#: src/iac_code/cli/main.py:1365
+#: src/iac_code/cli/main.py:752 src/iac_code/cli/main.py:841
+#: src/iac_code/cli/main.py:913 src/iac_code/cli/main.py:970
+#: src/iac_code/cli/main.py:1025 src/iac_code/cli/main.py:1075
+#: src/iac_code/cli/main.py:1129 src/iac_code/cli/main.py:1204
+#: src/iac_code/cli/main.py:1262 src/iac_code/cli/main.py:1317
+#: src/iac_code/cli/main.py:1372
 msgid "API key for A2A HTTP requests"
 msgstr "Clé d'API pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:746 src/iac_code/cli/main.py:835
-#: src/iac_code/cli/main.py:907 src/iac_code/cli/main.py:964
-#: src/iac_code/cli/main.py:1019 src/iac_code/cli/main.py:1069
-#: src/iac_code/cli/main.py:1123 src/iac_code/cli/main.py:1198
-#: src/iac_code/cli/main.py:1256 src/iac_code/cli/main.py:1311
-#: src/iac_code/cli/main.py:1366
+#: src/iac_code/cli/main.py:753 src/iac_code/cli/main.py:842
+#: src/iac_code/cli/main.py:914 src/iac_code/cli/main.py:971
+#: src/iac_code/cli/main.py:1026 src/iac_code/cli/main.py:1076
+#: src/iac_code/cli/main.py:1130 src/iac_code/cli/main.py:1205
+#: src/iac_code/cli/main.py:1263 src/iac_code/cli/main.py:1318
+#: src/iac_code/cli/main.py:1373
 msgid "HTTP header name for A2A API key"
 msgstr "Nom de l'en-tête HTTP pour la clé d'API A2A"
 
-#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:758 src/iac_code/cli/main.py:847
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Secret utilisé pour vérifier l'A2A Agent Card"
 
-#: src/iac_code/cli/main.py:756 src/iac_code/cli/main.py:845
+#: src/iac_code/cli/main.py:763 src/iac_code/cli/main.py:852
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "URL JWKS distante utilisée pour vérifier l'A2A Agent Card"
 
-#: src/iac_code/cli/main.py:762 src/iac_code/cli/main.py:851
+#: src/iac_code/cli/main.py:769 src/iac_code/cli/main.py:858
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Exiger une signature valide de l'A2A Agent Card"
 
-#: src/iac_code/cli/main.py:764
+#: src/iac_code/cli/main.py:771
 msgid "A2A call timeout in seconds"
 msgstr "Délai d'expiration de l'appel A2A en secondes"
 
-#: src/iac_code/cli/main.py:765
+#: src/iac_code/cli/main.py:772
 msgid "Use A2A streaming message delivery"
 msgstr "Utiliser la diffusion en continu de messages A2A"
 
-#: src/iac_code/cli/main.py:827
+#: src/iac_code/cli/main.py:834
 msgid "Discover an A2A Agent Card."
 msgstr "Découvre une A2A Agent Card."
 
-#: src/iac_code/cli/main.py:830
+#: src/iac_code/cli/main.py:837
 msgid "A2A agent base URL"
 msgstr "URL de base de l'agent A2A"
 
-#: src/iac_code/cli/main.py:897
+#: src/iac_code/cli/main.py:904
 msgid "Get an A2A task."
 msgstr "Récupère une tâche A2A."
 
-#: src/iac_code/cli/main.py:901 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1064 src/iac_code/cli/main.py:1113
-#: src/iac_code/cli/main.py:1192 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1305
+#: src/iac_code/cli/main.py:908 src/iac_code/cli/main.py:1021
+#: src/iac_code/cli/main.py:1071 src/iac_code/cli/main.py:1120
+#: src/iac_code/cli/main.py:1199 src/iac_code/cli/main.py:1256
+#: src/iac_code/cli/main.py:1312
 msgid "A2A task ID"
 msgstr "ID de tâche A2A"
 
-#: src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py:909
 msgid "Maximum task history items to return"
 msgstr "Nombre maximal d'éléments d'historique de tâche à retourner"
 
-#: src/iac_code/cli/main.py:950
+#: src/iac_code/cli/main.py:957
 msgid "List A2A tasks."
 msgstr "Liste les tâches A2A."
 
-#: src/iac_code/cli/main.py:954
+#: src/iac_code/cli/main.py:961
 msgid "Filter by A2A context ID"
 msgstr "Filtrer par ID de contexte A2A"
 
-#: src/iac_code/cli/main.py:955
+#: src/iac_code/cli/main.py:962
 msgid "Filter by A2A task state"
 msgstr "Filtrer par état de tâche A2A"
 
-#: src/iac_code/cli/main.py:956
+#: src/iac_code/cli/main.py:963
 msgid "Maximum tasks to return"
 msgstr "Nombre maximal de tâches à retourner"
 
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1251
+#: src/iac_code/cli/main.py:964 src/iac_code/cli/main.py:1258
 msgid "Pagination token"
 msgstr "Jeton de pagination"
 
-#: src/iac_code/cli/main.py:958
+#: src/iac_code/cli/main.py:965
 msgid "Include task artifacts"
 msgstr "Inclure les artefacts de tâche"
 
-#: src/iac_code/cli/main.py:959
+#: src/iac_code/cli/main.py:966
 msgid "Output format: table or json"
 msgstr "Format de sortie : table ou json"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py:1017
 msgid "Cancel an A2A task."
 msgstr "Annule une tâche A2A."
 
-#: src/iac_code/cli/main.py:1060
+#: src/iac_code/cli/main.py:1067
 msgid "Subscribe to an A2A task event stream."
 msgstr "S'abonne à un flux d'événements de tâche A2A."
 
-#: src/iac_code/cli/main.py:1109
+#: src/iac_code/cli/main.py:1116
 msgid "Create an A2A task push notification config."
 msgstr "Crée une configuration de notifications push de tâche A2A."
 
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1193
-#: src/iac_code/cli/main.py:1306
+#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1200
+#: src/iac_code/cli/main.py:1313
 msgid "Push config ID"
 msgstr "ID de configuration push"
 
-#: src/iac_code/cli/main.py:1115
+#: src/iac_code/cli/main.py:1122
 msgid "Push callback URL"
 msgstr "URL de rappel push"
 
-#: src/iac_code/cli/main.py:1116
+#: src/iac_code/cli/main.py:1123
 msgid "Notification verification token"
 msgstr "Jeton de vérification de notification"
 
-#: src/iac_code/cli/main.py:1117
+#: src/iac_code/cli/main.py:1124
 msgid "Callback authentication scheme"
 msgstr "Schéma d'authentification du rappel"
 
-#: src/iac_code/cli/main.py:1118
+#: src/iac_code/cli/main.py:1125
 msgid "Callback authentication credentials"
 msgstr "Identifiants d'authentification du rappel"
 
-#: src/iac_code/cli/main.py:1188
+#: src/iac_code/cli/main.py:1195
 msgid "Get an A2A task push notification config."
 msgstr "Récupère une configuration de notifications push de tâche A2A."
 
-#: src/iac_code/cli/main.py:1245
+#: src/iac_code/cli/main.py:1252
 msgid "List A2A task push notification configs."
 msgstr "Liste les configurations de notifications push de tâches A2A."
 
-#: src/iac_code/cli/main.py:1250
+#: src/iac_code/cli/main.py:1257
 msgid "Maximum configs to return"
 msgstr "Nombre maximal de configurations à retourner"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py:1308
 msgid "Delete an A2A task push notification config."
 msgstr "Supprime une configuration de notifications push de tâche A2A."
 
-#: src/iac_code/cli/main.py:1358
+#: src/iac_code/cli/main.py:1365
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Récupère une A2A Agent Card étendue authentifiée."
 
-#: src/iac_code/cli/main.py:1401
+#: src/iac_code/cli/main.py:1408
 msgid "Preview A2A route resolution."
 msgstr "Aperçu de la résolution des routes A2A."
 
-#: src/iac_code/cli/main.py:1408
+#: src/iac_code/cli/main.py:1415
 msgid "Route name to resolve"
 msgstr "Nom de route à résoudre"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py:1416
 msgid "Skill ID to resolve"
 msgstr "ID de compétence à résoudre"
 
-#: src/iac_code/cli/main.py:1410
+#: src/iac_code/cli/main.py:1417
 msgid "Prompt text used for tag/name route matching"
 msgstr "Texte du prompt utilisé pour la correspondance des routes par tag/nom"
 
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py:1422
 msgid "Directory for persisted A2A routes"
 msgstr "Répertoire pour les routes A2A persistées"
 
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py:1424
 msgid "Save the provided routes as a route snapshot"
 msgstr "Enregistre les routes fournies sous forme d'instantané de routes"
 
@@ -2103,4 +2111,3 @@ msgstr "  Option 2 - npmmirror (miroir pour la Chine) :"
 
 #~ msgid "Provider switched: {status}"
 #~ msgstr "Provider changé : {status}"
-

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 20:30+0800\n"
+"POT-Creation-Date: 2026-05-29 09:47+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -150,8 +150,8 @@ msgstr "iac-code を A2A クライアントとして使用します。"
 msgid "YAML config file containing A2A client options"
 msgstr "A2A クライアントオプションを含む YAML 設定ファイル"
 
-#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1450
-#: src/iac_code/cli/main.py:1811 src/iac_code/cli/main.py:1850
+#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py:1818 src/iac_code/cli/main.py:1857
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -256,234 +256,242 @@ msgid ""
 "redis-streams"
 msgstr "A2A トランスポート: http、stdio、unix、websocket、grpc、grpc-jsonrpc、または redis-streams"
 
-#: src/iac_code/cli/main.py:602
+#: src/iac_code/cli/main.py:561
+msgid ""
+"Expose A2A thinking signal types; repeat for multiple. Values: raw-"
+"thinking, tool-trace."
+msgstr ""
+"A2A thinking 信号タイプを公開します。複数指定するには繰り返します。値：raw-thinking、"
+"tool-trace。"
+
+#: src/iac_code/cli/main.py:608
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
 msgstr "A2A サーバーの依存関係が不足しています。次のコマンドでインストールしてください: pip install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:733
+#: src/iac_code/cli/main.py:740
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "A2A JSON-RPC エンドポイントにプロンプトを送信します。"
 
-#: src/iac_code/cli/main.py:736 src/iac_code/cli/main.py:900
-#: src/iac_code/cli/main.py:953 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1063 src/iac_code/cli/main.py:1112
-#: src/iac_code/cli/main.py:1191 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1361
+#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:907
+#: src/iac_code/cli/main.py:960 src/iac_code/cli/main.py:1020
+#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1119
+#: src/iac_code/cli/main.py:1198 src/iac_code/cli/main.py:1255
+#: src/iac_code/cli/main.py:1311 src/iac_code/cli/main.py:1368
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "A2A JSON-RPC エンドポイント URL"
 
-#: src/iac_code/cli/main.py:737 src/iac_code/cli/main.py:1406
+#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:1413
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "ルート仕様: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:738
+#: src/iac_code/cli/main.py:745
 msgid "Named A2A route to call"
 msgstr "呼び出す名前付き A2A ルート"
 
-#: src/iac_code/cli/main.py:739
+#: src/iac_code/cli/main.py:746
 msgid "Prompt to send"
 msgstr "送信するプロンプト"
 
-#: src/iac_code/cli/main.py:740
+#: src/iac_code/cli/main.py:747
 msgid "Working directory metadata to send with the request"
 msgstr "リクエストと共に送信する作業ディレクトリのメタデータ"
 
-#: src/iac_code/cli/main.py:741
+#: src/iac_code/cli/main.py:748
 msgid "A2A context ID to continue"
 msgstr "継続する A2A コンテキスト ID"
 
-#: src/iac_code/cli/main.py:742 src/iac_code/cli/main.py:831
-#: src/iac_code/cli/main.py:903 src/iac_code/cli/main.py:960
-#: src/iac_code/cli/main.py:1015 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1119 src/iac_code/cli/main.py:1194
-#: src/iac_code/cli/main.py:1252 src/iac_code/cli/main.py:1307
-#: src/iac_code/cli/main.py:1362
+#: src/iac_code/cli/main.py:749 src/iac_code/cli/main.py:838
+#: src/iac_code/cli/main.py:910 src/iac_code/cli/main.py:967
+#: src/iac_code/cli/main.py:1022 src/iac_code/cli/main.py:1072
+#: src/iac_code/cli/main.py:1126 src/iac_code/cli/main.py:1201
+#: src/iac_code/cli/main.py:1259 src/iac_code/cli/main.py:1314
+#: src/iac_code/cli/main.py:1369
 msgid "Bearer token for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の Bearer トークン"
 
-#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:832
-#: src/iac_code/cli/main.py:904 src/iac_code/cli/main.py:961
-#: src/iac_code/cli/main.py:1016 src/iac_code/cli/main.py:1066
-#: src/iac_code/cli/main.py:1120 src/iac_code/cli/main.py:1195
-#: src/iac_code/cli/main.py:1253 src/iac_code/cli/main.py:1308
-#: src/iac_code/cli/main.py:1363
+#: src/iac_code/cli/main.py:750 src/iac_code/cli/main.py:839
+#: src/iac_code/cli/main.py:911 src/iac_code/cli/main.py:968
+#: src/iac_code/cli/main.py:1023 src/iac_code/cli/main.py:1073
+#: src/iac_code/cli/main.py:1127 src/iac_code/cli/main.py:1202
+#: src/iac_code/cli/main.py:1260 src/iac_code/cli/main.py:1315
+#: src/iac_code/cli/main.py:1370
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の Basic 認証ユーザー名"
 
-#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:833
-#: src/iac_code/cli/main.py:905 src/iac_code/cli/main.py:962
-#: src/iac_code/cli/main.py:1017 src/iac_code/cli/main.py:1067
-#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1196
-#: src/iac_code/cli/main.py:1254 src/iac_code/cli/main.py:1309
-#: src/iac_code/cli/main.py:1364
+#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:912 src/iac_code/cli/main.py:969
+#: src/iac_code/cli/main.py:1024 src/iac_code/cli/main.py:1074
+#: src/iac_code/cli/main.py:1128 src/iac_code/cli/main.py:1203
+#: src/iac_code/cli/main.py:1261 src/iac_code/cli/main.py:1316
+#: src/iac_code/cli/main.py:1371
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の Basic 認証パスワード"
 
-#: src/iac_code/cli/main.py:745 src/iac_code/cli/main.py:834
-#: src/iac_code/cli/main.py:906 src/iac_code/cli/main.py:963
-#: src/iac_code/cli/main.py:1018 src/iac_code/cli/main.py:1068
-#: src/iac_code/cli/main.py:1122 src/iac_code/cli/main.py:1197
-#: src/iac_code/cli/main.py:1255 src/iac_code/cli/main.py:1310
-#: src/iac_code/cli/main.py:1365
+#: src/iac_code/cli/main.py:752 src/iac_code/cli/main.py:841
+#: src/iac_code/cli/main.py:913 src/iac_code/cli/main.py:970
+#: src/iac_code/cli/main.py:1025 src/iac_code/cli/main.py:1075
+#: src/iac_code/cli/main.py:1129 src/iac_code/cli/main.py:1204
+#: src/iac_code/cli/main.py:1262 src/iac_code/cli/main.py:1317
+#: src/iac_code/cli/main.py:1372
 msgid "API key for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の API キー"
 
-#: src/iac_code/cli/main.py:746 src/iac_code/cli/main.py:835
-#: src/iac_code/cli/main.py:907 src/iac_code/cli/main.py:964
-#: src/iac_code/cli/main.py:1019 src/iac_code/cli/main.py:1069
-#: src/iac_code/cli/main.py:1123 src/iac_code/cli/main.py:1198
-#: src/iac_code/cli/main.py:1256 src/iac_code/cli/main.py:1311
-#: src/iac_code/cli/main.py:1366
+#: src/iac_code/cli/main.py:753 src/iac_code/cli/main.py:842
+#: src/iac_code/cli/main.py:914 src/iac_code/cli/main.py:971
+#: src/iac_code/cli/main.py:1026 src/iac_code/cli/main.py:1076
+#: src/iac_code/cli/main.py:1130 src/iac_code/cli/main.py:1205
+#: src/iac_code/cli/main.py:1263 src/iac_code/cli/main.py:1318
+#: src/iac_code/cli/main.py:1373
 msgid "HTTP header name for A2A API key"
 msgstr "A2A API キー用の HTTP ヘッダー名"
 
-#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:758 src/iac_code/cli/main.py:847
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "A2A Agent Card の検証に使用するシークレット"
 
-#: src/iac_code/cli/main.py:756 src/iac_code/cli/main.py:845
+#: src/iac_code/cli/main.py:763 src/iac_code/cli/main.py:852
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "A2A Agent Card の検証に使用するリモート JWKS URL"
 
-#: src/iac_code/cli/main.py:762 src/iac_code/cli/main.py:851
+#: src/iac_code/cli/main.py:769 src/iac_code/cli/main.py:858
 msgid "Require a valid A2A Agent Card signature"
 msgstr "有効な A2A Agent Card 署名を要求します"
 
-#: src/iac_code/cli/main.py:764
+#: src/iac_code/cli/main.py:771
 msgid "A2A call timeout in seconds"
 msgstr "A2A 呼び出しのタイムアウト（秒）"
 
-#: src/iac_code/cli/main.py:765
+#: src/iac_code/cli/main.py:772
 msgid "Use A2A streaming message delivery"
 msgstr "A2A ストリーミングメッセージ配信を使用します"
 
-#: src/iac_code/cli/main.py:827
+#: src/iac_code/cli/main.py:834
 msgid "Discover an A2A Agent Card."
 msgstr "A2A Agent Card を検出します。"
 
-#: src/iac_code/cli/main.py:830
+#: src/iac_code/cli/main.py:837
 msgid "A2A agent base URL"
 msgstr "A2A エージェントのベース URL"
 
-#: src/iac_code/cli/main.py:897
+#: src/iac_code/cli/main.py:904
 msgid "Get an A2A task."
 msgstr "A2A タスクを取得します。"
 
-#: src/iac_code/cli/main.py:901 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1064 src/iac_code/cli/main.py:1113
-#: src/iac_code/cli/main.py:1192 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1305
+#: src/iac_code/cli/main.py:908 src/iac_code/cli/main.py:1021
+#: src/iac_code/cli/main.py:1071 src/iac_code/cli/main.py:1120
+#: src/iac_code/cli/main.py:1199 src/iac_code/cli/main.py:1256
+#: src/iac_code/cli/main.py:1312
 msgid "A2A task ID"
 msgstr "A2A タスク ID"
 
-#: src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py:909
 msgid "Maximum task history items to return"
 msgstr "返却するタスク履歴項目の最大数"
 
-#: src/iac_code/cli/main.py:950
+#: src/iac_code/cli/main.py:957
 msgid "List A2A tasks."
 msgstr "A2A タスクを一覧表示します。"
 
-#: src/iac_code/cli/main.py:954
+#: src/iac_code/cli/main.py:961
 msgid "Filter by A2A context ID"
 msgstr "A2A コンテキスト ID でフィルタリングします"
 
-#: src/iac_code/cli/main.py:955
+#: src/iac_code/cli/main.py:962
 msgid "Filter by A2A task state"
 msgstr "A2A タスク状態でフィルタリングします"
 
-#: src/iac_code/cli/main.py:956
+#: src/iac_code/cli/main.py:963
 msgid "Maximum tasks to return"
 msgstr "返却するタスクの最大数"
 
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1251
+#: src/iac_code/cli/main.py:964 src/iac_code/cli/main.py:1258
 msgid "Pagination token"
 msgstr "ページネーショントークン"
 
-#: src/iac_code/cli/main.py:958
+#: src/iac_code/cli/main.py:965
 msgid "Include task artifacts"
 msgstr "タスクアーティファクトを含めます"
 
-#: src/iac_code/cli/main.py:959
+#: src/iac_code/cli/main.py:966
 msgid "Output format: table or json"
 msgstr "出力形式: table または json"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py:1017
 msgid "Cancel an A2A task."
 msgstr "A2A タスクをキャンセルします。"
 
-#: src/iac_code/cli/main.py:1060
+#: src/iac_code/cli/main.py:1067
 msgid "Subscribe to an A2A task event stream."
 msgstr "A2A タスクのイベントストリームを購読します。"
 
-#: src/iac_code/cli/main.py:1109
+#: src/iac_code/cli/main.py:1116
 msgid "Create an A2A task push notification config."
 msgstr "A2A タスクプッシュ通知設定を作成します。"
 
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1193
-#: src/iac_code/cli/main.py:1306
+#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1200
+#: src/iac_code/cli/main.py:1313
 msgid "Push config ID"
 msgstr "プッシュ設定 ID"
 
-#: src/iac_code/cli/main.py:1115
+#: src/iac_code/cli/main.py:1122
 msgid "Push callback URL"
 msgstr "プッシュコールバック URL"
 
-#: src/iac_code/cli/main.py:1116
+#: src/iac_code/cli/main.py:1123
 msgid "Notification verification token"
 msgstr "通知検証トークン"
 
-#: src/iac_code/cli/main.py:1117
+#: src/iac_code/cli/main.py:1124
 msgid "Callback authentication scheme"
 msgstr "コールバック認証方式"
 
-#: src/iac_code/cli/main.py:1118
+#: src/iac_code/cli/main.py:1125
 msgid "Callback authentication credentials"
 msgstr "コールバック認証資格情報"
 
-#: src/iac_code/cli/main.py:1188
+#: src/iac_code/cli/main.py:1195
 msgid "Get an A2A task push notification config."
 msgstr "A2A タスクプッシュ通知設定を取得します。"
 
-#: src/iac_code/cli/main.py:1245
+#: src/iac_code/cli/main.py:1252
 msgid "List A2A task push notification configs."
 msgstr "A2A タスクプッシュ通知設定を一覧表示します。"
 
-#: src/iac_code/cli/main.py:1250
+#: src/iac_code/cli/main.py:1257
 msgid "Maximum configs to return"
 msgstr "返却する設定の最大数"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py:1308
 msgid "Delete an A2A task push notification config."
 msgstr "A2A タスクプッシュ通知設定を削除します。"
 
-#: src/iac_code/cli/main.py:1358
+#: src/iac_code/cli/main.py:1365
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "認証済みの拡張 A2A Agent Card を取得します。"
 
-#: src/iac_code/cli/main.py:1401
+#: src/iac_code/cli/main.py:1408
 msgid "Preview A2A route resolution."
 msgstr "A2A ルート解決をプレビューします。"
 
-#: src/iac_code/cli/main.py:1408
+#: src/iac_code/cli/main.py:1415
 msgid "Route name to resolve"
 msgstr "解決するルート名"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py:1416
 msgid "Skill ID to resolve"
 msgstr "解決するスキル ID"
 
-#: src/iac_code/cli/main.py:1410
+#: src/iac_code/cli/main.py:1417
 msgid "Prompt text used for tag/name route matching"
 msgstr "タグ/名前ルートのマッチングに使用するプロンプトテキスト"
 
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py:1422
 msgid "Directory for persisted A2A routes"
 msgstr "永続化された A2A ルート用のディレクトリ"
 
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py:1424
 msgid "Save the provided routes as a route snapshot"
 msgstr "指定されたルートをルートスナップショットとして保存します"
 
@@ -2063,4 +2071,3 @@ msgstr "  方法 2 - npmmirror（中国向けミラー）："
 
 #~ msgid "Provider switched: {status}"
 #~ msgstr "Provider が切り替わりました: {status}"
-

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 20:30+0800\n"
+"POT-Creation-Date: 2026-05-29 09:47+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: pt\n"
@@ -154,8 +154,8 @@ msgstr "Usa o iac-code como cliente A2A."
 msgid "YAML config file containing A2A client options"
 msgstr "Arquivo de configuração YAML com opções do cliente A2A"
 
-#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1450
-#: src/iac_code/cli/main.py:1811 src/iac_code/cli/main.py:1850
+#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py:1818 src/iac_code/cli/main.py:1857
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -268,7 +268,15 @@ msgstr ""
 "Transporte A2A: http, stdio, unix, websocket, grpc, grpc-jsonrpc ou "
 "redis-streams"
 
-#: src/iac_code/cli/main.py:602
+#: src/iac_code/cli/main.py:561
+msgid ""
+"Expose A2A thinking signal types; repeat for multiple. Values: raw-"
+"thinking, tool-trace."
+msgstr ""
+"Expõe tipos de sinal de thinking A2A; repita para múltiplos. Valores: raw-"
+"thinking, tool-trace."
+
+#: src/iac_code/cli/main.py:608
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -276,228 +284,228 @@ msgstr ""
 "As dependências do servidor A2A estão ausentes. Instale com: pip install "
 "'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:733
+#: src/iac_code/cli/main.py:740
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Envia um prompt para um endpoint JSON-RPC A2A."
 
-#: src/iac_code/cli/main.py:736 src/iac_code/cli/main.py:900
-#: src/iac_code/cli/main.py:953 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1063 src/iac_code/cli/main.py:1112
-#: src/iac_code/cli/main.py:1191 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1361
+#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:907
+#: src/iac_code/cli/main.py:960 src/iac_code/cli/main.py:1020
+#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1119
+#: src/iac_code/cli/main.py:1198 src/iac_code/cli/main.py:1255
+#: src/iac_code/cli/main.py:1311 src/iac_code/cli/main.py:1368
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL do endpoint JSON-RPC A2A"
 
-#: src/iac_code/cli/main.py:737 src/iac_code/cli/main.py:1406
+#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:1413
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Especificação de rota: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:738
+#: src/iac_code/cli/main.py:745
 msgid "Named A2A route to call"
 msgstr "Rota A2A nomeada a chamar"
 
-#: src/iac_code/cli/main.py:739
+#: src/iac_code/cli/main.py:746
 msgid "Prompt to send"
 msgstr "Prompt para enviar"
 
-#: src/iac_code/cli/main.py:740
+#: src/iac_code/cli/main.py:747
 msgid "Working directory metadata to send with the request"
 msgstr "Metadados do diretório de trabalho a enviar com a requisição"
 
-#: src/iac_code/cli/main.py:741
+#: src/iac_code/cli/main.py:748
 msgid "A2A context ID to continue"
 msgstr "ID de contexto A2A para continuar"
 
-#: src/iac_code/cli/main.py:742 src/iac_code/cli/main.py:831
-#: src/iac_code/cli/main.py:903 src/iac_code/cli/main.py:960
-#: src/iac_code/cli/main.py:1015 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1119 src/iac_code/cli/main.py:1194
-#: src/iac_code/cli/main.py:1252 src/iac_code/cli/main.py:1307
-#: src/iac_code/cli/main.py:1362
+#: src/iac_code/cli/main.py:749 src/iac_code/cli/main.py:838
+#: src/iac_code/cli/main.py:910 src/iac_code/cli/main.py:967
+#: src/iac_code/cli/main.py:1022 src/iac_code/cli/main.py:1072
+#: src/iac_code/cli/main.py:1126 src/iac_code/cli/main.py:1201
+#: src/iac_code/cli/main.py:1259 src/iac_code/cli/main.py:1314
+#: src/iac_code/cli/main.py:1369
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Token Bearer para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:832
-#: src/iac_code/cli/main.py:904 src/iac_code/cli/main.py:961
-#: src/iac_code/cli/main.py:1016 src/iac_code/cli/main.py:1066
-#: src/iac_code/cli/main.py:1120 src/iac_code/cli/main.py:1195
-#: src/iac_code/cli/main.py:1253 src/iac_code/cli/main.py:1308
-#: src/iac_code/cli/main.py:1363
+#: src/iac_code/cli/main.py:750 src/iac_code/cli/main.py:839
+#: src/iac_code/cli/main.py:911 src/iac_code/cli/main.py:968
+#: src/iac_code/cli/main.py:1023 src/iac_code/cli/main.py:1073
+#: src/iac_code/cli/main.py:1127 src/iac_code/cli/main.py:1202
+#: src/iac_code/cli/main.py:1260 src/iac_code/cli/main.py:1315
+#: src/iac_code/cli/main.py:1370
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Nome de usuário de autenticação básica para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:833
-#: src/iac_code/cli/main.py:905 src/iac_code/cli/main.py:962
-#: src/iac_code/cli/main.py:1017 src/iac_code/cli/main.py:1067
-#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1196
-#: src/iac_code/cli/main.py:1254 src/iac_code/cli/main.py:1309
-#: src/iac_code/cli/main.py:1364
+#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:912 src/iac_code/cli/main.py:969
+#: src/iac_code/cli/main.py:1024 src/iac_code/cli/main.py:1074
+#: src/iac_code/cli/main.py:1128 src/iac_code/cli/main.py:1203
+#: src/iac_code/cli/main.py:1261 src/iac_code/cli/main.py:1316
+#: src/iac_code/cli/main.py:1371
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Senha de autenticação básica para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:745 src/iac_code/cli/main.py:834
-#: src/iac_code/cli/main.py:906 src/iac_code/cli/main.py:963
-#: src/iac_code/cli/main.py:1018 src/iac_code/cli/main.py:1068
-#: src/iac_code/cli/main.py:1122 src/iac_code/cli/main.py:1197
-#: src/iac_code/cli/main.py:1255 src/iac_code/cli/main.py:1310
-#: src/iac_code/cli/main.py:1365
+#: src/iac_code/cli/main.py:752 src/iac_code/cli/main.py:841
+#: src/iac_code/cli/main.py:913 src/iac_code/cli/main.py:970
+#: src/iac_code/cli/main.py:1025 src/iac_code/cli/main.py:1075
+#: src/iac_code/cli/main.py:1129 src/iac_code/cli/main.py:1204
+#: src/iac_code/cli/main.py:1262 src/iac_code/cli/main.py:1317
+#: src/iac_code/cli/main.py:1372
 msgid "API key for A2A HTTP requests"
 msgstr "Chave de API para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:746 src/iac_code/cli/main.py:835
-#: src/iac_code/cli/main.py:907 src/iac_code/cli/main.py:964
-#: src/iac_code/cli/main.py:1019 src/iac_code/cli/main.py:1069
-#: src/iac_code/cli/main.py:1123 src/iac_code/cli/main.py:1198
-#: src/iac_code/cli/main.py:1256 src/iac_code/cli/main.py:1311
-#: src/iac_code/cli/main.py:1366
+#: src/iac_code/cli/main.py:753 src/iac_code/cli/main.py:842
+#: src/iac_code/cli/main.py:914 src/iac_code/cli/main.py:971
+#: src/iac_code/cli/main.py:1026 src/iac_code/cli/main.py:1076
+#: src/iac_code/cli/main.py:1130 src/iac_code/cli/main.py:1205
+#: src/iac_code/cli/main.py:1263 src/iac_code/cli/main.py:1318
+#: src/iac_code/cli/main.py:1373
 msgid "HTTP header name for A2A API key"
 msgstr "Nome do cabeçalho HTTP para a chave de API A2A"
 
-#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:758 src/iac_code/cli/main.py:847
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Segredo usado para verificar o A2A Agent Card"
 
-#: src/iac_code/cli/main.py:756 src/iac_code/cli/main.py:845
+#: src/iac_code/cli/main.py:763 src/iac_code/cli/main.py:852
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "URL JWKS remota usada para verificar o A2A Agent Card"
 
-#: src/iac_code/cli/main.py:762 src/iac_code/cli/main.py:851
+#: src/iac_code/cli/main.py:769 src/iac_code/cli/main.py:858
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Exigir uma assinatura válida do A2A Agent Card"
 
-#: src/iac_code/cli/main.py:764
+#: src/iac_code/cli/main.py:771
 msgid "A2A call timeout in seconds"
 msgstr "Tempo limite da chamada A2A em segundos"
 
-#: src/iac_code/cli/main.py:765
+#: src/iac_code/cli/main.py:772
 msgid "Use A2A streaming message delivery"
 msgstr "Usar entrega de mensagens em streaming A2A"
 
-#: src/iac_code/cli/main.py:827
+#: src/iac_code/cli/main.py:834
 msgid "Discover an A2A Agent Card."
 msgstr "Descobre um A2A Agent Card."
 
-#: src/iac_code/cli/main.py:830
+#: src/iac_code/cli/main.py:837
 msgid "A2A agent base URL"
 msgstr "URL base do agente A2A"
 
-#: src/iac_code/cli/main.py:897
+#: src/iac_code/cli/main.py:904
 msgid "Get an A2A task."
 msgstr "Obtém uma tarefa A2A."
 
-#: src/iac_code/cli/main.py:901 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1064 src/iac_code/cli/main.py:1113
-#: src/iac_code/cli/main.py:1192 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1305
+#: src/iac_code/cli/main.py:908 src/iac_code/cli/main.py:1021
+#: src/iac_code/cli/main.py:1071 src/iac_code/cli/main.py:1120
+#: src/iac_code/cli/main.py:1199 src/iac_code/cli/main.py:1256
+#: src/iac_code/cli/main.py:1312
 msgid "A2A task ID"
 msgstr "ID da tarefa A2A"
 
-#: src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py:909
 msgid "Maximum task history items to return"
 msgstr "Número máximo de itens do histórico de tarefas a retornar"
 
-#: src/iac_code/cli/main.py:950
+#: src/iac_code/cli/main.py:957
 msgid "List A2A tasks."
 msgstr "Lista as tarefas A2A."
 
-#: src/iac_code/cli/main.py:954
+#: src/iac_code/cli/main.py:961
 msgid "Filter by A2A context ID"
 msgstr "Filtrar por ID de contexto A2A"
 
-#: src/iac_code/cli/main.py:955
+#: src/iac_code/cli/main.py:962
 msgid "Filter by A2A task state"
 msgstr "Filtrar por estado de tarefa A2A"
 
-#: src/iac_code/cli/main.py:956
+#: src/iac_code/cli/main.py:963
 msgid "Maximum tasks to return"
 msgstr "Número máximo de tarefas a retornar"
 
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1251
+#: src/iac_code/cli/main.py:964 src/iac_code/cli/main.py:1258
 msgid "Pagination token"
 msgstr "Token de paginação"
 
-#: src/iac_code/cli/main.py:958
+#: src/iac_code/cli/main.py:965
 msgid "Include task artifacts"
 msgstr "Incluir artefatos de tarefa"
 
-#: src/iac_code/cli/main.py:959
+#: src/iac_code/cli/main.py:966
 msgid "Output format: table or json"
 msgstr "Formato de saída: table ou json"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py:1017
 msgid "Cancel an A2A task."
 msgstr "Cancela uma tarefa A2A."
 
-#: src/iac_code/cli/main.py:1060
+#: src/iac_code/cli/main.py:1067
 msgid "Subscribe to an A2A task event stream."
 msgstr "Assina um fluxo de eventos de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1109
+#: src/iac_code/cli/main.py:1116
 msgid "Create an A2A task push notification config."
 msgstr "Cria uma configuração de notificação push de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1193
-#: src/iac_code/cli/main.py:1306
+#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1200
+#: src/iac_code/cli/main.py:1313
 msgid "Push config ID"
 msgstr "ID da configuração push"
 
-#: src/iac_code/cli/main.py:1115
+#: src/iac_code/cli/main.py:1122
 msgid "Push callback URL"
 msgstr "URL de callback push"
 
-#: src/iac_code/cli/main.py:1116
+#: src/iac_code/cli/main.py:1123
 msgid "Notification verification token"
 msgstr "Token de verificação de notificação"
 
-#: src/iac_code/cli/main.py:1117
+#: src/iac_code/cli/main.py:1124
 msgid "Callback authentication scheme"
 msgstr "Esquema de autenticação de callback"
 
-#: src/iac_code/cli/main.py:1118
+#: src/iac_code/cli/main.py:1125
 msgid "Callback authentication credentials"
 msgstr "Credenciais de autenticação de callback"
 
-#: src/iac_code/cli/main.py:1188
+#: src/iac_code/cli/main.py:1195
 msgid "Get an A2A task push notification config."
 msgstr "Obtém uma configuração de notificação push de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1245
+#: src/iac_code/cli/main.py:1252
 msgid "List A2A task push notification configs."
 msgstr "Lista as configurações de notificação push de tarefas A2A."
 
-#: src/iac_code/cli/main.py:1250
+#: src/iac_code/cli/main.py:1257
 msgid "Maximum configs to return"
 msgstr "Número máximo de configurações a retornar"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py:1308
 msgid "Delete an A2A task push notification config."
 msgstr "Exclui uma configuração de notificação push de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1358
+#: src/iac_code/cli/main.py:1365
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Obtém um A2A Agent Card estendido autenticado."
 
-#: src/iac_code/cli/main.py:1401
+#: src/iac_code/cli/main.py:1408
 msgid "Preview A2A route resolution."
 msgstr "Pré-visualização da resolução de rotas A2A."
 
-#: src/iac_code/cli/main.py:1408
+#: src/iac_code/cli/main.py:1415
 msgid "Route name to resolve"
 msgstr "Nome da rota a resolver"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py:1416
 msgid "Skill ID to resolve"
 msgstr "ID da habilidade a resolver"
 
-#: src/iac_code/cli/main.py:1410
+#: src/iac_code/cli/main.py:1417
 msgid "Prompt text used for tag/name route matching"
 msgstr "Texto do prompt usado para correspondência de rotas por tag/nome"
 
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py:1422
 msgid "Directory for persisted A2A routes"
 msgstr "Diretório para rotas A2A persistidas"
 
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py:1424
 msgid "Save the provided routes as a route snapshot"
 msgstr "Salva as rotas fornecidas como um snapshot de rotas"
 
@@ -2083,4 +2091,3 @@ msgstr "  Opção 2 - npmmirror (espelho para a China):"
 
 #~ msgid "Provider switched: {status}"
 #~ msgstr "Provider alterado: {status}"
-

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 20:30+0800\n"
+"POT-Creation-Date: 2026-05-29 09:47+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"
 "Last-Translator: \n"
 "Language: zh\n"
@@ -146,8 +146,8 @@ msgstr "将 iac-code 作为 A2A 客户端使用。"
 msgid "YAML config file containing A2A client options"
 msgstr "包含 A2A 客户端选项的 YAML 配置文件"
 
-#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1450
-#: src/iac_code/cli/main.py:1811 src/iac_code/cli/main.py:1850
+#: src/iac_code/cli/main.py:57 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py:1818 src/iac_code/cli/main.py:1857
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -250,234 +250,240 @@ msgid ""
 "redis-streams"
 msgstr "A2A 传输方式：http、stdio、unix、websocket、grpc、grpc-jsonrpc 或 redis-streams"
 
-#: src/iac_code/cli/main.py:602
+#: src/iac_code/cli/main.py:561
+msgid ""
+"Expose A2A thinking signal types; repeat for multiple. Values: raw-"
+"thinking, tool-trace."
+msgstr "暴露 A2A thinking 信号类型；可重复指定多个。取值：raw-thinking、tool-trace。"
+
+#: src/iac_code/cli/main.py:608
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
 msgstr "缺少 A2A 服务器依赖。请使用以下命令安装：pip install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:733
+#: src/iac_code/cli/main.py:740
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "向 A2A JSON-RPC 端点发送提示。"
 
-#: src/iac_code/cli/main.py:736 src/iac_code/cli/main.py:900
-#: src/iac_code/cli/main.py:953 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1063 src/iac_code/cli/main.py:1112
-#: src/iac_code/cli/main.py:1191 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1361
+#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:907
+#: src/iac_code/cli/main.py:960 src/iac_code/cli/main.py:1020
+#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1119
+#: src/iac_code/cli/main.py:1198 src/iac_code/cli/main.py:1255
+#: src/iac_code/cli/main.py:1311 src/iac_code/cli/main.py:1368
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "A2A JSON-RPC 端点 URL"
 
-#: src/iac_code/cli/main.py:737 src/iac_code/cli/main.py:1406
+#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:1413
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "路由规范：name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:738
+#: src/iac_code/cli/main.py:745
 msgid "Named A2A route to call"
 msgstr "要调用的命名 A2A 路由"
 
-#: src/iac_code/cli/main.py:739
+#: src/iac_code/cli/main.py:746
 msgid "Prompt to send"
 msgstr "要发送的提示"
 
-#: src/iac_code/cli/main.py:740
+#: src/iac_code/cli/main.py:747
 msgid "Working directory metadata to send with the request"
 msgstr "随请求一起发送的工作目录元数据"
 
-#: src/iac_code/cli/main.py:741
+#: src/iac_code/cli/main.py:748
 msgid "A2A context ID to continue"
 msgstr "要继续的 A2A 上下文 ID"
 
-#: src/iac_code/cli/main.py:742 src/iac_code/cli/main.py:831
-#: src/iac_code/cli/main.py:903 src/iac_code/cli/main.py:960
-#: src/iac_code/cli/main.py:1015 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1119 src/iac_code/cli/main.py:1194
-#: src/iac_code/cli/main.py:1252 src/iac_code/cli/main.py:1307
-#: src/iac_code/cli/main.py:1362
+#: src/iac_code/cli/main.py:749 src/iac_code/cli/main.py:838
+#: src/iac_code/cli/main.py:910 src/iac_code/cli/main.py:967
+#: src/iac_code/cli/main.py:1022 src/iac_code/cli/main.py:1072
+#: src/iac_code/cli/main.py:1126 src/iac_code/cli/main.py:1201
+#: src/iac_code/cli/main.py:1259 src/iac_code/cli/main.py:1314
+#: src/iac_code/cli/main.py:1369
 msgid "Bearer token for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的 Bearer 令牌"
 
-#: src/iac_code/cli/main.py:743 src/iac_code/cli/main.py:832
-#: src/iac_code/cli/main.py:904 src/iac_code/cli/main.py:961
-#: src/iac_code/cli/main.py:1016 src/iac_code/cli/main.py:1066
-#: src/iac_code/cli/main.py:1120 src/iac_code/cli/main.py:1195
-#: src/iac_code/cli/main.py:1253 src/iac_code/cli/main.py:1308
-#: src/iac_code/cli/main.py:1363
+#: src/iac_code/cli/main.py:750 src/iac_code/cli/main.py:839
+#: src/iac_code/cli/main.py:911 src/iac_code/cli/main.py:968
+#: src/iac_code/cli/main.py:1023 src/iac_code/cli/main.py:1073
+#: src/iac_code/cli/main.py:1127 src/iac_code/cli/main.py:1202
+#: src/iac_code/cli/main.py:1260 src/iac_code/cli/main.py:1315
+#: src/iac_code/cli/main.py:1370
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的基本认证用户名"
 
-#: src/iac_code/cli/main.py:744 src/iac_code/cli/main.py:833
-#: src/iac_code/cli/main.py:905 src/iac_code/cli/main.py:962
-#: src/iac_code/cli/main.py:1017 src/iac_code/cli/main.py:1067
-#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1196
-#: src/iac_code/cli/main.py:1254 src/iac_code/cli/main.py:1309
-#: src/iac_code/cli/main.py:1364
+#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:912 src/iac_code/cli/main.py:969
+#: src/iac_code/cli/main.py:1024 src/iac_code/cli/main.py:1074
+#: src/iac_code/cli/main.py:1128 src/iac_code/cli/main.py:1203
+#: src/iac_code/cli/main.py:1261 src/iac_code/cli/main.py:1316
+#: src/iac_code/cli/main.py:1371
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的基本认证密码"
 
-#: src/iac_code/cli/main.py:745 src/iac_code/cli/main.py:834
-#: src/iac_code/cli/main.py:906 src/iac_code/cli/main.py:963
-#: src/iac_code/cli/main.py:1018 src/iac_code/cli/main.py:1068
-#: src/iac_code/cli/main.py:1122 src/iac_code/cli/main.py:1197
-#: src/iac_code/cli/main.py:1255 src/iac_code/cli/main.py:1310
-#: src/iac_code/cli/main.py:1365
+#: src/iac_code/cli/main.py:752 src/iac_code/cli/main.py:841
+#: src/iac_code/cli/main.py:913 src/iac_code/cli/main.py:970
+#: src/iac_code/cli/main.py:1025 src/iac_code/cli/main.py:1075
+#: src/iac_code/cli/main.py:1129 src/iac_code/cli/main.py:1204
+#: src/iac_code/cli/main.py:1262 src/iac_code/cli/main.py:1317
+#: src/iac_code/cli/main.py:1372
 msgid "API key for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的 API 密钥"
 
-#: src/iac_code/cli/main.py:746 src/iac_code/cli/main.py:835
-#: src/iac_code/cli/main.py:907 src/iac_code/cli/main.py:964
-#: src/iac_code/cli/main.py:1019 src/iac_code/cli/main.py:1069
-#: src/iac_code/cli/main.py:1123 src/iac_code/cli/main.py:1198
-#: src/iac_code/cli/main.py:1256 src/iac_code/cli/main.py:1311
-#: src/iac_code/cli/main.py:1366
+#: src/iac_code/cli/main.py:753 src/iac_code/cli/main.py:842
+#: src/iac_code/cli/main.py:914 src/iac_code/cli/main.py:971
+#: src/iac_code/cli/main.py:1026 src/iac_code/cli/main.py:1076
+#: src/iac_code/cli/main.py:1130 src/iac_code/cli/main.py:1205
+#: src/iac_code/cli/main.py:1263 src/iac_code/cli/main.py:1318
+#: src/iac_code/cli/main.py:1373
 msgid "HTTP header name for A2A API key"
 msgstr "A2A API 密钥使用的 HTTP 请求头名称"
 
-#: src/iac_code/cli/main.py:751 src/iac_code/cli/main.py:840
+#: src/iac_code/cli/main.py:758 src/iac_code/cli/main.py:847
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "用于验证 A2A Agent Card 的密钥"
 
-#: src/iac_code/cli/main.py:756 src/iac_code/cli/main.py:845
+#: src/iac_code/cli/main.py:763 src/iac_code/cli/main.py:852
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "用于验证 A2A Agent Card 的远程 JWKS URL"
 
-#: src/iac_code/cli/main.py:762 src/iac_code/cli/main.py:851
+#: src/iac_code/cli/main.py:769 src/iac_code/cli/main.py:858
 msgid "Require a valid A2A Agent Card signature"
 msgstr "要求 A2A Agent Card 提供有效签名"
 
-#: src/iac_code/cli/main.py:764
+#: src/iac_code/cli/main.py:771
 msgid "A2A call timeout in seconds"
 msgstr "A2A 调用超时时间（秒）"
 
-#: src/iac_code/cli/main.py:765
+#: src/iac_code/cli/main.py:772
 msgid "Use A2A streaming message delivery"
 msgstr "使用 A2A 流式消息传递"
 
-#: src/iac_code/cli/main.py:827
+#: src/iac_code/cli/main.py:834
 msgid "Discover an A2A Agent Card."
 msgstr "发现 A2A Agent Card。"
 
-#: src/iac_code/cli/main.py:830
+#: src/iac_code/cli/main.py:837
 msgid "A2A agent base URL"
 msgstr "A2A 代理基础 URL"
 
-#: src/iac_code/cli/main.py:897
+#: src/iac_code/cli/main.py:904
 msgid "Get an A2A task."
 msgstr "获取 A2A 任务。"
 
-#: src/iac_code/cli/main.py:901 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1064 src/iac_code/cli/main.py:1113
-#: src/iac_code/cli/main.py:1192 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1305
+#: src/iac_code/cli/main.py:908 src/iac_code/cli/main.py:1021
+#: src/iac_code/cli/main.py:1071 src/iac_code/cli/main.py:1120
+#: src/iac_code/cli/main.py:1199 src/iac_code/cli/main.py:1256
+#: src/iac_code/cli/main.py:1312
 msgid "A2A task ID"
 msgstr "A2A 任务 ID"
 
-#: src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py:909
 msgid "Maximum task history items to return"
 msgstr "最多返回的任务历史条目数"
 
-#: src/iac_code/cli/main.py:950
+#: src/iac_code/cli/main.py:957
 msgid "List A2A tasks."
 msgstr "列出 A2A 任务。"
 
-#: src/iac_code/cli/main.py:954
+#: src/iac_code/cli/main.py:961
 msgid "Filter by A2A context ID"
 msgstr "按 A2A 上下文 ID 过滤"
 
-#: src/iac_code/cli/main.py:955
+#: src/iac_code/cli/main.py:962
 msgid "Filter by A2A task state"
 msgstr "按 A2A 任务状态过滤"
 
-#: src/iac_code/cli/main.py:956
+#: src/iac_code/cli/main.py:963
 msgid "Maximum tasks to return"
 msgstr "最多返回的任务数"
 
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1251
+#: src/iac_code/cli/main.py:964 src/iac_code/cli/main.py:1258
 msgid "Pagination token"
 msgstr "分页令牌"
 
-#: src/iac_code/cli/main.py:958
+#: src/iac_code/cli/main.py:965
 msgid "Include task artifacts"
 msgstr "包含任务工件"
 
-#: src/iac_code/cli/main.py:959
+#: src/iac_code/cli/main.py:966
 msgid "Output format: table or json"
 msgstr "输出格式：table 或 json"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py:1017
 msgid "Cancel an A2A task."
 msgstr "取消 A2A 任务。"
 
-#: src/iac_code/cli/main.py:1060
+#: src/iac_code/cli/main.py:1067
 msgid "Subscribe to an A2A task event stream."
 msgstr "订阅 A2A 任务事件流。"
 
-#: src/iac_code/cli/main.py:1109
+#: src/iac_code/cli/main.py:1116
 msgid "Create an A2A task push notification config."
 msgstr "创建 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1193
-#: src/iac_code/cli/main.py:1306
+#: src/iac_code/cli/main.py:1121 src/iac_code/cli/main.py:1200
+#: src/iac_code/cli/main.py:1313
 msgid "Push config ID"
 msgstr "推送配置 ID"
 
-#: src/iac_code/cli/main.py:1115
+#: src/iac_code/cli/main.py:1122
 msgid "Push callback URL"
 msgstr "推送回调 URL"
 
-#: src/iac_code/cli/main.py:1116
+#: src/iac_code/cli/main.py:1123
 msgid "Notification verification token"
 msgstr "通知验证令牌"
 
-#: src/iac_code/cli/main.py:1117
+#: src/iac_code/cli/main.py:1124
 msgid "Callback authentication scheme"
 msgstr "回调认证方案"
 
-#: src/iac_code/cli/main.py:1118
+#: src/iac_code/cli/main.py:1125
 msgid "Callback authentication credentials"
 msgstr "回调认证凭据"
 
-#: src/iac_code/cli/main.py:1188
+#: src/iac_code/cli/main.py:1195
 msgid "Get an A2A task push notification config."
 msgstr "获取 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1245
+#: src/iac_code/cli/main.py:1252
 msgid "List A2A task push notification configs."
 msgstr "列出 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1250
+#: src/iac_code/cli/main.py:1257
 msgid "Maximum configs to return"
 msgstr "最多返回的配置数"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py:1308
 msgid "Delete an A2A task push notification config."
 msgstr "删除 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1358
+#: src/iac_code/cli/main.py:1365
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "获取经过身份验证的扩展 A2A Agent Card。"
 
-#: src/iac_code/cli/main.py:1401
+#: src/iac_code/cli/main.py:1408
 msgid "Preview A2A route resolution."
 msgstr "预览 A2A 路由解析。"
 
-#: src/iac_code/cli/main.py:1408
+#: src/iac_code/cli/main.py:1415
 msgid "Route name to resolve"
 msgstr "要解析的路由名称"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py:1416
 msgid "Skill ID to resolve"
 msgstr "要解析的技能 ID"
 
-#: src/iac_code/cli/main.py:1410
+#: src/iac_code/cli/main.py:1417
 msgid "Prompt text used for tag/name route matching"
 msgstr "用于标签/名称路由匹配的提示文本"
 
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py:1422
 msgid "Directory for persisted A2A routes"
 msgstr "持久化 A2A 路由的目录"
 
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py:1424
 msgid "Save the provided routes as a route snapshot"
 msgstr "将提供的路由保存为路由快照"
 
@@ -2042,4 +2048,3 @@ msgstr "  方式 2 - npmmirror（国内镜像）："
 
 #~ msgid "Provider switched: {status}"
 #~ msgstr "Provider 已切换: {status}"
-

--- a/tests/a2a/test_agent_card.py
+++ b/tests/a2a/test_agent_card.py
@@ -1,6 +1,7 @@
 from a2a.server.routes.agent_card_routes import agent_card_to_dict
 
 from iac_code.a2a.agent_card import build_agent_card
+from iac_code.a2a.exposure import A2AExposureType
 
 
 def test_agent_card_declares_a2a_1_jsonrpc_interface() -> None:
@@ -47,6 +48,21 @@ def test_agent_card_advertises_optional_iac_code_extension() -> None:
 
     extension = data["capabilities"]["extensions"][0]
     assert extension["uri"] == "urn:iac-code:a2a:artifact-metadata:v1"
+    assert extension.get("required", False) is False
+
+
+def test_agent_card_advertises_enabled_thinking_exposure_types() -> None:
+    card = build_agent_card(
+        host="127.0.0.1",
+        port=41242,
+        token_enabled=False,
+        thinking_exposure_types=[A2AExposureType.RAW_THINKING, A2AExposureType.TOOL_TRACE],
+    )
+    data = agent_card_to_dict(card)
+
+    extension = data["capabilities"]["extensions"][1]
+    assert extension["uri"] == "urn:iac-code:a2a:thinking-exposure:v1"
+    assert extension["params"]["enabledTypes"] == ["raw_thinking", "tool_trace"]
     assert extension.get("required", False) is False
 
 

--- a/tests/a2a/test_events.py
+++ b/tests/a2a/test_events.py
@@ -3,6 +3,7 @@ from a2a.types import TaskArtifactUpdateEvent
 from google.protobuf.json_format import MessageToDict
 
 from iac_code.a2a.events import _ERROR_TEXT_MAX_CHARS, _METADATA_MAX_CHARS, _truncate, publish_stream_event
+from iac_code.a2a.exposure import A2AExposureType
 from iac_code.types.stream_events import (
     ErrorEvent,
     MessageEndEvent,
@@ -168,6 +169,42 @@ async def test_thinking_delta_is_explicitly_ignored() -> None:
     queue = FakeEventQueue()
 
     await publish_stream_event(queue, task_id="task-1", context_id="ctx-1", event=ThinkingDeltaEvent(text="hidden"))
+
+    assert queue.events == []
+
+
+@pytest.mark.asyncio
+async def test_thinking_delta_publishes_raw_metadata_when_enabled() -> None:
+    queue = FakeEventQueue()
+
+    await publish_stream_event(
+        queue,
+        task_id="task-1",
+        context_id="ctx-1",
+        event=ThinkingDeltaEvent(text="visible"),
+        exposure_types={A2AExposureType.RAW_THINKING},
+    )
+
+    assert len(queue.events) == 1
+    dumped = dump(queue.events[0])
+    assert dumped["status"]["state"] == "TASK_STATE_WORKING"
+    assert dumped["metadata"]["iac_code"]["thinking"] == {
+        "type": "raw_thinking",
+        "text": "visible",
+    }
+
+
+@pytest.mark.asyncio
+async def test_tool_events_are_suppressed_when_tool_trace_is_not_enabled() -> None:
+    queue = FakeEventQueue()
+
+    await publish_stream_event(
+        queue,
+        task_id="task-1",
+        context_id="ctx-1",
+        event=ToolUseStartEvent(tool_use_id="tool-1", name="bash"),
+        exposure_types=frozenset(),
+    )
 
     assert queue.events == []
 

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -6,6 +6,7 @@ from a2a.types import TaskStatusUpdateEvent
 from google.protobuf.json_format import MessageToDict
 
 from iac_code.a2a.executor import IacCodeA2AExecutor
+from iac_code.a2a.exposure import A2AExposureType
 from iac_code.a2a.metrics import NoOpA2AMetrics
 from iac_code.a2a.persistence import A2APersistenceStore
 from iac_code.a2a.task_store import A2ATaskStore
@@ -50,6 +51,7 @@ async def test_executor_passes_artifact_store_to_stream_event_publisher(
     artifact_store = object()
     seen_artifact_stores: list[object | None] = []
     seen_auto_approve_permissions: list[bool] = []
+    seen_exposure_types: list[frozenset[A2AExposureType]] = []
 
     async def spy_publish_stream_event(
         event_queue,
@@ -60,9 +62,11 @@ async def test_executor_passes_artifact_store_to_stream_event_publisher(
         artifact_store=None,
         permission_resolver=None,
         auto_approve_permissions=False,
+        exposure_types=None,
     ):
         seen_artifact_stores.append(artifact_store)
         seen_auto_approve_permissions.append(auto_approve_permissions)
+        seen_exposure_types.append(exposure_types)
         return None
 
     loop = FakeAgentLoop(
@@ -80,12 +84,18 @@ async def test_executor_passes_artifact_store_to_stream_event_publisher(
     monkeypatch.setattr("iac_code.a2a.executor.publish_stream_event", spy_publish_stream_event)
 
     store = A2ATaskStore(metrics=NoOpA2AMetrics())
-    executor = IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus", artifact_store=artifact_store)
+    executor = IacCodeA2AExecutor(
+        task_store=store,
+        model="qwen3.6-plus",
+        artifact_store=artifact_store,
+        thinking_exposure_types=[A2AExposureType.RAW_THINKING, A2AExposureType.TOOL_TRACE],
+    )
 
     await executor.execute(FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}), FakeEventQueue())
 
     assert seen_artifact_stores == [artifact_store]
     assert seen_auto_approve_permissions == [False]
+    assert seen_exposure_types == [frozenset({A2AExposureType.RAW_THINKING, A2AExposureType.TOOL_TRACE})]
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_exposure.py
+++ b/tests/a2a/test_exposure.py
@@ -1,0 +1,24 @@
+import pytest
+
+from iac_code.a2a.exposure import A2AExposureType, normalize_a2a_exposure_types
+
+
+def test_normalize_a2a_exposure_types_defaults_to_tool_trace() -> None:
+    assert normalize_a2a_exposure_types(None) == frozenset({A2AExposureType.TOOL_TRACE})
+
+
+def test_normalize_a2a_exposure_types_accepts_multi_select_lists_and_aliases() -> None:
+    assert normalize_a2a_exposure_types(["raw-thinking", "tool_trace"]) == frozenset(
+        {A2AExposureType.RAW_THINKING, A2AExposureType.TOOL_TRACE}
+    )
+
+
+def test_normalize_a2a_exposure_types_accepts_comma_separated_string() -> None:
+    assert normalize_a2a_exposure_types("raw-thinking, tool-trace") == frozenset(
+        {A2AExposureType.RAW_THINKING, A2AExposureType.TOOL_TRACE}
+    )
+
+
+def test_normalize_a2a_exposure_types_rejects_unsupported_types() -> None:
+    with pytest.raises(ValueError, match="Unsupported A2A thinking exposure type"):
+        normalize_a2a_exposure_types(["thought-summary"])

--- a/tests/cli/test_a2a_command.py
+++ b/tests/cli/test_a2a_command.py
@@ -24,6 +24,7 @@ def test_a2a_help_shows_common_server_options_only() -> None:
     assert "--host" in stdout
     assert "--port" in stdout
     assert "--transport" in stdout
+    assert "--thinking-exposure" in stdout
     assert "--debug" in stdout
     assert "--socket-path" not in stdout
     assert "--token" not in stdout
@@ -94,6 +95,7 @@ def test_a2a_command_passes_config_options_to_server(monkeypatch, tmp_path) -> N
         push_consumer_name: str | None,
         push_lease_timeout_ms: int,
         auto_approve_permissions: bool,
+        thinking_exposure: list[str] | None,
     ) -> None:
         called.update(
             {
@@ -127,6 +129,7 @@ def test_a2a_command_passes_config_options_to_server(monkeypatch, tmp_path) -> N
                 "push_consumer_name": push_consumer_name,
                 "push_lease_timeout_ms": push_lease_timeout_ms,
                 "auto_approve_permissions": auto_approve_permissions,
+                "thinking_exposure": thinking_exposure,
             }
         )
 
@@ -159,6 +162,9 @@ def test_a2a_command_passes_config_options_to_server(monkeypatch, tmp_path) -> N
                 "push-consumer-name: worker-a",
                 "push-lease-timeout-ms: 120000",
                 "auto-approve-permissions: true",
+                "thinking-exposure:",
+                "  - raw-thinking",
+                "  - tool-trace",
             ]
         ),
         encoding="utf-8",
@@ -205,6 +211,7 @@ def test_a2a_command_passes_config_options_to_server(monkeypatch, tmp_path) -> N
         "push_consumer_name": "worker-a",
         "push_lease_timeout_ms": 120000,
         "auto_approve_permissions": True,
+        "thinking_exposure": ["raw-thinking", "tool-trace"],
     }
 
 
@@ -236,6 +243,7 @@ def test_a2a_command_loads_config_file_and_cli_overrides(monkeypatch, tmp_path) 
                 "persistence_dir: /tmp/from-config",
                 "push_notifications: true",
                 "auto_approve_permissions: true",
+                "thinking_exposure: raw-thinking, tool-trace",
             ]
         ),
         encoding="utf-8",
@@ -254,6 +262,40 @@ def test_a2a_command_loads_config_file_and_cli_overrides(monkeypatch, tmp_path) 
     assert captured["persistence_dir"] == "/tmp/from-config"
     assert captured["push_notifications"] is True
     assert captured["auto_approve_permissions"] is True
+    assert captured["thinking_exposure"] == "raw-thinking, tool-trace"
+
+
+def test_a2a_command_accepts_repeated_thinking_exposure_flags(monkeypatch) -> None:
+    captured = {}
+
+    def fake_run_server(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("iac_code.a2a.app.run_server", fake_run_server)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "a2a",
+            "--thinking-exposure",
+            "raw-thinking",
+            "--thinking-exposure",
+            "tool-trace",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["thinking_exposure"] == ["raw-thinking", "tool-trace"]
+
+
+def test_a2a_command_reports_invalid_thinking_exposure(tmp_path) -> None:
+    config = tmp_path / "a2a.yml"
+    config.write_text("thinking-exposure: thought-summary\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["a2a", "--config", str(config)])
+
+    assert result.exit_code == 1
+    assert "Unsupported A2A thinking exposure type 'thought_summary'" in result.stderr
 
 
 def test_a2a_command_passes_unix_transport_options(monkeypatch, tmp_path) -> None:

--- a/website/docs/a2a/command-reference.md
+++ b/website/docs/a2a/command-reference.md
@@ -93,6 +93,7 @@ By default, the server binds to `127.0.0.1:41242` and serves JSON-RPC over HTTP.
 | `--host` | `127.0.0.1` | HTTP server host |
 | `--port` | `41242` | HTTP server port |
 | `--transport` | `http` | Server transport: `http`, `stdio`, `unix`, `websocket`, `grpc`, `grpc-jsonrpc`, or `redis-streams` |
+| `--thinking-exposure` | `tool-trace` | Expose an A2A thinking signal type; repeat for multiple. Values: `raw-thinking`, `tool-trace` |
 | `--debug`, `-d` | `false` | Enable debug logging |
 
 Example:
@@ -236,6 +237,20 @@ Redis Streams transport options:
 | `request-stream` | `iac-code:a2a:requests` | Request stream name |
 | `response-stream` | `iac-code:a2a:responses` | Response stream name |
 | `consumer-group` | `iac-code` | Request stream consumer group |
+
+### Thinking Exposure
+
+| Config key | Default | Description |
+|--------|---------|-------------|
+| `thinking-exposure` | `tool-trace` | Non-answer runtime signal types exposed through A2A `metadata.iac_code`. Use a YAML list, a comma-separated string, or repeated `--thinking-exposure` flags. Supported values are `tool-trace` and `raw-thinking`. |
+
+`tool-trace` preserves the existing tool progress, permission, and result metadata. `raw-thinking` emits provider reasoning chunks as `metadata.iac_code.thinking` updates with `type: raw_thinking` and `text`. iac-code does not currently produce separate thought-summary or progress-summary events, so those are not valid exposure types.
+
+```yaml
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
+```
 
 ### Permission Behavior
 

--- a/website/docs/a2a/getting-started.md
+++ b/website/docs/a2a/getting-started.md
@@ -33,6 +33,9 @@ persistence-dir: ~/.iac-code/a2a
 artifact-dir: ~/.iac-code/a2a/artifacts
 signing-secret: local-card-signing-secret
 push-notifications: true
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
 ```
 
 Run it with:
@@ -42,6 +45,8 @@ iac-code a2a --config a2a-server.yml
 ```
 
 `push-notifications: true` enables A2A task push notification config methods and terminal-state delivery. Use `push-queue: redis-streams` with `push-redis-url` when multiple workers need to coordinate push delivery.
+
+`thinking-exposure` controls which non-answer runtime signals are exposed through `metadata.iac_code` during streaming. The default is `tool-trace`; add `raw-thinking` only for trusted clients that are allowed to see provider reasoning content.
 
 The server exposes:
 

--- a/website/docs/a2a/protocol-reference.md
+++ b/website/docs/a2a/protocol-reference.md
@@ -366,6 +366,8 @@ Tool and usage details are delivered through `metadata.iac_code`:
 | `iac_code.tool.input` | Completed tool input, truncated to 4000 characters per field |
 | `iac_code.tool.result` | Tool result, truncated to 4000 characters per field |
 | `iac_code.permission.autoApproved` | `false` when a tool permission request was rejected by A2A server mode |
+| `iac_code.thinking.type` | `raw_thinking` when `raw-thinking` is enabled in `thinking-exposure` |
+| `iac_code.thinking.text` | Raw provider reasoning chunk, truncated to 4000 characters, emitted only for trusted configurations that enable `raw-thinking` |
 | `iac_code.usage.inputTokens` | Input token count for the turn |
 | `iac_code.usage.outputTokens` | Output token count for the turn |
 | `iac_code.usage.totalTokens` | Total token count for the turn |
@@ -381,6 +383,14 @@ urn:iac-code:a2a:artifact-metadata:v1
 ```
 
 This extension identifies the `metadata.iac_code` namespace used for tool progress, permission decisions, token usage, and local artifact metadata. If the server is configured with any required extension, clients must include its URI in the `A2A-Extensions` header. Missing required extensions return the standard A2A `ExtensionSupportRequiredError`.
+
+When `thinking-exposure` enables one or more signal types, the Agent Card also advertises:
+
+```text
+urn:iac-code:a2a:thinking-exposure:v1
+```
+
+The extension params include `enabledTypes`, such as `["tool_trace", "raw_thinking"]`. This is an iac-code metadata extension, not a core A2A streaming event type.
 
 ## Error Handling
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/command-reference.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/command-reference.md
@@ -93,6 +93,7 @@ Standardmaessig bindet der Server an `127.0.0.1:41242` und stellt JSON-RPC ueber
 | `--host` | `127.0.0.1` | HTTP-Serverhost |
 | `--port` | `41242` | HTTP-Serverport |
 | `--transport` | `http` | Server-Transport: `http`, `stdio`, `unix`, `websocket`, `grpc`, `grpc-jsonrpc` oder `redis-streams` |
+| `--thinking-exposure` | `tool-trace` | Legt einen A2A-Thinking-Signaltyp offen; fuer mehrere Werte wiederholen. Werte: `raw-thinking`, `tool-trace` |
 | `--debug`, `-d` | `false` | Debug-Logging aktivieren |
 
 Beispiel:
@@ -236,6 +237,20 @@ Redis-Streams-Transportoptionen:
 | `request-stream` | `iac-code:a2a:requests` | Name des Request Streams |
 | `response-stream` | `iac-code:a2a:responses` | Name des Response Streams |
 | `consumer-group` | `iac-code` | Consumer Group des Request Streams |
+
+### Thinking-Offenlegung
+
+| Konfigurationsschluessel | Standard | Beschreibung |
+|--------|---------|-------------|
+| `thinking-exposure` | `tool-trace` | Nicht zur Antwort gehoerende Laufzeitsignaltypen, die ueber A2A `metadata.iac_code` offengelegt werden. Verwenden Sie eine YAML-Liste, eine kommaseparierte Zeichenkette oder wiederholte `--thinking-exposure`-Flags. Unterstuetzte Werte sind `tool-trace` und `raw-thinking`. |
+
+`tool-trace` behaelt die vorhandenen Metadaten fuer Tool-Fortschritt, Berechtigungen und Ergebnisse bei. `raw-thinking` gibt Provider-Reasoning-Chunks als `metadata.iac_code.thinking`-Updates mit `type: raw_thinking` und `text` aus. iac-code erzeugt derzeit keine separaten thought-summary- oder progress-summary-Events, daher sind diese keine gueltigen Offenlegungstypen.
+
+```yaml
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
+```
 
 ### Berechtigungsverhalten
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/getting-started.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/getting-started.md
@@ -33,6 +33,9 @@ persistence-dir: ~/.iac-code/a2a
 artifact-dir: ~/.iac-code/a2a/artifacts
 signing-secret: local-card-signing-secret
 push-notifications: true
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
 ```
 
 Fuehren Sie ihn aus mit:
@@ -42,6 +45,8 @@ iac-code a2a --config a2a-server.yml
 ```
 
 `push-notifications: true` aktiviert A2A-Task-Push-Notification-Config-Methoden und Zustellung fuer Terminalzustaende. Verwenden Sie `push-queue: redis-streams` mit `push-redis-url`, wenn mehrere Worker die Push-Zustellung koordinieren muessen.
+
+`thinking-exposure` steuert, welche nicht zur Antwort gehoerenden Laufzeitsignale waehrend des Streamings ueber `metadata.iac_code` offengelegt werden. Standard ist `tool-trace`; fuegen Sie `raw-thinking` nur fuer vertrauenswuerdige Clients hinzu, die Provider-Reasoning-Inhalte sehen duerfen.
 
 Der Server stellt bereit:
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
@@ -366,6 +366,8 @@ Tool- und Nutzungsdetails werden ueber `metadata.iac_code` geliefert:
 | `iac_code.tool.input` | Abgeschlossene Tool-Eingabe, pro Feld auf 4000 Zeichen gekuerzt |
 | `iac_code.tool.result` | Tool-Ergebnis, pro Feld auf 4000 Zeichen gekuerzt |
 | `iac_code.permission.autoApproved` | `false`, wenn eine Tool-Berechtigungsanfrage vom A2A-Servermodus abgelehnt wurde |
+| `iac_code.thinking.type` | `raw_thinking`, wenn `raw-thinking` in `thinking-exposure` aktiviert ist |
+| `iac_code.thinking.text` | Roher Provider-Reasoning-Chunk, auf 4000 Zeichen gekuerzt, nur fuer vertrauenswuerdige Konfigurationen ausgegeben, die `raw-thinking` aktivieren |
 | `iac_code.usage.inputTokens` | Anzahl der Eingabetoken fuer den Turn |
 | `iac_code.usage.outputTokens` | Anzahl der Ausgabetoken fuer den Turn |
 | `iac_code.usage.totalTokens` | Gesamtzahl der Token fuer den Turn |
@@ -381,6 +383,14 @@ urn:iac-code:a2a:artifact-metadata:v1
 ```
 
 Diese Extension identifiziert den Namespace `metadata.iac_code`, der fuer Tool-Fortschritt, Berechtigungsentscheidungen, Token-Nutzung und lokale Artifact-Metadaten verwendet wird. Wenn der Server mit einer erforderlichen Extension konfiguriert ist, muessen Clients ihre URI im Header `A2A-Extensions` einschliessen. Fehlende erforderliche Extensions geben den standardmaessigen A2A-`ExtensionSupportRequiredError` zurueck.
+
+Wenn `thinking-exposure` einen oder mehrere Signaltypen aktiviert, kuendigt die Agent Card auch Folgendes an:
+
+```text
+urn:iac-code:a2a:thinking-exposure:v1
+```
+
+Die Extension-Params enthalten `enabledTypes`, zum Beispiel `["tool_trace", "raw_thinking"]`. Dies ist eine iac-code-Metadatenerweiterung und kein zentraler A2A-Streaming-Event-Typ.
 
 ## Fehlerbehandlung
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/command-reference.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/command-reference.md
@@ -93,6 +93,7 @@ De forma predeterminada, el servidor se enlaza a `127.0.0.1:41242` y sirve JSON-
 | `--host` | `127.0.0.1` | Host del servidor HTTP |
 | `--port` | `41242` | Puerto del servidor HTTP |
 | `--transport` | `http` | Transporte del servidor: `http`, `stdio`, `unix`, `websocket`, `grpc`, `grpc-jsonrpc` o `redis-streams` |
+| `--thinking-exposure` | `tool-trace` | Expone un tipo de señal de thinking A2A; repite para varios. Valores: `raw-thinking`, `tool-trace` |
 | `--debug`, `-d` | `false` | Habilitar logging de depuración |
 
 Ejemplo:
@@ -236,6 +237,20 @@ Opciones de transporte Redis Streams:
 | `request-stream` | `iac-code:a2a:requests` | Nombre del stream de solicitudes |
 | `response-stream` | `iac-code:a2a:responses` | Nombre del stream de respuestas |
 | `consumer-group` | `iac-code` | Grupo de consumidores del stream de solicitudes |
+
+### Exposición de thinking
+
+| Clave de configuración | Predeterminado | Descripción |
+|--------|---------|-------------|
+| `thinking-exposure` | `tool-trace` | Tipos de señales de runtime que no son respuesta expuestas mediante A2A `metadata.iac_code`. Usa una lista YAML, una cadena separada por comas o flags `--thinking-exposure` repetidas. Los valores admitidos son `tool-trace` y `raw-thinking`. |
+
+`tool-trace` conserva los metadatos existentes de progreso de herramientas, permisos y resultados. `raw-thinking` emite chunks de razonamiento del provider como actualizaciones `metadata.iac_code.thinking` con `type: raw_thinking` y `text`. iac-code no produce actualmente eventos separados de thought-summary o progress-summary, por lo que no son tipos de exposición válidos.
+
+```yaml
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
+```
 
 ### Comportamiento de permisos
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/getting-started.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/getting-started.md
@@ -33,6 +33,9 @@ persistence-dir: ~/.iac-code/a2a
 artifact-dir: ~/.iac-code/a2a/artifacts
 signing-secret: local-card-signing-secret
 push-notifications: true
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
 ```
 
 Ejecútalo con:
@@ -42,6 +45,8 @@ iac-code a2a --config a2a-server.yml
 ```
 
 `push-notifications: true` habilita los métodos de configuración de notificaciones push de tareas A2A y la entrega de estados terminales. Usa `push-queue: redis-streams` con `push-redis-url` cuando varios workers necesiten coordinar la entrega push.
+
+`thinking-exposure` controla qué señales de runtime que no son respuesta se exponen mediante `metadata.iac_code` durante streaming. El valor predeterminado es `tool-trace`; agrega `raw-thinking` solo para clientes de confianza autorizados a ver contenido de razonamiento del provider.
 
 El servidor expone:
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
@@ -366,6 +366,8 @@ Los detalles de herramientas y uso se entregan mediante `metadata.iac_code`:
 | `iac_code.tool.input` | Entrada completada de la herramienta, truncada a 4000 caracteres por campo |
 | `iac_code.tool.result` | Resultado de la herramienta, truncado a 4000 caracteres por campo |
 | `iac_code.permission.autoApproved` | `false` cuando una solicitud de permiso de herramienta fue rechazada por el modo servidor A2A |
+| `iac_code.thinking.type` | `raw_thinking` cuando `raw-thinking` está habilitado en `thinking-exposure` |
+| `iac_code.thinking.text` | Chunk bruto de razonamiento del provider, truncado a 4000 caracteres, emitido solo para configuraciones de confianza que habilitan `raw-thinking` |
 | `iac_code.usage.inputTokens` | Recuento de tokens de entrada del turno |
 | `iac_code.usage.outputTokens` | Recuento de tokens de salida del turno |
 | `iac_code.usage.totalTokens` | Recuento total de tokens del turno |
@@ -381,6 +383,14 @@ urn:iac-code:a2a:artifact-metadata:v1
 ```
 
 Esta extensión identifica el namespace `metadata.iac_code` usado para progreso de herramientas, decisiones de permisos, uso de tokens y metadatos de artefactos locales. Si el servidor está configurado con alguna extensión requerida, los clientes deben incluir su URI en el encabezado `A2A-Extensions`. Las extensiones requeridas ausentes devuelven el `ExtensionSupportRequiredError` estándar de A2A.
+
+Cuando `thinking-exposure` habilita uno o más tipos de señal, la Agent Card también anuncia:
+
+```text
+urn:iac-code:a2a:thinking-exposure:v1
+```
+
+Los params de la extensión incluyen `enabledTypes`, como `["tool_trace", "raw_thinking"]`. Esta es una extensión de metadatos de iac-code, no un tipo de evento de streaming central de A2A.
 
 ## Manejo de errores
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/command-reference.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/command-reference.md
@@ -93,6 +93,7 @@ Par défaut, le serveur se lie à `127.0.0.1:41242` et sert JSON-RPC via HTTP. L
 | `--host` | `127.0.0.1` | Hôte du serveur HTTP |
 | `--port` | `41242` | Port du serveur HTTP |
 | `--transport` | `http` | Transport serveur : `http`, `stdio`, `unix`, `websocket`, `grpc`, `grpc-jsonrpc` ou `redis-streams` |
+| `--thinking-exposure` | `tool-trace` | Expose un type de signal de thinking A2A ; répétez pour en fournir plusieurs. Valeurs : `raw-thinking`, `tool-trace` |
 | `--debug`, `-d` | `false` | Activer la journalisation de débogage |
 
 Exemple :
@@ -236,6 +237,20 @@ Options du transport Redis Streams :
 | `request-stream` | `iac-code:a2a:requests` | Nom du stream de requêtes |
 | `response-stream` | `iac-code:a2a:responses` | Nom du stream de réponses |
 | `consumer-group` | `iac-code` | Groupe de consommateurs du stream de requêtes |
+
+### Exposition du thinking
+
+| Clé de configuration | Défaut | Description |
+|--------|---------|-------------|
+| `thinking-exposure` | `tool-trace` | Types de signaux d'exécution hors réponse exposés via A2A `metadata.iac_code`. Utilisez une liste YAML, une chaîne séparée par des virgules ou des flags `--thinking-exposure` répétés. Les valeurs prises en charge sont `tool-trace` et `raw-thinking`. |
+
+`tool-trace` préserve les métadonnées existantes de progression d'outil, d'autorisation et de résultat. `raw-thinking` émet les chunks de raisonnement du provider sous forme de mises à jour `metadata.iac_code.thinking` avec `type: raw_thinking` et `text`. iac-code ne produit actuellement pas d'événements séparés thought-summary ou progress-summary ; ces valeurs ne sont donc pas des types d'exposition valides.
+
+```yaml
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
+```
 
 ### Comportement des autorisations
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/getting-started.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/getting-started.md
@@ -33,6 +33,9 @@ persistence-dir: ~/.iac-code/a2a
 artifact-dir: ~/.iac-code/a2a/artifacts
 signing-secret: local-card-signing-secret
 push-notifications: true
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
 ```
 
 Exécutez-le avec :
@@ -42,6 +45,8 @@ iac-code a2a --config a2a-server.yml
 ```
 
 `push-notifications: true` active les méthodes de configuration des notifications push de tâche A2A et la livraison des états terminaux. Utilisez `push-queue: redis-streams` avec `push-redis-url` lorsque plusieurs workers doivent coordonner la livraison push.
+
+`thinking-exposure` contrôle les signaux d'exécution hors réponse exposés via `metadata.iac_code` pendant le streaming. La valeur par défaut est `tool-trace` ; n'ajoutez `raw-thinking` que pour les clients de confiance autorisés à voir le contenu de raisonnement du provider.
 
 Le serveur expose :
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
@@ -366,6 +366,8 @@ Les détails d'outils et d'utilisation sont livrés via `metadata.iac_code` :
 | `iac_code.tool.input` | Entrée d'outil terminée, tronquée à 4000 caractères par champ |
 | `iac_code.tool.result` | Résultat d'outil, tronqué à 4000 caractères par champ |
 | `iac_code.permission.autoApproved` | `false` lorsqu'une demande d'autorisation d'outil a été rejetée par le mode serveur A2A |
+| `iac_code.thinking.type` | `raw_thinking` lorsque `raw-thinking` est activé dans `thinking-exposure` |
+| `iac_code.thinking.text` | Chunk brut de raisonnement du provider, tronqué à 4000 caractères, émis seulement pour les configurations de confiance qui activent `raw-thinking` |
 | `iac_code.usage.inputTokens` | Nombre de jetons d'entrée pour le tour |
 | `iac_code.usage.outputTokens` | Nombre de jetons de sortie pour le tour |
 | `iac_code.usage.totalTokens` | Nombre total de jetons pour le tour |
@@ -381,6 +383,14 @@ urn:iac-code:a2a:artifact-metadata:v1
 ```
 
 Cette extension identifie l'espace de noms `metadata.iac_code` utilisé pour la progression des outils, les décisions d'autorisation, l'utilisation des jetons et les métadonnées d'artefacts locaux. Si le serveur est configuré avec une extension obligatoire, les clients doivent inclure son URI dans l'en-tête `A2A-Extensions`. Les extensions obligatoires manquantes renvoient l'erreur A2A standard `ExtensionSupportRequiredError`.
+
+Lorsque `thinking-exposure` active un ou plusieurs types de signal, l'Agent Card annonce aussi :
+
+```text
+urn:iac-code:a2a:thinking-exposure:v1
+```
+
+Les params de l'extension incluent `enabledTypes`, par exemple `["tool_trace", "raw_thinking"]`. Il s'agit d'une extension de métadonnées iac-code, pas d'un type d'événement de streaming A2A central.
 
 ## Gestion des erreurs
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/command-reference.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/command-reference.md
@@ -93,6 +93,7 @@ iac-code a2a
 | `--host` | `127.0.0.1` | HTTP サーバーホスト |
 | `--port` | `41242` | HTTP サーバーポート |
 | `--transport` | `http` | サーバートランスポート: `http`, `stdio`, `unix`, `websocket`, `grpc`, `grpc-jsonrpc`, or `redis-streams` |
+| `--thinking-exposure` | `tool-trace` | A2A thinking 信号タイプを公開します。複数指定するには繰り返します。値：`raw-thinking`、`tool-trace` |
 | `--debug`, `-d` | `false` | デバッグログを有効化 |
 
 例:
@@ -236,6 +237,20 @@ Redis Streams トランスポートオプション:
 | `request-stream` | `iac-code:a2a:requests` | リクエスト stream 名 |
 | `response-stream` | `iac-code:a2a:responses` | レスポンス stream 名 |
 | `consumer-group` | `iac-code` | リクエスト stream consumer group |
+
+### Thinking の公開
+
+| Config key | Default | 説明 |
+|--------|---------|-------------|
+| `thinking-exposure` | `tool-trace` | A2A `metadata.iac_code` を通じて公開する非回答ランタイム信号タイプ。YAML リスト、カンマ区切り文字列、または繰り返しの `--thinking-exposure` フラグを使用できます。対応値は `tool-trace` と `raw-thinking` です。 |
+
+`tool-trace` は既存のツール進行状況、権限、結果メタデータを維持します。`raw-thinking` は provider 推論チャンクを `metadata.iac_code.thinking` 更新として出力し、`type: raw_thinking` と `text` を含みます。iac-code は現在、独立した thought-summary または progress-summary イベントを生成しないため、それらは有効な公開タイプではありません。
+
+```yaml
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
+```
 
 ### 権限の挙動
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/getting-started.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/getting-started.md
@@ -33,6 +33,9 @@ persistence-dir: ~/.iac-code/a2a
 artifact-dir: ~/.iac-code/a2a/artifacts
 signing-secret: local-card-signing-secret
 push-notifications: true
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
 ```
 
 次のように実行します。
@@ -42,6 +45,8 @@ iac-code a2a --config a2a-server.yml
 ```
 
 `push-notifications: true` は、A2A タスクプッシュ通知設定メソッドと終端状態の配信を有効にします。複数のワーカーがプッシュ配信を調整する必要がある場合は、`push-queue: redis-streams` と `push-redis-url` を使用してください。
+
+`thinking-exposure` は、ストリーミング中に `metadata.iac_code` 経由で公開する非回答ランタイム信号を制御します。デフォルトは `tool-trace` です。provider の推論内容を見てもよい信頼済みクライアントにだけ `raw-thinking` を追加してください。
 
 サーバーは次を公開します。
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
@@ -366,6 +366,8 @@ iac-code は A2A コンテキストを内部エージェントランタイムに
 | `iac_code.tool.input` | 完了したツール入力。フィールドごとに 4000 文字へ切り詰め |
 | `iac_code.tool.result` | ツール結果。フィールドごとに 4000 文字へ切り詰め |
 | `iac_code.permission.autoApproved` | A2A サーバーモードによってツール権限リクエストが拒否された場合は `false` |
+| `iac_code.thinking.type` | `thinking-exposure` で `raw-thinking` が有効な場合は `raw_thinking` |
+| `iac_code.thinking.text` | 生の provider 推論チャンク。4000 文字に切り詰められ、信頼済み設定で `raw-thinking` が有効な場合のみ出力 |
 | `iac_code.usage.inputTokens` | ターンの入力トークン数 |
 | `iac_code.usage.outputTokens` | ターンの出力トークン数 |
 | `iac_code.usage.totalTokens` | ターンの合計トークン数 |
@@ -381,6 +383,14 @@ urn:iac-code:a2a:artifact-metadata:v1
 ```
 
 この拡張は、ツール進行状況、権限判断、トークン使用量、ローカルアーティファクトメタデータに使用される `metadata.iac_code` 名前空間を識別します。サーバーが必須拡張を設定している場合、クライアントはその URI を `A2A-Extensions` ヘッダーに含める必要があります。必須拡張がない場合、標準 A2A `ExtensionSupportRequiredError` が返されます。
+
+`thinking-exposure` が 1 つ以上の信号タイプを有効にしている場合、Agent Card は次も広告します。
+
+```text
+urn:iac-code:a2a:thinking-exposure:v1
+```
+
+拡張 params には `enabledTypes` が含まれます。例：`["tool_trace", "raw_thinking"]`。これは iac-code メタデータ拡張であり、A2A コアのストリーミングイベントタイプではありません。
 
 ## エラー処理
 

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/command-reference.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/command-reference.md
@@ -93,6 +93,7 @@ Por padrão, o servidor faz bind em `127.0.0.1:41242` e serve JSON-RPC sobre HTT
 | `--host` | `127.0.0.1` | Host do servidor HTTP |
 | `--port` | `41242` | Porta do servidor HTTP |
 | `--transport` | `http` | Transport do servidor: `http`, `stdio`, `unix`, `websocket`, `grpc`, `grpc-jsonrpc` ou `redis-streams` |
+| `--thinking-exposure` | `tool-trace` | Expõe um tipo de sinal de thinking A2A; repita para múltiplos. Valores: `raw-thinking`, `tool-trace` |
 | `--debug`, `-d` | `false` | Habilitar logs de debug |
 
 Exemplo:
@@ -236,6 +237,20 @@ Opções de transport Redis Streams:
 | `request-stream` | `iac-code:a2a:requests` | Nome do stream de requisições |
 | `response-stream` | `iac-code:a2a:responses` | Nome do stream de respostas |
 | `consumer-group` | `iac-code` | Consumer group do stream de requisições |
+
+### Exposição de thinking
+
+| Chave de configuração | Padrão | Descrição |
+|--------|--------|-----------|
+| `thinking-exposure` | `tool-trace` | Tipos de sinais de runtime fora da resposta expostos via A2A `metadata.iac_code`. Use uma lista YAML, uma string separada por vírgulas ou flags `--thinking-exposure` repetidas. Os valores suportados são `tool-trace` e `raw-thinking`. |
+
+`tool-trace` preserva os metadados existentes de progresso de ferramenta, permissões e resultados. `raw-thinking` emite chunks de raciocínio do provider como atualizações `metadata.iac_code.thinking` com `type: raw_thinking` e `text`. O iac-code atualmente não produz eventos separados de thought-summary ou progress-summary, portanto eles não são tipos de exposição válidos.
+
+```yaml
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
+```
 
 ### Comportamento de permissões
 

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/getting-started.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/getting-started.md
@@ -33,6 +33,9 @@ persistence-dir: ~/.iac-code/a2a
 artifact-dir: ~/.iac-code/a2a/artifacts
 signing-secret: local-card-signing-secret
 push-notifications: true
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
 ```
 
 Execute com:
@@ -42,6 +45,8 @@ iac-code a2a --config a2a-server.yml
 ```
 
 `push-notifications: true` habilita os métodos de configuração de notificações push de tarefas A2A e a entrega de estados terminais. Use `push-queue: redis-streams` com `push-redis-url` quando vários workers precisarem coordenar a entrega push.
+
+`thinking-exposure` controla quais sinais de runtime que não fazem parte da resposta são expostos via `metadata.iac_code` durante streaming. O padrão é `tool-trace`; adicione `raw-thinking` apenas para clientes confiáveis que podem ver conteúdo de raciocínio do provider.
 
 O servidor expõe:
 

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
@@ -366,6 +366,8 @@ Detalhes de ferramentas e uso são entregues por `metadata.iac_code`:
 | `iac_code.tool.input` | Entrada completa da ferramenta, truncada para 4000 caracteres por campo |
 | `iac_code.tool.result` | Resultado da ferramenta, truncado para 4000 caracteres por campo |
 | `iac_code.permission.autoApproved` | `false` quando uma solicitação de permissão de ferramenta foi rejeitada pelo modo servidor A2A |
+| `iac_code.thinking.type` | `raw_thinking` quando `raw-thinking` está habilitado em `thinking-exposure` |
+| `iac_code.thinking.text` | Chunk bruto de raciocínio do provider, truncado para 4000 caracteres, emitido apenas em configurações confiáveis que habilitam `raw-thinking` |
 | `iac_code.usage.inputTokens` | Contagem de tokens de entrada do turno |
 | `iac_code.usage.outputTokens` | Contagem de tokens de saída do turno |
 | `iac_code.usage.totalTokens` | Contagem total de tokens do turno |
@@ -381,6 +383,14 @@ urn:iac-code:a2a:artifact-metadata:v1
 ```
 
 Esta extensão identifica o namespace `metadata.iac_code` usado para progresso de ferramentas, decisões de permissão, uso de tokens e metadados de artefatos locais. Se o servidor estiver configurado com qualquer extensão obrigatória, os clientes devem incluir seu URI no cabeçalho `A2A-Extensions`. Extensões obrigatórias ausentes retornam o `ExtensionSupportRequiredError` A2A padrão.
+
+Quando `thinking-exposure` habilita um ou mais tipos de sinal, o Agent Card também anuncia:
+
+```text
+urn:iac-code:a2a:thinking-exposure:v1
+```
+
+Os params da extensão incluem `enabledTypes`, como `["tool_trace", "raw_thinking"]`. Esta é uma extensão de metadados do iac-code, não um tipo de evento de streaming central do A2A.
 
 ## Tratamento de erros
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/command-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/command-reference.md
@@ -93,6 +93,7 @@ iac-code a2a
 | `--host` | `127.0.0.1` | HTTP server host |
 | `--port` | `41242` | HTTP server port |
 | `--transport` | `http` | Server transport：`http`、`stdio`、`unix`、`websocket`、`grpc`、`grpc-jsonrpc` 或 `redis-streams` |
+| `--thinking-exposure` | `tool-trace` | 暴露一种 A2A thinking 信号类型；可重复指定多个。取值：`raw-thinking`、`tool-trace` |
 | `--debug`, `-d` | `false` | 启用 debug logging |
 
 示例：
@@ -236,6 +237,20 @@ Redis Streams 传输选项：
 | `request-stream` | `iac-code:a2a:requests` | Request stream 名称 |
 | `response-stream` | `iac-code:a2a:responses` | Response stream 名称 |
 | `consumer-group` | `iac-code` | Request stream consumer group |
+
+### Thinking 暴露
+
+| 配置键 | 默认值 | 描述 |
+|--------|---------|-------------|
+| `thinking-exposure` | `tool-trace` | 通过 A2A `metadata.iac_code` 暴露的非回答运行时信号类型。可使用 YAML 列表、逗号分隔字符串，或重复的 `--thinking-exposure` flag。支持值为 `tool-trace` 和 `raw-thinking`。 |
+
+`tool-trace` 保留现有的工具进度、权限和结果元数据。`raw-thinking` 会将 provider 推理 chunk 作为 `metadata.iac_code.thinking` 更新发出，包含 `type: raw_thinking` 和 `text`。iac-code 目前不会生成独立的 thought-summary 或 progress-summary 事件，因此这些不是有效的暴露类型。
+
+```yaml
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
+```
 
 ### 权限行为
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/getting-started.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/getting-started.md
@@ -33,6 +33,9 @@ persistence-dir: ~/.iac-code/a2a
 artifact-dir: ~/.iac-code/a2a/artifacts
 signing-secret: local-card-signing-secret
 push-notifications: true
+thinking-exposure:
+  - tool-trace
+  - raw-thinking
 ```
 
 使用以下命令运行：
@@ -42,6 +45,8 @@ iac-code a2a --config a2a-server.yml
 ```
 
 `push-notifications: true` 会启用 A2A 任务推送通知配置方法和终态投递。当多个 worker 需要协调推送投递时，请将 `push-queue: redis-streams` 与 `push-redis-url` 搭配使用。
+
+`thinking-exposure` 控制流式过程中通过 `metadata.iac_code` 暴露哪些非回答运行时信号。默认值是 `tool-trace`；只有允许看到 provider 推理内容的受信任客户端才应添加 `raw-thinking`。
 
 服务器暴露：
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/protocol-reference.md
@@ -366,6 +366,8 @@ Assistant text 作为 status message 投递：
 | `iac_code.tool.input` | 已完成工具输入，每个字段截断为 4000 个字符 |
 | `iac_code.tool.result` | 工具结果，每个字段截断为 4000 个字符 |
 | `iac_code.permission.autoApproved` | A2A server 模式拒绝工具权限请求时为 `false` |
+| `iac_code.thinking.type` | 在 `thinking-exposure` 中启用 `raw-thinking` 时为 `raw_thinking` |
+| `iac_code.thinking.text` | 原始 provider 推理 chunk，截断为 4000 个字符，仅在受信任配置启用 `raw-thinking` 时发出 |
 | `iac_code.usage.inputTokens` | 该轮次的 input token 数 |
 | `iac_code.usage.outputTokens` | 该轮次的 output token 数 |
 | `iac_code.usage.totalTokens` | 该轮次的 total token 数 |
@@ -381,6 +383,14 @@ urn:iac-code:a2a:artifact-metadata:v1
 ```
 
 该扩展标识 `metadata.iac_code` 命名空间，该命名空间用于工具进度、权限决策、token 用量和本地 artifact 元数据。如果服务器配置了任何必需扩展，客户端必须在 `A2A-Extensions` header 中包含其 URI。缺少必需扩展会返回标准 A2A `ExtensionSupportRequiredError`。
+
+当 `thinking-exposure` 启用一种或多种信号类型时，Agent Card 还会公布：
+
+```text
+urn:iac-code:a2a:thinking-exposure:v1
+```
+
+扩展 params 包含 `enabledTypes`，例如 `["tool_trace", "raw_thinking"]`。这是 iac-code 元数据扩展，不是 A2A 核心流式事件类型。
 
 ## 错误处理
 


### PR DESCRIPTION
## Summary
- add configurable A2A thinking exposure types with multi-select CLI/config support
- expose raw provider thinking through iac_code metadata only when explicitly enabled
- advertise enabled exposure types in the Agent Card and document the extension

## Tests
- uv run --extra a2a --extra a2a-grpc pytest tests/a2a tests/cli/test_a2a_command.py