### PR TITLE
docs: update website with comprehensive provider list, search, and UI improvements

### DIFF
--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -17,9 +17,9 @@ Environment variables are useful for CI/CD pipelines, containers, and one-off ov
 
 | Variable | Description |
 |---|---|
-| `IAC_CODE_PROVIDER` | Model provider name (case-insensitive): `Anthropic`, `OpenAI`, `DashScope`, `DashScopeTokenPlan`, `DeepSeek`, `OpenAPICompatible` |
+| `IAC_CODE_PROVIDER` | Model provider name (case-insensitive). Valid values: `DashScope`, `DashScope Token Plan`, `OpenAI`, `Anthropic`, `DeepSeek`, `Gemini`, `Azure OpenAI`, `ModelScope`, `Kimi CN`, `Kimi Intl`, `MiniMax CN`, `MiniMax Intl`, `ZhiPu CN`, `ZhiPu Intl`, `Volcengine CN`, `SiliconFlow CN`, `SiliconFlow Intl`, `Aliyun CodingPlan`, `Aliyun CodingPlan Intl`, `ZhiPu CN CodingPlan`, `ZhiPu Intl CodingPlan`, `Volcengine CodingPlan`, `OpenAPI Compatible`, `Anthropic Compatible`, `OpenRouter`, `Ollama`, `LM Studio` |
 | `IAC_CODE_MODEL` | Model name |
-| `IAC_CODE_BASE_URL` | API endpoint for `OpenAPICompatible` only; ignored for other providers |
+| `IAC_CODE_BASE_URL` | API endpoint for `OpenAPI Compatible` and `Anthropic Compatible` only; ignored for other providers |
 | `IAC_CODE_API_KEY` | Provider API key; overrides the active provider's key in `.credentials.yml` |
 
 See [LLM Providers](./llm-providers.md) for provider details.
@@ -54,5 +54,7 @@ See [Alibaba Cloud Credentials](./alibaba-cloud-credentials.md) for more details
 | `IAC_CODE_CONFIG_DIR` | Override the runtime configuration directory (default `~/.iac-code/`); supports `~` and `$VAR` expansion. All persisted artifacts (credentials, settings, history, projects, image cache, skills, telemetry, etc.) follow it |
 | `IAC_CODE_ENV` | Deployment environment label (default: `production`) |
 | `IAC_CODE_TENANT_ID` | Tenant identifier for telemetry; auto-prefixed with `iac_tenant_` if not already |
+| `IAC_CODE_GIT_BASH_PATH` | Path to Git Bash `bash.exe` on Windows when it is not on PATH |
+| `IAC_CODE_A2A_PUSH_KEYRING` | Environment-managed encrypted push secret keyring for A2A (JSON format) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Standard OpenTelemetry endpoint; when set, enables OTLP export |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | Capture GenAI message/tool content on spans: `SPAN_ONLY`, `EVENT_ONLY`, `SPAN_AND_EVENT` |

--- a/website/docs/configuration/llm-providers.md
+++ b/website/docs/configuration/llm-providers.md
@@ -5,27 +5,74 @@ description: Supported model providers and environment variables.
 
 # LLM Providers
 
-IaC Code supports multiple model provider backends.
-
-| Provider value | Purpose |
-|---|---|
-| `Anthropic` | Anthropic models |
-| `OpenAI` | OpenAI models |
-| `DashScope` | Alibaba Cloud DashScope compatible endpoint |
-| `DeepSeek` | DeepSeek models |
-| `OpenAPICompatible` | Custom OpenAI-compatible endpoint |
-
-Provider selection can come from CLI options, environment variables, or configuration files. Precedence is:
+IaC Code supports multiple model provider backends. Provider selection can come from CLI options, environment variables, or configuration files. Precedence is:
 
 ```text
 CLI arguments > environment variables > configuration files
 ```
 
-LLM environment variables:
+## Cloud Providers
+
+| Provider value | Purpose |
+|---|---|
+| `DashScope` | Alibaba Cloud DashScope (Bailian) compatible endpoint |
+| `DashScope Token Plan` | Alibaba Cloud DashScope Token Plan endpoint |
+| `OpenAI` | OpenAI models |
+| `Anthropic` | Anthropic models |
+| `DeepSeek` | DeepSeek models |
+| `Gemini` | Google Gemini models |
+| `Azure OpenAI` | Azure OpenAI Service |
+| `ModelScope` | ModelScope inference endpoint |
+
+## China-region Providers
+
+| Provider value | Purpose |
+|---|---|
+| `Kimi CN` | Kimi (Moonshot AI) China endpoint |
+| `MiniMax CN` | MiniMax China endpoint |
+| `ZhiPu CN` | ZhiPu AI (GLM) China endpoint |
+| `Volcengine CN` | Volcengine (ByteDance) China endpoint |
+| `SiliconFlow CN` | SiliconFlow China endpoint |
+
+## International Providers
+
+| Provider value | Purpose |
+|---|---|
+| `Kimi Intl` | Kimi (Moonshot AI) international endpoint |
+| `MiniMax Intl` | MiniMax international endpoint |
+| `ZhiPu Intl` | ZhiPu AI (GLM) international endpoint |
+| `SiliconFlow Intl` | SiliconFlow international endpoint |
+
+## CodingPlan Providers
+
+| Provider value | Purpose |
+|---|---|
+| `Aliyun CodingPlan` | Alibaba Cloud CodingPlan endpoint |
+| `Aliyun CodingPlan Intl` | Alibaba Cloud CodingPlan international endpoint |
+| `ZhiPu CN CodingPlan` | ZhiPu AI CodingPlan China endpoint |
+| `ZhiPu Intl CodingPlan` | ZhiPu AI CodingPlan international endpoint |
+| `Volcengine CodingPlan` | Volcengine CodingPlan endpoint |
+
+## Compatible / Custom Endpoints
+
+| Provider value | Purpose |
+|---|---|
+| `OpenAPI Compatible` | Any OpenAI-compatible API endpoint |
+| `Anthropic Compatible` | Any Anthropic-compatible API endpoint |
+| `OpenRouter` | OpenRouter aggregation gateway |
+
+## Local Providers
+
+| Provider value | Purpose |
+|---|---|
+| `Ollama` | Ollama local model server |
+| `LM Studio` | LM Studio local model server |
+
+## LLM Environment Variables
 
 | Variable | Description |
 |---|---|
-| `IAC_CODE_PROVIDER` | Model provider name, case-insensitive |
+| `IAC_CODE_PROVIDER` | Model provider name (case-insensitive). See tables above for valid values |
 | `IAC_CODE_MODEL` | Model name |
-| `IAC_CODE_BASE_URL` | API endpoint for `OpenAPICompatible` |
+| `IAC_CODE_BASE_URL` | API endpoint for `OpenAPI Compatible` and `Anthropic Compatible` only; ignored for other providers |
 | `IAC_CODE_API_KEY` | Provider API key |

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -62,6 +62,17 @@ const config: Config = {
     },
   },
 
