### PR TITLE
ci: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,108 @@
+name: Bug Report
+description: Report a bug in iac-code
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run `iac-code`
+        2. Enter prompt '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened. Include error messages or logs if available.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: "Output of `python --version`"
+      placeholder: "3.10.x"
+    validations:
+      required: true
+
+  - type: input
+    id: iac-code-version
+    attributes:
+      label: iac-code Version
+      description: "Output of `pip show iac-code | grep Version`"
+      placeholder: "0.x.x"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: llm-provider
+    attributes:
+      label: LLM Provider
+      description: Which LLM provider are you using?
+      options:
+        - Anthropic (Claude)
+        - OpenAI
+        - Alibaba Cloud (DashScope / Qwen)
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: iac-type
+    attributes:
+      label: IaC Type
+      description: Which IaC type are you working with?
+      options:
+        - ROS (Resource Orchestration Service)
+        - Terraform
+        - Not applicable
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or logs that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: DingTalk Group
+    url: https://qr.dingtalk.com/action/joingroup?code=v1,k1,ubm/77U7qRh/STFZUNBP26X4PNg2z6+uhiPcLGtDNfU=&_dt_no_comment=1&origin=11
+    about: Join our DingTalk group for real-time support and discussion
+  - name: Discord
+    url: https://discord.gg/qECFuFBwF
+    about: Join our Discord server for community support

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for iac-code
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your feature suggestion! Please describe your idea below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: What problem does this feature solve? Or what use case does it enable?
+      placeholder: I'd like to be able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Related Area
+      description: Which area of iac-code does this relate to?
+      options:
+        - CLI / Interactive Mode
+        - Template Generation (ROS / Terraform)
+        - LLM Provider Support
+        - Agent / Tool Execution
+        - A2A / ACP Protocol
+        - Skills System
+        - i18n / Localization
+        - Documentation
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or references that might help.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add bug report issue template with environment info fields (OS, Python version, iac-code version, LLM provider, IaC type)
- Add feature request issue template with related area selection
- Add template config with DingTalk and Discord contact links

## Test plan
- [x] Verify templates render correctly on GitHub Issues → New Issue page
- [x] Confirm form fields and dropdowns work as expected
