### PR TITLE
Fix LLM provider robustness issues

### DIFF
--- a/src/iac_code/agent/agent_loop.py
+++ b/src/iac_code/agent/agent_loop.py
@@ -329,6 +329,7 @@ class AgentLoop:
 
                 if not message_ended:
                     step_span.set_attribute(GenAiAttr.REACT_FINISH_REASON, "error")
+                    yield MessageEndEvent(stop_reason="stream_error", usage=Usage())
                     break
 
                 # Build assistant message for context

--- a/src/iac_code/providers/openai_provider.py
+++ b/src/iac_code/providers/openai_provider.py
@@ -351,6 +351,15 @@ class OpenAIProvider(Provider):
                     "(e.g. {base_url}/v1)."
                 ).format(base_url=base_url)
             )
+        if not response.choices:
+            base_url = str(self._base_url or self._client.base_url).rstrip("/")
+            message = _(
+                "API returned an invalid response. Please check that your "
+                "API Base URL is correct (current: {base_url}). "
+                "Many OpenAI-compatible endpoints require a /v1 suffix "
+                "(e.g. {base_url}/v1)."
+            ).format(base_url=base_url)
+            raise RuntimeError(message + " Response choices were empty.")
         choice = response.choices[0]
         message = choice.message
 

--- a/src/iac_code/providers/openrouter_provider.py
+++ b/src/iac_code/providers/openrouter_provider.py
@@ -23,18 +23,21 @@ class OpenRouterProvider(OpenAIProvider):
         provider_key: str = "openrouter",
         **kwargs: Any,
     ) -> None:
+        client = kwargs.pop("client", None)
+        if client is None:
+            client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                default_headers={
+                    "HTTP-Referer": "https://github.com/aliyun/iac-code",
+                    "X-Title": "iac-code",
+                },
+            )
         super().__init__(
             model=model,
             api_key=api_key,
             base_url=base_url,
+            client=client,
             effort=effort,
-        )
-        self._PROVIDER_KEY = provider_key
-        self._client = AsyncOpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            default_headers={
-                "HTTP-Referer": "https://github.com/aliyun/iac-code",
-                "X-Title": "iac-code",
-            },
+            provider_key=provider_key,
         )

--- a/tests/agent/test_agent_loop_new.py
+++ b/tests/agent/test_agent_loop_new.py
@@ -275,6 +275,22 @@ class TestAgentLoopStreaming:
         assert loop.get_session_usage().has_recorded_usage is False
         assert not store.path_for("/tmp/status-project", "zero-session").exists()
 
+    async def test_abnormal_provider_stream_emits_stream_error_end(self, mock_provider, mock_registry):
+        async def fake_stream(messages, system, tools=None, max_tokens=8192):
+            yield MessageStartEvent(message_id="m1")
+            yield TextDeltaEvent(text="partial")
+
+        mock_provider.stream = fake_stream
+
+        loop = AgentLoop(provider_manager=mock_provider, system_prompt="test", tool_registry=mock_registry)
+
+        events = [e async for e in loop.run_streaming("Hi")]
+
+        assert any(isinstance(e, TextDeltaEvent) and e.text == "partial" for e in events)
+        assert isinstance(events[-1], MessageEndEvent)
+        assert events[-1].stop_reason == "stream_error"
+        assert events[-1].usage == Usage()
+
     async def test_replace_session_reloads_usage_totals(self, mock_provider, mock_registry, tmp_path):
         from iac_code.services.session_usage import SessionUsageStore
 

--- a/tests/providers/test_new_providers.py
+++ b/tests/providers/test_new_providers.py
@@ -55,6 +55,30 @@ class TestNewProviderImports:
         assert p.get_model_name() == "test"
         assert p._PROVIDER_KEY == "openrouter"
 
+    def test_openrouter_provider_creates_one_client(self, monkeypatch):
+        calls = []
+
+        class FakeAsyncOpenAI:
+            def __init__(self, **kwargs):
+                calls.append(kwargs)
+                self.base_url = kwargs.get("base_url") or "https://fake.openai.local"
+
+        monkeypatch.setattr("iac_code.providers.openai_provider.AsyncOpenAI", FakeAsyncOpenAI)
+        monkeypatch.setattr("iac_code.providers.openrouter_provider.AsyncOpenAI", FakeAsyncOpenAI, raising=False)
+
+        from iac_code.providers.openrouter_provider import OpenRouterProvider
+
+        p = OpenRouterProvider(model="test", api_key="key", base_url="https://openrouter.ai/api/v1")
+
+        assert p.get_model_name() == "test"
+        assert len(calls) == 1
+        assert calls[0]["api_key"] == "key"
+        assert calls[0]["base_url"] == "https://openrouter.ai/api/v1"
+        assert calls[0]["default_headers"] == {
+            "HTTP-Referer": "https://github.com/aliyun/iac-code",
+            "X-Title": "iac-code",
+        }
+
     def test_azure_openai_provider(self):
         from iac_code.providers.azure_openai_provider import AzureOpenAIProvider
 

--- a/tests/providers/test_openai_provider.py
+++ b/tests/providers/test_openai_provider.py
@@ -367,6 +367,18 @@ class TestOpenAIComplete:
         with pytest.raises(RuntimeError, match="invalid response"):
             await provider.complete(messages=[Message.user("x")], system="")
 
+    async def test_empty_choices_raises_runtime_error(self):
+        response = ns(id="x", choices=[], usage=None)
+        client = FakeOpenAIClient(create_response=response, base_url="https://api.example.com")
+        provider = OpenAIProvider(
+            model="gpt-4.1",
+            base_url="https://api.example.com",
+            client=client,
+        )
+
+        with pytest.raises(RuntimeError, match="invalid response.*choices"):
+            await provider.complete(messages=[Message.user("x")], system="")
+
 
 @pytest.mark.asyncio
 class TestOpenAICacheMetrics:


### PR DESCRIPTION
Fixes #79.

## Summary
- Raise a descriptive RuntimeError when non-streaming OpenAI-compatible responses contain no choices.
- Emit a stream_error MessageEndEvent when provider streams end without MessageEndEvent.
- Construct OpenRouter AsyncOpenAI only once while preserving required headers.

## Tests
- make test
- make lint