+  themes: [
+    [
+      '@easyops-cn/docusaurus-search-local',
+      {
+        hashed: true,
+        language: ['en', 'zh'],
+        indexBlog: false,
+      },
+    ],
+  ],
+
   presets: [
     [
       'classic',
@@ -99,6 +110,11 @@ const config: Config = {
           position: 'left',
         },
         {
+          href: 'https://github.com/aliyun/iac-code',
+          label: 'GitHub',
+          position: 'right',
+        },
+        {
           type: 'localeDropdown',
           position: 'right',
         },
@@ -121,6 +137,36 @@ const config: Config = {
             {
               label: 'Slash Commands',
               to: '/docs/cli/commands',
+            },
+          ],
+        },
+        {
+          title: 'Community',
+          items: [
+            {
+              label: 'GitHub',
+              href: 'https://github.com/aliyun/iac-code',
+            },
+            {
+              label: 'Issues',
+              href: 'https://github.com/aliyun/iac-code/issues',
+            },
+            {
+              label: 'Discussions',
+              href: 'https://github.com/aliyun/iac-code/discussions',
+            },
+          ],
+        },
+        {
+          title: 'More',
+          items: [
+            {
+              label: 'PyPI',
+              href: 'https://pypi.org/project/iac-code/',
+            },
+            {
+              label: 'Contact',
+              to: '/docs/contact',
             },
           ],
         },

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
@@ -17,9 +17,9 @@ Umgebungsvariablen sind nuetzlich fuer CI/CD-Pipelines, Container und einmalige 
 
 | Variable | Beschreibung |
 |---|---|
-| `IAC_CODE_PROVIDER` | Name des Modellanbieters (Gross-/Kleinschreibung wird nicht beachtet): `Anthropic`, `OpenAI`, `DashScope`, `DashScopeTokenPlan`, `DeepSeek`, `OpenAPICompatible` |
+| `IAC_CODE_PROVIDER` | Name des Modellanbieters (Gross-/Kleinschreibung wird nicht beachtet). Gueltige Werte: `DashScope`, `DashScope Token Plan`, `OpenAI`, `Anthropic`, `DeepSeek`, `Gemini`, `Azure OpenAI`, `ModelScope`, `Kimi CN`, `Kimi Intl`, `MiniMax CN`, `MiniMax Intl`, `ZhiPu CN`, `ZhiPu Intl`, `Volcengine CN`, `SiliconFlow CN`, `SiliconFlow Intl`, `Aliyun CodingPlan`, `Aliyun CodingPlan Intl`, `ZhiPu CN CodingPlan`, `ZhiPu Intl CodingPlan`, `Volcengine CodingPlan`, `OpenAPI Compatible`, `Anthropic Compatible`, `OpenRouter`, `Ollama`, `LM Studio` |
 | `IAC_CODE_MODEL` | Modellname |
-| `IAC_CODE_BASE_URL` | API-Endpunkt nur fuer `OpenAPICompatible`; wird fuer andere Anbieter ignoriert |
+| `IAC_CODE_BASE_URL` | API-Endpunkt nur fuer `OpenAPI Compatible` und `Anthropic Compatible`; wird fuer andere Anbieter ignoriert |
 | `IAC_CODE_API_KEY` | API-Schluessel des Anbieters; ueberschreibt den Schluessel des aktiven Anbieters in `.credentials.yml` |
 
 Siehe [LLM-Anbieter](./llm-providers.md) fuer Anbieterdetails.
@@ -54,5 +54,7 @@ Siehe [Alibaba Cloud-Anmeldedaten](./alibaba-cloud-credentials.md) fuer weitere 
 | `IAC_CODE_CONFIG_DIR` | Ueberschreibt das Laufzeitkonfigurationsverzeichnis (Standard `~/.iac-code/`); unterstuetzt `~`- und `$VAR`-Erweiterung. Alle persistierten Artefakte (Anmeldedaten, Einstellungen, Verlauf, projects, image-cache, skills, telemetry usw.) folgen diesem Verzeichnis |
 | `IAC_CODE_ENV` | Bezeichnung der Bereitstellungsumgebung (Standard: `production`) |
 | `IAC_CODE_TENANT_ID` | Mandantenkennung fuer Telemetrie; wird automatisch mit `iac_tenant_` vorangestellt, wenn nicht bereits vorhanden |
+| `IAC_CODE_GIT_BASH_PATH` | Pfad zu Git Bash `bash.exe` unter Windows, wenn nicht im PATH |
+| `IAC_CODE_A2A_PUSH_KEYRING` | Umgebungsgesteuerter verschluesselter A2A-Push-Secret-Keyring (JSON-Format) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Standard-OpenTelemetry-Endpunkt; aktiviert den OTLP-Export, wenn gesetzt |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | GenAI-Nachrichten-/Tool-Inhalte auf Spans erfassen: `SPAN_ONLY`, `EVENT_ONLY`, `SPAN_AND_EVENT` |

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
@@ -5,27 +5,74 @@ description: Unterstuetzte Modellanbieter und Umgebungsvariablen.
 
 # LLM-Anbieter
 
-IaC Code unterstuetzt mehrere Modellanbieter-Backends.
-
-| Anbieterwert | Zweck |
-|---|---|
-| `Anthropic` | Anthropic-Modelle |
-| `OpenAI` | OpenAI-Modelle |
-| `DashScope` | Alibaba Cloud DashScope-kompatibler Endpunkt |
-| `DeepSeek` | DeepSeek-Modelle |
-| `OpenAPICompatible` | Benutzerdefinierter OpenAI-kompatibler Endpunkt |
-
-Die Anbieterauswahl kann ueber CLI-Optionen, Umgebungsvariablen oder Konfigurationsdateien erfolgen. Die Rangfolge ist:
+IaC Code unterstuetzt mehrere Modellanbieter-Backends. Die Anbieterauswahl kann ueber CLI-Optionen, Umgebungsvariablen oder Konfigurationsdateien erfolgen. Die Rangfolge ist:
 
 ```text
 CLI-Argumente > Umgebungsvariablen > Konfigurationsdateien
 ```
 
-LLM-Umgebungsvariablen:
+## Cloud-Anbieter
+
+| Anbieterwert | Zweck |
+|---|---|
+| `DashScope` | Alibaba Cloud DashScope (Bailian) kompatibler Endpunkt |
+| `DashScope Token Plan` | Alibaba Cloud DashScope Token Plan Endpunkt |
+| `OpenAI` | OpenAI-Modelle |
+| `Anthropic` | Anthropic-Modelle |
+| `DeepSeek` | DeepSeek-Modelle |
+| `Gemini` | Google Gemini-Modelle |
+| `Azure OpenAI` | Azure OpenAI-Dienst |
+| `ModelScope` | ModelScope-Inferenz-Endpunkt |
+
+## Anbieter in China
+
+| Anbieterwert | Zweck |
+|---|---|
+| `Kimi CN` | Kimi (Moonshot AI) China-Endpunkt |
+| `MiniMax CN` | MiniMax China-Endpunkt |
+| `ZhiPu CN` | ZhiPu AI (GLM) China-Endpunkt |
+| `Volcengine CN` | Volcengine (ByteDance) China-Endpunkt |
+| `SiliconFlow CN` | SiliconFlow China-Endpunkt |
+
+## Internationale Anbieter
+
+| Anbieterwert | Zweck |
+|---|---|
+| `Kimi Intl` | Kimi (Moonshot AI) internationaler Endpunkt |
+| `MiniMax Intl` | MiniMax internationaler Endpunkt |
+| `ZhiPu Intl` | ZhiPu AI (GLM) internationaler Endpunkt |
+| `SiliconFlow Intl` | SiliconFlow internationaler Endpunkt |
+
+## CodingPlan-Anbieter
+
+| Anbieterwert | Zweck |
+|---|---|
+| `Aliyun CodingPlan` | Alibaba Cloud CodingPlan-Endpunkt |
+| `Aliyun CodingPlan Intl` | Alibaba Cloud CodingPlan internationaler Endpunkt |
+| `ZhiPu CN CodingPlan` | ZhiPu AI CodingPlan China-Endpunkt |
+| `ZhiPu Intl CodingPlan` | ZhiPu AI CodingPlan internationaler Endpunkt |
+| `Volcengine CodingPlan` | Volcengine CodingPlan-Endpunkt |
+
+## Kompatibel / Benutzerdefinierte Endpunkte
+
+| Anbieterwert | Zweck |
+|---|---|
+| `OpenAPI Compatible` | Beliebiger OpenAI-kompatibler API-Endpunkt |
+| `Anthropic Compatible` | Beliebiger Anthropic-kompatibler API-Endpunkt |
+| `OpenRouter` | OpenRouter-Aggregations-Gateway |
+
+## Lokale Anbieter
+
+| Anbieterwert | Zweck |
+|---|---|
+| `Ollama` | Ollama lokaler Modellserver |
+| `LM Studio` | LM Studio lokaler Modellserver |
+
+## LLM-Umgebungsvariablen
 
 | Variable | Beschreibung |
 |---|---|
-| `IAC_CODE_PROVIDER` | Name des Modellanbieters, Gross-/Kleinschreibung wird nicht beachtet |
+| `IAC_CODE_PROVIDER` | Name des Modellanbieters (Gross-/Kleinschreibung wird nicht beachtet). Gueltige Werte siehe obige Tabellen |
 | `IAC_CODE_MODEL` | Modellname |
-| `IAC_CODE_BASE_URL` | API-Endpunkt fuer `OpenAPICompatible` |
+| `IAC_CODE_BASE_URL` | API-Endpunkt nur fuer `OpenAPI Compatible` und `Anthropic Compatible`; wird fuer andere Anbieter ignoriert |
 | `IAC_CODE_API_KEY` | API-Schluessel des Anbieters |

--- a/website/i18n/de/docusaurus-theme-classic/footer.json
+++ b/website/i18n/de/docusaurus-theme-classic/footer.json
@@ -15,8 +15,36 @@
     "message": "Slash-Befehle",
     "description": "The label of footer link with label=Slash Commands linking to /docs/cli/commands"
   },
+  "link.title.Community": {
+    "message": "Community",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/aliyun/iac-code"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/aliyun/iac-code/issues"
+  },
+  "link.item.label.Discussions": {
+    "message": "Diskussionen",
+    "description": "The label of footer link with label=Discussions linking to https://github.com/aliyun/iac-code/discussions"
+  },
+  "link.title.More": {
+    "message": "Mehr",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.PyPI": {
+    "message": "PyPI",
+    "description": "The label of footer link with label=PyPI linking to https://pypi.org/project/iac-code/"
+  },
+  "link.item.label.Contact": {
+    "message": "Kontakt",
+    "description": "The label of footer link with label=Contact linking to /docs/contact"
+  },
   "copyright": {
-    "message": "Copyright © 2026 IaC Code contributors.",
+    "message": "Copyright © 2026 IaC Code Mitwirkende.",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/de/docusaurus-theme-classic/navbar.json
@@ -14,5 +14,9 @@
   "item.label.CLI": {
     "message": "CLI",
     "description": "Navbar item with label CLI"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
   }
 }

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
@@ -17,9 +17,9 @@ Las variables de entorno son utiles para pipelines de CI/CD, contenedores y sobr
 
 | Variable | Descripcion |
 |---|---|
-| `IAC_CODE_PROVIDER` | Nombre del proveedor de modelos (sin distincion de mayusculas/minusculas): `Anthropic`, `OpenAI`, `DashScope`, `DashScopeTokenPlan`, `DeepSeek`, `OpenAPICompatible` |
+| `IAC_CODE_PROVIDER` | Nombre del proveedor de modelos (sin distincion de mayusculas/minusculas). Valores validos: `DashScope`, `DashScope Token Plan`, `OpenAI`, `Anthropic`, `DeepSeek`, `Gemini`, `Azure OpenAI`, `ModelScope`, `Kimi CN`, `Kimi Intl`, `MiniMax CN`, `MiniMax Intl`, `ZhiPu CN`, `ZhiPu Intl`, `Volcengine CN`, `SiliconFlow CN`, `SiliconFlow Intl`, `Aliyun CodingPlan`, `Aliyun CodingPlan Intl`, `ZhiPu CN CodingPlan`, `ZhiPu Intl CodingPlan`, `Volcengine CodingPlan`, `OpenAPI Compatible`, `Anthropic Compatible`, `OpenRouter`, `Ollama`, `LM Studio` |
 | `IAC_CODE_MODEL` | Nombre del modelo |
-| `IAC_CODE_BASE_URL` | Endpoint de API solo para `OpenAPICompatible`; se ignora para otros proveedores |
+| `IAC_CODE_BASE_URL` | Endpoint de API para `OpenAPI Compatible` y `Anthropic Compatible` solamente; se ignora para otros proveedores |
 | `IAC_CODE_API_KEY` | Clave API del proveedor; sobreescribe la clave del proveedor activo en `.credentials.yml` |
 
 Consulta [Proveedores de LLM](./llm-providers.md) para mas detalles sobre los proveedores.
@@ -54,5 +54,7 @@ Consulta [Credenciales de Alibaba Cloud](./alibaba-cloud-credentials.md) para ma
 | `IAC_CODE_CONFIG_DIR` | Sobreescribe el directorio de configuracion en tiempo de ejecucion (predeterminado `~/.iac-code/`); admite expansion de `~` y `$VAR`. Todos los artefactos persistidos (credenciales, ajustes, historial, projects, image-cache, skills, telemetry, etc.) siguen este directorio |
 | `IAC_CODE_ENV` | Etiqueta del entorno de despliegue (predeterminado: `production`) |
 | `IAC_CODE_TENANT_ID` | Identificador de tenant para telemetria; se le agrega automaticamente el prefijo `iac_tenant_` si no lo tiene |
+| `IAC_CODE_GIT_BASH_PATH` | Ruta a `bash.exe` de Git Bash en Windows cuando no esta en el PATH |
+| `IAC_CODE_A2A_PUSH_KEYRING` | Keyring de secretos push A2A cifrados gestionado por el entorno (formato JSON) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint estandar de OpenTelemetry; cuando se establece, habilita la exportacion OTLP |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | Capturar contenido de mensajes/herramientas de GenAI en spans: `SPAN_ONLY`, `EVENT_ONLY`, `SPAN_AND_EVENT` |

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
@@ -5,27 +5,74 @@ description: Proveedores de modelos soportados y variables de entorno.
 
 # Proveedores de LLM
 
-IaC Code admite multiples backends de proveedores de modelos.
-
-| Valor del proveedor | Proposito |
-|---|---|
-| `Anthropic` | Modelos de Anthropic |
-| `OpenAI` | Modelos de OpenAI |
-| `DashScope` | Endpoint compatible con DashScope de Alibaba Cloud |
-| `DeepSeek` | Modelos de DeepSeek |
-| `OpenAPICompatible` | Endpoint personalizado compatible con OpenAI |
-
-La seleccion del proveedor puede provenir de las opciones del CLI, variables de entorno o archivos de configuracion. La precedencia es:
+IaC Code admite multiples backends de proveedores de modelos. La seleccion del proveedor puede provenir de las opciones del CLI, variables de entorno o archivos de configuracion. La precedencia es:
 
 ```text
 CLI arguments > environment variables > configuration files
 ```
 
-Variables de entorno de LLM:
+## Proveedores en la Nube
+
+| Valor del proveedor | Proposito |
+|---|---|
+| `DashScope` | Endpoint compatible con Alibaba Cloud DashScope (Bailian) |
+| `DashScope Token Plan` | Endpoint Alibaba Cloud DashScope Token Plan |
+| `OpenAI` | Modelos de OpenAI |
+| `Anthropic` | Modelos de Anthropic |
+| `DeepSeek` | Modelos de DeepSeek |
+| `Gemini` | Modelos de Google Gemini |
+| `Azure OpenAI` | Servicio Azure OpenAI |
+| `ModelScope` | Endpoint de inferencia ModelScope |
+
+## Proveedores en China
+
+| Valor del proveedor | Proposito |
+|---|---|
+| `Kimi CN` | Endpoint Kimi (Moonshot AI) en China |
+| `MiniMax CN` | Endpoint MiniMax en China |
+| `ZhiPu CN` | Endpoint ZhiPu AI (GLM) en China |
+| `Volcengine CN` | Endpoint Volcengine (ByteDance) en China |
+| `SiliconFlow CN` | Endpoint SiliconFlow en China |
+
+## Proveedores Internacionales
+
+| Valor del proveedor | Proposito |
+|---|---|
+| `Kimi Intl` | Endpoint internacional Kimi (Moonshot AI) |
+| `MiniMax Intl` | Endpoint internacional MiniMax |
+| `ZhiPu Intl` | Endpoint internacional ZhiPu AI (GLM) |
+| `SiliconFlow Intl` | Endpoint internacional SiliconFlow |
+
+## Proveedores CodingPlan
+
+| Valor del proveedor | Proposito |
+|---|---|
+| `Aliyun CodingPlan` | Endpoint Alibaba Cloud CodingPlan |
+| `Aliyun CodingPlan Intl` | Endpoint internacional Alibaba Cloud CodingPlan |
+| `ZhiPu CN CodingPlan` | Endpoint ZhiPu AI CodingPlan en China |
+| `ZhiPu Intl CodingPlan` | Endpoint internacional ZhiPu AI CodingPlan |
+| `Volcengine CodingPlan` | Endpoint Volcengine CodingPlan |
+
+## Compatible / Endpoints Personalizados
+
+| Valor del proveedor | Proposito |
+|---|---|
+| `OpenAPI Compatible` | Cualquier endpoint de API compatible con OpenAI |
+| `Anthropic Compatible` | Cualquier endpoint de API compatible con Anthropic |
+| `OpenRouter` | Gateway de agregacion OpenRouter |
+
+## Proveedores Locales
+
+| Valor del proveedor | Proposito |
+|---|---|
+| `Ollama` | Servidor de modelos local Ollama |
+| `LM Studio` | Servidor de modelos local LM Studio |
+
+## Variables de Entorno de LLM
 
 | Variable | Descripcion |
 |---|---|
-| `IAC_CODE_PROVIDER` | Nombre del proveedor de modelos, sin distincion de mayusculas/minusculas |
+| `IAC_CODE_PROVIDER` | Nombre del proveedor de modelos (sin distincion de mayusculas/minusculas). Consulta las tablas anteriores para valores validos |
 | `IAC_CODE_MODEL` | Nombre del modelo |
-| `IAC_CODE_BASE_URL` | Endpoint de API para `OpenAPICompatible` |
+| `IAC_CODE_BASE_URL` | Endpoint de API para `OpenAPI Compatible` y `Anthropic Compatible` solamente; se ignora para otros proveedores |
 | `IAC_CODE_API_KEY` | Clave API del proveedor |

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -15,8 +15,36 @@
     "message": "Comandos slash",
     "description": "The label of footer link with label=Slash Commands linking to /docs/cli/commands"
   },
+  "link.title.Community": {
+    "message": "Comunidad",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/aliyun/iac-code"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/aliyun/iac-code/issues"
+  },
+  "link.item.label.Discussions": {
+    "message": "Discusiones",
+    "description": "The label of footer link with label=Discussions linking to https://github.com/aliyun/iac-code/discussions"
+  },
+  "link.title.More": {
+    "message": "Mas",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.PyPI": {
+    "message": "PyPI",
+    "description": "The label of footer link with label=PyPI linking to https://pypi.org/project/iac-code/"
+  },
+  "link.item.label.Contact": {
+    "message": "Contacto",
+    "description": "The label of footer link with label=Contact linking to /docs/contact"
+  },
   "copyright": {
-    "message": "Copyright © 2026 IaC Code contributors.",
+    "message": "Copyright © 2026 Colaboradores de IaC Code.",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/es/docusaurus-theme-classic/navbar.json
@@ -14,5 +14,9 @@
   "item.label.CLI": {
     "message": "CLI",
     "description": "Navbar item with label CLI"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
   }
 }

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
@@ -17,9 +17,9 @@ Les variables d'environnement sont utiles pour les pipelines CI/CD, les conteneu
 
 | Variable | Description |
 |---|---|
-| `IAC_CODE_PROVIDER` | Nom du fournisseur de modèles (insensible à la casse) : `Anthropic`, `OpenAI`, `DashScope`, `DashScopeTokenPlan`, `DeepSeek`, `OpenAPICompatible` |
+| `IAC_CODE_PROVIDER` | Nom du fournisseur de modèles (insensible à la casse). Valeurs valides : `DashScope`, `DashScope Token Plan`, `OpenAI`, `Anthropic`, `DeepSeek`, `Gemini`, `Azure OpenAI`, `ModelScope`, `Kimi CN`, `Kimi Intl`, `MiniMax CN`, `MiniMax Intl`, `ZhiPu CN`, `ZhiPu Intl`, `Volcengine CN`, `SiliconFlow CN`, `SiliconFlow Intl`, `Aliyun CodingPlan`, `Aliyun CodingPlan Intl`, `ZhiPu CN CodingPlan`, `ZhiPu Intl CodingPlan`, `Volcengine CodingPlan`, `OpenAPI Compatible`, `Anthropic Compatible`, `OpenRouter`, `Ollama`, `LM Studio` |
 | `IAC_CODE_MODEL` | Nom du modèle |
-| `IAC_CODE_BASE_URL` | Point de terminaison API pour `OpenAPICompatible` uniquement ; ignoré pour les autres fournisseurs |
+| `IAC_CODE_BASE_URL` | Point de terminaison API pour `OpenAPI Compatible` et `Anthropic Compatible` uniquement ; ignoré pour les autres fournisseurs |
 | `IAC_CODE_API_KEY` | Clé API du fournisseur ; remplace la clé du fournisseur actif dans `.credentials.yml` |
 
 Consultez [Fournisseurs LLM](./llm-providers.md) pour les détails des fournisseurs.
@@ -54,5 +54,7 @@ Consultez [Identifiants Alibaba Cloud](./alibaba-cloud-credentials.md) pour plus
 | `IAC_CODE_CONFIG_DIR` | Remplace le répertoire de configuration à l'exécution (par défaut `~/.iac-code/`) ; prend en charge l'expansion de `~` et `$VAR`. Tous les artefacts persistés (identifiants, paramètres, historique, projects, image-cache, skills, telemetry, etc.) suivent ce répertoire |
 | `IAC_CODE_ENV` | Label d'environnement de déploiement (par défaut : `production`) |
 | `IAC_CODE_TENANT_ID` | Identifiant de locataire pour la télémétrie ; préfixé automatiquement avec `iac_tenant_` si ce n'est pas déjà le cas |
+| `IAC_CODE_GIT_BASH_PATH` | Chemin vers `bash.exe` de Git Bash sous Windows lorsqu'il n'est pas dans le PATH |
+| `IAC_CODE_A2A_PUSH_KEYRING` | Trousseau de clés secret push A2A chiffré géré par l'environnement (format JSON) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Point de terminaison OpenTelemetry standard ; lorsqu'il est défini, active l'export OTLP |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | Capturer le contenu des messages/outils GenAI sur les spans : `SPAN_ONLY`, `EVENT_ONLY`, `SPAN_AND_EVENT` |

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
@@ -5,27 +5,74 @@ description: Fournisseurs de modèles pris en charge et variables d'environnemen
 
 # Fournisseurs LLM
 
-IaC Code prend en charge plusieurs backends de fournisseurs de modèles.
-
-| Valeur du fournisseur | Fonction |
-|---|---|
-| `Anthropic` | Modèles Anthropic |
-| `OpenAI` | Modèles OpenAI |
-| `DashScope` | Point de terminaison compatible Alibaba Cloud DashScope |
-| `DeepSeek` | Modèles DeepSeek |
-| `OpenAPICompatible` | Point de terminaison personnalisé compatible OpenAI |
-
-La sélection du fournisseur peut provenir des options CLI, des variables d'environnement ou des fichiers de configuration. L'ordre de priorité est :
+IaC Code prend en charge plusieurs backends de fournisseurs de modèles. La sélection du fournisseur peut provenir des options CLI, des variables d'environnement ou des fichiers de configuration. L'ordre de priorité est :
 
 ```text
 CLI arguments > environment variables > configuration files
 ```
 
-Variables d'environnement LLM :
+## Fournisseurs Cloud
+
+| Valeur du fournisseur | Fonction |
+|---|---|
+| `DashScope` | Point de terminaison compatible Alibaba Cloud DashScope (Bailian) |
+| `DashScope Token Plan` | Point de terminaison Alibaba Cloud DashScope Token Plan |
+| `OpenAI` | Modèles OpenAI |
+| `Anthropic` | Modèles Anthropic |
+| `DeepSeek` | Modèles DeepSeek |
+| `Gemini` | Modèles Google Gemini |
+| `Azure OpenAI` | Service Azure OpenAI |
+| `ModelScope` | Point de terminaison d'inférence ModelScope |
+
+## Fournisseurs en Chine
+
+| Valeur du fournisseur | Fonction |
+|---|---|
+| `Kimi CN` | Point de terminaison Kimi (Moonshot AI) en Chine |
+| `MiniMax CN` | Point de terminaison MiniMax en Chine |
+| `ZhiPu CN` | Point de terminaison ZhiPu AI (GLM) en Chine |
+| `Volcengine CN` | Point de terminaison Volcengine (ByteDance) en Chine |
+| `SiliconFlow CN` | Point de terminaison SiliconFlow en Chine |
+
+## Fournisseurs Internationaux
+
+| Valeur du fournisseur | Fonction |
+|---|---|
+| `Kimi Intl` | Point de terminaison international Kimi (Moonshot AI) |
+| `MiniMax Intl` | Point de terminaison international MiniMax |
+| `ZhiPu Intl` | Point de terminaison international ZhiPu AI (GLM) |
+| `SiliconFlow Intl` | Point de terminaison international SiliconFlow |
+
+## Fournisseurs CodingPlan
+
+| Valeur du fournisseur | Fonction |
+|---|---|
+| `Aliyun CodingPlan` | Point de terminaison Alibaba Cloud CodingPlan |
+| `Aliyun CodingPlan Intl` | Point de terminaison international Alibaba Cloud CodingPlan |
+| `ZhiPu CN CodingPlan` | Point de terminaison ZhiPu AI CodingPlan en Chine |
+| `ZhiPu Intl CodingPlan` | Point de terminaison international ZhiPu AI CodingPlan |
+| `Volcengine CodingPlan` | Point de terminaison Volcengine CodingPlan |
+
+## Compatible / Points de terminaison personnalisés
+
+| Valeur du fournisseur | Fonction |
+|---|---|
+| `OpenAPI Compatible` | Tout point de terminaison API compatible OpenAI |
+| `Anthropic Compatible` | Tout point de terminaison API compatible Anthropic |
+| `OpenRouter` | Passerelle d'agrégation OpenRouter |
+
+## Fournisseurs Locaux
+
+| Valeur du fournisseur | Fonction |
+|---|---|
+| `Ollama` | Serveur de modèles local Ollama |
+| `LM Studio` | Serveur de modèles local LM Studio |
+
+## Variables d'environnement LLM
 
 | Variable | Description |
 |---|---|
-| `IAC_CODE_PROVIDER` | Nom du fournisseur de modèles, insensible à la casse |
+| `IAC_CODE_PROVIDER` | Nom du fournisseur de modèles (insensible à la casse). Consultez les tableaux ci-dessus pour les valeurs valides |
 | `IAC_CODE_MODEL` | Nom du modèle |
-| `IAC_CODE_BASE_URL` | Point de terminaison API pour `OpenAPICompatible` |
+| `IAC_CODE_BASE_URL` | Point de terminaison API pour `OpenAPI Compatible` et `Anthropic Compatible` uniquement ; ignoré pour les autres fournisseurs |
 | `IAC_CODE_API_KEY` | Clé API du fournisseur |

--- a/website/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/website/i18n/fr/docusaurus-theme-classic/footer.json
@@ -15,8 +15,36 @@
     "message": "Commandes slash",
     "description": "The label of footer link with label=Slash Commands linking to /docs/cli/commands"
   },
+  "link.title.Community": {
+    "message": "Communauté",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/aliyun/iac-code"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/aliyun/iac-code/issues"
+  },
+  "link.item.label.Discussions": {
+    "message": "Discussions",
+    "description": "The label of footer link with label=Discussions linking to https://github.com/aliyun/iac-code/discussions"
+  },
+  "link.title.More": {
+    "message": "Plus",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.PyPI": {
+    "message": "PyPI",
+    "description": "The label of footer link with label=PyPI linking to https://pypi.org/project/iac-code/"
+  },
+  "link.item.label.Contact": {
+    "message": "Contact",
+    "description": "The label of footer link with label=Contact linking to /docs/contact"
+  },
   "copyright": {
-    "message": "Copyright © 2026 IaC Code contributors.",
+    "message": "Copyright © 2026 Contributeurs IaC Code.",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -14,5 +14,9 @@
   "item.label.CLI": {
     "message": "CLI",
     "description": "Navbar item with label CLI"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
   }
 }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
@@ -17,9 +17,9 @@ CLI 引数 > 環境変数 > 設定ファイル
 
 | 変数 | 説明 |
 |---|---|
-| `IAC_CODE_PROVIDER` | モデルプロバイダー名（大文字小文字不問）：`Anthropic`、`OpenAI`、`DashScope`、`DashScopeTokenPlan`、`DeepSeek`、`OpenAPICompatible` |
+| `IAC_CODE_PROVIDER` | モデルプロバイダー名（大文字小文字不問）。有効な値：`DashScope`、`DashScope Token Plan`、`OpenAI`、`Anthropic`、`DeepSeek`、`Gemini`、`Azure OpenAI`、`ModelScope`、`Kimi CN`、`Kimi Intl`、`MiniMax CN`、`MiniMax Intl`、`ZhiPu CN`、`ZhiPu Intl`、`Volcengine CN`、`SiliconFlow CN`、`SiliconFlow Intl`、`Aliyun CodingPlan`、`Aliyun CodingPlan Intl`、`ZhiPu CN CodingPlan`、`ZhiPu Intl CodingPlan`、`Volcengine CodingPlan`、`OpenAPI Compatible`、`Anthropic Compatible`、`OpenRouter`、`Ollama`、`LM Studio` |
 | `IAC_CODE_MODEL` | モデル名 |
-| `IAC_CODE_BASE_URL` | `OpenAPICompatible` 専用の API エンドポイント。他のプロバイダーでは無視されます |
+| `IAC_CODE_BASE_URL` | `OpenAPI Compatible` と `Anthropic Compatible` 専用の API エンドポイント。他のプロバイダーでは無視されます |
 | `IAC_CODE_API_KEY` | プロバイダー API キー。`.credentials.yml` のアクティブプロバイダーのキーを上書きします |
 
 詳細は [LLM プロバイダー](./llm-providers.md) をご覧ください。
@@ -54,5 +54,7 @@ CLI 引数 > 環境変数 > 設定ファイル
 | `IAC_CODE_CONFIG_DIR` | ランタイム設定ディレクトリを上書き（デフォルト `~/.iac-code/`）。`~` と `$VAR` の展開をサポート。永続化されるすべての成果物（認証情報、設定、履歴、projects、image-cache、skills、telemetry など）はこのディレクトリに従います |
 | `IAC_CODE_ENV` | デプロイ環境ラベル（デフォルト：`production`） |
 | `IAC_CODE_TENANT_ID` | テレメトリ用テナント識別子。`iac_tenant_` プレフィックスが付いていない場合は自動的に付加されます |
+| `IAC_CODE_GIT_BASH_PATH` | Windows で Git Bash が PATH にない場合の `bash.exe` パス |
+| `IAC_CODE_A2A_PUSH_KEYRING` | 環境管理された A2A 暗号化プッシュシークレットキーリング（JSON 形式） |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | 標準 OpenTelemetry エンドポイント。設定すると OTLP エクスポートが有効になります |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | スパンで GenAI メッセージ/ツールコンテンツをキャプチャ：`SPAN_ONLY`、`EVENT_ONLY`、`SPAN_AND_EVENT` |

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
@@ -5,27 +5,74 @@ description: サポートされるモデルプロバイダーと環境変数。
 
 # LLM プロバイダー
 
-IaC Code は複数のモデルプロバイダーバックエンドをサポートしています。
-
-| プロバイダー値 | 用途 |
-|---|---|
-| `Anthropic` | Anthropic モデル |
-| `OpenAI` | OpenAI モデル |
-| `DashScope` | Alibaba Cloud DashScope 互換エンドポイント |
-| `DeepSeek` | DeepSeek モデル |
-| `OpenAPICompatible` | カスタム OpenAI 互換エンドポイント |
-
-プロバイダーの選択は CLI オプション、環境変数、または設定ファイルから行えます。優先順位は以下の通りです：
+IaC Code は複数のモデルプロバイダーバックエンドをサポートしています。プロバイダーの選択は CLI オプション、環境変数、または設定ファイルから行えます。優先順位は以下の通りです：
 
 ```text
 CLI 引数 > 環境変数 > 設定ファイル
 ```
 
-LLM 環境変数：
+## クラウドプロバイダー
+
+| プロバイダー値 | 用途 |
+|---|---|
+| `DashScope` | Alibaba Cloud DashScope（百炼）互換エンドポイント |
+| `DashScope Token Plan` | Alibaba Cloud DashScope Token Plan エンドポイント |
+| `OpenAI` | OpenAI モデル |
+| `Anthropic` | Anthropic モデル |
+| `DeepSeek` | DeepSeek モデル |
+| `Gemini` | Google Gemini モデル |
+| `Azure OpenAI` | Azure OpenAI サービス |
+| `ModelScope` | ModelScope 推論エンドポイント |
+
+## 中国国内プロバイダー
+
+| プロバイダー値 | 用途 |
+|---|---|
+| `Kimi CN` | Kimi（Moonshot AI）中国国内エンドポイント |
+| `MiniMax CN` | MiniMax 中国国内エンドポイント |
+| `ZhiPu CN` | ZhiPu AI（GLM）中国国内エンドポイント |
+| `Volcengine CN` | Volcengine（ByteDance）中国国内エンドポイント |
+| `SiliconFlow CN` | SiliconFlow 中国国内エンドポイント |
+
+## 国際プロバイダー
+
+| プロバイダー値 | 用途 |
+|---|---|
+| `Kimi Intl` | Kimi（Moonshot AI）国際エンドポイント |
+| `MiniMax Intl` | MiniMax 国際エンドポイント |
+| `ZhiPu Intl` | ZhiPu AI（GLM）国際エンドポイント |
+| `SiliconFlow Intl` | SiliconFlow 国際エンドポイント |
+
+## CodingPlan プロバイダー
+
+| プロバイダー値 | 用途 |
+|---|---|
+| `Aliyun CodingPlan` | Alibaba Cloud CodingPlan エンドポイント |
+| `Aliyun CodingPlan Intl` | Alibaba Cloud CodingPlan 国際エンドポイント |
+| `ZhiPu CN CodingPlan` | ZhiPu AI CodingPlan 中国国内エンドポイント |
+| `ZhiPu Intl CodingPlan` | ZhiPu AI CodingPlan 国際エンドポイント |
+| `Volcengine CodingPlan` | Volcengine CodingPlan エンドポイント |
+
+## 互換 / カスタムエンドポイント
+
+| プロバイダー値 | 用途 |
+|---|---|
+| `OpenAPI Compatible` | 任意の OpenAI 互換 API エンドポイント |
+| `Anthropic Compatible` | 任意の Anthropic 互換 API エンドポイント |
+| `OpenRouter` | OpenRouter アグリゲーションゲートウェイ |
+
+## ローカルプロバイダー
+
+| プロバイダー値 | 用途 |
+|---|---|
+| `Ollama` | Ollama ローカルモデルサーバー |
+| `LM Studio` | LM Studio ローカルモデルサーバー |
+
+## LLM 環境変数
 
 | 変数 | 説明 |
 |---|---|
-| `IAC_CODE_PROVIDER` | モデルプロバイダー名（大文字小文字不問） |
+| `IAC_CODE_PROVIDER` | モデルプロバイダー名（大文字小文字不問）。有効な値は上記の表を参照 |
 | `IAC_CODE_MODEL` | モデル名 |
-| `IAC_CODE_BASE_URL` | `OpenAPICompatible` 用の API エンドポイント |
+| `IAC_CODE_BASE_URL` | `OpenAPI Compatible` と `Anthropic Compatible` 用の API エンドポイント。他のプロバイダーでは無視されます |
 | `IAC_CODE_API_KEY` | プロバイダー API キー |

--- a/website/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ja/docusaurus-theme-classic/footer.json
@@ -15,8 +15,36 @@
     "message": "スラッシュコマンド",
     "description": "The label of footer link with label=Slash Commands linking to /docs/cli/commands"
   },
+  "link.title.Community": {
+    "message": "コミュニティ",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/aliyun/iac-code"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/aliyun/iac-code/issues"
+  },
+  "link.item.label.Discussions": {
+    "message": "ディスカッション",
+    "description": "The label of footer link with label=Discussions linking to https://github.com/aliyun/iac-code/discussions"
+  },
+  "link.title.More": {
+    "message": "その他",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.PyPI": {
+    "message": "PyPI",
+    "description": "The label of footer link with label=PyPI linking to https://pypi.org/project/iac-code/"
+  },
+  "link.item.label.Contact": {
+    "message": "お問い合わせ",
+    "description": "The label of footer link with label=Contact linking to /docs/contact"
+  },
   "copyright": {
-    "message": "Copyright © 2026 IaC Code contributors.",
+    "message": "Copyright © 2026 IaC Code コントリビューター",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/ja/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/ja/docusaurus-theme-classic/navbar.json
@@ -14,5 +14,9 @@
   "item.label.CLI": {
     "message": "CLI",
     "description": "Navbar item with label CLI"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
   }
 }

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
@@ -17,9 +17,9 @@ As variaveis de ambiente sao uteis para pipelines de CI/CD, containers e substit
 
 | Variavel | Descricao |
 |---|---|
-| `IAC_CODE_PROVIDER` | Nome do provedor de modelo (insensivel a maiusculas e minusculas): `Anthropic`, `OpenAI`, `DashScope`, `DashScopeTokenPlan`, `DeepSeek`, `OpenAPICompatible` |
+| `IAC_CODE_PROVIDER` | Nome do provedor de modelo (insensivel a maiusculas e minusculas). Valores validos: `DashScope`, `DashScope Token Plan`, `OpenAI`, `Anthropic`, `DeepSeek`, `Gemini`, `Azure OpenAI`, `ModelScope`, `Kimi CN`, `Kimi Intl`, `MiniMax CN`, `MiniMax Intl`, `ZhiPu CN`, `ZhiPu Intl`, `Volcengine CN`, `SiliconFlow CN`, `SiliconFlow Intl`, `Aliyun CodingPlan`, `Aliyun CodingPlan Intl`, `ZhiPu CN CodingPlan`, `ZhiPu Intl CodingPlan`, `Volcengine CodingPlan`, `OpenAPI Compatible`, `Anthropic Compatible`, `OpenRouter`, `Ollama`, `LM Studio` |
 | `IAC_CODE_MODEL` | Nome do modelo |
-| `IAC_CODE_BASE_URL` | Endpoint de API apenas para `OpenAPICompatible`; ignorado para outros provedores |
+| `IAC_CODE_BASE_URL` | Endpoint de API para `OpenAPI Compatible` e `Anthropic Compatible` apenas; ignorado para outros provedores |
 | `IAC_CODE_API_KEY` | Chave de API do provedor; substitui a chave do provedor ativo em `.credentials.yml` |
 
 Consulte [Provedores de LLM](./llm-providers.md) para detalhes sobre os provedores.
@@ -54,5 +54,7 @@ Consulte [Credenciais da Alibaba Cloud](./alibaba-cloud-credentials.md) para mai
 | `IAC_CODE_CONFIG_DIR` | Substitui o diretorio de configuracao em tempo de execucao (padrao `~/.iac-code/`); suporta expansao de `~` e `$VAR`. Todos os artefatos persistidos (credenciais, configuracoes, historico, projects, image-cache, skills, telemetry, etc.) seguem este diretorio |
 | `IAC_CODE_ENV` | Rotulo do ambiente de implantacao (padrao: `production`) |
 | `IAC_CODE_TENANT_ID` | Identificador de tenant para telemetria; prefixado automaticamente com `iac_tenant_` se ainda nao estiver |
+| `IAC_CODE_GIT_BASH_PATH` | Caminho para `bash.exe` do Git Bash no Windows quando nao esta no PATH |
+| `IAC_CODE_A2A_PUSH_KEYRING` | Keyring criptografado de push secrets A2A gerenciado pelo ambiente (formato JSON) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint padrao do OpenTelemetry; quando definido, habilita a exportacao OTLP |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | Capturar conteudo de mensagens/ferramentas GenAI em spans: `SPAN_ONLY`, `EVENT_ONLY`, `SPAN_AND_EVENT` |

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
@@ -5,27 +5,74 @@ description: Provedores de modelos suportados e variaveis de ambiente.
 
 # Provedores de LLM
 
-O IaC Code suporta multiplos backends de provedores de modelos.
-
-| Valor do provedor | Finalidade |
-|---|---|
-| `Anthropic` | Modelos Anthropic |
-| `OpenAI` | Modelos OpenAI |
-| `DashScope` | Endpoint compativel com DashScope da Alibaba Cloud |
-| `DeepSeek` | Modelos DeepSeek |
-| `OpenAPICompatible` | Endpoint personalizado compativel com OpenAI |
-
-A selecao do provedor pode vir de opcoes do CLI, variaveis de ambiente ou arquivos de configuracao. A precedencia e:
+O IaC Code suporta multiplos backends de provedores de modelos. A selecao do provedor pode vir de opcoes do CLI, variaveis de ambiente ou arquivos de configuracao. A precedencia e:
 
 ```text
 CLI arguments > environment variables > configuration files
 ```
 
-Variaveis de ambiente de LLM:
+## Provedores na Nuvem
+
+| Valor do provedor | Finalidade |
+|---|---|
+| `DashScope` | Endpoint compativel com Alibaba Cloud DashScope (Bailian) |
+| `DashScope Token Plan` | Endpoint Alibaba Cloud DashScope Token Plan |
+| `OpenAI` | Modelos OpenAI |
+| `Anthropic` | Modelos Anthropic |
+| `DeepSeek` | Modelos DeepSeek |
+| `Gemini` | Modelos Google Gemini |
+| `Azure OpenAI` | Servico Azure OpenAI |
+| `ModelScope` | Endpoint de inferencia ModelScope |
+
+## Provedores na China
+
+| Valor do provedor | Finalidade |
+|---|---|
+| `Kimi CN` | Endpoint Kimi (Moonshot AI) na China |
+| `MiniMax CN` | Endpoint MiniMax na China |
+| `ZhiPu CN` | Endpoint ZhiPu AI (GLM) na China |
+| `Volcengine CN` | Endpoint Volcengine (ByteDance) na China |
+| `SiliconFlow CN` | Endpoint SiliconFlow na China |
+
+## Provedores Internacionais
+
+| Valor do provedor | Finalidade |
+|---|---|
+| `Kimi Intl` | Endpoint internacional Kimi (Moonshot AI) |
+| `MiniMax Intl` | Endpoint internacional MiniMax |
+| `ZhiPu Intl` | Endpoint internacional ZhiPu AI (GLM) |
+| `SiliconFlow Intl` | Endpoint internacional SiliconFlow |
+
+## Provedores CodingPlan
+
+| Valor do provedor | Finalidade |
+|---|---|
+| `Aliyun CodingPlan` | Endpoint Alibaba Cloud CodingPlan |
+| `Aliyun CodingPlan Intl` | Endpoint internacional Alibaba Cloud CodingPlan |
+| `ZhiPu CN CodingPlan` | Endpoint ZhiPu AI CodingPlan na China |
+| `ZhiPu Intl CodingPlan` | Endpoint internacional ZhiPu AI CodingPlan |
+| `Volcengine CodingPlan` | Endpoint Volcengine CodingPlan |
+
+## Compativeis / Endpoints Personalizados
+
+| Valor do provedor | Finalidade |
+|---|---|
+| `OpenAPI Compatible` | Qualquer endpoint de API compativel com OpenAI |
+| `Anthropic Compatible` | Qualquer endpoint de API compativel com Anthropic |
+| `OpenRouter` | Gateway de agregacao OpenRouter |
+
+## Provedores Locais
+
+| Valor do provedor | Finalidade |
+|---|---|
+| `Ollama` | Servidor de modelo local Ollama |
+| `LM Studio` | Servidor de modelo local LM Studio |
+
+## Variaveis de Ambiente de LLM
 
 | Variavel | Descricao |
 |---|---|
-| `IAC_CODE_PROVIDER` | Nome do provedor de modelo, insensivel a maiusculas e minusculas |
+| `IAC_CODE_PROVIDER` | Nome do provedor de modelo (insensivel a maiusculas e minusculas). Consulte as tabelas acima para valores validos |
 | `IAC_CODE_MODEL` | Nome do modelo |
-| `IAC_CODE_BASE_URL` | Endpoint de API para `OpenAPICompatible` |
+| `IAC_CODE_BASE_URL` | Endpoint de API para `OpenAPI Compatible` e `Anthropic Compatible` apenas; ignorado para outros provedores |
 | `IAC_CODE_API_KEY` | Chave de API do provedor |

--- a/website/i18n/pt/docusaurus-theme-classic/footer.json
+++ b/website/i18n/pt/docusaurus-theme-classic/footer.json
@@ -15,8 +15,36 @@
     "message": "Comandos slash",
     "description": "The label of footer link with label=Slash Commands linking to /docs/cli/commands"
   },
+  "link.title.Community": {
+    "message": "Comunidade",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/aliyun/iac-code"
+  },
+  "link.item.label.Issues": {
+    "message": "Issues",
+    "description": "The label of footer link with label=Issues linking to https://github.com/aliyun/iac-code/issues"
+  },
+  "link.item.label.Discussions": {
+    "message": "Discussoes",
+    "description": "The label of footer link with label=Discussions linking to https://github.com/aliyun/iac-code/discussions"
+  },
+  "link.title.More": {
+    "message": "Mais",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.PyPI": {
+    "message": "PyPI",
+    "description": "The label of footer link with label=PyPI linking to https://pypi.org/project/iac-code/"
+  },
+  "link.item.label.Contact": {
+    "message": "Contato",
+    "description": "The label of footer link with label=Contact linking to /docs/contact"
+  },
   "copyright": {
-    "message": "Copyright © 2026 IaC Code contributors.",
+    "message": "Copyright © 2026 Colaboradores do IaC Code.",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/pt/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/pt/docusaurus-theme-classic/navbar.json
@@ -14,5 +14,9 @@
   "item.label.CLI": {
     "message": "CLI",
     "description": "Navbar item with label CLI"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
   }
 }

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/environment-variables.md
@@ -17,9 +17,9 @@ CLI 参数 > 环境变量 > 配置文件
 
 | 变量 | 说明 |
 |---|---|
-| `IAC_CODE_PROVIDER` | 模型提供商名称（大小写不敏感）：`Anthropic`、`OpenAI`、`DashScope`、`DashScopeTokenPlan`、`DeepSeek`、`OpenAPICompatible` |
+| `IAC_CODE_PROVIDER` | 模型提供商名称（大小写不敏感）。有效值：`DashScope`、`DashScope Token Plan`、`OpenAI`、`Anthropic`、`DeepSeek`、`Gemini`、`Azure OpenAI`、`ModelScope`、`Kimi CN`、`Kimi Intl`、`MiniMax CN`、`MiniMax Intl`、`ZhiPu CN`、`ZhiPu Intl`、`Volcengine CN`、`SiliconFlow CN`、`SiliconFlow Intl`、`Aliyun CodingPlan`、`Aliyun CodingPlan Intl`、`ZhiPu CN CodingPlan`、`ZhiPu Intl CodingPlan`、`Volcengine CodingPlan`、`OpenAPI Compatible`、`Anthropic Compatible`、`OpenRouter`、`Ollama`、`LM Studio` |
 | `IAC_CODE_MODEL` | 模型名称 |
-| `IAC_CODE_BASE_URL` | `OpenAPICompatible` 使用的 API 端点；其他提供商会忽略此值 |
+| `IAC_CODE_BASE_URL` | `OpenAPI Compatible` 和 `Anthropic Compatible` 使用的 API 端点；其他提供商会忽略此值 |
 | `IAC_CODE_API_KEY` | 提供商 API Key；覆盖 `.credentials.yml` 中活跃提供商的密钥 |
 
 详见 [LLM 提供商](./llm-providers.md)。
@@ -54,5 +54,7 @@ CLI 参数 > 环境变量 > 配置文件
 | `IAC_CODE_CONFIG_DIR` | 覆盖运行时配置目录（默认 `~/.iac-code/`）；支持 `~` 和 `$VAR` 展开。所有持久化产物（凭证、设置、历史、projects、image-cache、skills、telemetry 等）均会跟随该目录 |
 | `IAC_CODE_ENV` | 部署环境标签（默认：`production`） |
 | `IAC_CODE_TENANT_ID` | 遥测租户标识；如未以 `iac_tenant_` 开头则自动添加前缀 |
+| `IAC_CODE_GIT_BASH_PATH` | Windows 下 Git Bash `bash.exe` 的路径（不在 PATH 中时使用） |
+| `IAC_CODE_A2A_PUSH_KEYRING` | 由环境管理的 A2A 加密推送密钥环（JSON 格式） |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | 标准 OpenTelemetry 端点；设置后启用 OTLP 导出 |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | 在 span 上捕获 GenAI 消息/工具内容：`SPAN_ONLY`、`EVENT_ONLY`、`SPAN_AND_EVENT` |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/configuration/llm-providers.md
@@ -5,27 +5,74 @@ description: 支持的模型提供商和环境变量。
 
 # LLM 提供商
 
-IaC Code 支持多种模型提供商后端。
-
-| 提供商值 | 用途 |
-|---|---|
-| `Anthropic` | Anthropic 模型 |
-| `OpenAI` | OpenAI 模型 |
-| `DashScope` | 阿里云百炼兼容端点 |
-| `DeepSeek` | DeepSeek 模型 |
-| `OpenAPICompatible` | 自定义 OpenAI 兼容端点 |
-
-提供商选择可以来自 CLI 参数、环境变量或配置文件。优先级为：
+IaC Code 支持多种模型提供商后端。提供商选择可以来自 CLI 参数、环境变量或配置文件。优先级为：
 
 ```text
 CLI 参数 > 环境变量 > 配置文件
 ```
 
-LLM 环境变量：
+## 云服务提供商
+
+| 提供商值 | 用途 |
+|---|---|
+| `DashScope` | 阿里云百炼（DashScope）兼容端点 |
+| `DashScope Token Plan` | 阿里云百炼 Token 计划端点 |
+| `OpenAI` | OpenAI 模型 |
+| `Anthropic` | Anthropic 模型 |
+| `DeepSeek` | DeepSeek 模型 |
+| `Gemini` | Google Gemini 模型 |
+| `Azure OpenAI` | Azure OpenAI 服务 |
+| `ModelScope` | 魔搭推理端点 |
+
+## 国内提供商
+
+| 提供商值 | 用途 |
+|---|---|
+| `Kimi CN` | Kimi（月之暗面）国内端点 |
+| `MiniMax CN` | MiniMax 国内端点 |
+| `ZhiPu CN` | 智谱 AI（GLM）国内端点 |
+| `Volcengine CN` | 火山引擎（字节跳动）国内端点 |
+| `SiliconFlow CN` | 硅基流动国内端点 |
+
+## 国际提供商
+
+| 提供商值 | 用途 |
+|---|---|
+| `Kimi Intl` | Kimi（月之暗面）国际端点 |
+| `MiniMax Intl` | MiniMax 国际端点 |
+| `ZhiPu Intl` | 智谱 AI（GLM）国际端点 |
+| `SiliconFlow Intl` | 硅基流动国际端点 |
+
+## CodingPlan 提供商
+
+| 提供商值 | 用途 |
+|---|---|
+| `Aliyun CodingPlan` | 阿里云 CodingPlan 端点 |
+| `Aliyun CodingPlan Intl` | 阿里云 CodingPlan 国际端点 |
+| `ZhiPu CN CodingPlan` | 智谱 AI CodingPlan 国内端点 |
+| `ZhiPu Intl CodingPlan` | 智谱 AI CodingPlan 国际端点 |
+| `Volcengine CodingPlan` | 火山引擎 CodingPlan 端点 |
+
+## 兼容 / 自定义端点
+
+| 提供商值 | 用途 |
+|---|---|
+| `OpenAPI Compatible` | 任意 OpenAI 兼容 API 端点 |
+| `Anthropic Compatible` | 任意 Anthropic 兼容 API 端点 |
+| `OpenRouter` | OpenRouter 聚合网关 |
+
+## 本地提供商
+
+| 提供商值 | 用途 |
+|---|---|
+| `Ollama` | Ollama 本地模型服务 |
+| `LM Studio` | LM Studio 本地模型服务 |
+
+## LLM 环境变量
 
 | 变量 | 说明 |
 |---|---|
-| `IAC_CODE_PROVIDER` | 模型提供商名称，大小写不敏感 |
+| `IAC_CODE_PROVIDER` | 模型提供商名称（大小写不敏感），有效值见上表 |
 | `IAC_CODE_MODEL` | 模型名称 |
-| `IAC_CODE_BASE_URL` | `OpenAPICompatible` 使用的 API 端点 |
+| `IAC_CODE_BASE_URL` | `OpenAPI Compatible` 和 `Anthropic Compatible` 使用的 API 端点；其他提供商会忽略此值 |
 | `IAC_CODE_API_KEY` | 提供商 API Key |

--- a/website/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -15,8 +15,36 @@
     "message": "Slash 命令",
     "description": "The label of footer link with label=Slash Commands linking to /docs/cli/commands"
   },
+  "link.title.Community": {
+    "message": "社区",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/aliyun/iac-code"
+  },
+  "link.item.label.Issues": {
+    "message": "问题反馈",
+    "description": "The label of footer link with label=Issues linking to https://github.com/aliyun/iac-code/issues"
+  },
+  "link.item.label.Discussions": {
+    "message": "讨论区",
+    "description": "The label of footer link with label=Discussions linking to https://github.com/aliyun/iac-code/discussions"
+  },
+  "link.title.More": {
+    "message": "更多",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.PyPI": {
+    "message": "PyPI",
+    "description": "The label of footer link with label=PyPI linking to https://pypi.org/project/iac-code/"
+  },
+  "link.item.label.Contact": {
+    "message": "联系我们",
+    "description": "The label of footer link with label=Contact linking to /docs/contact"
+  },
   "copyright": {
-    "message": "Copyright © 2026 IaC Code contributors.",
+    "message": "Copyright © 2026 IaC Code 贡献者",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -14,5 +14,9 @@
   "item.label.CLI": {
     "message": "CLI",
     "description": "Navbar item with label CLI"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
         "@docusaurus/core": "3.10.1",
         "@docusaurus/faster": "3.10.1",
         "@docusaurus/preset-classic": "3.10.1",
+        "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -4134,6 +4135,125 @@
         "node": ">=20.0"
       }
     },
+    "node_modules/@easyops-cn/autocomplete.js": {
+      "version": "0.38.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
+      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "immediate": "^3.2.3"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local": {
+      "version": "0.55.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.1.tgz",
+      "integrity": "sha512-jmBKj1J+tajqNrCvECwKCQYTWwHVZDGApy8lLOYEPe+Dm0/f3Ccdw8BP5/OHNpltr7WDNY2roQXn+TWn2f1kig==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/plugin-content-docs": "^2 || ^3",
+        "@docusaurus/theme-translations": "^2 || ^3",
+        "@docusaurus/utils": "^2 || ^3",
+        "@docusaurus/utils-common": "^2 || ^3",
+        "@docusaurus/utils-validation": "^2 || ^3",
+        "@easyops-cn/autocomplete.js": "^0.38.1",
+        "@node-rs/jieba": "^1.6.0",
+        "cheerio": "^1.0.0",
+        "clsx": "^2.1.1",
+        "comlink": "^4.4.2",
+        "debug": "^4.2.0",
+        "fs-extra": "^10.0.0",
+        "klaw-sync": "^6.0.0",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2 || ^3",
+        "open-ask-ai": "^0.7.3",
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || 17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "open-ask-ai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.10.0.tgz",
@@ -4808,6 +4928,271 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@node-rs/jieba": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba/-/jieba-1.10.4.tgz",
+      "integrity": "sha512-GvDgi8MnBiyWd6tksojej8anIx18244NmIOc1ovEw8WKNUejcccLfyu8vj66LWSuoZuKILVtNsOy4jvg3aoxIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/jieba-android-arm-eabi": "1.10.4",
+        "@node-rs/jieba-android-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-x64": "1.10.4",
+        "@node-rs/jieba-freebsd-x64": "1.10.4",
+        "@node-rs/jieba-linux-arm-gnueabihf": "1.10.4",
+        "@node-rs/jieba-linux-arm64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-arm64-musl": "1.10.4",
+        "@node-rs/jieba-linux-x64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-x64-musl": "1.10.4",
+        "@node-rs/jieba-wasm32-wasi": "1.10.4",
+        "@node-rs/jieba-win32-arm64-msvc": "1.10.4",
+        "@node-rs/jieba-win32-ia32-msvc": "1.10.4",
+        "@node-rs/jieba-win32-x64-msvc": "1.10.4"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm-eabi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.10.4.tgz",
+      "integrity": "sha512-MhyvW5N3Fwcp385d0rxbCWH42kqDBatQTyP8XbnYbju2+0BO/eTeCCLYj7Agws4pwxn2LtdldXRSKavT7WdzNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.10.4.tgz",
+      "integrity": "sha512-XyDwq5+rQ+Tk55A+FGi6PtJbzf974oqnpyCcCPzwU3QVXJCa2Rr4Lci+fx8oOpU4plT3GuD+chXMYLsXipMgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.10.4.tgz",
+      "integrity": "sha512-G++RYEJ2jo0rxF9626KUy90wp06TRUjAsvY/BrIzEOX/ingQYV/HjwQzNPRR1P1o32a6/U8RGo7zEBhfdybL6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.10.4.tgz",
+      "integrity": "sha512-MmDNeOb2TXIZCPyWCi2upQnZpPjAxw5ZGEj6R8kNsPXVFALHIKMa6ZZ15LCOkSTsKXVC17j2t4h+hSuyYb6qfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-freebsd-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.10.4.tgz",
+      "integrity": "sha512-/x7aVQ8nqUWhpXU92RZqd333cq639i/olNpd9Z5hdlyyV5/B65LLy+Je2B2bfs62PVVm5QXRpeBcZqaHelp/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm-gnueabihf": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.10.4.tgz",
+      "integrity": "sha512-crd2M35oJBRLkoESs0O6QO3BBbhpv+tqXuKsqhIG94B1d02RVxtRIvSDwO33QurxqSdvN9IeSnVpHbDGkuXm3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.10.4.tgz",
+      "integrity": "sha512-omIzNX1psUzPcsdnUhGU6oHeOaTCuCjUgOA/v/DGkvWC1jLcnfXe4vdYbtXMh4XOCuIgS1UCcvZEc8vQLXFbXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.10.4.tgz",
+      "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.10.4.tgz",
+      "integrity": "sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.10.4.tgz",
+      "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-wasm32-wasi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.10.4.tgz",
+      "integrity": "sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/jieba-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-arm64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.10.4.tgz",
+      "integrity": "sha512-nwMtViFm4hjqhz1it/juQnxpXgqlGltCuWJ02bw70YUDMDlbyTy3grCJPpQQpueeETcALUnTxda8pZuVrLRcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-ia32-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.10.4.tgz",
+      "integrity": "sha512-DCAvLx7Z+W4z5oKS+7vUowAJr0uw9JBw8x1Y23Xs/xMA4Em+OOSiaF5/tCJqZUCJ8uC4QeImmgDFiBqGNwxlyA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-x64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.anpm.alibaba-inc.com/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.10.4.tgz",
+      "integrity": "sha512-+sqemSfS1jjb+Tt7InNbNzrRh1Ua3vProVvC4BZRPg010/leCbGFFiQHpzcPRfpxAXZrzG5Y0YBTsPzN/I4yHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7676,6 +8061,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmmirror.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -8888,6 +9279,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -10580,6 +10996,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -11166,6 +11588,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmmirror.com/kleur/-/kleur-3.0.3.tgz",
@@ -11593,6 +12024,24 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.anpm.alibaba-inc.com/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.20.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/lunr-languages/-/lunr-languages-1.20.0.tgz",
+      "integrity": "sha512-3LVgE7ekWXt04NBci/hjm+NXJxXZeRXuyClL0kA0HONyBOjxhP3ZQkuWIM4Ok3pbeptUW/rj3XcJcJuJVPwPYA==",
+      "license": "MPL-1.1"
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
@@ -14548,6 +14997,18 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.anpm.alibaba-inc.com/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -18394,6 +18855,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.26.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.21.0",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.21.0.tgz",
@@ -19253,6 +19723,40 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.anpm.alibaba-inc.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.anpm.alibaba-inc.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.anpm.alibaba-inc.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
     "@docusaurus/core": "3.10.1",
     "@docusaurus/faster": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
+    "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -37,32 +37,32 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'ACP Protocol',
-      items: [
-        'acp/overview',
-        'acp/getting-started',
-        'acp/protocol-reference',
-        'acp/http-transport',
-        'acp/examples',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'A2A Protocol',
-      items: [
-        'a2a/overview',
-        'a2a/getting-started',
-        'a2a/command-reference',
-        'a2a/protocol-reference',
-        'a2a/http-transport',
-        'a2a/examples',
-      ],
-    },
-    {
-      type: 'category',
       label: 'Automation',
       items: [
         'automation/non-interactive-mode',
+        {
+          type: 'category',
+          label: 'ACP Protocol',
+          items: [
+            'acp/overview',
+            'acp/getting-started',
+            'acp/protocol-reference',
+            'acp/http-transport',
+            'acp/examples',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'A2A Protocol',
+          items: [
+            'a2a/overview',
+            'a2a/getting-started',
+            'a2a/command-reference',
+            'a2a/protocol-reference',
+            'a2a/http-transport',
+            'a2a/examples',
+          ],
+        },
       ],
     },
     'contact',


### PR DESCRIPTION
## Summary
- Update LLM providers documentation from 5 to all 27 supported providers, organized by category
- Update environment variables documentation with correct `IAC_CODE_PROVIDER` values and add missing `IAC_CODE_GIT_BASH_PATH`, `IAC_CODE_A2A_PUSH_KEYRING`
- Add local search functionality via `docusaurus-search-local` (supports CJK)
- Add GitHub repository link to navbar
- Restructure sidebar: move ACP and A2A protocols under Automation category
- Enhance footer with Community (GitHub, Issues, Discussions) and More (PyPI, Contact) columns
- Complete i18n for all 7 languages (en, zh-Hans, ja, fr, de, es, pt) including navbar, footer, and copyright

## Test plan
- [x] `npx docusaurus build` passes for all 7 locales
- [x] Verify search works locally with `npm run serve`
- [x] Verify sidebar structure shows ACP/A2A nested under Automation
- [x] Verify GitHub link appears in navbar
- [x] Verify footer shows 3 columns with correct translations