### PR TITLE
feat: add self-update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ LOCALES := zh es fr de ja pt
 VERSION := $(shell sed -n 's/^__version__ = "\(.*\)"/\1/p' src/iac_code/__init__.py)
 
 translate: ## Extract, update and compile translations
-	@uv run pybabel extract -F babel.cfg --project=iac-code --version=$(VERSION) -o src/iac_code/i18n/messages.pot . > /dev/null 2>&1 && echo "Extract: OK" || (echo "Extract: FAILED"; exit 1)
+	@uv run pybabel extract -F babel.cfg --add-location=file --project=iac-code --version=$(VERSION) -o src/iac_code/i18n/messages.pot . > /dev/null 2>&1 && echo "Extract: OK" || (echo "Extract: FAILED"; exit 1)
 	@for lang in $(LOCALES); do \
-		uv run pybabel update -i src/iac_code/i18n/messages.pot -d src/iac_code/i18n/locales -l $$lang > /dev/null 2>&1 && echo "Update  $$lang: OK" || (echo "Update  $$lang: FAILED"; exit 1); \
+		uv run pybabel update --ignore-pot-creation-date -i src/iac_code/i18n/messages.pot -d src/iac_code/i18n/locales -l $$lang > /dev/null 2>&1 && echo "Update  $$lang: OK" || (echo "Update  $$lang: FAILED"; exit 1); \
 	done
 	@for lang in $(LOCALES); do \
 		perl -i -pe 's/^"Project-Id-Version: .*/"Project-Id-Version: iac-code $(VERSION)\\n"/' src/iac_code/i18n/locales/$$lang/LC_MESSAGES/messages.po; \

--- a/src/iac_code/cli/main.py
+++ b/src/iac_code/cli/main.py
@@ -28,6 +28,10 @@ completion_init()
 # this works regardless of where it's called relative to `import typer` / click.
 setup_i18n()
 
+# Import subcommands with Typer parameter help after i18n setup, because Typer
+# captures custom option help text when the function signature is defined.
+from iac_code.cli.update import update as _update_command  # noqa: E402
+
 app = typer.Typer(
     name="iac-code",
     help=_("AI-powered infrastructure orchestration tool"),
@@ -53,6 +57,8 @@ if sys.platform == "win32":
         name="install-git-bash",
         help=_("Install Git for Windows via the npmmirror mirror (Windows only)."),
     )(_install_git_bash)
+
+app.command(name="update", help=_("Update iac-code to the latest version."))(_update_command)
 
 
 @a2a_client_app.callback()

--- a/src/iac_code/cli/update.py
+++ b/src/iac_code/cli/update.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import shlex
+
+import typer
+
+from iac_code import __version__
+from iac_code.i18n import _
+from iac_code.services.update_checker import check_for_updates_once, run_update_command
+
+
+def update(
+    check: bool = typer.Option(False, "--check", help=_("Check for updates without installing.")),
+) -> None:
+    """Update iac-code to the latest available version."""
+    state = check_for_updates_once(current_version=__version__, force=True)
+    pending = state.pending
+    if pending is None:
+        typer.echo(_("iac-code is already up to date (v{}).").format(__version__))
+        raise typer.Exit()
+
+    if check:
+        typer.echo(_("Update available: v{} -> v{}").format(pending.current_version, pending.version))
+        typer.echo(_("Run {} to update.").format(shlex.join(pending.update_command)))
+        raise typer.Exit()
+
+    typer.echo(_("Updating iac-code from v{} to v{}...").format(pending.current_version, pending.version))
+    try:
+        result = run_update_command(pending)
+    except OSError as exc:
+        typer.echo(_("Update command failed: {}").format(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    if result.returncode != 0:
+        typer.echo(_("Update command failed with exit code {}.").format(result.returncode), err=True)
+        raise typer.Exit(result.returncode)
+
+    typer.echo(_("Successfully updated to v{}!").format(pending.version))

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 13:32+0800\n"
+"POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: de\n"
@@ -17,14 +17,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/iac_code/config.py:164
+#: src/iac_code/config.py
 #, python-brace-format
 msgid "Invalid IAC_CODE_PROVIDER value: {!r}. Valid values (case-insensitive): {}"
 msgstr ""
 "Ungültiger IAC_CODE_PROVIDER-Wert: {!r}. Gültige Werte "
 "(Groß-/Kleinschreibung wird ignoriert): {}"
 
-#: src/iac_code/a2a/transports/base.py:175
+#: src/iac_code/a2a/transports/base.py
 msgid ""
 "Unix domain socket transport is not supported on Windows. Use --transport"
 " http or --transport stdio instead."
@@ -32,22 +32,21 @@ msgstr ""
 "Unix-Domain-Socket-Transport wird unter Windows nicht unterstützt. "
 "Verwenden Sie stattdessen --transport http oder --transport stdio."
 
-#: src/iac_code/acp/server.py:413 src/iac_code/acp/server.py:429
-#: src/iac_code/acp/server.py:456
+#: src/iac_code/acp/server.py
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
-#: src/iac_code/acp/server.py:416
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session name is ambiguous. Candidates: {candidates}"
 msgstr "Der Sitzungsname ist mehrdeutig. Kandidaten: {candidates}"
 
-#: src/iac_code/acp/server.py:434 src/iac_code/acp/server.py:708
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session belongs to another project. Run: {hint}"
 msgstr "Die Sitzung gehört zu einem anderen Projekt. Ausführen: {hint}"
 
-#: src/iac_code/acp/slash_registry.py:46
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Command '/{cmd_name}' is not supported over ACP. Supported commands: "
@@ -56,21 +55,21 @@ msgstr ""
 "Der Befehl '/{cmd_name}' wird über ACP nicht unterstützt. Unterstützte "
 "Befehle: {supported}"
 
-#: src/iac_code/acp/slash_registry.py:62
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Command '/{cmd_name}' handler not implemented."
 msgstr "Der Handler für den Befehl '/{cmd_name}' ist nicht implementiert."
 
-#: src/iac_code/acp/slash_registry.py:74
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Compaction failed: {error}"
 msgstr "Komprimierung fehlgeschlagen: {error}"
 
-#: src/iac_code/acp/slash_registry.py:77 src/iac_code/commands/compact.py:24
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Nothing to compact: conversation is empty."
 msgstr "Nichts zu komprimieren: Die Konversation ist leer."
 
-#: src/iac_code/acp/slash_registry.py:80 src/iac_code/commands/compact.py:27
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Conversation too short to compact: all messages are within the recent "
@@ -79,11 +78,11 @@ msgstr ""
 "Konversation zu kurz zum Komprimieren: Alle Nachrichten liegen im "
 "Erhaltungsfenster der letzten {turns} Runden."
 
-#: src/iac_code/acp/slash_registry.py:84 src/iac_code/commands/compact.py:30
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Compaction failed. See logs for details."
 msgstr "Komprimierung fehlgeschlagen. Details finden Sie in den Protokollen."
 
-#: src/iac_code/acp/slash_registry.py:89
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent} reduction)."
@@ -92,123 +91,121 @@ msgstr ""
 "Kontext komprimiert: {original} → {compacted} Tokens ({percent} "
 "Reduzierung). Kontextnutzung: {usage}"
 
-#: src/iac_code/acp/slash_registry.py:103
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Clear failed: {error}"
 msgstr "Löschen fehlgeschlagen: {error}"
 
-#: src/iac_code/acp/slash_registry.py:104
+#: src/iac_code/acp/slash_registry.py
 msgid "Conversation history cleared."
 msgstr "Konversationsverlauf gelöscht."
 
-#: src/iac_code/acp/slash_registry.py:120 src/iac_code/commands/debug.py:34
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging is on. Log file: {path}"
 msgstr "Debug-Protokollierung ist aktiv. Protokolldatei: {path}"
 
-#: src/iac_code/acp/slash_registry.py:121 src/iac_code/commands/debug.py:35
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging is off."
 msgstr "Debug-Protokollierung ist inaktiv."
 
-#: src/iac_code/acp/slash_registry.py:125 src/iac_code/commands/debug.py:39
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging enabled. Log file: {path}"
 msgstr "Debug-Protokollierung aktiviert. Protokolldatei: {path}"
 
-#: src/iac_code/acp/slash_registry.py:129 src/iac_code/commands/debug.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging disabled."
 msgstr "Debug-Protokollierung deaktiviert."
 
-#: src/iac_code/acp/slash_registry.py:131 src/iac_code/commands/debug.py:45
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Usage: /debug [on|off]"
 msgstr "Verwendung: /debug [on|off]"
 
-#: src/iac_code/acp/slash_registry.py:136 src/iac_code/commands/memory.py:84
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/memory.py
 msgid "Memory manager is unavailable."
 msgstr "Der Speicher-Manager ist nicht verfügbar."
 
-#: src/iac_code/acp/slash_registry.py:146 src/iac_code/commands/rename.py:21
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 msgid "Usage: /rename <name>"
 msgstr "Verwendung: /rename <name>"
 
-#: src/iac_code/acp/slash_registry.py:152
+#: src/iac_code/acp/slash_registry.py
 msgid "Rename is only available after a session is created."
 msgstr "Umbenennen ist erst verfügbar, nachdem eine Sitzung erstellt wurde."
 
-#: src/iac_code/acp/slash_registry.py:163 src/iac_code/commands/rename.py:42
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Session is already named {name}"
 msgstr "Die Sitzung heißt bereits {name}"
 
-#: src/iac_code/acp/slash_registry.py:164 src/iac_code/commands/rename.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Renamed session to {name}"
 msgstr "Sitzung in {name} umbenannt"
 
-#: src/iac_code/agent/agent_loop.py:413 src/iac_code/agent/agent_loop.py:428
-#: src/iac_code/ui/repl.py:813 src/iac_code/ui/repl.py:827
+#: src/iac_code/agent/agent_loop.py src/iac_code/ui/repl.py
 msgid "Permission denied."
 msgstr "Zugriff verweigert."
 
-#: src/iac_code/agent/agent_tool.py:266
+#: src/iac_code/agent/agent_tool.py
 #, python-brace-format
 msgid "Done ({tool_count} tool uses · {token_display} tokens)"
 msgstr "Fertig ({tool_count} Tool-Aufrufe · {token_display} Tokens)"
 
-#: src/iac_code/agent/agent_tool.py:276
+#: src/iac_code/agent/agent_tool.py
 msgid "Explore"
 msgstr "Erkunden"
 
-#: src/iac_code/agent/agent_tool.py:277
+#: src/iac_code/agent/agent_tool.py
 msgid "Plan"
 msgstr "Plan"
 
-#: src/iac_code/agent/agent_tool.py:278 src/iac_code/agent/agent_tool.py:279
-#: src/iac_code/agent/agent_tool.py:280
+#: src/iac_code/agent/agent_tool.py
 msgid "Agent"
 msgstr "Agent"
 
-#: src/iac_code/cli/headless.py:50
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool started: {}"
 msgstr "Tool gestartet: {}"
 
-#: src/iac_code/cli/headless.py:53
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool failed: {}"
 msgstr "Tool fehlgeschlagen: {}"
 
-#: src/iac_code/cli/headless.py:55
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool finished: {}"
 msgstr "Tool abgeschlossen: {}"
 
-#: src/iac_code/cli/headless.py:59
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool failed: {}"
 msgstr "Untertool fehlgeschlagen: {}"
 
-#: src/iac_code/cli/headless.py:61
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool finished: {}"
 msgstr "Untertool abgeschlossen: {}"
 
-#: src/iac_code/cli/headless.py:63
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool started: {}"
 msgstr "Untertool gestartet: {}"
 
-#: src/iac_code/cli/headless.py:65
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack {}: {} ({:.1f}%)"
 msgstr "Stack {}: {} ({:.1f}%)"
 
-#: src/iac_code/cli/headless.py:71
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack group {}: {} ({}%)"
 msgstr "Stack-Gruppe {}: {} ({}%)"
 
-#: src/iac_code/cli/headless.py:110
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -228,27 +225,27 @@ msgstr ""
 "  Dokumentation: https://aliyun.github.io/iac-"
 "code/de/docs/configuration/authentication\n"
 
-#: src/iac_code/cli/install_git_bash.py:40
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git Bash is already installed at {}"
 msgstr "Git Bash ist bereits installiert unter {}"
 
-#: src/iac_code/cli/install_git_bash.py:43
+#: src/iac_code/cli/install_git_bash.py
 msgid "Installing Git for Windows via npmmirror..."
 msgstr "Git for Windows wird über npmmirror installiert..."
 
-#: src/iac_code/cli/install_git_bash.py:59
+#: src/iac_code/cli/install_git_bash.py
 msgid "powershell.exe was not found on PATH; cannot run installer."
 msgstr ""
 "powershell.exe wurde nicht im PATH gefunden; das Installationsprogramm "
 "kann nicht ausgeführt werden."
 
-#: src/iac_code/cli/install_git_bash.py:66
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Installation failed (PowerShell exited with code {})"
 msgstr "Installation fehlgeschlagen (PowerShell beendet mit Code {})"
 
-#: src/iac_code/cli/install_git_bash.py:77
+#: src/iac_code/cli/install_git_bash.py
 msgid ""
 "Installer exited but bash.exe was not found in common locations; UAC may "
 "have been cancelled or the installer used a non-standard path."
@@ -257,29 +254,32 @@ msgstr ""
 "gefunden; UAC wurde möglicherweise abgebrochen oder der Installer hat "
 "einen nicht standardmäßigen Pfad verwendet."
 
-#: src/iac_code/cli/install_git_bash.py:84
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git for Windows installed at {}"
 msgstr "Git for Windows installiert unter {}"
 
-#: src/iac_code/cli/main.py:33 src/iac_code/commands/help.py:26
+#: src/iac_code/cli/main.py src/iac_code/commands/help.py
 msgid "AI-powered infrastructure orchestration tool"
 msgstr "KI-gestütztes Tool zur Orchestrierung von Infrastruktur"
 
-#: src/iac_code/cli/main.py:41
+#: src/iac_code/cli/main.py
 msgid "Use iac-code as an A2A client."
 msgstr "iac-code als A2A-Client verwenden."
 
-#: src/iac_code/cli/main.py:54
+#: src/iac_code/cli/main.py
 msgid "Install Git for Windows via the npmmirror mirror (Windows only)."
 msgstr "Git for Windows über den npmmirror-Spiegel installieren (nur Windows)."
 
-#: src/iac_code/cli/main.py:61
+#: src/iac_code/cli/main.py
+msgid "Update iac-code to the latest version."
+msgstr "iac-code auf die neueste Version aktualisieren."
+
+#: src/iac_code/cli/main.py
 msgid "YAML config file containing A2A client options"
 msgstr "YAML-Konfigurationsdatei mit A2A-Client-Optionen"
 
-#: src/iac_code/cli/main.py:68 src/iac_code/cli/main.py:1501
-#: src/iac_code/cli/main.py:1862 src/iac_code/cli/main.py:1901
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -287,48 +287,47 @@ msgstr ""
 "A2A-Client-Abhängigkeiten fehlen. Installieren mit: pip install 'iac-"
 "code[a2a]'"
 
-#: src/iac_code/cli/main.py:82
+#: src/iac_code/cli/main.py
 msgid "LLM model to use"
 msgstr "Zu verwendendes LLM-Modell"
 
-#: src/iac_code/cli/main.py:83
+#: src/iac_code/cli/main.py
 msgid "Non-interactive mode: run a single prompt and exit"
 msgstr "Nicht-interaktiver Modus: Einen Prompt ausführen und beenden"
 
-#: src/iac_code/cli/main.py:84
+#: src/iac_code/cli/main.py
 msgid "Output format: text, json, stream-json"
 msgstr "Ausgabeformat: text, json, stream-json"
 
-#: src/iac_code/cli/main.py:85
+#: src/iac_code/cli/main.py
 msgid "Maximum agent turns in headless mode"
 msgstr "Maximale Agent-Runden im Headless-Modus"
 
-#: src/iac_code/cli/main.py:86 src/iac_code/cli/main.py:366
-#: src/iac_code/cli/main.py:591
+#: src/iac_code/cli/main.py
 msgid "Enable debug logging"
 msgstr "Debug-Protokollierung aktivieren"
 
-#: src/iac_code/cli/main.py:87
+#: src/iac_code/cli/main.py
 msgid "Show headless progress on stderr"
 msgstr "Headless-Fortschritt auf stderr anzeigen"
 
-#: src/iac_code/cli/main.py:88
+#: src/iac_code/cli/main.py
 msgid "Show version and exit"
 msgstr "Version anzeigen und beenden"
 
-#: src/iac_code/cli/main.py:89
+#: src/iac_code/cli/main.py
 msgid "Resume a session by ID or name"
 msgstr "Sitzung per ID oder Name fortsetzen"
 
-#: src/iac_code/cli/main.py:90
+#: src/iac_code/cli/main.py
 msgid "Resume the most recent session"
 msgstr "Die zuletzt genutzte Sitzung fortsetzen"
 
-#: src/iac_code/cli/main.py:97 src/iac_code/i18n/__init__.py:55
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid "Install completion for the current shell."
 msgstr "Vervollständigung für die aktuelle Shell installieren."
 
-#: src/iac_code/cli/main.py:105 src/iac_code/i18n/__init__.py:56
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid ""
 "Show completion for the current shell, to copy it or customize the "
 "installation."
@@ -336,7 +335,7 @@ msgstr ""
 "Vervollständigung für die aktuelle Shell anzeigen, zum Kopieren oder "
 "Anpassen der Installation."
 
-#: src/iac_code/cli/main.py:110
+#: src/iac_code/cli/main.py
 msgid ""
 "Comma-separated tool permission patterns to allow, e.g. 'bash(git "
 "*),write_file'"
@@ -344,53 +343,53 @@ msgstr ""
 "Durch Komma getrennte Tool-Berechtigungsmuster zum Erlauben, z.B. "
 "'bash(git *),write_file'*),write_file'"
 
-#: src/iac_code/cli/main.py:115
+#: src/iac_code/cli/main.py
 msgid "Comma-separated tool permission patterns to deny"
 msgstr "Durch Komma getrennte Tool-Berechtigungsmuster zum Verweigern"
 
-#: src/iac_code/cli/main.py:120
+#: src/iac_code/cli/main.py
 msgid "Permission mode: default, accept_edits, bypass_permissions, dont_ask"
 msgstr ""
 "Permission mode: default, accept_edits, bypass_permissions, "
 "dont_askBerechtigungsmodus: default, accept_edits, bypass_permissions, "
 "dont_ask"
 
-#: src/iac_code/cli/main.py:151
+#: src/iac_code/cli/main.py
 msgid "Error: --resume and --continue cannot be used together."
 msgstr ""
 "Error: --resume and --continue cannot be used together.Fehler: --resume "
 "und --continue können nicht gemeinsam verwendet werden."
 
-#: src/iac_code/cli/main.py:163
+#: src/iac_code/cli/main.py
 #, python-brace-format
 msgid "Invalid --output-format '{}'. Valid values: {}"
 msgstr "Ungültiges --output-format '{}'. Gültige Werte: {}"
 
-#: src/iac_code/cli/main.py:361
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an ACP server."
 msgstr "iac-code als ACP-Server ausführen."
 
-#: src/iac_code/cli/main.py:363
+#: src/iac_code/cli/main.py
 msgid "Transport type: stdio or http"
 msgstr "Transporttyp: stdio oder http"
 
-#: src/iac_code/cli/main.py:364
+#: src/iac_code/cli/main.py
 msgid "HTTP server port"
 msgstr "HTTP-Server-Port"
 
-#: src/iac_code/cli/main.py:365 src/iac_code/cli/main.py:581
+#: src/iac_code/cli/main.py
 msgid "HTTP server host"
 msgstr "HTTP-Server-Host"
 
-#: src/iac_code/cli/main.py:577
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an A2A 1.0 server."
 msgstr "iac-code als A2A 1.0-Server ausführen."
 
-#: src/iac_code/cli/main.py:580
+#: src/iac_code/cli/main.py
 msgid "YAML config file for A2A server options"
 msgstr "YAML-Konfigurationsdatei für A2A-Server-Optionen"
 
-#: src/iac_code/cli/main.py:584
+#: src/iac_code/cli/main.py
 msgid ""
 "HTTP server port. 41242 is the iac-code default inspired by Gemini CLI, "
 "not a registered A2A port."
@@ -398,7 +397,7 @@ msgstr ""
 "HTTP-Serverport. 41242 ist der von Gemini CLI inspirierte iac-code-"
 "Standard, kein registrierter A2A-Port."
 
-#: src/iac_code/cli/main.py:589
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc, or "
 "redis-streams"
@@ -406,7 +405,7 @@ msgstr ""
 "A2A-Transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc oder "
 "redis-streams"
 
-#: src/iac_code/cli/main.py:595
+#: src/iac_code/cli/main.py
 msgid ""
 "Expose A2A thinking signal types; repeat for multiple. Values: raw-"
 "thinking, tool-trace."
@@ -414,7 +413,7 @@ msgstr ""
 "Legt A2A-Thinking-Signaltypen offen; fuer mehrere Werte wiederholen. "
 "Werte: raw-thinking, tool-trace."
 
-#: src/iac_code/cli/main.py:646
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -422,609 +421,598 @@ msgstr ""
 "A2A-Server-Abhängigkeiten fehlen. Installieren mit: pip install 'iac-"
 "code[a2a]'"
 
-#: src/iac_code/cli/main.py:778
+#: src/iac_code/cli/main.py
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Sendet einen Prompt an einen A2A-JSON-RPC-Endpunkt."
 
-#: src/iac_code/cli/main.py:781 src/iac_code/cli/main.py:951
-#: src/iac_code/cli/main.py:1004 src/iac_code/cli/main.py:1064
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1163
-#: src/iac_code/cli/main.py:1242 src/iac_code/cli/main.py:1299
-#: src/iac_code/cli/main.py:1355 src/iac_code/cli/main.py:1412
+#: src/iac_code/cli/main.py
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL des A2A-JSON-RPC-Endpunkts"
 
-#: src/iac_code/cli/main.py:782 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Routen-Spezifikation: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:783
+#: src/iac_code/cli/main.py
 msgid "Named A2A route to call"
 msgstr "Aufzurufende benannte A2A-Route"
 
-#: src/iac_code/cli/main.py:784
+#: src/iac_code/cli/main.py
 msgid "Prompt to send"
 msgstr "Zu sendender Prompt"
 
-#: src/iac_code/cli/main.py:785
+#: src/iac_code/cli/main.py
 msgid "Working directory metadata to send with the request"
 msgstr "Arbeitsverzeichnis-Metadaten, die mit der Anfrage gesendet werden"
 
-#: src/iac_code/cli/main.py:786
+#: src/iac_code/cli/main.py
 msgid "A2A context ID to continue"
 msgstr "Fortzusetzende A2A-Kontext-ID"
 
-#: src/iac_code/cli/main.py:787 src/iac_code/cli/main.py:882
-#: src/iac_code/cli/main.py:954 src/iac_code/cli/main.py:1011
-#: src/iac_code/cli/main.py:1066 src/iac_code/cli/main.py:1116
-#: src/iac_code/cli/main.py:1170 src/iac_code/cli/main.py:1245
-#: src/iac_code/cli/main.py:1303 src/iac_code/cli/main.py:1358
-#: src/iac_code/cli/main.py:1413
+#: src/iac_code/cli/main.py
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Bearer-Token für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:788 src/iac_code/cli/main.py:883
-#: src/iac_code/cli/main.py:955 src/iac_code/cli/main.py:1012
-#: src/iac_code/cli/main.py:1067 src/iac_code/cli/main.py:1117
-#: src/iac_code/cli/main.py:1171 src/iac_code/cli/main.py:1246
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1359
-#: src/iac_code/cli/main.py:1414
+#: src/iac_code/cli/main.py
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Basic-Auth-Benutzername für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:789 src/iac_code/cli/main.py:884
-#: src/iac_code/cli/main.py:956 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1068 src/iac_code/cli/main.py:1118
-#: src/iac_code/cli/main.py:1172 src/iac_code/cli/main.py:1247
-#: src/iac_code/cli/main.py:1305 src/iac_code/cli/main.py:1360
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Basic-Auth-Passwort für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:790 src/iac_code/cli/main.py:885
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1069 src/iac_code/cli/main.py:1119
-#: src/iac_code/cli/main.py:1173 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1306 src/iac_code/cli/main.py:1361
-#: src/iac_code/cli/main.py:1416
+#: src/iac_code/cli/main.py
 msgid "API key for A2A HTTP requests"
 msgstr "API-Schlüssel für A2A-HTTP-Anfragen"
 
-#: src/iac_code/cli/main.py:791 src/iac_code/cli/main.py:886
-#: src/iac_code/cli/main.py:958 src/iac_code/cli/main.py:1015
-#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1120
-#: src/iac_code/cli/main.py:1174 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1307 src/iac_code/cli/main.py:1362
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py
 msgid "HTTP header name for A2A API key"
 msgstr "HTTP-Header-Name für den A2A-API-Schlüssel"
 
-#: src/iac_code/cli/main.py:796 src/iac_code/cli/main.py:891
+#: src/iac_code/cli/main.py
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Geheimnis zur Verifizierung der A2A Agent Card"
 
-#: src/iac_code/cli/main.py:801 src/iac_code/cli/main.py:896
+#: src/iac_code/cli/main.py
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "Remote-JWKS-URL zur Verifizierung der A2A Agent Card"
 
-#: src/iac_code/cli/main.py:807 src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Eine gültige A2A-Agent-Card-Signatur erfordern"
 
-#: src/iac_code/cli/main.py:809
+#: src/iac_code/cli/main.py
 msgid "A2A call timeout in seconds"
 msgstr "A2A-Aufruf-Timeout in Sekunden"
 
-#: src/iac_code/cli/main.py:810
+#: src/iac_code/cli/main.py
 msgid "Use A2A streaming message delivery"
 msgstr "A2A-Streaming-Nachrichtenübertragung verwenden"
 
-#: src/iac_code/cli/main.py:878
+#: src/iac_code/cli/main.py
 msgid "Discover an A2A Agent Card."
 msgstr "Eine A2A Agent Card entdecken."
 
-#: src/iac_code/cli/main.py:881
+#: src/iac_code/cli/main.py
 msgid "A2A agent base URL"
 msgstr "Basis-URL des A2A-Agenten"
 
-#: src/iac_code/cli/main.py:948
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task."
 msgstr "Eine A2A-Aufgabe abrufen."
 
-#: src/iac_code/cli/main.py:952 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1115 src/iac_code/cli/main.py:1164
-#: src/iac_code/cli/main.py:1243 src/iac_code/cli/main.py:1300
-#: src/iac_code/cli/main.py:1356
+#: src/iac_code/cli/main.py
 msgid "A2A task ID"
 msgstr "A2A-Aufgaben-ID"
 
-#: src/iac_code/cli/main.py:953
+#: src/iac_code/cli/main.py
 msgid "Maximum task history items to return"
 msgstr "Maximale Anzahl zurückzugebender Aufgabenverlaufselemente"
 
-#: src/iac_code/cli/main.py:1001
+#: src/iac_code/cli/main.py
 msgid "List A2A tasks."
 msgstr "A2A-Aufgaben auflisten."
 
-#: src/iac_code/cli/main.py:1005
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A context ID"
 msgstr "Nach A2A-Kontext-ID filtern"
 
-#: src/iac_code/cli/main.py:1006
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A task state"
 msgstr "Nach A2A-Aufgabenzustand filtern"
 
-#: src/iac_code/cli/main.py:1007
+#: src/iac_code/cli/main.py
 msgid "Maximum tasks to return"
 msgstr "Maximale Anzahl zurückzugebender Aufgaben"
 
-#: src/iac_code/cli/main.py:1008 src/iac_code/cli/main.py:1302
+#: src/iac_code/cli/main.py
 msgid "Pagination token"
 msgstr "Paginierungs-Token"
 
-#: src/iac_code/cli/main.py:1009
+#: src/iac_code/cli/main.py
 msgid "Include task artifacts"
 msgstr "Aufgaben-Artefakte einschließen"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py
 msgid "Output format: table or json"
 msgstr "Ausgabeformat: table oder json"
 
-#: src/iac_code/cli/main.py:1061
+#: src/iac_code/cli/main.py
 msgid "Cancel an A2A task."
 msgstr "Eine A2A-Aufgabe abbrechen."
 
-#: src/iac_code/cli/main.py:1111
+#: src/iac_code/cli/main.py
 msgid "Subscribe to an A2A task event stream."
 msgstr "A2A-Aufgaben-Ereignisstrom abonnieren."
 
-#: src/iac_code/cli/main.py:1160
+#: src/iac_code/cli/main.py
 msgid "Create an A2A task push notification config."
 msgstr "Eine Push-Benachrichtigungskonfiguration für eine A2A-Aufgabe erstellen."
 
-#: src/iac_code/cli/main.py:1165 src/iac_code/cli/main.py:1244
-#: src/iac_code/cli/main.py:1357
+#: src/iac_code/cli/main.py
 msgid "Push config ID"
 msgstr "Push-Konfigurations-ID"
 
-#: src/iac_code/cli/main.py:1166
+#: src/iac_code/cli/main.py
 msgid "Push callback URL"
 msgstr "Push-Callback-URL"
 
-#: src/iac_code/cli/main.py:1167
+#: src/iac_code/cli/main.py
 msgid "Notification verification token"
 msgstr "Token zur Benachrichtigungsverifizierung"
 
-#: src/iac_code/cli/main.py:1168
+#: src/iac_code/cli/main.py
 msgid "Callback authentication scheme"
 msgstr "Callback-Authentifizierungsschema"
 
-#: src/iac_code/cli/main.py:1169
+#: src/iac_code/cli/main.py
 msgid "Callback authentication credentials"
 msgstr "Callback-Authentifizierungsanmeldeinformationen"
 
-#: src/iac_code/cli/main.py:1239
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task push notification config."
 msgstr "Eine Push-Benachrichtigungskonfiguration für eine A2A-Aufgabe abrufen."
 
-#: src/iac_code/cli/main.py:1296
+#: src/iac_code/cli/main.py
 msgid "List A2A task push notification configs."
 msgstr "Push-Benachrichtigungskonfigurationen für A2A-Aufgaben auflisten."
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py
 msgid "Maximum configs to return"
 msgstr "Maximale Anzahl zurückzugebender Konfigurationen"
 
-#: src/iac_code/cli/main.py:1352
+#: src/iac_code/cli/main.py
 msgid "Delete an A2A task push notification config."
 msgstr "Eine Push-Benachrichtigungskonfiguration für eine A2A-Aufgabe löschen."
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Eine authentifizierte erweiterte A2A Agent Card abrufen."
 
-#: src/iac_code/cli/main.py:1452
+#: src/iac_code/cli/main.py
 msgid "Preview A2A route resolution."
 msgstr "Vorschau der A2A-Routenauflösung."
 
-#: src/iac_code/cli/main.py:1459
+#: src/iac_code/cli/main.py
 msgid "Route name to resolve"
 msgstr "Aufzulösender Routenname"
 
-#: src/iac_code/cli/main.py:1460
+#: src/iac_code/cli/main.py
 msgid "Skill ID to resolve"
 msgstr "Aufzulösende Skill-ID"
 
-#: src/iac_code/cli/main.py:1461
+#: src/iac_code/cli/main.py
 msgid "Prompt text used for tag/name route matching"
 msgstr "Prompt-Text für die Tag-/Namens-Routenübereinstimmung"
 
-#: src/iac_code/cli/main.py:1466
+#: src/iac_code/cli/main.py
 msgid "Directory for persisted A2A routes"
 msgstr "Verzeichnis für persistierte A2A-Routen"
 
-#: src/iac_code/cli/main.py:1468
+#: src/iac_code/cli/main.py
 msgid "Save the provided routes as a route snapshot"
 msgstr "Speichert die angegebenen Routen als Routen-Snapshot"
 
-#: src/iac_code/commands/__init__.py:26
+#: src/iac_code/cli/update.py
+msgid "Check for updates without installing."
+msgstr "Auf Updates prüfen, ohne zu installieren."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "iac-code is already up to date (v{})."
+msgstr "iac-code ist bereits auf dem neuesten Stand (v{})."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update available: v{} -> v{}"
+msgstr "Update verfügbar: v{} -> v{}"
+
+#: src/iac_code/cli/update.py src/iac_code/ui/banner.py
+#, python-brace-format
+msgid "Run {} to update."
+msgstr "Führe {} aus, um zu aktualisieren."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Updating iac-code from v{} to v{}..."
+msgstr "iac-code wird von v{} auf v{} aktualisiert..."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed: {}"
+msgstr "Update-Befehl fehlgeschlagen: {}"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed with exit code {}."
+msgstr "Update-Befehl mit Exit-Code {} fehlgeschlagen."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Successfully updated to v{}!"
+msgstr "Erfolgreich auf v{} aktualisiert!"
+
+#: src/iac_code/commands/__init__.py
 msgid "Show available commands"
 msgstr "Verfügbare Befehle anzeigen"
 
-#: src/iac_code/commands/__init__.py:35
+#: src/iac_code/commands/__init__.py
 msgid "Clear conversation history"
 msgstr "Konversationsverlauf löschen"
 
-#: src/iac_code/commands/__init__.py:43
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch model"
 msgstr "Modell anzeigen oder wechseln"
 
-#: src/iac_code/commands/__init__.py:52
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch thinking effort"
 msgstr "Thinking-Effort anzeigen oder wechseln"
 
-#: src/iac_code/commands/__init__.py:61
+#: src/iac_code/commands/__init__.py
 msgid "Compact conversation context"
 msgstr "Konversationskontext komprimieren"
 
-#: src/iac_code/commands/__init__.py:63
+#: src/iac_code/commands/__init__.py
 msgid "Compacting conversation"
 msgstr "Konversation wird komprimiert"
 
-#: src/iac_code/commands/__init__.py:70
+#: src/iac_code/commands/__init__.py
 msgid "Exit the application"
 msgstr "Anwendung beenden"
 
-#: src/iac_code/commands/__init__.py:79
+#: src/iac_code/commands/__init__.py
 msgid "Authenticate with LLM provider"
 msgstr "Beim LLM-Anbieter authentifizieren"
 
-#: src/iac_code/commands/__init__.py:88
+#: src/iac_code/commands/__init__.py
 msgid "Toggle debug logging"
 msgstr "Debug-Protokollierung umschalten"
 
-#: src/iac_code/commands/__init__.py:97
+#: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"
 msgstr "Persistente Erinnerungen anzeigen und verwalten"
 
-#: src/iac_code/commands/__init__.py:99
+#: src/iac_code/commands/__init__.py
 msgid "[<name>|search <query>|delete <name>|help]"
 msgstr "[<Name>|search <Suchbegriff>|delete <Name>|help]"
 
-#: src/iac_code/commands/__init__.py:106
+#: src/iac_code/commands/__init__.py
 msgid "Resume a previous session"
 msgstr "Eine frühere Sitzung fortsetzen"
 
-#: src/iac_code/commands/__init__.py:108
+#: src/iac_code/commands/__init__.py
 msgid "[conversation id or search term]"
 msgstr "[Konversations-ID oder Suchbegriff]"
 
-#: src/iac_code/commands/__init__.py:115
+#: src/iac_code/commands/__init__.py
 msgid "Rename the current session"
 msgstr "Aktuelle Sitzung umbenennen"
 
-#: src/iac_code/commands/__init__.py:124
+#: src/iac_code/commands/__init__.py
 msgid "Manage skills"
 msgstr "Skills verwalten"
 
-#: src/iac_code/commands/__init__.py:132
+#: src/iac_code/commands/__init__.py
 msgid "Show current session status"
 msgstr "Aktuellen Sitzungsstatus anzeigen"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:1117
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Navigate"
 msgstr "Navigieren"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:538
-#: src/iac_code/commands/auth.py:570 src/iac_code/commands/auth.py:577
-#: src/iac_code/commands/auth.py:612 src/iac_code/commands/auth.py:619
-#: src/iac_code/commands/auth.py:640 src/iac_code/commands/auth.py:1117
-#: src/iac_code/commands/auth.py:1551 src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:536
-#: src/iac_code/commands/auth.py:538 src/iac_code/commands/auth.py:570
-#: src/iac_code/commands/auth.py:577 src/iac_code/commands/auth.py:612
-#: src/iac_code/commands/auth.py:619 src/iac_code/commands/auth.py:640
-#: src/iac_code/commands/auth.py:1117 src/iac_code/commands/auth.py:1443
-#: src/iac_code/commands/auth.py:1551
+#: src/iac_code/commands/auth.py
 msgid "Back"
 msgstr "Zurück"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Keep"
 msgstr "Behalten"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Re-enter"
 msgstr "Erneut eingeben"
 
-#: src/iac_code/commands/auth.py:749 src/iac_code/commands/auth.py:863
-#: src/iac_code/commands/auth.py:921 src/iac_code/commands/auth.py:929
-#: src/iac_code/commands/auth.py:956
+#: src/iac_code/commands/auth.py
 msgid " (current)"
 msgstr " (aktuell)"
 
-#: src/iac_code/commands/auth.py:752
+#: src/iac_code/commands/auth.py
 msgid "Custom model..."
 msgstr "Benutzerdefiniertes Modell …"
 
-#: src/iac_code/commands/auth.py:755
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select model for {provider}"
 msgstr "Modell für {provider} auswählen"
 
-#: src/iac_code/commands/auth.py:757
+#: src/iac_code/commands/auth.py
 msgid "Select model"
 msgstr "Modell auswählen"
 
-#: src/iac_code/commands/auth.py:765
+#: src/iac_code/commands/auth.py
 msgid "Enter custom model name: "
 msgstr "Benutzerdefinierten Modellnamen eingeben: "
 
-#: src/iac_code/commands/auth.py:791
+#: src/iac_code/commands/auth.py
 msgid "Error: console not available"
 msgstr "Fehler: Konsole nicht verfügbar"
 
-#: src/iac_code/commands/auth.py:820
+#: src/iac_code/commands/auth.py
 msgid "Configure LLM Provider"
 msgstr "LLM-Anbieter konfigurieren"
 
-#: src/iac_code/commands/auth.py:821
+#: src/iac_code/commands/auth.py
 msgid "Configure IaC Cloud Service"
 msgstr "IaC-Cloud-Dienst konfigurieren"
 
-#: src/iac_code/commands/auth.py:823
+#: src/iac_code/commands/auth.py
 msgid "Select configuration type"
 msgstr "Konfigurationstyp auswählen"
 
-#: src/iac_code/commands/auth.py:825 src/iac_code/commands/auth.py:981
-#: src/iac_code/commands/auth.py:997 src/iac_code/commands/auth.py:1076
-#: src/iac_code/commands/auth.py:1490 src/iac_code/commands/auth.py:1531
+#: src/iac_code/commands/auth.py
 msgid "Auth cancelled"
 msgstr "Authentifizierung abgebrochen"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:961
-#: src/iac_code/commands/auth.py:1051
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select provider — {group}"
 msgstr "Anbieter auswählen — {group}"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:919
-#: src/iac_code/commands/auth.py:1036
+#: src/iac_code/commands/auth.py
 msgid "Third-party"
 msgstr "Drittanbieter"
 
-#: src/iac_code/commands/auth.py:877
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider}"
 msgstr "{status}: {provider}"
 
-#: src/iac_code/commands/auth.py:878 src/iac_code/commands/auth.py:1029
+#: src/iac_code/commands/auth.py
 msgid "Configured"
 msgstr "Konfiguriert"
 
-#: src/iac_code/commands/auth.py:933
+#: src/iac_code/commands/auth.py
 msgid "Select provider"
 msgstr "Anbieter auswählen"
 
-#: src/iac_code/commands/auth.py:974
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Configure {provider}"
 msgstr "{provider} konfigurieren"
 
-#: src/iac_code/commands/auth.py:990
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Enter API key for {provider}"
 msgstr "API-Key für {provider} eingeben"
 
-#: src/iac_code/commands/auth.py:1028
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider} / {model}"
 msgstr "{status}: {provider} / {model}"
 
-#: src/iac_code/commands/auth.py:1037 src/iac_code/commands/auth.py:1058
+#: src/iac_code/commands/auth.py
 msgid "Alibaba Cloud"
 msgstr "Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1038 src/iac_code/providers/registry.py:427
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "ZhiPu AI"
 msgstr "ZhiPu AI"
 
-#: src/iac_code/commands/auth.py:1039
+#: src/iac_code/commands/auth.py
 msgid "Kimi"
 msgstr "Kimi"
 
-#: src/iac_code/commands/auth.py:1040
+#: src/iac_code/commands/auth.py
 msgid "MiniMax"
 msgstr "MiniMax"
 
-#: src/iac_code/commands/auth.py:1041 src/iac_code/providers/registry.py:429
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Volcengine"
 msgstr "Volcengine"
 
-#: src/iac_code/commands/auth.py:1042
+#: src/iac_code/commands/auth.py
 msgid "SiliconFlow"
 msgstr "SiliconFlow"
 
-#: src/iac_code/commands/auth.py:1043 src/iac_code/providers/registry.py:420
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: src/iac_code/commands/auth.py:1044 src/iac_code/providers/registry.py:418
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: src/iac_code/commands/auth.py:1045 src/iac_code/providers/registry.py:419
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Anthropic"
 msgstr "Anthropic"
 
-#: src/iac_code/commands/auth.py:1046 src/iac_code/providers/registry.py:422
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
-#: src/iac_code/commands/auth.py:1047 src/iac_code/providers/registry.py:435
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Azure OpenAI"
 msgstr "Azure OpenAI"
 
-#: src/iac_code/commands/auth.py:1048 src/iac_code/providers/registry.py:434
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenRouter"
 msgstr "OpenRouter"
 
-#: src/iac_code/commands/auth.py:1049
+#: src/iac_code/commands/auth.py
 msgid "Local"
 msgstr "Lokal"
 
-#: src/iac_code/commands/auth.py:1050
+#: src/iac_code/commands/auth.py
 msgid "Compatible"
 msgstr "Kompatibel"
 
-#: src/iac_code/commands/auth.py:1067
+#: src/iac_code/commands/auth.py
 msgid "Select Cloud Provider"
 msgstr "Cloud-Anbieter auswählen"
 
-#: src/iac_code/commands/auth.py:1083
+#: src/iac_code/commands/auth.py
 msgid "Credential"
 msgstr "Anmeldedaten"
 
-#: src/iac_code/commands/auth.py:1084 src/iac_code/commands/auth.py:1199
-#: src/iac_code/commands/auth.py:1527 src/iac_code/commands/status.py:36
-#: src/iac_code/ui/renderer.py:455
+#: src/iac_code/commands/auth.py src/iac_code/commands/status.py
+#: src/iac_code/ui/renderer.py
 msgid "Region"
 msgstr "Region"
 
-#: src/iac_code/commands/auth.py:1086
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud"
 msgstr "Alibaba Cloud konfigurieren"
 
-#: src/iac_code/commands/auth.py:1188
+#: src/iac_code/commands/auth.py
 msgid "Current configuration"
 msgstr "Aktuelle Konfiguration"
 
-#: src/iac_code/commands/auth.py:1190
+#: src/iac_code/commands/auth.py
 msgid "Mode"
 msgstr "Modus"
 
-#: src/iac_code/commands/auth.py:1196
+#: src/iac_code/commands/auth.py
 msgid "(not set)"
 msgstr "(nicht gesetzt)"
 
-#: src/iac_code/commands/auth.py:1205
+#: src/iac_code/commands/auth.py
 msgid "AccessKey"
 msgstr "AccessKey"
 
-#: src/iac_code/commands/auth.py:1207 src/iac_code/commands/auth.py:1219
+#: src/iac_code/commands/auth.py
 msgid "STS Token"
 msgstr "STS-Token"
 
-#: src/iac_code/commands/auth.py:1209
+#: src/iac_code/commands/auth.py
 msgid "RAM Role"
 msgstr "RAM-Rolle"
 
-#: src/iac_code/commands/auth.py:1211
+#: src/iac_code/commands/auth.py
 msgid "OAuth Login (Browser)"
 msgstr "OAuth-Anmeldung (Browser)"
 
-#: src/iac_code/commands/auth.py:1217
+#: src/iac_code/commands/auth.py
 msgid "AccessKey ID"
 msgstr "AccessKey-ID"
 
-#: src/iac_code/commands/auth.py:1218
+#: src/iac_code/commands/auth.py
 msgid "AccessKey Secret"
 msgstr "AccessKey-Secret"
 
-#: src/iac_code/commands/auth.py:1220
+#: src/iac_code/commands/auth.py
 msgid "RAM Role ARN"
 msgstr "RAM-Rollen-ARN"
 
-#: src/iac_code/commands/auth.py:1221
+#: src/iac_code/commands/auth.py
 msgid "Session Name"
 msgstr "Sitzungsname"
 
-#: src/iac_code/commands/auth.py:1222
+#: src/iac_code/commands/auth.py
 msgid "OAuth Site Type"
 msgstr "OAuth-Standorttyp"
 
-#: src/iac_code/commands/auth.py:1223
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token"
 msgstr "OAuth-Zugriffstoken"
 
-#: src/iac_code/commands/auth.py:1224
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token"
 msgstr "OAuth-Refresh-Token"
 
-#: src/iac_code/commands/auth.py:1225
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token Expire"
 msgstr "Ablaufzeit des OAuth-Zugriffstokens"
 
-#: src/iac_code/commands/auth.py:1226
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token Expire"
 msgstr "Ablaufzeit des OAuth-Refresh-Tokens"
 
-#: src/iac_code/commands/auth.py:1227
+#: src/iac_code/commands/auth.py
 msgid "STS Expiration"
 msgstr "STS-Ablaufzeit"
 
-#: src/iac_code/commands/auth.py:1384
+#: src/iac_code/commands/auth.py
 msgid "China"
 msgstr "China"
 
-#: src/iac_code/commands/auth.py:1385
+#: src/iac_code/commands/auth.py
 msgid "International"
 msgstr "International"
 
-#: src/iac_code/commands/auth.py:1387
+#: src/iac_code/commands/auth.py
 msgid "Choose site type"
 msgstr "Standorttyp auswählen"
 
-#: src/iac_code/commands/auth.py:1402
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Alibaba Cloud OAuth login failed: {error}"
 msgstr "Alibaba Cloud OAuth-Anmeldung fehlgeschlagen: {error}"
 
-#: src/iac_code/commands/auth.py:1418
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud OAuth credentials saved"
 msgstr "Konfiguriert: Alibaba Cloud-OAuth-Anmeldedaten gespeichert"
 
-#: src/iac_code/commands/auth.py:1430
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud credentials"
 msgstr "Alibaba Cloud-Anmeldedaten konfigurieren"
 
-#: src/iac_code/commands/auth.py:1443
+#: src/iac_code/commands/auth.py
 msgid "Reconfigure credential"
 msgstr "Anmeldedaten neu konfigurieren"
 
-#: src/iac_code/commands/auth.py:1456
+#: src/iac_code/commands/auth.py
 msgid "Select credential type"
 msgstr "Anmeldedatentyp auswählen"
 
-#: src/iac_code/commands/auth.py:1512
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud credentials saved to ~/.iac-code"
 msgstr "Konfiguriert: Alibaba Cloud-Anmeldedaten unter ~/.iac-code gespeichert"
 
-#: src/iac_code/commands/auth.py:1519
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud region"
 msgstr "Alibaba Cloud-Region konfigurieren"
 
-#: src/iac_code/commands/auth.py:1545
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud region saved to ~/.iac-code"
 msgstr "Konfiguriert: Alibaba Cloud-Region unter ~/.iac-code gespeichert"
 
-#: src/iac_code/commands/compact.py:12
+#: src/iac_code/commands/compact.py
 msgid "Compact command requires a context."
 msgstr "Der Befehl compact erfordert einen Kontext."
 
-#: src/iac_code/commands/compact.py:16
+#: src/iac_code/commands/compact.py
 msgid "No active REPL."
 msgstr "Kein aktives REPL."
 
-#: src/iac_code/commands/compact.py:20
+#: src/iac_code/commands/compact.py
 msgid "No active agent loop."
 msgstr "Keine aktive Agent-Schleife."
 
-#: src/iac_code/commands/compact.py:35
+#: src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent_display} "
@@ -1033,108 +1021,107 @@ msgstr ""
 "Kontext komprimiert: {original} → {compacted} Tokens (Reduzierung "
 "{percent_display}). Kontextnutzung: {usage_display}"
 
-#: src/iac_code/commands/debug.py:21
+#: src/iac_code/commands/debug.py
 msgid "Debug command requires a context."
 msgstr "Der Befehl debug erfordert einen Kontext."
 
-#: src/iac_code/commands/debug.py:26
+#: src/iac_code/commands/debug.py
 msgid "No active session."
 msgstr "Keine aktive Sitzung."
 
-#: src/iac_code/commands/effort.py:54 src/iac_code/commands/model.py:95
-#: src/iac_code/commands/model.py:99
+#: src/iac_code/commands/effort.py src/iac_code/commands/model.py
 msgid "No configured providers. Run /auth first."
 msgstr "Keine konfigurierten Anbieter. Führen Sie zuerst /auth aus."
 
-#: src/iac_code/commands/effort.py:58
+#: src/iac_code/commands/effort.py
 msgid "No model selected. Run /model first."
 msgstr "Kein Modell ausgewählt. Führen Sie zuerst /model aus."
 
-#: src/iac_code/commands/effort.py:66
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Model {model} does not support effort."
 msgstr "Modell {model} unterstützt keinen Thinking-Effort."
 
-#: src/iac_code/commands/effort.py:80
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Invalid effort. Allowed: {labels}"
 msgstr "Ungültiger Thinking-Effort. Zulässig: {labels}"
 
-#: src/iac_code/commands/effort.py:85
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Current effort: {effort}"
 msgstr "Aktueller Thinking-Effort: {effort}"
 
-#: src/iac_code/commands/effort.py:94
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Select effort for {model}"
 msgstr "Thinking-Effort für {model} auswählen"
 
-#: src/iac_code/commands/effort.py:103 src/iac_code/commands/effort.py:107
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Kept effort as {effort}"
 msgstr "Thinking-Effort beibehalten: {effort}"
 
-#: src/iac_code/commands/effort.py:116
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Effort switched to: {effort}"
 msgstr "Thinking-Effort gewechselt auf: {effort}"
 
-#: src/iac_code/commands/help.py:29
+#: src/iac_code/commands/help.py
 msgid "Commands:"
 msgstr "Befehle:"
 
-#: src/iac_code/commands/help.py:36
+#: src/iac_code/commands/help.py
 msgid "Shortcuts:"
 msgstr "Tastenkürzel:"
 
-#: src/iac_code/commands/help.py:39
+#: src/iac_code/commands/help.py
 msgid "Send message"
 msgstr "Nachricht senden"
 
-#: src/iac_code/commands/help.py:40
+#: src/iac_code/commands/help.py
 msgid "New line"
 msgstr "Neue Zeile"
 
-#: src/iac_code/commands/help.py:41
+#: src/iac_code/commands/help.py
 msgid "Show command suggestions"
 msgstr "Befehlsvorschläge anzeigen"
 
-#: src/iac_code/commands/help.py:42
+#: src/iac_code/commands/help.py
 msgid "Exit"
 msgstr "Beenden"
 
-#: src/iac_code/commands/memory.py:10
+#: src/iac_code/commands/memory.py
 msgid "Usage: /memory [<name>|search <query>|delete <name>|help]"
 msgstr "Verwendung: /memory [<Name>|search <Suchbegriff>|delete <Name>|help]"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "Saved memories:"
 msgstr "Gespeicherte Erinnerungen:"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "No memories saved yet."
 msgstr "Noch keine Erinnerungen gespeichert."
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "Matching memories:"
 msgstr "Passende Erinnerungen:"
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "No matching memories."
 msgstr "Keine passenden Erinnerungen."
 
-#: src/iac_code/commands/memory.py:60 src/iac_code/commands/memory.py:75
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' not found."
 msgstr "Erinnerung '{name}' nicht gefunden."
 
-#: src/iac_code/commands/memory.py:64
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' deleted."
 msgstr "Erinnerung '{name}' gelöscht."
 
-#: src/iac_code/commands/model.py:57
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid ""
 "Model is managed by '{source}'. To change model, modify it in {source} or"
@@ -1143,183 +1130,181 @@ msgstr ""
 "Das Modell wird von '{source}' verwaltet. Ändern Sie es in {source} oder "
 "wechseln Sie den Provider über /auth."
 
-#: src/iac_code/commands/model.py:88 src/iac_code/commands/model.py:143
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Model switched to: {model}"
 msgstr "Modell gewechselt auf: {model}"
 
-#: src/iac_code/commands/model.py:92
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Current model: {model}"
 msgstr "Aktuelles Modell: {model}"
 
-#: src/iac_code/commands/model.py:118
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Kept model as {model}"
 msgstr "Modell beibehalten: {model}"
 
-#: src/iac_code/commands/rename.py:16 src/iac_code/commands/rename.py:28
+#: src/iac_code/commands/rename.py
 msgid "Rename is only available in interactive mode."
 msgstr "Umbenennen ist nur im interaktiven Modus verfügbar."
 
-#: src/iac_code/commands/rename.py:31
+#: src/iac_code/commands/rename.py
 msgid "Rename cancelled"
 msgstr "Umbenennen abgebrochen"
 
-#: src/iac_code/commands/resume.py:22
+#: src/iac_code/commands/resume.py
 msgid "Resume is only available in interactive mode."
 msgstr "/resume ist nur im interaktiven Modus verfügbar."
 
-#: src/iac_code/commands/resume.py:28
+#: src/iac_code/commands/resume.py
 msgid "Resume is unavailable: session index not initialised."
 msgstr "Fortsetzen nicht möglich: Sitzungsindex nicht initialisiert."
 
-#: src/iac_code/commands/resume.py:33 src/iac_code/commands/resume.py:36
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Session not found: {arg}"
 msgstr "Sitzung nicht gefunden: {arg}"
 
-#: src/iac_code/commands/resume.py:52 src/iac_code/commands/resume.py:68
+#: src/iac_code/commands/resume.py
 msgid "Resume cancelled"
 msgstr "Fortsetzen abgebrochen"
 
-#: src/iac_code/commands/resume.py:55
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Unable to resolve session: {arg}"
 msgstr "Sitzung konnte nicht aufgelöst werden: {arg}"
 
-#: src/iac_code/commands/skills.py:14
+#: src/iac_code/commands/skills.py
 msgid "Skills management is only available in interactive mode."
 msgstr "Skill-Verwaltung ist nur im interaktiven Modus verfügbar."
 
-#: src/iac_code/commands/skills.py:25
+#: src/iac_code/commands/skills.py
 msgid "Skills update cancelled"
 msgstr "Skill-Aktualisierung abgebrochen"
 
-#: src/iac_code/commands/skills.py:29
+#: src/iac_code/commands/skills.py
 msgid "Skills updated"
 msgstr "Skills aktualisiert"
 
-#: src/iac_code/commands/status.py:19
+#: src/iac_code/commands/status.py
 msgid "Status command requires a context."
 msgstr "Der Befehl status benötigt einen Kontext."
 
-#: src/iac_code/commands/status.py:22
+#: src/iac_code/commands/status.py
 msgid "Status command requires a REPL context."
 msgstr "Der Befehl status benötigt einen REPL-Kontext."
 
-#: src/iac_code/commands/status.py:24
+#: src/iac_code/commands/status.py
 msgid "Status is only available in interactive mode."
 msgstr "status ist nur im interaktiven Modus verfügbar."
 
-#: src/iac_code/commands/status.py:33 src/iac_code/ui/banner.py:136
-#: src/iac_code/ui/banner.py:138
+#: src/iac_code/commands/status.py src/iac_code/ui/banner.py
 msgid "Session"
 msgstr "Sitzung"
 
-#: src/iac_code/commands/status.py:34
+#: src/iac_code/commands/status.py
 msgid "Provider"
 msgstr "Anbieter"
 
-#: src/iac_code/commands/status.py:34 src/iac_code/commands/status.py:35
-#: src/iac_code/commands/status.py:36
+#: src/iac_code/commands/status.py
 msgid "not configured"
 msgstr "nicht konfiguriert"
 
-#: src/iac_code/commands/status.py:35
+#: src/iac_code/commands/status.py
 msgid "Model"
 msgstr "Modell"
 
-#: src/iac_code/commands/status.py:37
+#: src/iac_code/commands/status.py
 msgid "CWD"
 msgstr "Aktuelles Verzeichnis"
 
-#: src/iac_code/commands/status.py:41
+#: src/iac_code/commands/status.py
 msgid "API Token Usage (recorded):"
 msgstr "API-Token-Nutzung (aufgezeichnet):"
 
-#: src/iac_code/commands/status.py:44
+#: src/iac_code/commands/status.py
 msgid "Input"
 msgstr "Eingabe"
 
-#: src/iac_code/commands/status.py:45
+#: src/iac_code/commands/status.py
 msgid "Output"
 msgstr "Ausgabe"
 
-#: src/iac_code/commands/status.py:46
+#: src/iac_code/commands/status.py
 msgid "Cache read"
 msgstr "Cache-Lesezugriffe"
 
-#: src/iac_code/commands/status.py:47
+#: src/iac_code/commands/status.py
 msgid "Total"
 msgstr "Gesamt"
 
-#: src/iac_code/commands/status.py:50
+#: src/iac_code/commands/status.py
 msgid "No recorded API usage for this session yet."
 msgstr "Für diese Sitzung wurde noch keine API-Nutzung aufgezeichnet."
 
-#: src/iac_code/commands/status.py:54
+#: src/iac_code/commands/status.py
 msgid "Turns"
 msgstr "Runden"
 
-#: src/iac_code/commands/status.py:55
+#: src/iac_code/commands/status.py
 msgid "Context"
 msgstr "Kontext"
 
-#: src/iac_code/commands/status.py:57
+#: src/iac_code/commands/status.py
 msgid "Session Status"
 msgstr "Sitzungsstatus"
 
-#: src/iac_code/commands/status.py:73
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{session_id} (resumed)"
 msgstr "{session_id} (fortgesetzt)"
 
-#: src/iac_code/commands/status.py:81
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{percent} used ({total} / {window})"
 msgstr "{percent} verwendet ({total} / {window})"
 
 # Typer/Click built-in strings
-#: src/iac_code/i18n/__init__.py:51
+#: src/iac_code/i18n/__init__.py
 msgid "Options"
 msgstr "Optionen"
 
-#: src/iac_code/i18n/__init__.py:52
+#: src/iac_code/i18n/__init__.py
 msgid "Commands"
 msgstr "Befehle"
 
-#: src/iac_code/i18n/__init__.py:53
+#: src/iac_code/i18n/__init__.py
 msgid "Arguments"
 msgstr "Argumente"
 
-#: src/iac_code/i18n/__init__.py:54
+#: src/iac_code/i18n/__init__.py
 msgid "Show this message and exit."
 msgstr "Diese Meldung anzeigen und beenden."
 
-#: src/iac_code/i18n/__init__.py:57
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "default: {default}"
 msgstr "Standard: {default}"
 
-#: src/iac_code/i18n/__init__.py:58
+#: src/iac_code/i18n/__init__.py
 msgid "required"
 msgstr "erforderlich"
 
-#: src/iac_code/i18n/__init__.py:59
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "env var: {var}"
 msgstr "Umgebungsvariable: {var}"
 
-#: src/iac_code/i18n/__init__.py:60
+#: src/iac_code/i18n/__init__.py
 msgid "(dynamic)"
 msgstr "(dynamisch)"
 
-#: src/iac_code/i18n/__init__.py:61
+#: src/iac_code/i18n/__init__.py
 msgid "Aborted!"
 msgstr "Abgebrochen!"
 
-#: src/iac_code/providers/manager.py:78
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Cannot determine provider for model: {model}. Run /auth to configure."
 msgstr ""
@@ -1328,14 +1313,14 @@ msgstr ""
 "configure.Anbieter für Modell {model} kann nicht ermittelt werden. Führen"
 " Sie /auth aus, um die Konfiguration vorzunehmen."
 
-#: src/iac_code/providers/manager.py:95
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Unknown provider key: '{key}'. Run /auth to configure."
 msgstr ""
 "Unbekannter Anbieterschlüssel: '{key}'. Führen Sie /auth aus, um die "
 "Konfiguration vorzunehmen."
 
-#: src/iac_code/providers/manager.py:100
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid ""
 "No API key configured for provider '{provider}' (model: {model}). Run "
@@ -1344,7 +1329,7 @@ msgstr ""
 "Kein API-Schlüssel für Anbieter '{provider}' konfiguriert (Modell: "
 "{model}). Führen Sie /auth aus, um die Konfiguration vorzunehmen."
 
-#: src/iac_code/providers/openai_provider.py:307
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned no data. Please check that your API Base URL is correct "
@@ -1355,7 +1340,7 @@ msgstr ""
 "korrekt ist (aktuell: {base_url}). Viele OpenAI-kompatible Endpunkte "
 "erfordern ein /v1-Suffix (z. B. {base_url}/v1)."
 
-#: src/iac_code/providers/openai_provider.py:348
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned an invalid response. Please check that your API Base URL is "
@@ -1366,83 +1351,83 @@ msgstr ""
 " Base URL korrekt ist (aktuell: {base_url}). Viele OpenAI-kompatible "
 "Endpunkte erfordern ein /v1-Suffix (z. B. {base_url}/v1)."
 
-#: src/iac_code/providers/registry.py:416
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
 msgstr "Alibaba Cloud Bailian"
 
-#: src/iac_code/providers/registry.py:417
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian Token Plan"
 msgstr "Alibaba Cloud Bailian Token Plan"
 
-#: src/iac_code/providers/registry.py:421
+#: src/iac_code/providers/registry.py
 msgid "OpenAPI Compatible"
 msgstr "OpenAPI-kompatibel"
 
-#: src/iac_code/providers/registry.py:423
+#: src/iac_code/providers/registry.py
 msgid "Kimi (China)"
 msgstr "Kimi (China)"
 
-#: src/iac_code/providers/registry.py:424
+#: src/iac_code/providers/registry.py
 msgid "Kimi (International)"
 msgstr "Kimi (International)"
 
-#: src/iac_code/providers/registry.py:425
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (China)"
 msgstr "MiniMax (China)"
 
-#: src/iac_code/providers/registry.py:426
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (International)"
 msgstr "MiniMax (International)"
 
-#: src/iac_code/providers/registry.py:428
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI (International)"
 msgstr "ZhiPu AI (International)"
 
-#: src/iac_code/providers/registry.py:430
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (China)"
 msgstr "SiliconFlow (China)"
 
-#: src/iac_code/providers/registry.py:431
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (International)"
 msgstr "SiliconFlow (International)"
 
-#: src/iac_code/providers/registry.py:432
+#: src/iac_code/providers/registry.py
 msgid "Ollama (Local)"
 msgstr "Ollama (Lokal)"
 
-#: src/iac_code/providers/registry.py:433
+#: src/iac_code/providers/registry.py
 msgid "LM Studio (Local)"
 msgstr "LM Studio (Lokal)"
 
-#: src/iac_code/providers/registry.py:436
+#: src/iac_code/providers/registry.py
 msgid "ModelScope"
 msgstr "ModelScope"
 
-#: src/iac_code/providers/registry.py:437
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan"
 msgstr "Alibaba Cloud CodingPlan"
 
-#: src/iac_code/providers/registry.py:438
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan (International)"
 msgstr "Alibaba Cloud CodingPlan (International)"
 
-#: src/iac_code/providers/registry.py:439
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan"
 msgstr "ZhiPu AI CodingPlan"
 
-#: src/iac_code/providers/registry.py:440
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan (International)"
 msgstr "ZhiPu AI CodingPlan (International)"
 
-#: src/iac_code/providers/registry.py:441
+#: src/iac_code/providers/registry.py
 msgid "Volcengine CodingPlan"
 msgstr "Volcengine CodingPlan"
 
-#: src/iac_code/providers/registry.py:442
+#: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Anthropic-kompatibel"
 
-#: src/iac_code/services/qwenpaw_source.py:205
+#: src/iac_code/services/qwenpaw_source.py
 #, python-brace-format
 msgid ""
 "[QwenPaw mode] Unknown provider '{provider_id}'. iac-code does not "
@@ -1458,90 +1443,90 @@ msgstr ""
 "deaktivieren Sie den QwenPaw-Modus (entfernen Sie 'llm_source: qwenpaw' "
 "aus settings.yml)."
 
-#: src/iac_code/services/session_metadata.py:52
+#: src/iac_code/services/session_metadata.py
 #, python-brace-format
 msgid "Session name must match {pattern}"
 msgstr "Der Sitzungsname muss {pattern} entsprechen"
 
-#: src/iac_code/services/session_storage.py:241
+#: src/iac_code/services/session_storage.py
 #, python-brace-format
 msgid "Session name already exists in this project: {name}"
 msgstr "Der Sitzungsname ist in diesem Projekt bereits vorhanden: {name}"
 
-#: src/iac_code/services/permissions/loader.py:50
+#: src/iac_code/services/permissions/loader.py
 #, python-brace-format
 msgid "Invalid --permission-mode {!r}. Valid values: {}"
 msgstr "Ungültiges --permission-mode {!r}. Gültige Werte: {}"
 
-#: src/iac_code/services/permissions/pipeline.py:54
-#: src/iac_code/tools/base.py:199 src/iac_code/tools/bash/bash_tool.py:175
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Allow {}?"
 msgstr "{} erlauben?"
 
-#: src/iac_code/services/providers/aliyun.py:144
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
 msgstr "Die Alibaba Cloud-OAuth-Site fehlt."
 
-#: src/iac_code/services/providers/aliyun.py:150
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth refresh token is missing."
 msgstr "Das Alibaba Cloud-OAuth-Refresh-Token fehlt."
 
-#: src/iac_code/services/providers/aliyun.py:158
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth access token is missing."
 msgstr "Das Alibaba Cloud-OAuth-Zugriffstoken fehlt."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:83
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Run /auth and choose OAuth Login (Browser)."
 msgstr "Führen Sie /auth aus und wählen Sie OAuth-Anmeldung (Browser)."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:106
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "Unknown Aliyun OAuth site: {site_type}"
 msgstr "Unbekannte Aliyun-OAuth-Site: {site_type}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:164
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Not found"
 msgstr "Nicht gefunden"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:170
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "invalid state"
 msgstr "ungültiger Status"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:171
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Invalid state"
 msgstr "Ungültiger Status"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:176
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "code not found"
 msgstr "Autorisierungscode nicht gefunden"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:177
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization code not found"
 msgstr "Autorisierungscode nicht gefunden"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:181
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization successful. You can close this window."
 msgstr "Autorisierung erfolgreich. Sie können dieses Fenster schließen."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:212
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "No available callback port in range {start}-{end}"
 msgstr "Kein verfügbarer Callback-Port im Bereich {start}-{end}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:227
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "OAuth login cancelled."
 msgstr "OAuth-Anmeldung abgebrochen."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:278
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Open in your browser:"
 msgstr "Im Browser öffnen:"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:299
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Waiting for browser authorization"
 msgstr "Warten auf Browserautorisierung"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:300
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "1. The browser may show official-cli; this is the Alibaba Cloud official "
 "CLI OAuth application."
@@ -1549,7 +1534,7 @@ msgstr ""
 "1. Der Browser kann official-cli anzeigen; dies ist die offizielle CLI-"
 "OAuth-Anwendung von Alibaba Cloud."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:302
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "2. If assignment is required, assign the RAM user or RAM role that is "
 "signed in. User groups are not supported."
@@ -1558,7 +1543,7 @@ msgstr ""
 "RAM-Benutzer oder die RAM-Rolle zu. Benutzergruppen werden nicht "
 "unterstützt."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:306
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "3. After assignment, close the old authorization page and run OAuth Login"
 " (Browser) again. If it still fails, sign out of Alibaba Cloud and sign "
@@ -1568,7 +1553,7 @@ msgstr ""
 "führen Sie OAuth-Anmeldung (Browser) erneut aus. Falls es weiterhin "
 "fehlschlägt, melden Sie sich bei Alibaba Cloud ab und wieder an."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:310
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "4. STS credentials refresh when possible until Alibaba Cloud expires "
 "them. If refresh fails, run /auth again."
@@ -1577,11 +1562,11 @@ msgstr ""
 "Alibaba Cloud sie ablaufen lässt. Wenn die Aktualisierung fehlschlägt, "
 "führen Sie /auth erneut aus."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:313
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Press Esc to cancel while waiting."
 msgstr "Drücken Sie Esc, um das Warten abzubrechen."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:321
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "Timed out waiting for OAuth callback. If Alibaba Cloud asked you to "
 "assign the official-cli application, assign it to the exact RAM user or "
@@ -1597,28 +1582,28 @@ msgstr ""
 "wieder an, und führen Sie /auth aus, um erneut OAuth-Anmeldung (Browser) "
 "zu wählen."
 
-#: src/iac_code/skills/skill_tool.py:85 src/iac_code/ui/repl.py:842
+#: src/iac_code/skills/skill_tool.py src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Skill '{name}' is disabled. Run /skills to enable it."
 msgstr ""
 "Skill '{name}' ist deaktiviert. Führen Sie /skills aus, um ihn zu "
 "aktivieren."
 
-#: src/iac_code/skills/skill_tool.py:137
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill '{name}' loaded (inline)."
 msgstr "Skill '{name}' geladen (inline)."
 
-#: src/iac_code/skills/skill_tool.py:221
+#: src/iac_code/skills/skill_tool.py
 msgid "Skill"
 msgstr "Skill"
 
-#: src/iac_code/skills/skill_tool.py:245
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill disabled: {name}"
 msgstr "Skill deaktiviert: {name}"
 
-#: src/iac_code/skills/bundled/simplify.py:25
+#: src/iac_code/skills/bundled/simplify.py
 msgid ""
 "Review changed code for reuse, quality, and efficiency, then fix issues "
 "found."
@@ -1626,99 +1611,99 @@ msgstr ""
 "Geänderten Code auf Wiederverwendbarkeit, Qualität und Effizienz prüfen "
 "und gefundene Probleme beheben."
 
-#: src/iac_code/tools/edit_file.py:116
+#: src/iac_code/tools/edit_file.py
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: src/iac_code/tools/edit_file.py:118
+#: src/iac_code/tools/edit_file.py
 msgid "Create"
 msgstr "Erstellen"
 
-#: src/iac_code/tools/edit_file.py:119
+#: src/iac_code/tools/edit_file.py
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: src/iac_code/tools/edit_file.py:126
+#: src/iac_code/tools/edit_file.py
 #, python-brace-format
 msgid "Editing {path}"
 msgstr "{path} wird bearbeitet"
 
-#: src/iac_code/tools/edit_file.py:127
+#: src/iac_code/tools/edit_file.py
 msgid "Editing file..."
 msgstr "Datei wird bearbeitet …"
 
-#: src/iac_code/tools/glob.py:86 src/iac_code/tools/grep.py:237
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Found 0 files"
 msgstr "0 Dateien gefunden"
 
-#: src/iac_code/tools/glob.py:89 src/iac_code/tools/grep.py:240
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Found {count} files"
 msgstr "{count} Dateien gefunden"
 
-#: src/iac_code/tools/glob.py:95 src/iac_code/tools/grep.py:246
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Search"
 msgstr "Suche"
 
-#: src/iac_code/tools/glob.py:100
+#: src/iac_code/tools/glob.py
 #, python-brace-format
 msgid "Searching {pattern}"
 msgstr "{pattern} wird durchsucht"
 
-#: src/iac_code/tools/glob.py:101
+#: src/iac_code/tools/glob.py
 msgid "Searching files..."
 msgstr "Dateien werden durchsucht …"
 
-#: src/iac_code/tools/grep.py:251
+#: src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Searching for {pattern}"
 msgstr "Suche nach {pattern}"
 
-#: src/iac_code/tools/grep.py:252
+#: src/iac_code/tools/grep.py
 msgid "Searching content..."
 msgstr "Inhalt wird durchsucht …"
 
-#: src/iac_code/tools/list_files.py:82
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Found {count} items"
 msgstr "{count} Einträge gefunden"
 
-#: src/iac_code/tools/list_files.py:88
+#: src/iac_code/tools/list_files.py
 msgid "List"
 msgstr "Liste"
 
-#: src/iac_code/tools/list_files.py:92
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Listing {path}"
 msgstr "{path} wird aufgelistet"
 
-#: src/iac_code/tools/list_files.py:93
+#: src/iac_code/tools/list_files.py
 msgid "Listing files..."
 msgstr "Dateien werden aufgelistet …"
 
-#: src/iac_code/tools/read_file.py:117
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Read {total} lines"
 msgstr "{total} Zeilen gelesen"
 
-#: src/iac_code/tools/read_file.py:120
+#: src/iac_code/tools/read_file.py
 msgid "Read"
 msgstr "Lesen"
 
-#: src/iac_code/tools/read_file.py:127
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Reading {path}"
 msgstr "{path} wird gelesen"
 
-#: src/iac_code/tools/read_file.py:128
+#: src/iac_code/tools/read_file.py
 msgid "Reading file..."
 msgstr "Datei wird gelesen …"
 
-#: src/iac_code/tools/web_fetch.py:94
+#: src/iac_code/tools/web_fetch.py
 msgid "URL cannot be empty."
 msgstr "Die URL darf nicht leer sein."
 
-#: src/iac_code/tools/web_fetch.py:100
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}"
 msgstr ""
@@ -1726,410 +1711,409 @@ msgstr ""
 "{url}Ungültige URL: Schema fehlt (z. B. http:// oder https://). Erhalten:"
 " {url}"
 
-#: src/iac_code/tools/web_fetch.py:103
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing host/netloc. Got: {url}"
 msgstr "Ungültige URL: Host fehlt. Erhalten: {url}"
 
-#: src/iac_code/tools/web_fetch.py:129
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "HTTP error {status}: {url}"
 msgstr "HTTP-Fehler {status}: {url}"
 
-#: src/iac_code/tools/web_fetch.py:131
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Failed to fetch {url}: {error}"
 msgstr "Abruf von {url} fehlgeschlagen: {error}"
 
-#: src/iac_code/tools/web_fetch.py:133
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Unexpected error fetching {url}: {error}"
 msgstr "Unerwarteter Fehler beim Abruf von {url}: {error}"
 
-#: src/iac_code/tools/web_fetch.py:147
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetched {chars} chars, {lines} lines"
 msgstr "{chars} Zeichen, {lines} Zeilen abgerufen"
 
-#: src/iac_code/tools/web_fetch.py:159
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetch"
 msgstr "Abruf"
 
-#: src/iac_code/tools/web_fetch.py:165
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetching {url}"
 msgstr "{url} wird abgerufen"
 
-#: src/iac_code/tools/web_fetch.py:166
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetching web page..."
 msgstr "Webseite wird abgerufen …"
 
-#: src/iac_code/tools/write_file.py:67
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Successfully wrote {lines} lines to {path}"
 msgstr "{lines} Zeilen erfolgreich nach {path} geschrieben"
 
-#: src/iac_code/tools/write_file.py:81
+#: src/iac_code/tools/write_file.py
 msgid "Write"
 msgstr "Schreiben"
 
-#: src/iac_code/tools/write_file.py:88
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Writing {path}"
 msgstr "{path} wird geschrieben"
 
-#: src/iac_code/tools/write_file.py:89
+#: src/iac_code/tools/write_file.py
 msgid "Writing file..."
 msgstr "Datei wird geschrieben …"
 
-#: src/iac_code/tools/bash/bash_tool.py:81
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Command timed out after {timeout} seconds: {command}"
 msgstr "Befehl nach {timeout} Sekunden abgelaufen: {command}"
 
-#: src/iac_code/tools/bash/bash_tool.py:103
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Error executing command: {}"
 msgstr "Fehler beim Ausführen des Befehls: {}"
 
-#: src/iac_code/tools/bash/bash_tool.py:129
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "{count} more lines"
 msgstr "{count} weitere Zeilen"
 
-#: src/iac_code/tools/bash/bash_tool.py:137
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Bash"
 msgstr "Bash"
 
-#: src/iac_code/tools/bash/bash_tool.py:143
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Running {cmd}"
 msgstr "{cmd} wird ausgeführt"
 
-#: src/iac_code/tools/bash/bash_tool.py:144
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Running command..."
 msgstr "Befehl wird ausgeführt …"
 
-#: src/iac_code/tools/bash/command_parser.py:42
+#: src/iac_code/tools/bash/command_parser.py
 msgid "parse error"
 msgstr "Analysefehler"
 
-#: src/iac_code/tools/bash/command_parser.py:46
+#: src/iac_code/tools/bash/command_parser.py
 msgid "unsupported shell construct"
 msgstr "Nicht unterstütztes Shell-Konstrukt"
 
-#: src/iac_code/tools/bash/path_validation.py:111
+#: src/iac_code/tools/bash/path_validation.py
 #, python-brace-format
 msgid "path outside allowed directories: {}"
 msgstr "Pfad außerhalb erlaubter Verzeichnisse: {}"
 
-#: src/iac_code/tools/bash/permissions.py:135
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s): {}"
 msgstr "Übereinstimmende Ablehnungsregel(n): {}"
 
-#: src/iac_code/tools/bash/permissions.py:142
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Übereinstimmende Abfrageregel(n): {}"
 
-#: src/iac_code/tools/bash/permissions.py:154
-#: src/iac_code/tools/bash/permissions.py:220
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched allow rule(s): {}"
 msgstr "Übereinstimmende Erlaubnisregel(n): {}"
 
-#: src/iac_code/tools/bash/permissions.py:162
+#: src/iac_code/tools/bash/permissions.py
 msgid "complex command requires confirmation"
 msgstr "Komplexer Befehl erfordert Bestätigung"
 
-#: src/iac_code/tools/bash/permissions.py:171
+#: src/iac_code/tools/bash/permissions.py
 msgid "sed in-place edit requires confirmation"
 msgstr "sed-In-Place-Bearbeitung erfordert Bestätigung"
 
-#: src/iac_code/tools/bash/permissions.py:194
+#: src/iac_code/tools/bash/permissions.py
 msgid "command failed basic safety checks"
 msgstr "Befehl hat grundlegende Sicherheitsprüfungen nicht bestanden"
 
-#: src/iac_code/tools/bash/permissions.py:210
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s) on full command: {}"
 msgstr "Ablehnungsregel(n) für den vollständigen Befehl: {}"
 
-#: src/iac_code/tools/bash/permissions.py:227
+#: src/iac_code/tools/bash/permissions.py
 msgid "command too complex to analyze"
 msgstr "Befehl zu komplex für die Analyse"
 
-#: src/iac_code/tools/bash/permissions.py:229
+#: src/iac_code/tools/bash/permissions.py
 msgid "could not parse command"
 msgstr "Befehl konnte nicht analysiert werden"
 
-#: src/iac_code/tools/bash/permissions.py:245
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "too many subcommands (>{})"
 msgstr "Zu viele Unterbefehle (>{})"
 
-#: src/iac_code/tools/bash/permissions.py:258
+#: src/iac_code/tools/bash/permissions.py
 msgid "multiple cd commands in compound command"
 msgstr "Mehrere cd-Befehle im zusammengesetzten Befehl"
 
-#: src/iac_code/tools/bash/permissions.py:271
+#: src/iac_code/tools/bash/permissions.py
 msgid "cd combined with git in compound command"
 msgstr "cd mit git kombiniert im zusammengesetzten Befehl"
 
-#: src/iac_code/tools/bash/safety_checks.py:151
+#: src/iac_code/tools/bash/safety_checks.py
 #, python-brace-format
 msgid "operation touches a sensitive path: {}"
 msgstr "Operation betrifft einen sensiblen Pfad: {}"
 
-#: src/iac_code/tools/cloud/base_api.py:92
+#: src/iac_code/tools/cloud/base_api.py
 msgid "CloudAPI"
 msgstr "CloudAPI"
 
-#: src/iac_code/tools/cloud/base_api.py:116
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Calling {action}..."
 msgstr "{action} wird aufgerufen …"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:400
-#: src/iac_code/tools/cloud/base_api.py:123
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#: src/iac_code/tools/cloud/base_api.py
 msgid "Call succeeded"
 msgstr "Aufruf erfolgreich"
 
-#: src/iac_code/tools/cloud/base_api.py:144
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Received response ({count} lines)"
 msgstr "Antwort empfangen ({count} Zeilen)"
 
-#: src/iac_code/tools/cloud/base_stack.py:133
+#: src/iac_code/tools/cloud/base_stack.py
 msgid "CloudStack"
 msgstr "CloudStack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:117
-#: src/iac_code/tools/cloud/base_stack.py:150
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
+#: src/iac_code/tools/cloud/base_stack.py
 #, python-brace-format
 msgid "Running {action}..."
 msgstr "{action} wird ausgeführt …"
 
-#: src/iac_code/tools/cloud/types.py:8
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_IN_PROGRESS"
 msgstr "ERSTELLUNG LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:9
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_FAILED"
 msgstr "ERSTELLUNG FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:10
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_COMPLETE"
 msgstr "ERSTELLUNG ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:11
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_IN_PROGRESS"
 msgstr "AKTUALISIERUNG LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:12
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_FAILED"
 msgstr "AKTUALISIERUNG FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:13
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_COMPLETE"
 msgstr "AKTUALISIERUNG ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:14
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_IN_PROGRESS"
 msgstr "LÖSCHUNG LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:15
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_FAILED"
 msgstr "LÖSCHUNG FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:16
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_COMPLETE"
 msgstr "LÖSCHUNG ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:17
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "ERSTELLUNGS-RÜCKNAHME LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:18
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_FAILED"
 msgstr "ERSTELLUNGS-RÜCKNAHME FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:19
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_COMPLETE"
 msgstr "ERSTELLUNGS-RÜCKNAHME ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:20
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_IN_PROGRESS"
 msgstr "RÜCKNAHME LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:21
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_FAILED"
 msgstr "RÜCKNAHME FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:22
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_COMPLETE"
 msgstr "RÜCKNAHME ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:23
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_IN_PROGRESS"
 msgstr "PRÜFUNG LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:24
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_FAILED"
 msgstr "PRÜFUNG FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:25
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_COMPLETE"
 msgstr "PRÜFUNG ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:26
+#: src/iac_code/tools/cloud/types.py
 msgid "REVIEW_IN_PROGRESS"
 msgstr "ÜBERPRÜFUNG LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:27
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_IN_PROGRESS"
 msgstr "IMPORT-ERSTELLUNG LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:28
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_FAILED"
 msgstr "IMPORT-ERSTELLUNG FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:29
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_COMPLETE"
 msgstr "IMPORT-ERSTELLUNG ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:30
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "IMPORT-ERSTELLUNGS-RÜCKNAHME LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:31
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_FAILED"
 msgstr "IMPORT-ERSTELLUNGS-RÜCKNAHME FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:32
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_COMPLETE"
 msgstr "IMPORT-ERSTELLUNGS-RÜCKNAHME ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:33
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_IN_PROGRESS"
 msgstr "IMPORT-AKTUALISIERUNG LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:34
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_FAILED"
 msgstr "IMPORT-AKTUALISIERUNG FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:35
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_COMPLETE"
 msgstr "IMPORT-AKTUALISIERUNG ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:36
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_IN_PROGRESS"
 msgstr "IMPORT-AKTUALISIERUNGS-RÜCKNAHME LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:37
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_FAILED"
 msgstr "IMPORT-AKTUALISIERUNGS-RÜCKNAHME FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/types.py:38
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_COMPLETE"
 msgstr "IMPORT-AKTUALISIERUNGS-RÜCKNAHME ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:40
+#: src/iac_code/tools/cloud/types.py
 msgid "INIT_COMPLETE"
 msgstr "INITIALISIERUNG ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:41
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_IN_PROGRESS"
 msgstr "IMPORT LÄUFT"
 
-#: src/iac_code/tools/cloud/types.py:42
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_COMPLETE"
 msgstr "IMPORT ABGESCHLOSSEN"
 
-#: src/iac_code/tools/cloud/types.py:43
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_FAILED"
 msgstr "IMPORT FEHLGESCHLAGEN"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:172
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 msgid "Aliyun API"
 msgstr "Aliyun API"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:399
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Aufruf erfolgreich (RequestId: {request_id})"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:57
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "DocSearch"
 msgstr "DocSearch"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:70
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Searching docs for {keywords}..."
 msgstr "Dokumentation wird durchsucht für {keywords} …"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:71
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Searching docs..."
 msgstr "Dokumentation wird durchsucht …"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:76
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "keywords cannot be empty."
 msgstr "Schlüsselwörter dürfen nicht leer sein."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:96
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "HTTP error {status} when searching docs."
 msgstr "HTTP-Fehler {status} bei der Dokumentationssuche."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:98
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Failed to search docs: {error}"
 msgstr "Dokumentationssuche fehlgeschlagen: {error}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:103
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Failed to parse search response as JSON."
 msgstr "Suchantwort konnte nicht als JSON gelesen werden."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:106
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Search API returned failure."
 msgstr "Die Such-API meldete einen Fehler."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:125
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "No documents found"
 msgstr "Keine Dokumente gefunden"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:126
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "No documents found for keywords: {keywords}"
 msgstr "Keine Dokumente für Schlüsselwörter: {keywords}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:141
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Found {count} documents (total {total})"
 msgstr "{count} Dokumente gefunden (gesamt {total})"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:143
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Use web_fetch tool to read full document content if needed."
 msgstr ""
 "Use web_fetch tool to read full document content if needed.Use web_fetch "
 "tool to read full document content if needed.Verwenden Sie bei Bedarf das"
 " Tool web_fetch für den vollständigen Dokumentinhalt."
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack.py:143
+#: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:100
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:48
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template YAML syntax error: {}"
 msgstr "YAML-Syntaxfehler in der Vorlage: {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:60
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template YAML syntax error (line {line}, column {col}): {problem}\n"
@@ -2140,12 +2124,12 @@ msgstr ""
 "Kontext:\n"
 "{context}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:66
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template JSON syntax error (line {line}, column {col}): {msg}"
 msgstr "JSON-Syntaxfehler in der Vorlage (Zeile {line}, Spalte {col}): {msg}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:85
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template {fmt} parse result is not an object (dict), please check the "
@@ -2154,7 +2138,7 @@ msgstr ""
 "Das {fmt}-Parseergebnis der Vorlage ist kein Objekt (dict), bitte "
 "überprüfen Sie das Vorlagenformat"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:104
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"
@@ -2162,16 +2146,16 @@ msgstr ""
 "In der Vorlage fehlt ROSTemplateFormatVersion (ROS-Vorlagen müssen dieses"
 " Feld enthalten, z.B. '2015-09-01')"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:110
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Template is missing Resources (ROS templates must include Resources)"
 msgstr "In der Vorlage fehlt Resources (ROS-Vorlagen müssen Resources enthalten)"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:112
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resources must be an object (dict), current type is {}"
 msgstr "Resources muss ein Objekt (dict) sein, aktueller Typ ist {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:117
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Resource '{name}' definition must be an object (dict), current type is "
@@ -2180,17 +2164,17 @@ msgstr ""
 "Die Definition der Ressource '{name}' muss ein Objekt (dict) sein, "
 "aktueller Typ ist {type}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:123
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' is missing the Type field"
 msgstr "Bei Ressource '{name}' fehlt das Feld Type"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:129
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' has incorrect type '{wrong}', should be '{correct}'"
 msgstr "Ressource '{name}' hat den falschen Typ '{wrong}', sollte '{correct}' sein"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:151
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template structure validation found the following issues, please fix and "
 "retry:"
@@ -2198,242 +2182,235 @@ msgstr ""
 "Die Strukturvalidierung der Vorlage hat folgende Probleme gefunden, bitte"
 " beheben und erneut versuchen:"
 
-#: src/iac_code/ui/banner.py:42 src/iac_code/ui/banner.py:54
+#: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
 msgstr "Update verfügbar! {} -> {}"
 
-#: src/iac_code/ui/banner.py:43
+#: src/iac_code/ui/banner.py
 msgid "Update command"
 msgstr "Aktualisierungsbefehl"
 
-#: src/iac_code/ui/banner.py:46 src/iac_code/ui/banner.py:58
+#: src/iac_code/ui/banner.py
 msgid "Release notes"
 msgstr "Versionshinweise"
 
-#: src/iac_code/ui/banner.py:55
-#, python-brace-format
-msgid "Run {} to update."
-msgstr "Führe {} aus, um zu aktualisieren."
-
-#: src/iac_code/ui/banner.py:110
+#: src/iac_code/ui/banner.py
 msgid "Your AI-powered Infrastructure as Code assistant"
 msgstr "Ihr KI-gestützter Infrastructure-as-Code-Assistent"
 
-#: src/iac_code/ui/banner.py:144
+#: src/iac_code/ui/banner.py
 msgid "Welcome back"
 msgstr "Willkommen zurück"
 
-#: src/iac_code/ui/banner.py:161
+#: src/iac_code/ui/banner.py
 msgid "Debug mode"
 msgstr "Debug-Modus"
 
-#: src/iac_code/ui/banner.py:162
+#: src/iac_code/ui/banner.py
 msgid "Log file"
 msgstr "Protokolldatei"
 
-#: src/iac_code/ui/renderer.py:388 src/iac_code/ui/renderer.py:668
-#: src/iac_code/ui/renderer.py:1455
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Nachgedacht für {seconds:.1f}s"
 
-#: src/iac_code/ui/renderer.py:404 src/iac_code/ui/renderer.py:700
-#: src/iac_code/ui/renderer.py:1476
+#: src/iac_code/ui/renderer.py
 msgid "(ctrl+o to expand)"
 msgstr "(ctrl+o zum Aufklappen)"
 
-#: src/iac_code/ui/renderer.py:431
+#: src/iac_code/ui/renderer.py
 msgid "Resource"
 msgstr "Ressource"
 
-#: src/iac_code/ui/renderer.py:432
+#: src/iac_code/ui/renderer.py
 msgid "Type"
 msgstr "Typ"
 
-#: src/iac_code/ui/renderer.py:433 src/iac_code/ui/renderer.py:456
+#: src/iac_code/ui/renderer.py
 msgid "Status"
 msgstr "Status"
 
-#: src/iac_code/ui/renderer.py:454
+#: src/iac_code/ui/renderer.py
 msgid "Account ID"
 msgstr "Konto-ID"
 
-#: src/iac_code/ui/renderer.py:542
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Done ({child_count} tool uses{token_info}{elapsed})"
 msgstr "Fertig ({child_count} Tool-Aufrufe{token_info}{elapsed})"
 
-#: src/iac_code/ui/renderer.py:572
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "+ {count} more tool uses (ctrl+o to expand)"
 msgstr "+ {count} weitere Tool-Aufrufe (ctrl+o zum Aufklappen)"
 
-#: src/iac_code/ui/renderer.py:1177
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Context auto-compacted: {original} → {compacted} tokens"
 msgstr "Kontext automatisch komprimiert: {original} → {compacted} Tokens"
 
-#: src/iac_code/ui/renderer.py:1262
+#: src/iac_code/ui/renderer.py
 msgid "Operation cancelled."
 msgstr "Vorgang abgebrochen."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "No API key configured."
 msgstr "Kein API-Key konfiguriert."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "Please run /auth to set up your LLM provider and API key."
 msgstr "Führen Sie /auth aus, um LLM-Anbieter und API-Key einzurichten."
 
-#: src/iac_code/ui/renderer.py:1272
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Fehler: {error}"
 
-#: src/iac_code/ui/renderer.py:1342
+#: src/iac_code/ui/renderer.py
 msgid "Allow this action?"
 msgstr "Diese Aktion zulassen?"
 
-#: src/iac_code/ui/renderer.py:1345
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow once"
 msgstr "Ja, einmal zulassen"
 
-#: src/iac_code/ui/renderer.py:1359
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Yes, always allow \"{rule}\" (this session)"
 msgstr "Ja, \"{rule}\" immer erlauben (diese Sitzung)"
 
-#: src/iac_code/ui/renderer.py:1364
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow always for this tool"
 msgstr "Ja, für dieses Tool immer zulassen"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "No, reject once"
 msgstr "Nein, einmal ablehnen"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "default"
 msgstr "Standard"
 
-#: src/iac_code/ui/renderer.py:1374
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "No, always deny \"{rule}\" (this session)"
 msgstr "Nein, immer \"{rule}\" ablehnen (diese Sitzung)"
 
-#: src/iac_code/ui/renderer.py:1379
+#: src/iac_code/ui/renderer.py
 msgid "No, always reject this tool"
 msgstr "Nein, dieses Tool immer ablehnen"
 
-#: src/iac_code/ui/repl.py:424
+#: src/iac_code/ui/repl.py
 msgid "Press Ctrl+C again to exit."
 msgstr "Drücken Sie erneut Ctrl+C zum Beenden."
 
-#: src/iac_code/ui/repl.py:449
+#: src/iac_code/ui/repl.py
 msgid "Interrupted."
 msgstr "Unterbrochen."
 
-#: src/iac_code/ui/repl.py:508
+#: src/iac_code/ui/repl.py
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/iac_code/ui/repl.py:510
+#: src/iac_code/ui/repl.py
 msgid "Run the shown update command and exit when it succeeds."
 msgstr ""
 "Führt den angezeigten Aktualisierungsbefehl aus und beendet das Programm "
 "bei Erfolg."
 
-#: src/iac_code/ui/repl.py:513
+#: src/iac_code/ui/repl.py
 msgid "Skip"
 msgstr "Überspringen"
 
-#: src/iac_code/ui/repl.py:515
+#: src/iac_code/ui/repl.py
 msgid "Continue with the current version for this session."
 msgstr "Für diese Sitzung mit der aktuellen Version fortfahren."
 
-#: src/iac_code/ui/repl.py:518
+#: src/iac_code/ui/repl.py
 msgid "Skip until next version"
 msgstr "Bis zur nächsten Version überspringen"
 
-#: src/iac_code/ui/repl.py:520
+#: src/iac_code/ui/repl.py
 msgid "Hide this update until a newer version is available."
 msgstr "Dieses Update ausblenden, bis eine neuere Version verfügbar ist."
 
-#: src/iac_code/ui/repl.py:539 src/iac_code/ui/repl.py:551
+#: src/iac_code/ui/repl.py
 msgid "Update command failed. Continuing with the current version."
 msgstr ""
 "Der Aktualisierungsbefehl ist fehlgeschlagen. Es wird mit der aktuellen "
 "Version fortgefahren."
 
-#: src/iac_code/ui/repl.py:544
+#: src/iac_code/ui/repl.py
 msgid "Update completed. Restart iac-code to continue."
 msgstr "Update abgeschlossen. Starten Sie iac-code neu, um fortzufahren."
 
-#: src/iac_code/ui/repl.py:582
+#: src/iac_code/ui/repl.py
 msgid "No image in clipboard."
 msgstr "Kein Bild in der Zwischenablage."
 
-#: src/iac_code/ui/repl.py:768
+#: src/iac_code/ui/repl.py
 msgid "Usage: !<shell command>"
 msgstr "Verwendung: !<Shell-Befehl>"
 
-#: src/iac_code/ui/repl.py:775
+#: src/iac_code/ui/repl.py
 msgid "Shell command support is unavailable."
 msgstr "Shell-Befehlsunterstützung ist nicht verfügbar."
 
-#: src/iac_code/ui/repl.py:845
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown skill: ${name}. Type / to list commands and skills."
 msgstr "Unbekannter Skill: ${name}. Tippe /, um Befehle und Skills aufzulisten."
 
-#: src/iac_code/ui/repl.py:847
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown command: /{name}. Type /help for available commands."
 msgstr ""
 "Unknown command: /{name}. Type /help for available commands.Unbekannter "
 "Befehl: /{name}. Geben Sie /help für verfügbare Befehle ein."
 
-#: src/iac_code/ui/repl.py:852
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "$ only invokes skills. Use /{name} instead."
 msgstr "$ ruft nur Skills auf. Verwende stattdessen /{name}."
 
-#: src/iac_code/ui/repl.py:874 src/iac_code/ui/repl.py:922
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command error: {error}"
 msgstr "Befehlsfehler: {error}"
 
-#: src/iac_code/ui/repl.py:881
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command has no handler: {name}"
 msgstr "Kein Handler für Befehl: {name}"
 
-#: src/iac_code/ui/repl.py:1156
+#: src/iac_code/ui/repl.py
 msgid "Goodbye!"
 msgstr "Auf Wiedersehen!"
 
-#: src/iac_code/ui/repl.py:1157
+#: src/iac_code/ui/repl.py
 msgid "Resume this session with:"
 msgstr "Diese Sitzung fortsetzen mit:"
 
-#: src/iac_code/ui/repl.py:1160
+#: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "Sitzungs-ID"
 
-#: src/iac_code/ui/repl.py:1210 src/iac_code/ui/repl.py:1214
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Session not found: {session_id}"
 msgstr "Sitzung nicht gefunden: {session_id}"
 
-#: src/iac_code/ui/repl.py:1263
+#: src/iac_code/ui/repl.py
 msgid "Session name: "
 msgstr "Sitzungsname: "
 
-#: src/iac_code/ui/repl.py:1269
+#: src/iac_code/ui/repl.py
 msgid "Session name cannot be empty."
 msgstr "Der Sitzungsname darf nicht leer sein."
 
-#: src/iac_code/ui/repl.py:1279
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "This session belongs to a different directory.\n"
@@ -2444,23 +2421,23 @@ msgstr ""
 "Zum Fortsetzen ausführen:\n"
 "  {cmd}"
 
-#: src/iac_code/ui/repl.py:1283
+#: src/iac_code/ui/repl.py
 msgid "Multiple sessions match. Resume one by ID:"
 msgstr "Mehrere Sitzungen passen. Setzen Sie eine per ID fort:"
 
-#: src/iac_code/ui/repl.py:1396
+#: src/iac_code/ui/repl.py
 msgid "This conversation is from a different directory."
 msgstr "Diese Konversation stammt aus einem anderen Verzeichnis."
 
-#: src/iac_code/ui/repl.py:1398
+#: src/iac_code/ui/repl.py
 msgid "To resume, run:"
 msgstr "Zum Fortsetzen ausführen:"
 
-#: src/iac_code/ui/repl.py:1403
+#: src/iac_code/ui/repl.py
 msgid "(Command copied to clipboard)"
 msgstr "(Befehl in die Zwischenablage kopiert)"
 
-#: src/iac_code/ui/repl.py:1560
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "Current model {model} does not support image input. Use /model to switch "
@@ -2469,12 +2446,12 @@ msgstr ""
 "Das aktuelle Modell {model} unterstützt keine Bildeingabe. Verwenden Sie "
 "/model, um zu einem Vision-fähigen Modell zu wechseln."
 
-#: src/iac_code/ui/repl.py:1569
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Image error: {err}"
 msgstr "Bildfehler: {err}"
 
-#: src/iac_code/ui/repl.py:1586
+#: src/iac_code/ui/repl.py
 msgid ""
 "Failed to persist image to cache; it will only exist in memory for this "
 "turn."
@@ -2482,193 +2459,193 @@ msgstr ""
 "Bild konnte nicht im Cache gespeichert werden; es existiert nur im "
 "Arbeitsspeicher für diesen Durchgang."
 
-#: src/iac_code/ui/spinner.py:52
+#: src/iac_code/ui/spinner.py
 msgid "Processing"
 msgstr "Verarbeitung"
 
-#: src/iac_code/ui/spinner.py:53
+#: src/iac_code/ui/spinner.py
 msgid "Working"
 msgstr "In Arbeit"
 
-#: src/iac_code/ui/spinner.py:62
+#: src/iac_code/ui/spinner.py
 msgid "Thought"
 msgstr "Gedacht"
 
-#: src/iac_code/ui/spinner.py:63
+#: src/iac_code/ui/spinner.py
 msgid "Processed"
 msgstr "Verarbeitet"
 
-#: src/iac_code/ui/spinner.py:64
+#: src/iac_code/ui/spinner.py
 msgid "Worked"
 msgstr "Erledigt"
 
-#: src/iac_code/ui/transcript_view.py:158
+#: src/iac_code/ui/transcript_view.py
 msgid "Prompt:"
 msgstr "Prompt:"
 
-#: src/iac_code/ui/transcript_view.py:186
+#: src/iac_code/ui/transcript_view.py
 msgid "Showing transcript · ctrl+o to toggle"
 msgstr "Vollständiges Protokoll · ctrl+o zum Umschalten"
 
-#: src/iac_code/ui/components/fuzzy_picker.py:120
+#: src/iac_code/ui/components/fuzzy_picker.py
 msgid "No matches found"
 msgstr "Keine Treffer"
 
-#: src/iac_code/ui/core/prompt_input.py:348
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Image in clipboard · ctrl+v to paste"
 msgstr "Bild in der Zwischenablage · Strg+V zum Einfügen"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Fill"
 msgstr "Ausfüllen"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: src/iac_code/ui/dialogs/global_search.py:55
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "No matching content"
 msgstr "Kein passender Inhalt"
 
-#: src/iac_code/ui/dialogs/global_search.py:61
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Search in Files"
 msgstr "In Dateien suchen"
 
-#: src/iac_code/ui/dialogs/global_search.py:62
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Type to search content..."
 msgstr "Tippen, um Inhalt zu suchen …"
 
-#: src/iac_code/ui/dialogs/global_search.py:63
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Enter search query"
 msgstr "Suchanfrage eingeben"
 
-#: src/iac_code/ui/dialogs/history_search.py:55
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Search Conversation History"
 msgstr "Konversationsverlauf durchsuchen"
 
-#: src/iac_code/ui/dialogs/history_search.py:56
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Type to search..."
 msgstr "Tippen, um zu suchen …"
 
-#: src/iac_code/ui/dialogs/history_search.py:57
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "No conversation history"
 msgstr "Kein Konversationsverlauf"
 
-#: src/iac_code/ui/dialogs/history_search.py:98
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Message Preview"
 msgstr "Nachrichtenvorschau"
 
-#: src/iac_code/ui/dialogs/quick_open.py:58
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Open File"
 msgstr "Datei öffnen"
 
-#: src/iac_code/ui/dialogs/quick_open.py:59
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Type to search files..."
 msgstr "Tippen, um Dateien zu suchen …"
 
-#: src/iac_code/ui/dialogs/quick_open.py:60
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "No matching files"
 msgstr "Keine passenden Dateien"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:116
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Search..."
 msgstr "Suchen …"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:374
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Resume Session"
 msgstr "Sitzung fortsetzen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:384
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "No sessions found"
 msgstr "Keine Sitzungen gefunden"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:444
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show current dir"
 msgstr "aktuelles Verzeichnis anzeigen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:446
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all projects"
 msgstr "alle Projekte anzeigen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:449
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all branches"
 msgstr "alle Branches anzeigen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:451
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "only show current branch"
 msgstr "nur aktuellen Branch anzeigen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:452
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "preview"
 msgstr "Vorschau"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:453
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Type to search"
 msgstr "Tippen, um zu suchen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:454
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "cancel"
 msgstr "abbrechen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:569
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} more line{s}"
 msgstr "{n} weitere Zeile{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:583
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} message{s}"
 msgstr "{n} Nachricht{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:597
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "resume"
 msgstr "fortsetzen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:601
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "back"
 msgstr "zurück"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:606
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "scroll"
 msgstr "scrollen"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:625
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "(empty session)"
 msgstr "(leere Sitzung)"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:745
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "just now"
 msgstr "gerade eben"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:748
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} minute{s} ago"
 msgstr "vor {n} Minute{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:751
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} hour{s} ago"
 msgstr "vor {n} Stunde{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:753
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} day{s} ago"
 msgstr "vor {n} Tag{s}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:52
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Search skills..."
 msgstr "Skills suchen..."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:159
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Skills"
 msgstr "Skills"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:161
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "{current} of {total}"
 msgstr "{current} von {total}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:165
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid ""
 "{count} skills - Space to toggle, Enter to save, Tab to sort, Esc to "
@@ -2677,90 +2654,90 @@ msgstr ""
 "{count} Skills - Leertaste zum Umschalten, Enter zum Speichern, Tab zum "
 "Sortieren, Esc zum Abbrechen"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:171
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "Sort: {mode}"
 msgstr "Sortieren: {mode}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:176
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "No skills found"
 msgstr "Keine Skills gefunden"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:245
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Bundled skills cannot be disabled."
 msgstr "Gebündelte Skills können nicht deaktiviert werden."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "on"
 msgstr "aktiviert"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "off"
 msgstr "deaktiviert"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:265
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "locked"
 msgstr "gesperrt"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:268
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "matched description"
 msgstr "Beschreibung stimmt überein"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:277
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "source"
 msgstr "Quelle"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:279
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "size"
 msgstr "Größe"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:280
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "name"
 msgstr "Name"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:285
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "bundled"
 msgstr "gebündelt"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:287
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "project"
 msgstr "Projekt"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:289
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "user"
 msgstr "Benutzer"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:296
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count}k tokens"
 msgstr "~{count}k Tokens"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:297
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count} tokens"
 msgstr "~{count} Tokens"
 
-#: src/iac_code/ui/suggestions/command_provider.py:79
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Search saved memories"
 msgstr "Gespeicherte Erinnerungen durchsuchen"
 
-#: src/iac_code/ui/suggestions/command_provider.py:80
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Delete a saved memory"
 msgstr "Eine gespeicherte Erinnerung löschen"
 
-#: src/iac_code/ui/suggestions/command_provider.py:81
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Show memory command help"
 msgstr "Hilfe zum memory-Befehl anzeigen"
 
-#: src/iac_code/ui/suggestions/command_provider.py:116
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Saved memory"
 msgstr "Gespeicherte Erinnerung"
 
-#: src/iac_code/utils/platform.py:39
+#: src/iac_code/utils/platform.py
 msgid "iac-code on Windows requires Git for Windows."
 msgstr "iac-code unter Windows erfordert Git for Windows."
 
-#: src/iac_code/utils/platform.py:41
+#: src/iac_code/utils/platform.py
 msgid ""
 "If installed but not on PATH, set IAC_CODE_GIT_BASH_PATH environment "
 "variable."
@@ -2768,15 +2745,15 @@ msgstr ""
 "Falls installiert, aber nicht im PATH, setzen Sie die Umgebungsvariable "
 "IAC_CODE_GIT_BASH_PATH."
 
-#: src/iac_code/utils/platform.py:44
+#: src/iac_code/utils/platform.py
 msgid "To install:"
 msgstr "Zum Installieren:"
 
-#: src/iac_code/utils/platform.py:47
+#: src/iac_code/utils/platform.py
 msgid "  Option 1 - winget (requires access to github.com):"
 msgstr "  Option 1 - winget (erfordert Zugang zu github.com):"
 
-#: src/iac_code/utils/platform.py:52
+#: src/iac_code/utils/platform.py
 msgid ""
 "  Option 2 - if you cannot reach github.com, run this to install via "
 "npmmirror:"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 13:32+0800\n"
+"POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: es\n"
@@ -17,14 +17,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/iac_code/config.py:164
+#: src/iac_code/config.py
 #, python-brace-format
 msgid "Invalid IAC_CODE_PROVIDER value: {!r}. Valid values (case-insensitive): {}"
 msgstr ""
 "Valor de IAC_CODE_PROVIDER no válido: {!r}. Valores válidos (sin "
 "distinguir mayúsculas/minúsculas): {}"
 
-#: src/iac_code/a2a/transports/base.py:175
+#: src/iac_code/a2a/transports/base.py
 msgid ""
 "Unix domain socket transport is not supported on Windows. Use --transport"
 " http or --transport stdio instead."
@@ -32,22 +32,21 @@ msgstr ""
 "El transporte de socket de dominio Unix no es compatible con Windows. Use"
 " --transport http o --transport stdio en su lugar."
 
-#: src/iac_code/acp/server.py:413 src/iac_code/acp/server.py:429
-#: src/iac_code/acp/server.py:456
+#: src/iac_code/acp/server.py
 msgid "Session not found"
 msgstr "Sesión no encontrada"
 
-#: src/iac_code/acp/server.py:416
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session name is ambiguous. Candidates: {candidates}"
 msgstr "El nombre de sesión es ambiguo. Sesiones candidatas: {candidates}"
 
-#: src/iac_code/acp/server.py:434 src/iac_code/acp/server.py:708
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session belongs to another project. Run: {hint}"
 msgstr "La sesión pertenece a otro proyecto. Ejecuta: {hint}"
 
-#: src/iac_code/acp/slash_registry.py:46
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Command '/{cmd_name}' is not supported over ACP. Supported commands: "
@@ -56,21 +55,21 @@ msgstr ""
 "El comando '/{cmd_name}' no está admitido en ACP. Comandos admitidos: "
 "{supported}"
 
-#: src/iac_code/acp/slash_registry.py:62
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Command '/{cmd_name}' handler not implemented."
 msgstr "El controlador del comando '/{cmd_name}' no está implementado."
 
-#: src/iac_code/acp/slash_registry.py:74
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Compaction failed: {error}"
 msgstr "Error al compactar: {error}"
 
-#: src/iac_code/acp/slash_registry.py:77 src/iac_code/commands/compact.py:24
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Nothing to compact: conversation is empty."
 msgstr "Nada que compactar: la conversación está vacía."
 
-#: src/iac_code/acp/slash_registry.py:80 src/iac_code/commands/compact.py:27
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Conversation too short to compact: all messages are within the recent "
@@ -79,14 +78,14 @@ msgstr ""
 "Conversación demasiado corta para compactar: todos los mensajes están "
 "dentro de la ventana de retención de las últimas {turns} interacciones."
 
-#: src/iac_code/acp/slash_registry.py:84 src/iac_code/commands/compact.py:30
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Compaction failed. See logs for details."
 msgstr ""
 "Compaction failed. See logs for details.Compaction failed. See logs for "
 "details.La compactación falló. Consulte los registros para obtener más "
 "información."
 
-#: src/iac_code/acp/slash_registry.py:89
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent} reduction)."
@@ -95,125 +94,123 @@ msgstr ""
 "Contexto compactado: {original} → {compacted} tokens (reducción del "
 "{percent}). Uso del contexto: {usage}"
 
-#: src/iac_code/acp/slash_registry.py:103
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Clear failed: {error}"
 msgstr "Error al borrar: {error}"
 
-#: src/iac_code/acp/slash_registry.py:104
+#: src/iac_code/acp/slash_registry.py
 msgid "Conversation history cleared."
 msgstr "Historial de conversación borrado."
 
-#: src/iac_code/acp/slash_registry.py:120 src/iac_code/commands/debug.py:34
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging is on. Log file: {path}"
 msgstr "El registro de depuración está activado. Archivo de registro: {path}"
 
-#: src/iac_code/acp/slash_registry.py:121 src/iac_code/commands/debug.py:35
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging is off."
 msgstr "El registro de depuración está desactivado."
 
-#: src/iac_code/acp/slash_registry.py:125 src/iac_code/commands/debug.py:39
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging enabled. Log file: {path}"
 msgstr "Registro de depuración habilitado. Archivo de registro: {path}"
 
-#: src/iac_code/acp/slash_registry.py:129 src/iac_code/commands/debug.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging disabled."
 msgstr "Registro de depuración deshabilitado."
 
-#: src/iac_code/acp/slash_registry.py:131 src/iac_code/commands/debug.py:45
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Usage: /debug [on|off]"
 msgstr "Uso: /debug [on|off]"
 
-#: src/iac_code/acp/slash_registry.py:136 src/iac_code/commands/memory.py:84
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/memory.py
 msgid "Memory manager is unavailable."
 msgstr "El gestor de memoria no está disponible."
 
-#: src/iac_code/acp/slash_registry.py:146 src/iac_code/commands/rename.py:21
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 msgid "Usage: /rename <name>"
 msgstr "Uso: /rename <nombre>"
 
-#: src/iac_code/acp/slash_registry.py:152
+#: src/iac_code/acp/slash_registry.py
 msgid "Rename is only available after a session is created."
 msgstr "El cambio de nombre solo está disponible después de crear una sesión."
 
-#: src/iac_code/acp/slash_registry.py:163 src/iac_code/commands/rename.py:42
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Session is already named {name}"
 msgstr "La sesión ya se llama {name}"
 
-#: src/iac_code/acp/slash_registry.py:164 src/iac_code/commands/rename.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Renamed session to {name}"
 msgstr "Sesión renombrada a {name}"
 
-#: src/iac_code/agent/agent_loop.py:413 src/iac_code/agent/agent_loop.py:428
-#: src/iac_code/ui/repl.py:813 src/iac_code/ui/repl.py:827
+#: src/iac_code/agent/agent_loop.py src/iac_code/ui/repl.py
 msgid "Permission denied."
 msgstr "Permiso denegado."
 
-#: src/iac_code/agent/agent_tool.py:266
+#: src/iac_code/agent/agent_tool.py
 #, python-brace-format
 msgid "Done ({tool_count} tool uses · {token_display} tokens)"
 msgstr ""
 "Done ({tool_count} tool uses · {token_display} tokens)Completado "
 "({tool_count} usos de herramientas · {token_display} tokens)"
 
-#: src/iac_code/agent/agent_tool.py:276
+#: src/iac_code/agent/agent_tool.py
 msgid "Explore"
 msgstr "Explorar"
 
-#: src/iac_code/agent/agent_tool.py:277
+#: src/iac_code/agent/agent_tool.py
 msgid "Plan"
 msgstr "Plan"
 
-#: src/iac_code/agent/agent_tool.py:278 src/iac_code/agent/agent_tool.py:279
-#: src/iac_code/agent/agent_tool.py:280
+#: src/iac_code/agent/agent_tool.py
 msgid "Agent"
 msgstr "Agente"
 
-#: src/iac_code/cli/headless.py:50
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool started: {}"
 msgstr "Herramienta iniciada: {}"
 
-#: src/iac_code/cli/headless.py:53
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool failed: {}"
 msgstr "Herramienta falló: {}"
 
-#: src/iac_code/cli/headless.py:55
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool finished: {}"
 msgstr "Herramienta finalizada: {}"
 
-#: src/iac_code/cli/headless.py:59
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool failed: {}"
 msgstr "Herramienta secundaria falló: {}"
 
-#: src/iac_code/cli/headless.py:61
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool finished: {}"
 msgstr "Herramienta secundaria finalizada: {}"
 
-#: src/iac_code/cli/headless.py:63
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool started: {}"
 msgstr "Herramienta secundaria iniciada: {}"
 
-#: src/iac_code/cli/headless.py:65
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack {}: {} ({:.1f}%)"
 msgstr "Pila {}: {} ({:.1f}%)"
 
-#: src/iac_code/cli/headless.py:71
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack group {}: {} ({}%)"
 msgstr "Grupo de pilas {}: {} ({}%)"
 
-#: src/iac_code/cli/headless.py:110
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -232,25 +229,25 @@ msgstr ""
 "  Documentación: https://aliyun.github.io/iac-"
 "code/es/docs/configuration/authentication\n"
 
-#: src/iac_code/cli/install_git_bash.py:40
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git Bash is already installed at {}"
 msgstr "Git Bash ya está instalado en {}"
 
-#: src/iac_code/cli/install_git_bash.py:43
+#: src/iac_code/cli/install_git_bash.py
 msgid "Installing Git for Windows via npmmirror..."
 msgstr "Instalando Git for Windows vía npmmirror..."
 
-#: src/iac_code/cli/install_git_bash.py:59
+#: src/iac_code/cli/install_git_bash.py
 msgid "powershell.exe was not found on PATH; cannot run installer."
 msgstr "powershell.exe no se encontró en PATH; no se puede ejecutar el instalador."
 
-#: src/iac_code/cli/install_git_bash.py:66
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Installation failed (PowerShell exited with code {})"
 msgstr "La instalación falló (PowerShell salió con código {})"
 
-#: src/iac_code/cli/install_git_bash.py:77
+#: src/iac_code/cli/install_git_bash.py
 msgid ""
 "Installer exited but bash.exe was not found in common locations; UAC may "
 "have been cancelled or the installer used a non-standard path."
@@ -259,29 +256,32 @@ msgstr ""
 "habituales; UAC pudo haber sido cancelado o el instalador usó una ruta no"
 " estándar."
 
-#: src/iac_code/cli/install_git_bash.py:84
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git for Windows installed at {}"
 msgstr "Git for Windows instalado en {}"
 
-#: src/iac_code/cli/main.py:33 src/iac_code/commands/help.py:26
+#: src/iac_code/cli/main.py src/iac_code/commands/help.py
 msgid "AI-powered infrastructure orchestration tool"
 msgstr "Herramienta de orquestación de infraestructura asistida por IA"
 
-#: src/iac_code/cli/main.py:41
+#: src/iac_code/cli/main.py
 msgid "Use iac-code as an A2A client."
 msgstr "Usa iac-code como cliente A2A."
 
-#: src/iac_code/cli/main.py:54
+#: src/iac_code/cli/main.py
 msgid "Install Git for Windows via the npmmirror mirror (Windows only)."
 msgstr "Instalar Git for Windows mediante el espejo npmmirror (solo Windows)."
 
-#: src/iac_code/cli/main.py:61
+#: src/iac_code/cli/main.py
+msgid "Update iac-code to the latest version."
+msgstr "Actualizar iac-code a la última versión."
+
+#: src/iac_code/cli/main.py
 msgid "YAML config file containing A2A client options"
 msgstr "Archivo de configuración YAML con opciones del cliente A2A"
 
-#: src/iac_code/cli/main.py:68 src/iac_code/cli/main.py:1501
-#: src/iac_code/cli/main.py:1862 src/iac_code/cli/main.py:1901
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -289,48 +289,47 @@ msgstr ""
 "Faltan las dependencias del cliente A2A. Instálalas con: pip install "
 "'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:82
+#: src/iac_code/cli/main.py
 msgid "LLM model to use"
 msgstr "Modelo LLM a utilizar"
 
-#: src/iac_code/cli/main.py:83
+#: src/iac_code/cli/main.py
 msgid "Non-interactive mode: run a single prompt and exit"
 msgstr "Modo no interactivo: ejecuta un único prompt y termina"
 
-#: src/iac_code/cli/main.py:84
+#: src/iac_code/cli/main.py
 msgid "Output format: text, json, stream-json"
 msgstr "Formato de salida: text, json, stream-json"
 
-#: src/iac_code/cli/main.py:85
+#: src/iac_code/cli/main.py
 msgid "Maximum agent turns in headless mode"
 msgstr "Turnos máximos del agente en modo sin interfaz"
 
-#: src/iac_code/cli/main.py:86 src/iac_code/cli/main.py:366
-#: src/iac_code/cli/main.py:591
+#: src/iac_code/cli/main.py
 msgid "Enable debug logging"
 msgstr "Habilitar el registro de depuración"
 
-#: src/iac_code/cli/main.py:87
+#: src/iac_code/cli/main.py
 msgid "Show headless progress on stderr"
 msgstr "Mostrar el progreso headless en stderr"
 
-#: src/iac_code/cli/main.py:88
+#: src/iac_code/cli/main.py
 msgid "Show version and exit"
 msgstr "Mostrar la versión y salir"
 
-#: src/iac_code/cli/main.py:89
+#: src/iac_code/cli/main.py
 msgid "Resume a session by ID or name"
 msgstr "Reanudar una sesión por ID o nombre"
 
-#: src/iac_code/cli/main.py:90
+#: src/iac_code/cli/main.py
 msgid "Resume the most recent session"
 msgstr "Reanudar la sesión más reciente"
 
-#: src/iac_code/cli/main.py:97 src/iac_code/i18n/__init__.py:55
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid "Install completion for the current shell."
 msgstr "Instalar la finalización automática para el shell actual."
 
-#: src/iac_code/cli/main.py:105 src/iac_code/i18n/__init__.py:56
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid ""
 "Show completion for the current shell, to copy it or customize the "
 "installation."
@@ -338,7 +337,7 @@ msgstr ""
 "Mostrar el script de finalización del shell actual para copiarlo o "
 "personalizar la instalación."
 
-#: src/iac_code/cli/main.py:110
+#: src/iac_code/cli/main.py
 msgid ""
 "Comma-separated tool permission patterns to allow, e.g. 'bash(git "
 "*),write_file'"
@@ -346,48 +345,48 @@ msgstr ""
 "Patrones de permisos de herramientas a permitir (separados por comas), "
 "p.ej. 'bash(git *),write_file'*),write_file'"
 
-#: src/iac_code/cli/main.py:115
+#: src/iac_code/cli/main.py
 msgid "Comma-separated tool permission patterns to deny"
 msgstr "Patrones de permisos de herramientas a denegar (separados por comas)"
 
-#: src/iac_code/cli/main.py:120
+#: src/iac_code/cli/main.py
 msgid "Permission mode: default, accept_edits, bypass_permissions, dont_ask"
 msgstr "Modo de permisos: default, accept_edits, bypass_permissions, dont_ask"
 
-#: src/iac_code/cli/main.py:151
+#: src/iac_code/cli/main.py
 msgid "Error: --resume and --continue cannot be used together."
 msgstr "Error: --resume y --continue no pueden usarse a la vez."
 
-#: src/iac_code/cli/main.py:163
+#: src/iac_code/cli/main.py
 #, python-brace-format
 msgid "Invalid --output-format '{}'. Valid values: {}"
 msgstr "--output-format '{}' no válido. Valores válidos: {}"
 
-#: src/iac_code/cli/main.py:361
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an ACP server."
 msgstr "Ejecutar iac-code como servidor ACP."
 
-#: src/iac_code/cli/main.py:363
+#: src/iac_code/cli/main.py
 msgid "Transport type: stdio or http"
 msgstr "Tipo de transporte: stdio o http"
 
-#: src/iac_code/cli/main.py:364
+#: src/iac_code/cli/main.py
 msgid "HTTP server port"
 msgstr "Puerto del servidor HTTP"
 
-#: src/iac_code/cli/main.py:365 src/iac_code/cli/main.py:581
+#: src/iac_code/cli/main.py
 msgid "HTTP server host"
 msgstr "Host del servidor HTTP"
 
-#: src/iac_code/cli/main.py:577
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an A2A 1.0 server."
 msgstr "Ejecuta iac-code como un servidor A2A 1.0."
 
-#: src/iac_code/cli/main.py:580
+#: src/iac_code/cli/main.py
 msgid "YAML config file for A2A server options"
 msgstr "Archivo de configuración YAML para opciones del servidor A2A"
 
-#: src/iac_code/cli/main.py:584
+#: src/iac_code/cli/main.py
 msgid ""
 "HTTP server port. 41242 is the iac-code default inspired by Gemini CLI, "
 "not a registered A2A port."
@@ -395,7 +394,7 @@ msgstr ""
 "Puerto del servidor HTTP. 41242 es el valor predeterminado de iac-code "
 "inspirado en Gemini CLI, no un puerto A2A registrado."
 
-#: src/iac_code/cli/main.py:589
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc, or "
 "redis-streams"
@@ -403,7 +402,7 @@ msgstr ""
 "Transporte A2A: http, stdio, unix, websocket, grpc, grpc-jsonrpc o redis-"
 "streams"
 
-#: src/iac_code/cli/main.py:595
+#: src/iac_code/cli/main.py
 msgid ""
 "Expose A2A thinking signal types; repeat for multiple. Values: raw-"
 "thinking, tool-trace."
@@ -411,7 +410,7 @@ msgstr ""
 "Expone tipos de señal de thinking A2A; repite para varios. Valores: raw-"
 "thinking, tool-trace."
 
-#: src/iac_code/cli/main.py:646
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -419,611 +418,600 @@ msgstr ""
 "Faltan las dependencias del servidor A2A. Instálalas con: pip install "
 "'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:778
+#: src/iac_code/cli/main.py
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Envía un prompt a un endpoint JSON-RPC A2A."
 
-#: src/iac_code/cli/main.py:781 src/iac_code/cli/main.py:951
-#: src/iac_code/cli/main.py:1004 src/iac_code/cli/main.py:1064
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1163
-#: src/iac_code/cli/main.py:1242 src/iac_code/cli/main.py:1299
-#: src/iac_code/cli/main.py:1355 src/iac_code/cli/main.py:1412
+#: src/iac_code/cli/main.py
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL del endpoint JSON-RPC A2A"
 
-#: src/iac_code/cli/main.py:782 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Especificación de ruta: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:783
+#: src/iac_code/cli/main.py
 msgid "Named A2A route to call"
 msgstr "Ruta A2A con nombre a llamar"
 
-#: src/iac_code/cli/main.py:784
+#: src/iac_code/cli/main.py
 msgid "Prompt to send"
 msgstr "Prompt a enviar"
 
-#: src/iac_code/cli/main.py:785
+#: src/iac_code/cli/main.py
 msgid "Working directory metadata to send with the request"
 msgstr "Metadatos del directorio de trabajo a enviar con la solicitud"
 
-#: src/iac_code/cli/main.py:786
+#: src/iac_code/cli/main.py
 msgid "A2A context ID to continue"
 msgstr "ID de contexto A2A a continuar"
 
-#: src/iac_code/cli/main.py:787 src/iac_code/cli/main.py:882
-#: src/iac_code/cli/main.py:954 src/iac_code/cli/main.py:1011
-#: src/iac_code/cli/main.py:1066 src/iac_code/cli/main.py:1116
-#: src/iac_code/cli/main.py:1170 src/iac_code/cli/main.py:1245
-#: src/iac_code/cli/main.py:1303 src/iac_code/cli/main.py:1358
-#: src/iac_code/cli/main.py:1413
+#: src/iac_code/cli/main.py
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Token Bearer para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:788 src/iac_code/cli/main.py:883
-#: src/iac_code/cli/main.py:955 src/iac_code/cli/main.py:1012
-#: src/iac_code/cli/main.py:1067 src/iac_code/cli/main.py:1117
-#: src/iac_code/cli/main.py:1171 src/iac_code/cli/main.py:1246
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1359
-#: src/iac_code/cli/main.py:1414
+#: src/iac_code/cli/main.py
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Nombre de usuario de autenticación básica para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:789 src/iac_code/cli/main.py:884
-#: src/iac_code/cli/main.py:956 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1068 src/iac_code/cli/main.py:1118
-#: src/iac_code/cli/main.py:1172 src/iac_code/cli/main.py:1247
-#: src/iac_code/cli/main.py:1305 src/iac_code/cli/main.py:1360
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Contraseña de autenticación básica para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:790 src/iac_code/cli/main.py:885
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1069 src/iac_code/cli/main.py:1119
-#: src/iac_code/cli/main.py:1173 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1306 src/iac_code/cli/main.py:1361
-#: src/iac_code/cli/main.py:1416
+#: src/iac_code/cli/main.py
 msgid "API key for A2A HTTP requests"
 msgstr "Clave de API para solicitudes HTTP A2A"
 
-#: src/iac_code/cli/main.py:791 src/iac_code/cli/main.py:886
-#: src/iac_code/cli/main.py:958 src/iac_code/cli/main.py:1015
-#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1120
-#: src/iac_code/cli/main.py:1174 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1307 src/iac_code/cli/main.py:1362
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py
 msgid "HTTP header name for A2A API key"
 msgstr "Nombre del encabezado HTTP para la clave de API A2A"
 
-#: src/iac_code/cli/main.py:796 src/iac_code/cli/main.py:891
+#: src/iac_code/cli/main.py
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Secreto utilizado para verificar la A2A Agent Card"
 
-#: src/iac_code/cli/main.py:801 src/iac_code/cli/main.py:896
+#: src/iac_code/cli/main.py
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "URL JWKS remota utilizada para verificar la A2A Agent Card"
 
-#: src/iac_code/cli/main.py:807 src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Requerir una firma válida de A2A Agent Card"
 
-#: src/iac_code/cli/main.py:809
+#: src/iac_code/cli/main.py
 msgid "A2A call timeout in seconds"
 msgstr "Tiempo de espera de llamada A2A en segundos"
 
-#: src/iac_code/cli/main.py:810
+#: src/iac_code/cli/main.py
 msgid "Use A2A streaming message delivery"
 msgstr "Usar entrega de mensajes en streaming A2A"
 
-#: src/iac_code/cli/main.py:878
+#: src/iac_code/cli/main.py
 msgid "Discover an A2A Agent Card."
 msgstr "Descubre una A2A Agent Card."
 
-#: src/iac_code/cli/main.py:881
+#: src/iac_code/cli/main.py
 msgid "A2A agent base URL"
 msgstr "URL base del agente A2A"
 
-#: src/iac_code/cli/main.py:948
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task."
 msgstr "Obtén una tarea A2A."
 
-#: src/iac_code/cli/main.py:952 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1115 src/iac_code/cli/main.py:1164
-#: src/iac_code/cli/main.py:1243 src/iac_code/cli/main.py:1300
-#: src/iac_code/cli/main.py:1356
+#: src/iac_code/cli/main.py
 msgid "A2A task ID"
 msgstr "ID de tarea A2A"
 
-#: src/iac_code/cli/main.py:953
+#: src/iac_code/cli/main.py
 msgid "Maximum task history items to return"
 msgstr "Número máximo de elementos del historial de tareas a devolver"
 
-#: src/iac_code/cli/main.py:1001
+#: src/iac_code/cli/main.py
 msgid "List A2A tasks."
 msgstr "Lista las tareas A2A."
 
-#: src/iac_code/cli/main.py:1005
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A context ID"
 msgstr "Filtrar por ID de contexto A2A"
 
-#: src/iac_code/cli/main.py:1006
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A task state"
 msgstr "Filtrar por estado de tarea A2A"
 
-#: src/iac_code/cli/main.py:1007
+#: src/iac_code/cli/main.py
 msgid "Maximum tasks to return"
 msgstr "Número máximo de tareas a devolver"
 
-#: src/iac_code/cli/main.py:1008 src/iac_code/cli/main.py:1302
+#: src/iac_code/cli/main.py
 msgid "Pagination token"
 msgstr "Token de paginación"
 
-#: src/iac_code/cli/main.py:1009
+#: src/iac_code/cli/main.py
 msgid "Include task artifacts"
 msgstr "Incluir artefactos de tarea"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py
 msgid "Output format: table or json"
 msgstr "Formato de salida: table o json"
 
-#: src/iac_code/cli/main.py:1061
+#: src/iac_code/cli/main.py
 msgid "Cancel an A2A task."
 msgstr "Cancela una tarea A2A."
 
-#: src/iac_code/cli/main.py:1111
+#: src/iac_code/cli/main.py
 msgid "Subscribe to an A2A task event stream."
 msgstr "Suscríbete a un flujo de eventos de tarea A2A."
 
-#: src/iac_code/cli/main.py:1160
+#: src/iac_code/cli/main.py
 msgid "Create an A2A task push notification config."
 msgstr "Crea una configuración de notificación push de tarea A2A."
 
-#: src/iac_code/cli/main.py:1165 src/iac_code/cli/main.py:1244
-#: src/iac_code/cli/main.py:1357
+#: src/iac_code/cli/main.py
 msgid "Push config ID"
 msgstr "ID de configuración push"
 
-#: src/iac_code/cli/main.py:1166
+#: src/iac_code/cli/main.py
 msgid "Push callback URL"
 msgstr "URL de callback push"
 
-#: src/iac_code/cli/main.py:1167
+#: src/iac_code/cli/main.py
 msgid "Notification verification token"
 msgstr "Token de verificación de notificación"
 
-#: src/iac_code/cli/main.py:1168
+#: src/iac_code/cli/main.py
 msgid "Callback authentication scheme"
 msgstr "Esquema de autenticación de callback"
 
-#: src/iac_code/cli/main.py:1169
+#: src/iac_code/cli/main.py
 msgid "Callback authentication credentials"
 msgstr "Credenciales de autenticación de callback"
 
-#: src/iac_code/cli/main.py:1239
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task push notification config."
 msgstr "Obtén una configuración de notificación push de tarea A2A."
 
-#: src/iac_code/cli/main.py:1296
+#: src/iac_code/cli/main.py
 msgid "List A2A task push notification configs."
 msgstr "Lista las configuraciones de notificación push de tareas A2A."
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py
 msgid "Maximum configs to return"
 msgstr "Número máximo de configuraciones a devolver"
 
-#: src/iac_code/cli/main.py:1352
+#: src/iac_code/cli/main.py
 msgid "Delete an A2A task push notification config."
 msgstr "Elimina una configuración de notificación push de tarea A2A."
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Obtén una A2A Agent Card extendida autenticada."
 
-#: src/iac_code/cli/main.py:1452
+#: src/iac_code/cli/main.py
 msgid "Preview A2A route resolution."
 msgstr "Vista previa de la resolución de rutas A2A."
 
-#: src/iac_code/cli/main.py:1459
+#: src/iac_code/cli/main.py
 msgid "Route name to resolve"
 msgstr "Nombre de ruta a resolver"
 
-#: src/iac_code/cli/main.py:1460
+#: src/iac_code/cli/main.py
 msgid "Skill ID to resolve"
 msgstr "ID de habilidad a resolver"
 
-#: src/iac_code/cli/main.py:1461
+#: src/iac_code/cli/main.py
 msgid "Prompt text used for tag/name route matching"
 msgstr ""
 "Texto del prompt utilizado para la coincidencia de rutas por "
 "etiqueta/nombre"
 
-#: src/iac_code/cli/main.py:1466
+#: src/iac_code/cli/main.py
 msgid "Directory for persisted A2A routes"
 msgstr "Directorio para rutas A2A persistentes"
 
-#: src/iac_code/cli/main.py:1468
+#: src/iac_code/cli/main.py
 msgid "Save the provided routes as a route snapshot"
 msgstr "Guarda las rutas proporcionadas como una instantánea de rutas"
 
-#: src/iac_code/commands/__init__.py:26
+#: src/iac_code/cli/update.py
+msgid "Check for updates without installing."
+msgstr "Buscar actualizaciones sin instalar."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "iac-code is already up to date (v{})."
+msgstr "iac-code ya está actualizado (v{})."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update available: v{} -> v{}"
+msgstr "Actualización disponible: v{} -> v{}"
+
+#: src/iac_code/cli/update.py src/iac_code/ui/banner.py
+#, python-brace-format
+msgid "Run {} to update."
+msgstr "Ejecuta {} para actualizar."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Updating iac-code from v{} to v{}..."
+msgstr "Actualizando iac-code de v{} a v{}..."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed: {}"
+msgstr "El comando de actualización falló: {}"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed with exit code {}."
+msgstr "El comando de actualización falló con código de salida {}."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Successfully updated to v{}!"
+msgstr "Actualizado correctamente a v{}!"
+
+#: src/iac_code/commands/__init__.py
 msgid "Show available commands"
 msgstr "Mostrar los comandos disponibles"
 
-#: src/iac_code/commands/__init__.py:35
+#: src/iac_code/commands/__init__.py
 msgid "Clear conversation history"
 msgstr "Borrar el historial de conversación"
 
-#: src/iac_code/commands/__init__.py:43
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch model"
 msgstr "Mostrar o cambiar de modelo"
 
-#: src/iac_code/commands/__init__.py:52
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch thinking effort"
 msgstr "Mostrar o cambiar el nivel de razonamiento (effort)"
 
-#: src/iac_code/commands/__init__.py:61
+#: src/iac_code/commands/__init__.py
 msgid "Compact conversation context"
 msgstr "Compactar el contexto de la conversación"
 
-#: src/iac_code/commands/__init__.py:63
+#: src/iac_code/commands/__init__.py
 msgid "Compacting conversation"
 msgstr "Compactando la conversación"
 
-#: src/iac_code/commands/__init__.py:70
+#: src/iac_code/commands/__init__.py
 msgid "Exit the application"
 msgstr "Salir de la aplicación"
 
-#: src/iac_code/commands/__init__.py:79
+#: src/iac_code/commands/__init__.py
 msgid "Authenticate with LLM provider"
 msgstr "Autenticar con el proveedor LLM"
 
-#: src/iac_code/commands/__init__.py:88
+#: src/iac_code/commands/__init__.py
 msgid "Toggle debug logging"
 msgstr "Activar o desactivar el registro de depuración"
 
-#: src/iac_code/commands/__init__.py:97
+#: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"
 msgstr "Ver y administrar memorias persistentes"
 
-#: src/iac_code/commands/__init__.py:99
+#: src/iac_code/commands/__init__.py
 msgid "[<name>|search <query>|delete <name>|help]"
 msgstr "[<nombre>|search <consulta>|delete <nombre>|help]"
 
-#: src/iac_code/commands/__init__.py:106
+#: src/iac_code/commands/__init__.py
 msgid "Resume a previous session"
 msgstr "Reanudar una sesión anterior"
 
-#: src/iac_code/commands/__init__.py:108
+#: src/iac_code/commands/__init__.py
 msgid "[conversation id or search term]"
 msgstr "[id de conversación o término de búsqueda]"
 
-#: src/iac_code/commands/__init__.py:115
+#: src/iac_code/commands/__init__.py
 msgid "Rename the current session"
 msgstr "Renombrar la sesión actual"
 
-#: src/iac_code/commands/__init__.py:124
+#: src/iac_code/commands/__init__.py
 msgid "Manage skills"
 msgstr "Gestionar habilidades"
 
-#: src/iac_code/commands/__init__.py:132
+#: src/iac_code/commands/__init__.py
 msgid "Show current session status"
 msgstr "Mostrar el estado actual de la sesión"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:1117
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Navigate"
 msgstr "Navegar"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:538
-#: src/iac_code/commands/auth.py:570 src/iac_code/commands/auth.py:577
-#: src/iac_code/commands/auth.py:612 src/iac_code/commands/auth.py:619
-#: src/iac_code/commands/auth.py:640 src/iac_code/commands/auth.py:1117
-#: src/iac_code/commands/auth.py:1551 src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:536
-#: src/iac_code/commands/auth.py:538 src/iac_code/commands/auth.py:570
-#: src/iac_code/commands/auth.py:577 src/iac_code/commands/auth.py:612
-#: src/iac_code/commands/auth.py:619 src/iac_code/commands/auth.py:640
-#: src/iac_code/commands/auth.py:1117 src/iac_code/commands/auth.py:1443
-#: src/iac_code/commands/auth.py:1551
+#: src/iac_code/commands/auth.py
 msgid "Back"
 msgstr "Atrás"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Keep"
 msgstr "Conservar"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Re-enter"
 msgstr "Volver a introducir"
 
-#: src/iac_code/commands/auth.py:749 src/iac_code/commands/auth.py:863
-#: src/iac_code/commands/auth.py:921 src/iac_code/commands/auth.py:929
-#: src/iac_code/commands/auth.py:956
+#: src/iac_code/commands/auth.py
 msgid " (current)"
 msgstr " (actual)"
 
-#: src/iac_code/commands/auth.py:752
+#: src/iac_code/commands/auth.py
 msgid "Custom model..."
 msgstr "Modelo personalizado..."
 
-#: src/iac_code/commands/auth.py:755
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select model for {provider}"
 msgstr "Seleccionar modelo para {provider}"
 
-#: src/iac_code/commands/auth.py:757
+#: src/iac_code/commands/auth.py
 msgid "Select model"
 msgstr "Seleccionar modelo"
 
-#: src/iac_code/commands/auth.py:765
+#: src/iac_code/commands/auth.py
 msgid "Enter custom model name: "
 msgstr "Introduzca el nombre del modelo personalizado: "
 
-#: src/iac_code/commands/auth.py:791
+#: src/iac_code/commands/auth.py
 msgid "Error: console not available"
 msgstr "Error: la consola no está disponible"
 
-#: src/iac_code/commands/auth.py:820
+#: src/iac_code/commands/auth.py
 msgid "Configure LLM Provider"
 msgstr "Configurar proveedor LLM"
 
-#: src/iac_code/commands/auth.py:821
+#: src/iac_code/commands/auth.py
 msgid "Configure IaC Cloud Service"
 msgstr "Configurar servicio cloud IaC"
 
-#: src/iac_code/commands/auth.py:823
+#: src/iac_code/commands/auth.py
 msgid "Select configuration type"
 msgstr "Seleccionar tipo de configuración"
 
-#: src/iac_code/commands/auth.py:825 src/iac_code/commands/auth.py:981
-#: src/iac_code/commands/auth.py:997 src/iac_code/commands/auth.py:1076
-#: src/iac_code/commands/auth.py:1490 src/iac_code/commands/auth.py:1531
+#: src/iac_code/commands/auth.py
 msgid "Auth cancelled"
 msgstr "Autenticación cancelada"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:961
-#: src/iac_code/commands/auth.py:1051
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select provider — {group}"
 msgstr "Seleccionar proveedor — {group}"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:919
-#: src/iac_code/commands/auth.py:1036
+#: src/iac_code/commands/auth.py
 msgid "Third-party"
 msgstr "Terceros"
 
-#: src/iac_code/commands/auth.py:877
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider}"
 msgstr "{status}: {provider}"
 
-#: src/iac_code/commands/auth.py:878 src/iac_code/commands/auth.py:1029
+#: src/iac_code/commands/auth.py
 msgid "Configured"
 msgstr "Configurado"
 
-#: src/iac_code/commands/auth.py:933
+#: src/iac_code/commands/auth.py
 msgid "Select provider"
 msgstr "Seleccionar proveedor"
 
-#: src/iac_code/commands/auth.py:974
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Configure {provider}"
 msgstr "Configurar {provider}"
 
-#: src/iac_code/commands/auth.py:990
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Enter API key for {provider}"
 msgstr "Introduzca la API key para {provider}"
 
-#: src/iac_code/commands/auth.py:1028
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider} / {model}"
 msgstr "{status}: {provider} / {model}"
 
-#: src/iac_code/commands/auth.py:1037 src/iac_code/commands/auth.py:1058
+#: src/iac_code/commands/auth.py
 msgid "Alibaba Cloud"
 msgstr "Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1038 src/iac_code/providers/registry.py:427
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "ZhiPu AI"
 msgstr "ZhiPu AI"
 
-#: src/iac_code/commands/auth.py:1039
+#: src/iac_code/commands/auth.py
 msgid "Kimi"
 msgstr "Kimi"
 
-#: src/iac_code/commands/auth.py:1040
+#: src/iac_code/commands/auth.py
 msgid "MiniMax"
 msgstr "MiniMax"
 
-#: src/iac_code/commands/auth.py:1041 src/iac_code/providers/registry.py:429
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Volcengine"
 msgstr "Volcengine"
 
-#: src/iac_code/commands/auth.py:1042
+#: src/iac_code/commands/auth.py
 msgid "SiliconFlow"
 msgstr "SiliconFlow"
 
-#: src/iac_code/commands/auth.py:1043 src/iac_code/providers/registry.py:420
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: src/iac_code/commands/auth.py:1044 src/iac_code/providers/registry.py:418
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: src/iac_code/commands/auth.py:1045 src/iac_code/providers/registry.py:419
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Anthropic"
 msgstr "Anthropic"
 
-#: src/iac_code/commands/auth.py:1046 src/iac_code/providers/registry.py:422
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
-#: src/iac_code/commands/auth.py:1047 src/iac_code/providers/registry.py:435
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Azure OpenAI"
 msgstr "Azure OpenAI"
 
-#: src/iac_code/commands/auth.py:1048 src/iac_code/providers/registry.py:434
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenRouter"
 msgstr "OpenRouter"
 
-#: src/iac_code/commands/auth.py:1049
+#: src/iac_code/commands/auth.py
 msgid "Local"
 msgstr "Local"
 
-#: src/iac_code/commands/auth.py:1050
+#: src/iac_code/commands/auth.py
 msgid "Compatible"
 msgstr "Compatible"
 
-#: src/iac_code/commands/auth.py:1067
+#: src/iac_code/commands/auth.py
 msgid "Select Cloud Provider"
 msgstr "Seleccionar proveedor de cloud"
 
-#: src/iac_code/commands/auth.py:1083
+#: src/iac_code/commands/auth.py
 msgid "Credential"
 msgstr "Credencial"
 
-#: src/iac_code/commands/auth.py:1084 src/iac_code/commands/auth.py:1199
-#: src/iac_code/commands/auth.py:1527 src/iac_code/commands/status.py:36
-#: src/iac_code/ui/renderer.py:455
+#: src/iac_code/commands/auth.py src/iac_code/commands/status.py
+#: src/iac_code/ui/renderer.py
 msgid "Region"
 msgstr "Región"
 
-#: src/iac_code/commands/auth.py:1086
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud"
 msgstr "Configurar Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1188
+#: src/iac_code/commands/auth.py
 msgid "Current configuration"
 msgstr "Configuración actual"
 
-#: src/iac_code/commands/auth.py:1190
+#: src/iac_code/commands/auth.py
 msgid "Mode"
 msgstr "Modo"
 
-#: src/iac_code/commands/auth.py:1196
+#: src/iac_code/commands/auth.py
 msgid "(not set)"
 msgstr "(sin definir)"
 
-#: src/iac_code/commands/auth.py:1205
+#: src/iac_code/commands/auth.py
 msgid "AccessKey"
 msgstr "AccessKey"
 
-#: src/iac_code/commands/auth.py:1207 src/iac_code/commands/auth.py:1219
+#: src/iac_code/commands/auth.py
 msgid "STS Token"
 msgstr "Token STS"
 
-#: src/iac_code/commands/auth.py:1209
+#: src/iac_code/commands/auth.py
 msgid "RAM Role"
 msgstr "Rol RAM"
 
-#: src/iac_code/commands/auth.py:1211
+#: src/iac_code/commands/auth.py
 msgid "OAuth Login (Browser)"
 msgstr "Inicio de sesión OAuth (navegador)"
 
-#: src/iac_code/commands/auth.py:1217
+#: src/iac_code/commands/auth.py
 msgid "AccessKey ID"
 msgstr "ID de AccessKey"
 
-#: src/iac_code/commands/auth.py:1218
+#: src/iac_code/commands/auth.py
 msgid "AccessKey Secret"
 msgstr "Secreto de AccessKey"
 
-#: src/iac_code/commands/auth.py:1220
+#: src/iac_code/commands/auth.py
 msgid "RAM Role ARN"
 msgstr "ARN del rol RAM"
 
-#: src/iac_code/commands/auth.py:1221
+#: src/iac_code/commands/auth.py
 msgid "Session Name"
 msgstr "Nombre de sesión"
 
-#: src/iac_code/commands/auth.py:1222
+#: src/iac_code/commands/auth.py
 msgid "OAuth Site Type"
 msgstr "Tipo de sitio OAuth"
 
-#: src/iac_code/commands/auth.py:1223
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token"
 msgstr "Token de acceso OAuth"
 
-#: src/iac_code/commands/auth.py:1224
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token"
 msgstr "Token de actualización OAuth"
 
-#: src/iac_code/commands/auth.py:1225
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token Expire"
 msgstr "Expiración del token de acceso OAuth"
 
-#: src/iac_code/commands/auth.py:1226
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token Expire"
 msgstr "Expiración del token de actualización OAuth"
 
-#: src/iac_code/commands/auth.py:1227
+#: src/iac_code/commands/auth.py
 msgid "STS Expiration"
 msgstr "Expiración STS"
 
-#: src/iac_code/commands/auth.py:1384
+#: src/iac_code/commands/auth.py
 msgid "China"
 msgstr "China"
 
-#: src/iac_code/commands/auth.py:1385
+#: src/iac_code/commands/auth.py
 msgid "International"
 msgstr "Internacional"
 
-#: src/iac_code/commands/auth.py:1387
+#: src/iac_code/commands/auth.py
 msgid "Choose site type"
 msgstr "Elegir tipo de sitio"
 
-#: src/iac_code/commands/auth.py:1402
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Alibaba Cloud OAuth login failed: {error}"
 msgstr "Error de inicio de sesión OAuth de Alibaba Cloud: {error}"
 
-#: src/iac_code/commands/auth.py:1418
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud OAuth credentials saved"
 msgstr "Configurado: credenciales OAuth de Alibaba Cloud guardadas"
 
-#: src/iac_code/commands/auth.py:1430
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud credentials"
 msgstr "Configurar credenciales de Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1443
+#: src/iac_code/commands/auth.py
 msgid "Reconfigure credential"
 msgstr "Reconfigurar la credencial"
 
-#: src/iac_code/commands/auth.py:1456
+#: src/iac_code/commands/auth.py
 msgid "Select credential type"
 msgstr "Seleccionar tipo de credencial"
 
-#: src/iac_code/commands/auth.py:1512
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud credentials saved to ~/.iac-code"
 msgstr "Configurado: credenciales de Alibaba Cloud guardadas en ~/.iac-code"
 
-#: src/iac_code/commands/auth.py:1519
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud region"
 msgstr "Configurar la región de Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1545
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud region saved to ~/.iac-code"
 msgstr "Configurado: región de Alibaba Cloud guardada en ~/.iac-code"
 
-#: src/iac_code/commands/compact.py:12
+#: src/iac_code/commands/compact.py
 msgid "Compact command requires a context."
 msgstr "El comando compact requiere un contexto."
 
-#: src/iac_code/commands/compact.py:16
+#: src/iac_code/commands/compact.py
 msgid "No active REPL."
 msgstr "No hay ningún REPL activo."
 
-#: src/iac_code/commands/compact.py:20
+#: src/iac_code/commands/compact.py
 msgid "No active agent loop."
 msgstr "No hay ningún bucle de agente activo."
 
-#: src/iac_code/commands/compact.py:35
+#: src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent_display} "
@@ -1032,108 +1020,107 @@ msgstr ""
 "Contexto compactado: {original} → {compacted} tokens (reducción "
 "{percent_display}). Uso del contexto: {usage_display}"
 
-#: src/iac_code/commands/debug.py:21
+#: src/iac_code/commands/debug.py
 msgid "Debug command requires a context."
 msgstr "El comando debug requiere un contexto."
 
-#: src/iac_code/commands/debug.py:26
+#: src/iac_code/commands/debug.py
 msgid "No active session."
 msgstr "No hay ninguna sesión activa."
 
-#: src/iac_code/commands/effort.py:54 src/iac_code/commands/model.py:95
-#: src/iac_code/commands/model.py:99
+#: src/iac_code/commands/effort.py src/iac_code/commands/model.py
 msgid "No configured providers. Run /auth first."
 msgstr "No hay proveedores configurados. Ejecute /auth primero."
 
-#: src/iac_code/commands/effort.py:58
+#: src/iac_code/commands/effort.py
 msgid "No model selected. Run /model first."
 msgstr "No hay ningún modelo seleccionado. Ejecute /model primero."
 
-#: src/iac_code/commands/effort.py:66
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Model {model} does not support effort."
 msgstr "El modelo {model} no admite effort."
 
-#: src/iac_code/commands/effort.py:80
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Invalid effort. Allowed: {labels}"
 msgstr "Valor de effort no válido. Valores permitidos: {labels}"
 
-#: src/iac_code/commands/effort.py:85
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Current effort: {effort}"
 msgstr "Effort actual: {effort}"
 
-#: src/iac_code/commands/effort.py:94
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Select effort for {model}"
 msgstr "Seleccionar effort para {model}"
 
-#: src/iac_code/commands/effort.py:103 src/iac_code/commands/effort.py:107
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Kept effort as {effort}"
 msgstr "Se mantiene el effort en {effort}"
 
-#: src/iac_code/commands/effort.py:116
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Effort switched to: {effort}"
 msgstr "Effort cambiado a: {effort}"
 
-#: src/iac_code/commands/help.py:29
+#: src/iac_code/commands/help.py
 msgid "Commands:"
 msgstr "Comandos:"
 
-#: src/iac_code/commands/help.py:36
+#: src/iac_code/commands/help.py
 msgid "Shortcuts:"
 msgstr "Atajos:"
 
-#: src/iac_code/commands/help.py:39
+#: src/iac_code/commands/help.py
 msgid "Send message"
 msgstr "Enviar mensaje"
 
-#: src/iac_code/commands/help.py:40
+#: src/iac_code/commands/help.py
 msgid "New line"
 msgstr "Nueva línea"
 
-#: src/iac_code/commands/help.py:41
+#: src/iac_code/commands/help.py
 msgid "Show command suggestions"
 msgstr "Mostrar sugerencias de comandos"
 
-#: src/iac_code/commands/help.py:42
+#: src/iac_code/commands/help.py
 msgid "Exit"
 msgstr "Salir"
 
-#: src/iac_code/commands/memory.py:10
+#: src/iac_code/commands/memory.py
 msgid "Usage: /memory [<name>|search <query>|delete <name>|help]"
 msgstr "Uso: /memory [<nombre>|search <consulta>|delete <nombre>|help]"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "Saved memories:"
 msgstr "Memorias guardadas:"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "No memories saved yet."
 msgstr "Todavía no hay memorias guardadas."
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "Matching memories:"
 msgstr "Memorias coincidentes:"
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "No matching memories."
 msgstr "No hay memorias coincidentes."
 
-#: src/iac_code/commands/memory.py:60 src/iac_code/commands/memory.py:75
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' not found."
 msgstr "No se encontró la memoria '{name}'."
 
-#: src/iac_code/commands/memory.py:64
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' deleted."
 msgstr "Memoria '{name}' eliminada."
 
-#: src/iac_code/commands/model.py:57
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid ""
 "Model is managed by '{source}'. To change model, modify it in {source} or"
@@ -1142,185 +1129,183 @@ msgstr ""
 "El modelo es gestionado por '{source}'. Para cambiarlo, modifíquelo en "
 "{source} o cambie de proveedor mediante /auth."
 
-#: src/iac_code/commands/model.py:88 src/iac_code/commands/model.py:143
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Model switched to: {model}"
 msgstr "Modelo cambiado a: {model}"
 
-#: src/iac_code/commands/model.py:92
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Current model: {model}"
 msgstr "Modelo actual: {model}"
 
-#: src/iac_code/commands/model.py:118
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Kept model as {model}"
 msgstr "Se mantiene el modelo como {model}"
 
-#: src/iac_code/commands/rename.py:16 src/iac_code/commands/rename.py:28
+#: src/iac_code/commands/rename.py
 msgid "Rename is only available in interactive mode."
 msgstr "El cambio de nombre solo está disponible en modo interactivo."
 
-#: src/iac_code/commands/rename.py:31
+#: src/iac_code/commands/rename.py
 msgid "Rename cancelled"
 msgstr "Cambio de nombre cancelado"
 
-#: src/iac_code/commands/resume.py:22
+#: src/iac_code/commands/resume.py
 msgid "Resume is only available in interactive mode."
 msgstr "Reanudar solo está disponible en modo interactivo."
 
-#: src/iac_code/commands/resume.py:28
+#: src/iac_code/commands/resume.py
 msgid "Resume is unavailable: session index not initialised."
 msgstr ""
 "Resume is unavailable: session index not initialised.Reanudar no está "
 "disponible: el índice de sesiones no se ha inicializado."
 
-#: src/iac_code/commands/resume.py:33 src/iac_code/commands/resume.py:36
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Session not found: {arg}"
 msgstr "Sesión no encontrada: {arg}"
 
-#: src/iac_code/commands/resume.py:52 src/iac_code/commands/resume.py:68
+#: src/iac_code/commands/resume.py
 msgid "Resume cancelled"
 msgstr "Reanudación cancelada"
 
-#: src/iac_code/commands/resume.py:55
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Unable to resolve session: {arg}"
 msgstr "No se pudo resolver la sesión: {arg}"
 
-#: src/iac_code/commands/skills.py:14
+#: src/iac_code/commands/skills.py
 msgid "Skills management is only available in interactive mode."
 msgstr "La gestión de habilidades solo está disponible en modo interactivo."
 
-#: src/iac_code/commands/skills.py:25
+#: src/iac_code/commands/skills.py
 msgid "Skills update cancelled"
 msgstr "Actualización de habilidades cancelada"
 
-#: src/iac_code/commands/skills.py:29
+#: src/iac_code/commands/skills.py
 msgid "Skills updated"
 msgstr "Habilidades actualizadas"
 
-#: src/iac_code/commands/status.py:19
+#: src/iac_code/commands/status.py
 msgid "Status command requires a context."
 msgstr "El comando status requiere un contexto."
 
-#: src/iac_code/commands/status.py:22
+#: src/iac_code/commands/status.py
 msgid "Status command requires a REPL context."
 msgstr "El comando status requiere un contexto REPL."
 
-#: src/iac_code/commands/status.py:24
+#: src/iac_code/commands/status.py
 msgid "Status is only available in interactive mode."
 msgstr "status solo está disponible en modo interactivo."
 
-#: src/iac_code/commands/status.py:33 src/iac_code/ui/banner.py:136
-#: src/iac_code/ui/banner.py:138
+#: src/iac_code/commands/status.py src/iac_code/ui/banner.py
 msgid "Session"
 msgstr "Sesión"
 
-#: src/iac_code/commands/status.py:34
+#: src/iac_code/commands/status.py
 msgid "Provider"
 msgstr "Proveedor"
 
-#: src/iac_code/commands/status.py:34 src/iac_code/commands/status.py:35
-#: src/iac_code/commands/status.py:36
+#: src/iac_code/commands/status.py
 msgid "not configured"
 msgstr "no configurado"
 
-#: src/iac_code/commands/status.py:35
+#: src/iac_code/commands/status.py
 msgid "Model"
 msgstr "Modelo"
 
-#: src/iac_code/commands/status.py:37
+#: src/iac_code/commands/status.py
 msgid "CWD"
 msgstr "Directorio actual"
 
-#: src/iac_code/commands/status.py:41
+#: src/iac_code/commands/status.py
 msgid "API Token Usage (recorded):"
 msgstr "Uso de tokens de API (registrado):"
 
-#: src/iac_code/commands/status.py:44
+#: src/iac_code/commands/status.py
 msgid "Input"
 msgstr "Entrada"
 
-#: src/iac_code/commands/status.py:45
+#: src/iac_code/commands/status.py
 msgid "Output"
 msgstr "Salida"
 
-#: src/iac_code/commands/status.py:46
+#: src/iac_code/commands/status.py
 msgid "Cache read"
 msgstr "Lectura de caché"
 
-#: src/iac_code/commands/status.py:47
+#: src/iac_code/commands/status.py
 msgid "Total"
 msgstr "Total"
 
-#: src/iac_code/commands/status.py:50
+#: src/iac_code/commands/status.py
 msgid "No recorded API usage for this session yet."
 msgstr "Aún no hay uso de API registrado para esta sesión."
 
-#: src/iac_code/commands/status.py:54
+#: src/iac_code/commands/status.py
 msgid "Turns"
 msgstr "Turnos"
 
-#: src/iac_code/commands/status.py:55
+#: src/iac_code/commands/status.py
 msgid "Context"
 msgstr "Contexto"
 
-#: src/iac_code/commands/status.py:57
+#: src/iac_code/commands/status.py
 msgid "Session Status"
 msgstr "Estado de la sesión"
 
-#: src/iac_code/commands/status.py:73
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{session_id} (resumed)"
 msgstr "{session_id} (reanudada)"
 
-#: src/iac_code/commands/status.py:81
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{percent} used ({total} / {window})"
 msgstr "{percent} usado ({total} / {window})"
 
 # Typer/Click built-in strings
-#: src/iac_code/i18n/__init__.py:51
+#: src/iac_code/i18n/__init__.py
 msgid "Options"
 msgstr "Opciones"
 
-#: src/iac_code/i18n/__init__.py:52
+#: src/iac_code/i18n/__init__.py
 msgid "Commands"
 msgstr "Comandos"
 
-#: src/iac_code/i18n/__init__.py:53
+#: src/iac_code/i18n/__init__.py
 msgid "Arguments"
 msgstr "Argumentos"
 
-#: src/iac_code/i18n/__init__.py:54
+#: src/iac_code/i18n/__init__.py
 msgid "Show this message and exit."
 msgstr "Mostrar este mensaje y salir."
 
-#: src/iac_code/i18n/__init__.py:57
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "default: {default}"
 msgstr "valor predeterminado: {default}"
 
-#: src/iac_code/i18n/__init__.py:58
+#: src/iac_code/i18n/__init__.py
 msgid "required"
 msgstr "obligatorio"
 
-#: src/iac_code/i18n/__init__.py:59
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "env var: {var}"
 msgstr "variable de entorno: {var}"
 
-#: src/iac_code/i18n/__init__.py:60
+#: src/iac_code/i18n/__init__.py
 msgid "(dynamic)"
 msgstr "(dinámico)"
 
-#: src/iac_code/i18n/__init__.py:61
+#: src/iac_code/i18n/__init__.py
 msgid "Aborted!"
 msgstr "¡Operación cancelada!"
 
-#: src/iac_code/providers/manager.py:78
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Cannot determine provider for model: {model}. Run /auth to configure."
 msgstr ""
@@ -1329,12 +1314,12 @@ msgstr ""
 "configure.No se puede determinar el proveedor para el modelo: {model}. "
 "Ejecute /auth para configurar."
 
-#: src/iac_code/providers/manager.py:95
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Unknown provider key: '{key}'. Run /auth to configure."
 msgstr "Clave de proveedor desconocida: '{key}'. Ejecute /auth para configurar."
 
-#: src/iac_code/providers/manager.py:100
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid ""
 "No API key configured for provider '{provider}' (model: {model}). Run "
@@ -1343,7 +1328,7 @@ msgstr ""
 "No se ha configurado una clave API para el proveedor '{provider}' "
 "(modelo: {model}). Ejecute /auth para configurar."
 
-#: src/iac_code/providers/openai_provider.py:307
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned no data. Please check that your API Base URL is correct "
@@ -1354,7 +1339,7 @@ msgstr ""
 "(actual: {base_url}). Muchos endpoints compatibles con OpenAI requieren "
 "el sufijo /v1 (p. ej., {base_url}/v1)."
 
-#: src/iac_code/providers/openai_provider.py:348
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned an invalid response. Please check that your API Base URL is "
@@ -1365,83 +1350,83 @@ msgstr ""
 " correcta (actual: {base_url}). Muchos endpoints compatibles con OpenAI "
 "requieren el sufijo /v1 (p. ej., {base_url}/v1)."
 
-#: src/iac_code/providers/registry.py:416
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
 msgstr "Alibaba Cloud Bailian"
 
-#: src/iac_code/providers/registry.py:417
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian Token Plan"
 msgstr "Alibaba Cloud Bailian Token Plan"
 
-#: src/iac_code/providers/registry.py:421
+#: src/iac_code/providers/registry.py
 msgid "OpenAPI Compatible"
 msgstr "Compatible con OpenAPI"
 
-#: src/iac_code/providers/registry.py:423
+#: src/iac_code/providers/registry.py
 msgid "Kimi (China)"
 msgstr "Kimi (China)"
 
-#: src/iac_code/providers/registry.py:424
+#: src/iac_code/providers/registry.py
 msgid "Kimi (International)"
 msgstr "Kimi (Internacional)"
 
-#: src/iac_code/providers/registry.py:425
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (China)"
 msgstr "MiniMax (China)"
 
-#: src/iac_code/providers/registry.py:426
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (International)"
 msgstr "MiniMax (Internacional)"
 
-#: src/iac_code/providers/registry.py:428
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI (International)"
 msgstr "ZhiPu AI (Internacional)"
 
-#: src/iac_code/providers/registry.py:430
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (China)"
 msgstr "SiliconFlow (China)"
 
-#: src/iac_code/providers/registry.py:431
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (International)"
 msgstr "SiliconFlow (Internacional)"
 
-#: src/iac_code/providers/registry.py:432
+#: src/iac_code/providers/registry.py
 msgid "Ollama (Local)"
 msgstr "Ollama (Local)"
 
-#: src/iac_code/providers/registry.py:433
+#: src/iac_code/providers/registry.py
 msgid "LM Studio (Local)"
 msgstr "LM Studio (Local)"
 
-#: src/iac_code/providers/registry.py:436
+#: src/iac_code/providers/registry.py
 msgid "ModelScope"
 msgstr "ModelScope"
 
-#: src/iac_code/providers/registry.py:437
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan"
 msgstr "Alibaba Cloud CodingPlan"
 
-#: src/iac_code/providers/registry.py:438
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan (International)"
 msgstr "Alibaba Cloud CodingPlan (Internacional)"
 
-#: src/iac_code/providers/registry.py:439
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan"
 msgstr "ZhiPu AI CodingPlan"
 
-#: src/iac_code/providers/registry.py:440
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan (International)"
 msgstr "ZhiPu AI CodingPlan (Internacional)"
 
-#: src/iac_code/providers/registry.py:441
+#: src/iac_code/providers/registry.py
 msgid "Volcengine CodingPlan"
 msgstr "Volcengine CodingPlan"
 
-#: src/iac_code/providers/registry.py:442
+#: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Compatible con Anthropic"
 
-#: src/iac_code/services/qwenpaw_source.py:205
+#: src/iac_code/services/qwenpaw_source.py
 #, python-brace-format
 msgid ""
 "[QwenPaw mode] Unknown provider '{provider_id}'. iac-code does not "
@@ -1456,90 +1441,90 @@ msgstr ""
 "Solución: cambie a un proveedor soportado en QwenPaw, o desactive el modo"
 " QwenPaw (elimine 'llm_source: qwenpaw' de settings.yml)."
 
-#: src/iac_code/services/session_metadata.py:52
+#: src/iac_code/services/session_metadata.py
 #, python-brace-format
 msgid "Session name must match {pattern}"
 msgstr "El nombre de sesión debe coincidir con {pattern}"
 
-#: src/iac_code/services/session_storage.py:241
+#: src/iac_code/services/session_storage.py
 #, python-brace-format
 msgid "Session name already exists in this project: {name}"
 msgstr "El nombre de sesión ya existe en este proyecto: {name}"
 
-#: src/iac_code/services/permissions/loader.py:50
+#: src/iac_code/services/permissions/loader.py
 #, python-brace-format
 msgid "Invalid --permission-mode {!r}. Valid values: {}"
 msgstr "Modo --permission-mode no válido: {!r}. Valores válidos: {}"
 
-#: src/iac_code/services/permissions/pipeline.py:54
-#: src/iac_code/tools/base.py:199 src/iac_code/tools/bash/bash_tool.py:175
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Allow {}?"
 msgstr "¿Permitir {}?"
 
-#: src/iac_code/services/providers/aliyun.py:144
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
 msgstr "Falta el sitio OAuth de Alibaba Cloud."
 
-#: src/iac_code/services/providers/aliyun.py:150
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth refresh token is missing."
 msgstr "Falta el token de actualización OAuth de Alibaba Cloud."
 
-#: src/iac_code/services/providers/aliyun.py:158
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth access token is missing."
 msgstr "Falta el token de acceso OAuth de Alibaba Cloud."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:83
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Run /auth and choose OAuth Login (Browser)."
 msgstr "Ejecute /auth y elija Inicio de sesión OAuth (navegador)."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:106
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "Unknown Aliyun OAuth site: {site_type}"
 msgstr "Sitio OAuth de Aliyun desconocido: {site_type}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:164
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:170
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "invalid state"
 msgstr "estado inválido"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:171
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Invalid state"
 msgstr "Estado inválido"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:176
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "code not found"
 msgstr "código de autorización no encontrado"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:177
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization code not found"
 msgstr "Código de autorización no encontrado"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:181
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization successful. You can close this window."
 msgstr "Autorización correcta. Puede cerrar esta ventana."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:212
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "No available callback port in range {start}-{end}"
 msgstr "No hay ningún puerto de callback disponible en el intervalo {start}-{end}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:227
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "OAuth login cancelled."
 msgstr "Inicio de sesión OAuth cancelado."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:278
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Open in your browser:"
 msgstr "Abrir en el navegador:"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:299
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Waiting for browser authorization"
 msgstr "Esperando la autorización del navegador"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:300
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "1. The browser may show official-cli; this is the Alibaba Cloud official "
 "CLI OAuth application."
@@ -1547,7 +1532,7 @@ msgstr ""
 "1. El navegador puede mostrar official-cli; es la aplicación OAuth "
 "oficial de la CLI de Alibaba Cloud."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:302
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "2. If assignment is required, assign the RAM user or RAM role that is "
 "signed in. User groups are not supported."
@@ -1555,7 +1540,7 @@ msgstr ""
 "2. Si se requiere asignación, asigne el usuario RAM o el rol RAM que "
 "tiene la sesión iniciada. Los grupos de usuarios no son compatibles."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:306
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "3. After assignment, close the old authorization page and run OAuth Login"
 " (Browser) again. If it still fails, sign out of Alibaba Cloud and sign "
@@ -1565,7 +1550,7 @@ msgstr ""
 "ejecute de nuevo Inicio de sesión OAuth (navegador). Si sigue fallando, "
 "cierre sesión en Alibaba Cloud e iníciela de nuevo."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:310
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "4. STS credentials refresh when possible until Alibaba Cloud expires "
 "them. If refresh fails, run /auth again."
@@ -1573,11 +1558,11 @@ msgstr ""
 "4. Las credenciales STS se actualizan cuando es posible hasta que Alibaba"
 " Cloud las caduque. Si la actualización falla, ejecute /auth de nuevo."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:313
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Press Esc to cancel while waiting."
 msgstr "Pulse Esc para cancelar la espera."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:321
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "Timed out waiting for OAuth callback. If Alibaba Cloud asked you to "
 "assign the official-cli application, assign it to the exact RAM user or "
@@ -1592,28 +1577,28 @@ msgstr ""
 "sesión de Alibaba Cloud e iníciela de nuevo si es necesario, y ejecute "
 "/auth para elegir de nuevo Inicio de sesión OAuth (navegador)."
 
-#: src/iac_code/skills/skill_tool.py:85 src/iac_code/ui/repl.py:842
+#: src/iac_code/skills/skill_tool.py src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Skill '{name}' is disabled. Run /skills to enable it."
 msgstr ""
 "La habilidad '{name}' está deshabilitada. Ejecute /skills para "
 "habilitarla."
 
-#: src/iac_code/skills/skill_tool.py:137
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill '{name}' loaded (inline)."
 msgstr "Skill '{name}' cargado (en línea)."
 
-#: src/iac_code/skills/skill_tool.py:221
+#: src/iac_code/skills/skill_tool.py
 msgid "Skill"
 msgstr "Skill"
 
-#: src/iac_code/skills/skill_tool.py:245
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill disabled: {name}"
 msgstr "Habilidad deshabilitada: {name}"
 
-#: src/iac_code/skills/bundled/simplify.py:25
+#: src/iac_code/skills/bundled/simplify.py
 msgid ""
 "Review changed code for reuse, quality, and efficiency, then fix issues "
 "found."
@@ -1621,99 +1606,99 @@ msgstr ""
 "Revise el código modificado en cuanto a reutilización, calidad y "
 "eficiencia; a continuación, corrija los problemas detectados."
 
-#: src/iac_code/tools/edit_file.py:116
+#: src/iac_code/tools/edit_file.py
 msgid "Edit"
 msgstr "Editar"
 
-#: src/iac_code/tools/edit_file.py:118
+#: src/iac_code/tools/edit_file.py
 msgid "Create"
 msgstr "Crear"
 
-#: src/iac_code/tools/edit_file.py:119
+#: src/iac_code/tools/edit_file.py
 msgid "Update"
 msgstr "Actualizar"
 
-#: src/iac_code/tools/edit_file.py:126
+#: src/iac_code/tools/edit_file.py
 #, python-brace-format
 msgid "Editing {path}"
 msgstr "Editando {path}"
 
-#: src/iac_code/tools/edit_file.py:127
+#: src/iac_code/tools/edit_file.py
 msgid "Editing file..."
 msgstr "Editando archivo..."
 
-#: src/iac_code/tools/glob.py:86 src/iac_code/tools/grep.py:237
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Found 0 files"
 msgstr "Se encontraron 0 archivos"
 
-#: src/iac_code/tools/glob.py:89 src/iac_code/tools/grep.py:240
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Found {count} files"
 msgstr "Se encontraron {count} archivos"
 
-#: src/iac_code/tools/glob.py:95 src/iac_code/tools/grep.py:246
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Search"
 msgstr "Buscar"
 
-#: src/iac_code/tools/glob.py:100
+#: src/iac_code/tools/glob.py
 #, python-brace-format
 msgid "Searching {pattern}"
 msgstr "Buscando {pattern}"
 
-#: src/iac_code/tools/glob.py:101
+#: src/iac_code/tools/glob.py
 msgid "Searching files..."
 msgstr "Buscando archivos..."
 
-#: src/iac_code/tools/grep.py:251
+#: src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Searching for {pattern}"
 msgstr "Buscando {pattern}"
 
-#: src/iac_code/tools/grep.py:252
+#: src/iac_code/tools/grep.py
 msgid "Searching content..."
 msgstr "Buscando contenido..."
 
-#: src/iac_code/tools/list_files.py:82
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Found {count} items"
 msgstr "Se encontraron {count} elementos"
 
-#: src/iac_code/tools/list_files.py:88
+#: src/iac_code/tools/list_files.py
 msgid "List"
 msgstr "Listar"
 
-#: src/iac_code/tools/list_files.py:92
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Listing {path}"
 msgstr "Listando {path}"
 
-#: src/iac_code/tools/list_files.py:93
+#: src/iac_code/tools/list_files.py
 msgid "Listing files..."
 msgstr "Listando archivos..."
 
-#: src/iac_code/tools/read_file.py:117
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Read {total} lines"
 msgstr "Leídas {total} líneas"
 
-#: src/iac_code/tools/read_file.py:120
+#: src/iac_code/tools/read_file.py
 msgid "Read"
 msgstr "Leer"
 
-#: src/iac_code/tools/read_file.py:127
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Reading {path}"
 msgstr "Leyendo {path}"
 
-#: src/iac_code/tools/read_file.py:128
+#: src/iac_code/tools/read_file.py
 msgid "Reading file..."
 msgstr "Leyendo archivo..."
 
-#: src/iac_code/tools/web_fetch.py:94
+#: src/iac_code/tools/web_fetch.py
 msgid "URL cannot be empty."
 msgstr "La URL no puede estar vacía."
 
-#: src/iac_code/tools/web_fetch.py:100
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}"
 msgstr ""
@@ -1721,410 +1706,409 @@ msgstr ""
 " URL: missing scheme (e.g. http:// or https://). Got: {url}URL no válida:"
 " falta el esquema (p. ej. http:// o https://). Recibido: {url}"
 
-#: src/iac_code/tools/web_fetch.py:103
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing host/netloc. Got: {url}"
 msgstr "URL no válida: falta el host. Recibido: {url}"
 
-#: src/iac_code/tools/web_fetch.py:129
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "HTTP error {status}: {url}"
 msgstr "Error HTTP {status}: {url}"
 
-#: src/iac_code/tools/web_fetch.py:131
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Failed to fetch {url}: {error}"
 msgstr "No se pudo obtener {url}: {error}"
 
-#: src/iac_code/tools/web_fetch.py:133
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Unexpected error fetching {url}: {error}"
 msgstr "Error inesperado al obtener {url}: {error}"
 
-#: src/iac_code/tools/web_fetch.py:147
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetched {chars} chars, {lines} lines"
 msgstr "Obtenidos {chars} caracteres, {lines} líneas"
 
-#: src/iac_code/tools/web_fetch.py:159
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetch"
 msgstr "Obtener"
 
-#: src/iac_code/tools/web_fetch.py:165
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetching {url}"
 msgstr "Obteniendo {url}"
 
-#: src/iac_code/tools/web_fetch.py:166
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetching web page..."
 msgstr "Obteniendo la página web..."
 
-#: src/iac_code/tools/write_file.py:67
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Successfully wrote {lines} lines to {path}"
 msgstr "Se escribieron correctamente {lines} líneas en {path}"
 
-#: src/iac_code/tools/write_file.py:81
+#: src/iac_code/tools/write_file.py
 msgid "Write"
 msgstr "Escribir"
 
-#: src/iac_code/tools/write_file.py:88
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Writing {path}"
 msgstr "Escribiendo {path}"
 
-#: src/iac_code/tools/write_file.py:89
+#: src/iac_code/tools/write_file.py
 msgid "Writing file..."
 msgstr "Escribiendo archivo..."
 
-#: src/iac_code/tools/bash/bash_tool.py:81
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Command timed out after {timeout} seconds: {command}"
 msgstr "El comando agotó el tiempo de espera tras {timeout} segundos: {command}"
 
-#: src/iac_code/tools/bash/bash_tool.py:103
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Error executing command: {}"
 msgstr "Error al ejecutar el comando: {}"
 
-#: src/iac_code/tools/bash/bash_tool.py:129
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "{count} more lines"
 msgstr "{count} líneas más"
 
-#: src/iac_code/tools/bash/bash_tool.py:137
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Bash"
 msgstr "Bash"
 
-#: src/iac_code/tools/bash/bash_tool.py:143
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Running {cmd}"
 msgstr "Ejecutando {cmd}"
 
-#: src/iac_code/tools/bash/bash_tool.py:144
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Running command..."
 msgstr "Ejecutando comando..."
 
-#: src/iac_code/tools/bash/command_parser.py:42
+#: src/iac_code/tools/bash/command_parser.py
 msgid "parse error"
 msgstr "Error de análisis"
 
-#: src/iac_code/tools/bash/command_parser.py:46
+#: src/iac_code/tools/bash/command_parser.py
 msgid "unsupported shell construct"
 msgstr "Construcción de shell no soportada"
 
-#: src/iac_code/tools/bash/path_validation.py:111
+#: src/iac_code/tools/bash/path_validation.py
 #, python-brace-format
 msgid "path outside allowed directories: {}"
 msgstr "Ruta fuera de los directorios permitidos: {}"
 
-#: src/iac_code/tools/bash/permissions.py:135
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s): {}"
 msgstr "Regla(s) de denegación coincidente(s): {}"
 
-#: src/iac_code/tools/bash/permissions.py:142
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Regla(s) de consulta coincidente(s): {}"
 
-#: src/iac_code/tools/bash/permissions.py:154
-#: src/iac_code/tools/bash/permissions.py:220
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched allow rule(s): {}"
 msgstr "Regla(s) de permiso coincidente(s): {}"
 
-#: src/iac_code/tools/bash/permissions.py:162
+#: src/iac_code/tools/bash/permissions.py
 msgid "complex command requires confirmation"
 msgstr "El comando complejo requiere confirmación"
 
-#: src/iac_code/tools/bash/permissions.py:171
+#: src/iac_code/tools/bash/permissions.py
 msgid "sed in-place edit requires confirmation"
 msgstr "La edición sed in situ requiere confirmación"
 
-#: src/iac_code/tools/bash/permissions.py:194
+#: src/iac_code/tools/bash/permissions.py
 msgid "command failed basic safety checks"
 msgstr "El comando no pasó las comprobaciones básicas de seguridad"
 
-#: src/iac_code/tools/bash/permissions.py:210
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s) on full command: {}"
 msgstr "Regla(s) de denegación del comando completo: {}"
 
-#: src/iac_code/tools/bash/permissions.py:227
+#: src/iac_code/tools/bash/permissions.py
 msgid "command too complex to analyze"
 msgstr "Comando demasiado complejo para analizar"
 
-#: src/iac_code/tools/bash/permissions.py:229
+#: src/iac_code/tools/bash/permissions.py
 msgid "could not parse command"
 msgstr "No se pudo analizar el comando"
 
-#: src/iac_code/tools/bash/permissions.py:245
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "too many subcommands (>{})"
 msgstr "Demasiados subcomandos (>{})"
 
-#: src/iac_code/tools/bash/permissions.py:258
+#: src/iac_code/tools/bash/permissions.py
 msgid "multiple cd commands in compound command"
 msgstr "Múltiples comandos cd en comando compuesto"
 
-#: src/iac_code/tools/bash/permissions.py:271
+#: src/iac_code/tools/bash/permissions.py
 msgid "cd combined with git in compound command"
 msgstr "cd combinado con git en comando compuesto"
 
-#: src/iac_code/tools/bash/safety_checks.py:151
+#: src/iac_code/tools/bash/safety_checks.py
 #, python-brace-format
 msgid "operation touches a sensitive path: {}"
 msgstr "La operación afecta una ruta sensible: {}"
 
-#: src/iac_code/tools/cloud/base_api.py:92
+#: src/iac_code/tools/cloud/base_api.py
 msgid "CloudAPI"
 msgstr "CloudAPI"
 
-#: src/iac_code/tools/cloud/base_api.py:116
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Calling {action}..."
 msgstr "Llamando a {action}..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:400
-#: src/iac_code/tools/cloud/base_api.py:123
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#: src/iac_code/tools/cloud/base_api.py
 msgid "Call succeeded"
 msgstr "Llamada correcta"
 
-#: src/iac_code/tools/cloud/base_api.py:144
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Received response ({count} lines)"
 msgstr "Respuesta recibida ({count} líneas)"
 
-#: src/iac_code/tools/cloud/base_stack.py:133
+#: src/iac_code/tools/cloud/base_stack.py
 msgid "CloudStack"
 msgstr "CloudStack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:117
-#: src/iac_code/tools/cloud/base_stack.py:150
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
+#: src/iac_code/tools/cloud/base_stack.py
 #, python-brace-format
 msgid "Running {action}..."
 msgstr "Ejecutando {action}..."
 
-#: src/iac_code/tools/cloud/types.py:8
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_IN_PROGRESS"
 msgstr "Creación en curso"
 
-#: src/iac_code/tools/cloud/types.py:9
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_FAILED"
 msgstr "Creación fallida"
 
-#: src/iac_code/tools/cloud/types.py:10
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_COMPLETE"
 msgstr "Creación completada"
 
-#: src/iac_code/tools/cloud/types.py:11
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_IN_PROGRESS"
 msgstr "Actualización en curso"
 
-#: src/iac_code/tools/cloud/types.py:12
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_FAILED"
 msgstr "Actualización fallida"
 
-#: src/iac_code/tools/cloud/types.py:13
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_COMPLETE"
 msgstr "Actualización completada"
 
-#: src/iac_code/tools/cloud/types.py:14
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_IN_PROGRESS"
 msgstr "Eliminación en curso"
 
-#: src/iac_code/tools/cloud/types.py:15
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_FAILED"
 msgstr "Eliminación fallida"
 
-#: src/iac_code/tools/cloud/types.py:16
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_COMPLETE"
 msgstr "Eliminación completada"
 
-#: src/iac_code/tools/cloud/types.py:17
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "Reversión de creación en curso"
 
-#: src/iac_code/tools/cloud/types.py:18
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_FAILED"
 msgstr "Reversión de creación fallida"
 
-#: src/iac_code/tools/cloud/types.py:19
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_COMPLETE"
 msgstr "Reversión de creación completada"
 
-#: src/iac_code/tools/cloud/types.py:20
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_IN_PROGRESS"
 msgstr "Reversión en curso"
 
-#: src/iac_code/tools/cloud/types.py:21
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_FAILED"
 msgstr "Reversión fallida"
 
-#: src/iac_code/tools/cloud/types.py:22
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_COMPLETE"
 msgstr "Reversión completada"
 
-#: src/iac_code/tools/cloud/types.py:23
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_IN_PROGRESS"
 msgstr "Comprobación en curso"
 
-#: src/iac_code/tools/cloud/types.py:24
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_FAILED"
 msgstr "Comprobación fallida"
 
-#: src/iac_code/tools/cloud/types.py:25
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_COMPLETE"
 msgstr "Comprobación completada"
 
-#: src/iac_code/tools/cloud/types.py:26
+#: src/iac_code/tools/cloud/types.py
 msgid "REVIEW_IN_PROGRESS"
 msgstr "Revisión en curso"
 
-#: src/iac_code/tools/cloud/types.py:27
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_IN_PROGRESS"
 msgstr "Importación y creación en curso"
 
-#: src/iac_code/tools/cloud/types.py:28
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_FAILED"
 msgstr "Importación y creación fallidas"
 
-#: src/iac_code/tools/cloud/types.py:29
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_COMPLETE"
 msgstr "Importación y creación completadas"
 
-#: src/iac_code/tools/cloud/types.py:30
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "Reversión de importación y creación en curso"
 
-#: src/iac_code/tools/cloud/types.py:31
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_FAILED"
 msgstr "Reversión de importación y creación fallida"
 
-#: src/iac_code/tools/cloud/types.py:32
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_COMPLETE"
 msgstr "Reversión de importación y creación completada"
 
-#: src/iac_code/tools/cloud/types.py:33
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_IN_PROGRESS"
 msgstr "Importación y actualización en curso"
 
-#: src/iac_code/tools/cloud/types.py:34
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_FAILED"
 msgstr "Importación y actualización fallidas"
 
-#: src/iac_code/tools/cloud/types.py:35
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_COMPLETE"
 msgstr "Importación y actualización completadas"
 
-#: src/iac_code/tools/cloud/types.py:36
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_IN_PROGRESS"
 msgstr "Reversión de importación y actualización en curso"
 
-#: src/iac_code/tools/cloud/types.py:37
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_FAILED"
 msgstr "Reversión de importación y actualización fallida"
 
-#: src/iac_code/tools/cloud/types.py:38
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_COMPLETE"
 msgstr "Reversión de importación y actualización completada"
 
-#: src/iac_code/tools/cloud/types.py:40
+#: src/iac_code/tools/cloud/types.py
 msgid "INIT_COMPLETE"
 msgstr "Inicialización completada"
 
-#: src/iac_code/tools/cloud/types.py:41
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_IN_PROGRESS"
 msgstr "Importación en curso"
 
-#: src/iac_code/tools/cloud/types.py:42
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_COMPLETE"
 msgstr "Importación completada"
 
-#: src/iac_code/tools/cloud/types.py:43
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_FAILED"
 msgstr "Importación fallida"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:172
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 msgid "Aliyun API"
 msgstr "Aliyun API"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:399
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Llamada correcta (RequestId: {request_id})"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:57
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "DocSearch"
 msgstr "DocSearch"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:70
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Searching docs for {keywords}..."
 msgstr "Buscando documentación para {keywords}..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:71
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Searching docs..."
 msgstr "Buscando documentación..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:76
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "keywords cannot be empty."
 msgstr "Las palabras clave no pueden estar vacías."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:96
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "HTTP error {status} when searching docs."
 msgstr "Error HTTP {status} al buscar documentación."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:98
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Failed to search docs: {error}"
 msgstr "No se pudo buscar en la documentación: {error}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:103
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Failed to parse search response as JSON."
 msgstr "No se pudo analizar la respuesta de búsqueda como JSON."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:106
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Search API returned failure."
 msgstr "La API de búsqueda devolvió un error."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:125
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "No documents found"
 msgstr "No se encontraron documentos"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:126
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "No documents found for keywords: {keywords}"
 msgstr "No se encontraron documentos para las palabras clave: {keywords}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:141
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Found {count} documents (total {total})"
 msgstr "Se encontraron {count} documentos (total {total})"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:143
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Use web_fetch tool to read full document content if needed."
 msgstr ""
 "Use web_fetch tool to read full document content if needed.Use web_fetch "
 "tool to read full document content if needed.Si es necesario, utilice la "
 "herramienta web_fetch para leer el documento completo."
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack.py:143
+#: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:100
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:48
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template YAML syntax error: {}"
 msgstr "Error de sintaxis YAML en la plantilla: {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:60
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template YAML syntax error (line {line}, column {col}): {problem}\n"
@@ -2136,14 +2120,14 @@ msgstr ""
 "Contexto:\n"
 "{context}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:66
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template JSON syntax error (line {line}, column {col}): {msg}"
 msgstr ""
 "Error de sintaxis JSON en la plantilla (línea {line}, columna {col}): "
 "{msg}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:85
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template {fmt} parse result is not an object (dict), please check the "
@@ -2152,7 +2136,7 @@ msgstr ""
 "El resultado del análisis {fmt} de la plantilla no es un objeto (dict), "
 "por favor verifique el formato de la plantilla"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:104
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"
@@ -2160,18 +2144,18 @@ msgstr ""
 "Falta ROSTemplateFormatVersion en la plantilla (las plantillas ROS deben "
 "incluir este campo, ej. '2015-09-01')"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:110
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Template is missing Resources (ROS templates must include Resources)"
 msgstr ""
 "Falta Resources en la plantilla (las plantillas ROS deben incluir "
 "Resources)"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:112
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resources must be an object (dict), current type is {}"
 msgstr "Resources debe ser un objeto (dict), el tipo actual es {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:117
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Resource '{name}' definition must be an object (dict), current type is "
@@ -2180,19 +2164,19 @@ msgstr ""
 "La definición del recurso '{name}' debe ser un objeto (dict), el tipo "
 "actual es {type}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:123
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' is missing the Type field"
 msgstr "Al recurso '{name}' le falta el campo Type"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:129
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' has incorrect type '{wrong}', should be '{correct}'"
 msgstr ""
 "El recurso '{name}' tiene el tipo incorrecto '{wrong}', debería ser "
 "'{correct}'"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:151
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template structure validation found the following issues, please fix and "
 "retry:"
@@ -2200,197 +2184,190 @@ msgstr ""
 "La validación de la estructura de la plantilla encontró los siguientes "
 "problemas, por favor corrija y reintente:"
 
-#: src/iac_code/ui/banner.py:42 src/iac_code/ui/banner.py:54
+#: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
 msgstr "¡Actualización disponible! {} -> {}"
 
-#: src/iac_code/ui/banner.py:43
+#: src/iac_code/ui/banner.py
 msgid "Update command"
 msgstr "Comando de actualización"
 
-#: src/iac_code/ui/banner.py:46 src/iac_code/ui/banner.py:58
+#: src/iac_code/ui/banner.py
 msgid "Release notes"
 msgstr "Notas de la versión"
 
-#: src/iac_code/ui/banner.py:55
-#, python-brace-format
-msgid "Run {} to update."
-msgstr "Ejecuta {} para actualizar."
-
-#: src/iac_code/ui/banner.py:110
+#: src/iac_code/ui/banner.py
 msgid "Your AI-powered Infrastructure as Code assistant"
 msgstr "Su asistente de infraestructura como código con IA"
 
-#: src/iac_code/ui/banner.py:144
+#: src/iac_code/ui/banner.py
 msgid "Welcome back"
 msgstr "Bienvenido de nuevo"
 
-#: src/iac_code/ui/banner.py:161
+#: src/iac_code/ui/banner.py
 msgid "Debug mode"
 msgstr "Modo depuración"
 
-#: src/iac_code/ui/banner.py:162
+#: src/iac_code/ui/banner.py
 msgid "Log file"
 msgstr "Archivo de registro"
 
-#: src/iac_code/ui/renderer.py:388 src/iac_code/ui/renderer.py:668
-#: src/iac_code/ui/renderer.py:1455
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Razonamiento durante {seconds:.1f} s"
 
-#: src/iac_code/ui/renderer.py:404 src/iac_code/ui/renderer.py:700
-#: src/iac_code/ui/renderer.py:1476
+#: src/iac_code/ui/renderer.py
 msgid "(ctrl+o to expand)"
 msgstr "(ctrl+o para expandir)"
 
-#: src/iac_code/ui/renderer.py:431
+#: src/iac_code/ui/renderer.py
 msgid "Resource"
 msgstr "Recurso"
 
-#: src/iac_code/ui/renderer.py:432
+#: src/iac_code/ui/renderer.py
 msgid "Type"
 msgstr "Tipo"
 
-#: src/iac_code/ui/renderer.py:433 src/iac_code/ui/renderer.py:456
+#: src/iac_code/ui/renderer.py
 msgid "Status"
 msgstr "Estado"
 
-#: src/iac_code/ui/renderer.py:454
+#: src/iac_code/ui/renderer.py
 msgid "Account ID"
 msgstr "ID de cuenta"
 
-#: src/iac_code/ui/renderer.py:542
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Done ({child_count} tool uses{token_info}{elapsed})"
 msgstr "Completado ({child_count} usos de herramientas{token_info}{elapsed})"
 
-#: src/iac_code/ui/renderer.py:572
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "+ {count} more tool uses (ctrl+o to expand)"
 msgstr "+ {count} usos de herramientas más (ctrl+o para expandir)"
 
-#: src/iac_code/ui/renderer.py:1177
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Context auto-compacted: {original} → {compacted} tokens"
 msgstr "Contexto compactado automáticamente: {original} → {compacted} tokens"
 
-#: src/iac_code/ui/renderer.py:1262
+#: src/iac_code/ui/renderer.py
 msgid "Operation cancelled."
 msgstr "Operación cancelada."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "No API key configured."
 msgstr "No hay ninguna API key configurada."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "Please run /auth to set up your LLM provider and API key."
 msgstr "Ejecute /auth para configurar el proveedor LLM y la API key."
 
-#: src/iac_code/ui/renderer.py:1272
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Error: {error}"
 
-#: src/iac_code/ui/renderer.py:1342
+#: src/iac_code/ui/renderer.py
 msgid "Allow this action?"
 msgstr "¿Permitir esta acción?"
 
-#: src/iac_code/ui/renderer.py:1345
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow once"
 msgstr "Sí, permitir una vez"
 
-#: src/iac_code/ui/renderer.py:1359
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Yes, always allow \"{rule}\" (this session)"
 msgstr "Sí, permitir siempre \"{rule}\" (esta sesión)"
 
-#: src/iac_code/ui/renderer.py:1364
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow always for this tool"
 msgstr "Sí, permitir siempre esta herramienta"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "No, reject once"
 msgstr "No, rechazar una vez"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "default"
 msgstr "predeterminado"
 
-#: src/iac_code/ui/renderer.py:1374
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "No, always deny \"{rule}\" (this session)"
 msgstr "No, siempre denegar \"{rule}\" (esta sesión)"
 
-#: src/iac_code/ui/renderer.py:1379
+#: src/iac_code/ui/renderer.py
 msgid "No, always reject this tool"
 msgstr "No, rechazar siempre esta herramienta"
 
-#: src/iac_code/ui/repl.py:424
+#: src/iac_code/ui/repl.py
 msgid "Press Ctrl+C again to exit."
 msgstr "Pulse Ctrl+C de nuevo para salir."
 
-#: src/iac_code/ui/repl.py:449
+#: src/iac_code/ui/repl.py
 msgid "Interrupted."
 msgstr "Interrumpido."
 
-#: src/iac_code/ui/repl.py:508
+#: src/iac_code/ui/repl.py
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/iac_code/ui/repl.py:510
+#: src/iac_code/ui/repl.py
 msgid "Run the shown update command and exit when it succeeds."
 msgstr ""
 "Ejecuta el comando de actualización mostrado y sale cuando finalice "
 "correctamente."
 
-#: src/iac_code/ui/repl.py:513
+#: src/iac_code/ui/repl.py
 msgid "Skip"
 msgstr "Omitir"
 
-#: src/iac_code/ui/repl.py:515
+#: src/iac_code/ui/repl.py
 msgid "Continue with the current version for this session."
 msgstr "Continuar con la versión actual durante esta sesión."
 
-#: src/iac_code/ui/repl.py:518
+#: src/iac_code/ui/repl.py
 msgid "Skip until next version"
 msgstr "Omitir hasta la siguiente versión"
 
-#: src/iac_code/ui/repl.py:520
+#: src/iac_code/ui/repl.py
 msgid "Hide this update until a newer version is available."
 msgstr ""
 "Ocultar esta actualización hasta que haya una versión más nueva "
 "disponible."
 
-#: src/iac_code/ui/repl.py:539 src/iac_code/ui/repl.py:551
+#: src/iac_code/ui/repl.py
 msgid "Update command failed. Continuing with the current version."
 msgstr "El comando de actualización falló. Se continuará con la versión actual."
 
-#: src/iac_code/ui/repl.py:544
+#: src/iac_code/ui/repl.py
 msgid "Update completed. Restart iac-code to continue."
 msgstr "Actualización completada. Reinicia iac-code para continuar."
 
-#: src/iac_code/ui/repl.py:582
+#: src/iac_code/ui/repl.py
 msgid "No image in clipboard."
 msgstr "No hay ninguna imagen en el portapapeles."
 
-#: src/iac_code/ui/repl.py:768
+#: src/iac_code/ui/repl.py
 msgid "Usage: !<shell command>"
 msgstr "Uso: !<comando de shell>"
 
-#: src/iac_code/ui/repl.py:775
+#: src/iac_code/ui/repl.py
 msgid "Shell command support is unavailable."
 msgstr "La compatibilidad con comandos de shell no está disponible."
 
-#: src/iac_code/ui/repl.py:845
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown skill: ${name}. Type / to list commands and skills."
 msgstr ""
 "Habilidad desconocida: ${name}. Escribe / para listar comandos y "
 "habilidades."
 
-#: src/iac_code/ui/repl.py:847
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown command: /{name}. Type /help for available commands."
 msgstr ""
@@ -2398,47 +2375,47 @@ msgstr ""
 "command: /{name}. Type /help for available commands.Comando desconocido: "
 "/{name}. Escriba /help para ver los comandos disponibles."
 
-#: src/iac_code/ui/repl.py:852
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "$ only invokes skills. Use /{name} instead."
 msgstr "$ solo invoca habilidades. Usa /{name} en su lugar."
 
-#: src/iac_code/ui/repl.py:874 src/iac_code/ui/repl.py:922
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command error: {error}"
 msgstr "Error de comando: {error}"
 
-#: src/iac_code/ui/repl.py:881
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command has no handler: {name}"
 msgstr "El comando no tiene controlador: {name}"
 
-#: src/iac_code/ui/repl.py:1156
+#: src/iac_code/ui/repl.py
 msgid "Goodbye!"
 msgstr "¡Hasta luego!"
 
-#: src/iac_code/ui/repl.py:1157
+#: src/iac_code/ui/repl.py
 msgid "Resume this session with:"
 msgstr "Para reanudar esta sesión, ejecute:"
 
-#: src/iac_code/ui/repl.py:1160
+#: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "ID de sesión"
 
-#: src/iac_code/ui/repl.py:1210 src/iac_code/ui/repl.py:1214
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Session not found: {session_id}"
 msgstr "Sesión no encontrada: {session_id}"
 
-#: src/iac_code/ui/repl.py:1263
+#: src/iac_code/ui/repl.py
 msgid "Session name: "
 msgstr "Nombre de sesión: "
 
-#: src/iac_code/ui/repl.py:1269
+#: src/iac_code/ui/repl.py
 msgid "Session name cannot be empty."
 msgstr "El nombre de sesión no puede estar vacío."
 
-#: src/iac_code/ui/repl.py:1279
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "This session belongs to a different directory.\n"
@@ -2449,23 +2426,23 @@ msgstr ""
 "Para reanudar, ejecute:\n"
 "  {cmd}"
 
-#: src/iac_code/ui/repl.py:1283
+#: src/iac_code/ui/repl.py
 msgid "Multiple sessions match. Resume one by ID:"
 msgstr "Varias sesiones coinciden. Reanuda una por ID:"
 
-#: src/iac_code/ui/repl.py:1396
+#: src/iac_code/ui/repl.py
 msgid "This conversation is from a different directory."
 msgstr "Esta conversación procede de otro directorio."
 
-#: src/iac_code/ui/repl.py:1398
+#: src/iac_code/ui/repl.py
 msgid "To resume, run:"
 msgstr "Para reanudar, ejecute:"
 
-#: src/iac_code/ui/repl.py:1403
+#: src/iac_code/ui/repl.py
 msgid "(Command copied to clipboard)"
 msgstr "(Comando copiado al portapapeles)"
 
-#: src/iac_code/ui/repl.py:1560
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "Current model {model} does not support image input. Use /model to switch "
@@ -2474,12 +2451,12 @@ msgstr ""
 "El modelo actual {model} no admite entrada de imágenes. Usa /model para "
 "cambiar a un modelo con capacidad de visión."
 
-#: src/iac_code/ui/repl.py:1569
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Image error: {err}"
 msgstr "Error de imagen: {err}"
 
-#: src/iac_code/ui/repl.py:1586
+#: src/iac_code/ui/repl.py
 msgid ""
 "Failed to persist image to cache; it will only exist in memory for this "
 "turn."
@@ -2487,193 +2464,193 @@ msgstr ""
 "No se pudo persistir la imagen en la caché; solo existirá en memoria "
 "durante este turno."
 
-#: src/iac_code/ui/spinner.py:52
+#: src/iac_code/ui/spinner.py
 msgid "Processing"
 msgstr "Procesando"
 
-#: src/iac_code/ui/spinner.py:53
+#: src/iac_code/ui/spinner.py
 msgid "Working"
 msgstr "En curso"
 
-#: src/iac_code/ui/spinner.py:62
+#: src/iac_code/ui/spinner.py
 msgid "Thought"
 msgstr "Razonamiento"
 
-#: src/iac_code/ui/spinner.py:63
+#: src/iac_code/ui/spinner.py
 msgid "Processed"
 msgstr "Procesado"
 
-#: src/iac_code/ui/spinner.py:64
+#: src/iac_code/ui/spinner.py
 msgid "Worked"
 msgstr "Finalizado"
 
-#: src/iac_code/ui/transcript_view.py:158
+#: src/iac_code/ui/transcript_view.py
 msgid "Prompt:"
 msgstr "Prompt:"
 
-#: src/iac_code/ui/transcript_view.py:186
+#: src/iac_code/ui/transcript_view.py
 msgid "Showing transcript · ctrl+o to toggle"
 msgstr "Mostrando transcripción · ctrl+o para alternar"
 
-#: src/iac_code/ui/components/fuzzy_picker.py:120
+#: src/iac_code/ui/components/fuzzy_picker.py
 msgid "No matches found"
 msgstr "No se encontraron coincidencias"
 
-#: src/iac_code/ui/core/prompt_input.py:348
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Image in clipboard · ctrl+v to paste"
 msgstr "Imagen en el portapapeles · ctrl+v para pegar"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Fill"
 msgstr "Rellenar"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: src/iac_code/ui/dialogs/global_search.py:55
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "No matching content"
 msgstr "No hay contenido coincidente"
 
-#: src/iac_code/ui/dialogs/global_search.py:61
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Search in Files"
 msgstr "Buscar en archivos"
 
-#: src/iac_code/ui/dialogs/global_search.py:62
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Type to search content..."
 msgstr "Escriba para buscar contenido..."
 
-#: src/iac_code/ui/dialogs/global_search.py:63
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Enter search query"
 msgstr "Introduzca la consulta de búsqueda"
 
-#: src/iac_code/ui/dialogs/history_search.py:55
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Search Conversation History"
 msgstr "Buscar en el historial de conversación"
 
-#: src/iac_code/ui/dialogs/history_search.py:56
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Type to search..."
 msgstr "Escriba para buscar..."
 
-#: src/iac_code/ui/dialogs/history_search.py:57
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "No conversation history"
 msgstr "No hay historial de conversación"
 
-#: src/iac_code/ui/dialogs/history_search.py:98
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Message Preview"
 msgstr "Vista previa del mensaje"
 
-#: src/iac_code/ui/dialogs/quick_open.py:58
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Open File"
 msgstr "Abrir archivo"
 
-#: src/iac_code/ui/dialogs/quick_open.py:59
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Type to search files..."
 msgstr "Escriba para buscar archivos..."
 
-#: src/iac_code/ui/dialogs/quick_open.py:60
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "No matching files"
 msgstr "No hay archivos coincidentes"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:116
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Search..."
 msgstr "Buscar…"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:374
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Resume Session"
 msgstr "Reanudar sesión"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:384
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "No sessions found"
 msgstr "No se encontraron sesiones"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:444
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show current dir"
 msgstr "mostrar directorio actual"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:446
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all projects"
 msgstr "mostrar todos los proyectos"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:449
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all branches"
 msgstr "mostrar todas las ramas"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:451
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "only show current branch"
 msgstr "mostrar solo la rama actual"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:452
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "preview"
 msgstr "vista previa"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:453
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Type to search"
 msgstr "Escriba para buscar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:454
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "cancel"
 msgstr "cancelar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:569
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} more line{s}"
 msgstr "{n} línea{s} más"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:583
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} message{s}"
 msgstr "{n} mensaje{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:597
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "resume"
 msgstr "reanudar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:601
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "back"
 msgstr "atrás"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:606
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "scroll"
 msgstr "desplazar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:625
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "(empty session)"
 msgstr "(sesión vacía)"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:745
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "just now"
 msgstr "ahora mismo"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:748
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} minute{s} ago"
 msgstr "hace {n} minuto{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:751
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} hour{s} ago"
 msgstr "hace {n} hora{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:753
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} day{s} ago"
 msgstr "hace {n} día{s}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:52
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Search skills..."
 msgstr "Buscar habilidades..."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:159
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Skills"
 msgstr "Habilidades"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:161
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "{current} of {total}"
 msgstr "{current} de {total}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:165
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid ""
 "{count} skills - Space to toggle, Enter to save, Tab to sort, Esc to "
@@ -2682,90 +2659,90 @@ msgstr ""
 "{count} habilidades - Espacio para alternar, Enter para guardar, Tab para"
 " ordenar, Esc para cancelar"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:171
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "Sort: {mode}"
 msgstr "Ordenar: {mode}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:176
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "No skills found"
 msgstr "No se encontraron habilidades"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:245
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Bundled skills cannot be disabled."
 msgstr "Las habilidades integradas no se pueden deshabilitar."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "on"
 msgstr "activada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "off"
 msgstr "desactivada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:265
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "locked"
 msgstr "bloqueada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:268
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "matched description"
 msgstr "coincide con la descripción"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:277
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "source"
 msgstr "origen"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:279
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "size"
 msgstr "tamaño"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:280
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "name"
 msgstr "nombre"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:285
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "bundled"
 msgstr "integrada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:287
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "project"
 msgstr "proyecto"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:289
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "user"
 msgstr "usuario"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:296
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count}k tokens"
 msgstr "~{count}k tokens"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:297
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count} tokens"
 msgstr "~{count} tokens"
 
-#: src/iac_code/ui/suggestions/command_provider.py:79
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Search saved memories"
 msgstr "Buscar memorias guardadas"
 
-#: src/iac_code/ui/suggestions/command_provider.py:80
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Delete a saved memory"
 msgstr "Eliminar una memoria guardada"
 
-#: src/iac_code/ui/suggestions/command_provider.py:81
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Show memory command help"
 msgstr "Mostrar la ayuda del comando memory"
 
-#: src/iac_code/ui/suggestions/command_provider.py:116
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Saved memory"
 msgstr "Memoria guardada"
 
-#: src/iac_code/utils/platform.py:39
+#: src/iac_code/utils/platform.py
 msgid "iac-code on Windows requires Git for Windows."
 msgstr "iac-code en Windows requiere Git for Windows."
 
-#: src/iac_code/utils/platform.py:41
+#: src/iac_code/utils/platform.py
 msgid ""
 "If installed but not on PATH, set IAC_CODE_GIT_BASH_PATH environment "
 "variable."
@@ -2773,15 +2750,15 @@ msgstr ""
 "Si está instalado pero no está en el PATH, establezca la variable de "
 "entorno IAC_CODE_GIT_BASH_PATH."
 
-#: src/iac_code/utils/platform.py:44
+#: src/iac_code/utils/platform.py
 msgid "To install:"
 msgstr "Para instalar:"
 
-#: src/iac_code/utils/platform.py:47
+#: src/iac_code/utils/platform.py
 msgid "  Option 1 - winget (requires access to github.com):"
 msgstr "  Opción 1 - winget (requiere acceso a github.com):"
 
-#: src/iac_code/utils/platform.py:52
+#: src/iac_code/utils/platform.py
 msgid ""
 "  Option 2 - if you cannot reach github.com, run this to install via "
 "npmmirror:"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 13:32+0800\n"
+"POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: fr\n"
@@ -17,14 +17,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/iac_code/config.py:164
+#: src/iac_code/config.py
 #, python-brace-format
 msgid "Invalid IAC_CODE_PROVIDER value: {!r}. Valid values (case-insensitive): {}"
 msgstr ""
 "Valeur IAC_CODE_PROVIDER invalide : {!r}. Valeurs valides (insensible à "
 "la casse) : {}"
 
-#: src/iac_code/a2a/transports/base.py:175
+#: src/iac_code/a2a/transports/base.py
 msgid ""
 "Unix domain socket transport is not supported on Windows. Use --transport"
 " http or --transport stdio instead."
@@ -32,22 +32,21 @@ msgstr ""
 "Le transport par socket de domaine Unix n'est pas pris en charge sous "
 "Windows. Utilisez --transport http ou --transport stdio à la place."
 
-#: src/iac_code/acp/server.py:413 src/iac_code/acp/server.py:429
-#: src/iac_code/acp/server.py:456
+#: src/iac_code/acp/server.py
 msgid "Session not found"
 msgstr "Session introuvable"
 
-#: src/iac_code/acp/server.py:416
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session name is ambiguous. Candidates: {candidates}"
 msgstr "Le nom de session est ambigu. Candidats : {candidates}"
 
-#: src/iac_code/acp/server.py:434 src/iac_code/acp/server.py:708
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session belongs to another project. Run: {hint}"
 msgstr "La session appartient à un autre projet. Exécutez : {hint}"
 
-#: src/iac_code/acp/slash_registry.py:46
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Command '/{cmd_name}' is not supported over ACP. Supported commands: "
@@ -56,21 +55,21 @@ msgstr ""
 "La commande « /{cmd_name} » n’est pas prise en charge via ACP. Commandes "
 "prises en charge : {supported}"
 
-#: src/iac_code/acp/slash_registry.py:62
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Command '/{cmd_name}' handler not implemented."
 msgstr "Gestionnaire de la commande « /{cmd_name} » non implémenté."
 
-#: src/iac_code/acp/slash_registry.py:74
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Compaction failed: {error}"
 msgstr "Échec de la compaction : {error}"
 
-#: src/iac_code/acp/slash_registry.py:77 src/iac_code/commands/compact.py:24
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Nothing to compact: conversation is empty."
 msgstr "Rien à compacter : la conversation est vide."
 
-#: src/iac_code/acp/slash_registry.py:80 src/iac_code/commands/compact.py:27
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Conversation too short to compact: all messages are within the recent "
@@ -79,11 +78,11 @@ msgstr ""
 "Conversation trop courte pour être compactée : tous les messages se "
 "situent dans la fenêtre de conservation des {turns} derniers tours."
 
-#: src/iac_code/acp/slash_registry.py:84 src/iac_code/commands/compact.py:30
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Compaction failed. See logs for details."
 msgstr "Échec de la compaction. Consultez les journaux pour plus de détails."
 
-#: src/iac_code/acp/slash_registry.py:89
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent} reduction)."
@@ -92,123 +91,121 @@ msgstr ""
 "Contexte compacté : {original} → {compacted} tokens (réduction "
 "{percent}). Utilisation du contexte : {usage}"
 
-#: src/iac_code/acp/slash_registry.py:103
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Clear failed: {error}"
 msgstr "Échec de l’effacement : {error}"
 
-#: src/iac_code/acp/slash_registry.py:104
+#: src/iac_code/acp/slash_registry.py
 msgid "Conversation history cleared."
 msgstr "Historique de conversation effacé."
 
-#: src/iac_code/acp/slash_registry.py:120 src/iac_code/commands/debug.py:34
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging is on. Log file: {path}"
 msgstr "Journalisation debug activée. Fichier de journal : {path}"
 
-#: src/iac_code/acp/slash_registry.py:121 src/iac_code/commands/debug.py:35
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging is off."
 msgstr "Journalisation debug désactivée."
 
-#: src/iac_code/acp/slash_registry.py:125 src/iac_code/commands/debug.py:39
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging enabled. Log file: {path}"
 msgstr "Journalisation debug activée. Fichier de journal : {path}"
 
-#: src/iac_code/acp/slash_registry.py:129 src/iac_code/commands/debug.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging disabled."
 msgstr "Journalisation debug désactivée."
 
-#: src/iac_code/acp/slash_registry.py:131 src/iac_code/commands/debug.py:45
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Usage: /debug [on|off]"
 msgstr "Utilisation : /debug [on|off]"
 
-#: src/iac_code/acp/slash_registry.py:136 src/iac_code/commands/memory.py:84
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/memory.py
 msgid "Memory manager is unavailable."
 msgstr "Le gestionnaire de mémoire est indisponible."
 
-#: src/iac_code/acp/slash_registry.py:146 src/iac_code/commands/rename.py:21
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 msgid "Usage: /rename <name>"
 msgstr "Utilisation : /rename <nom>"
 
-#: src/iac_code/acp/slash_registry.py:152
+#: src/iac_code/acp/slash_registry.py
 msgid "Rename is only available after a session is created."
 msgstr "Le renommage n'est disponible qu'après la création d'une session."
 
-#: src/iac_code/acp/slash_registry.py:163 src/iac_code/commands/rename.py:42
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Session is already named {name}"
 msgstr "La session porte déjà le nom {name}"
 
-#: src/iac_code/acp/slash_registry.py:164 src/iac_code/commands/rename.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Renamed session to {name}"
 msgstr "Session renommée en {name}"
 
-#: src/iac_code/agent/agent_loop.py:413 src/iac_code/agent/agent_loop.py:428
-#: src/iac_code/ui/repl.py:813 src/iac_code/ui/repl.py:827
+#: src/iac_code/agent/agent_loop.py src/iac_code/ui/repl.py
 msgid "Permission denied."
 msgstr "Permission refusée."
 
-#: src/iac_code/agent/agent_tool.py:266
+#: src/iac_code/agent/agent_tool.py
 #, python-brace-format
 msgid "Done ({tool_count} tool uses · {token_display} tokens)"
 msgstr "Terminé ({tool_count} utilisations d’outil · {token_display} tokens)"
 
-#: src/iac_code/agent/agent_tool.py:276
+#: src/iac_code/agent/agent_tool.py
 msgid "Explore"
 msgstr "Explorer"
 
-#: src/iac_code/agent/agent_tool.py:277
+#: src/iac_code/agent/agent_tool.py
 msgid "Plan"
 msgstr "Plan"
 
-#: src/iac_code/agent/agent_tool.py:278 src/iac_code/agent/agent_tool.py:279
-#: src/iac_code/agent/agent_tool.py:280
+#: src/iac_code/agent/agent_tool.py
 msgid "Agent"
 msgstr "Agent"
 
-#: src/iac_code/cli/headless.py:50
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool started: {}"
 msgstr "Outil démarré : {}"
 
-#: src/iac_code/cli/headless.py:53
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool failed: {}"
 msgstr "Outil échoué : {}"
 
-#: src/iac_code/cli/headless.py:55
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool finished: {}"
 msgstr "Outil terminé : {}"
 
-#: src/iac_code/cli/headless.py:59
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool failed: {}"
 msgstr "Outil enfant échoué : {}"
 
-#: src/iac_code/cli/headless.py:61
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool finished: {}"
 msgstr "Outil enfant terminé : {}"
 
-#: src/iac_code/cli/headless.py:63
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool started: {}"
 msgstr "Outil enfant démarré : {}"
 
-#: src/iac_code/cli/headless.py:65
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack {}: {} ({:.1f}%)"
 msgstr "Pile {} : {} ({:.1f}%)"
 
-#: src/iac_code/cli/headless.py:71
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack group {}: {} ({}%)"
 msgstr "Groupe de piles {} : {} ({}%)"
 
-#: src/iac_code/cli/headless.py:110
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -228,27 +225,27 @@ msgstr ""
 "  Documentation : https://aliyun.github.io/iac-"
 "code/fr/docs/configuration/authentication\n"
 
-#: src/iac_code/cli/install_git_bash.py:40
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git Bash is already installed at {}"
 msgstr "Git Bash est déjà installé dans {}"
 
-#: src/iac_code/cli/install_git_bash.py:43
+#: src/iac_code/cli/install_git_bash.py
 msgid "Installing Git for Windows via npmmirror..."
 msgstr "Installation de Git for Windows via npmmirror..."
 
-#: src/iac_code/cli/install_git_bash.py:59
+#: src/iac_code/cli/install_git_bash.py
 msgid "powershell.exe was not found on PATH; cannot run installer."
 msgstr ""
 "powershell.exe est introuvable dans PATH ; impossible d'exécuter "
 "l'installateur."
 
-#: src/iac_code/cli/install_git_bash.py:66
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Installation failed (PowerShell exited with code {})"
 msgstr "L'installation a échoué (PowerShell est sorti avec le code {})"
 
-#: src/iac_code/cli/install_git_bash.py:77
+#: src/iac_code/cli/install_git_bash.py
 msgid ""
 "Installer exited but bash.exe was not found in common locations; UAC may "
 "have been cancelled or the installer used a non-standard path."
@@ -257,29 +254,32 @@ msgstr ""
 "emplacements habituels ; UAC a peut-être été annulé ou l'installateur a "
 "utilisé un chemin non standard."
 
-#: src/iac_code/cli/install_git_bash.py:84
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git for Windows installed at {}"
 msgstr "Git for Windows installé dans {}"
 
-#: src/iac_code/cli/main.py:33 src/iac_code/commands/help.py:26
+#: src/iac_code/cli/main.py src/iac_code/commands/help.py
 msgid "AI-powered infrastructure orchestration tool"
 msgstr "Outil d’orchestration d’infrastructure assisté par IA"
 
-#: src/iac_code/cli/main.py:41
+#: src/iac_code/cli/main.py
 msgid "Use iac-code as an A2A client."
 msgstr "Utilise iac-code comme client A2A."
 
-#: src/iac_code/cli/main.py:54
+#: src/iac_code/cli/main.py
 msgid "Install Git for Windows via the npmmirror mirror (Windows only)."
 msgstr "Installer Git for Windows via le miroir npmmirror (Windows uniquement)."
 
-#: src/iac_code/cli/main.py:61
+#: src/iac_code/cli/main.py
+msgid "Update iac-code to the latest version."
+msgstr "Mettre à jour iac-code vers la dernière version."
+
+#: src/iac_code/cli/main.py
 msgid "YAML config file containing A2A client options"
 msgstr "Fichier de configuration YAML contenant les options client A2A"
 
-#: src/iac_code/cli/main.py:68 src/iac_code/cli/main.py:1501
-#: src/iac_code/cli/main.py:1862 src/iac_code/cli/main.py:1901
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -287,48 +287,47 @@ msgstr ""
 "Les dépendances du client A2A sont manquantes. Installez-les avec : pip "
 "install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:82
+#: src/iac_code/cli/main.py
 msgid "LLM model to use"
 msgstr "Modèle LLM à utiliser"
 
-#: src/iac_code/cli/main.py:83
+#: src/iac_code/cli/main.py
 msgid "Non-interactive mode: run a single prompt and exit"
 msgstr "Mode non interactif : exécuter un seul prompt puis quitter"
 
-#: src/iac_code/cli/main.py:84
+#: src/iac_code/cli/main.py
 msgid "Output format: text, json, stream-json"
 msgstr "Format de sortie : text, json, stream-json"
 
-#: src/iac_code/cli/main.py:85
+#: src/iac_code/cli/main.py
 msgid "Maximum agent turns in headless mode"
 msgstr "Nombre maximal de tours d’agent en mode headless"
 
-#: src/iac_code/cli/main.py:86 src/iac_code/cli/main.py:366
-#: src/iac_code/cli/main.py:591
+#: src/iac_code/cli/main.py
 msgid "Enable debug logging"
 msgstr "Activer la journalisation debug"
 
-#: src/iac_code/cli/main.py:87
+#: src/iac_code/cli/main.py
 msgid "Show headless progress on stderr"
 msgstr "Afficher la progression headless sur stderr"
 
-#: src/iac_code/cli/main.py:88
+#: src/iac_code/cli/main.py
 msgid "Show version and exit"
 msgstr "Afficher la version et quitter"
 
-#: src/iac_code/cli/main.py:89
+#: src/iac_code/cli/main.py
 msgid "Resume a session by ID or name"
 msgstr "Reprendre une session par ID ou nom"
 
-#: src/iac_code/cli/main.py:90
+#: src/iac_code/cli/main.py
 msgid "Resume the most recent session"
 msgstr "Reprendre la session la plus récente"
 
-#: src/iac_code/cli/main.py:97 src/iac_code/i18n/__init__.py:55
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid "Install completion for the current shell."
 msgstr "Installer la complétion pour le shell actuel."
 
-#: src/iac_code/cli/main.py:105 src/iac_code/i18n/__init__.py:56
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid ""
 "Show completion for the current shell, to copy it or customize the "
 "installation."
@@ -336,7 +335,7 @@ msgstr ""
 "Afficher la complétion pour le shell actuel afin de la copier ou de "
 "personnaliser l’installation."
 
-#: src/iac_code/cli/main.py:110
+#: src/iac_code/cli/main.py
 msgid ""
 "Comma-separated tool permission patterns to allow, e.g. 'bash(git "
 "*),write_file'"
@@ -344,50 +343,50 @@ msgstr ""
 "Modèles de permissions d'outils à autoriser (séparés par des virgules), "
 "ex. 'bash(git *),write_file'*),write_file'"
 
-#: src/iac_code/cli/main.py:115
+#: src/iac_code/cli/main.py
 msgid "Comma-separated tool permission patterns to deny"
 msgstr "Modèles de permissions d'outils à refuser (séparés par des virgules)"
 
-#: src/iac_code/cli/main.py:120
+#: src/iac_code/cli/main.py
 msgid "Permission mode: default, accept_edits, bypass_permissions, dont_ask"
 msgstr ""
 "Permission mode: default, accept_edits, bypass_permissions, dont_askMode "
 "de permissions : default, accept_edits, bypass_permissions, dont_ask"
 
-#: src/iac_code/cli/main.py:151
+#: src/iac_code/cli/main.py
 msgid "Error: --resume and --continue cannot be used together."
 msgstr "Erreur : --resume et --continue ne peuvent pas être utilisés ensemble."
 
-#: src/iac_code/cli/main.py:163
+#: src/iac_code/cli/main.py
 #, python-brace-format
 msgid "Invalid --output-format '{}'. Valid values: {}"
 msgstr "--output-format '{}' invalide. Valeurs valides : {}"
 
-#: src/iac_code/cli/main.py:361
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an ACP server."
 msgstr "Exécuter iac-code comme serveur ACP."
 
-#: src/iac_code/cli/main.py:363
+#: src/iac_code/cli/main.py
 msgid "Transport type: stdio or http"
 msgstr "Type de transport : stdio ou http"
 
-#: src/iac_code/cli/main.py:364
+#: src/iac_code/cli/main.py
 msgid "HTTP server port"
 msgstr "Port du serveur HTTP"
 
-#: src/iac_code/cli/main.py:365 src/iac_code/cli/main.py:581
+#: src/iac_code/cli/main.py
 msgid "HTTP server host"
 msgstr "Hôte du serveur HTTP"
 
-#: src/iac_code/cli/main.py:577
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an A2A 1.0 server."
 msgstr "Exécute iac-code en tant que serveur A2A 1.0."
 
-#: src/iac_code/cli/main.py:580
+#: src/iac_code/cli/main.py
 msgid "YAML config file for A2A server options"
 msgstr "Fichier de configuration YAML pour les options du serveur A2A"
 
-#: src/iac_code/cli/main.py:584
+#: src/iac_code/cli/main.py
 msgid ""
 "HTTP server port. 41242 is the iac-code default inspired by Gemini CLI, "
 "not a registered A2A port."
@@ -395,7 +394,7 @@ msgstr ""
 "Port du serveur HTTP. 41242 est la valeur par défaut d'iac-code inspirée "
 "de Gemini CLI, pas un port A2A enregistré."
 
-#: src/iac_code/cli/main.py:589
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc, or "
 "redis-streams"
@@ -403,7 +402,7 @@ msgstr ""
 "Transport A2A : http, stdio, unix, websocket, grpc, grpc-jsonrpc ou "
 "redis-streams"
 
-#: src/iac_code/cli/main.py:595
+#: src/iac_code/cli/main.py
 msgid ""
 "Expose A2A thinking signal types; repeat for multiple. Values: raw-"
 "thinking, tool-trace."
@@ -411,7 +410,7 @@ msgstr ""
 "Expose les types de signal de thinking A2A ; répétez pour en fournir "
 "plusieurs. Valeurs : raw-thinking, tool-trace."
 
-#: src/iac_code/cli/main.py:646
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -419,615 +418,604 @@ msgstr ""
 "Les dépendances du serveur A2A sont manquantes. Installez-les avec : pip "
 "install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:778
+#: src/iac_code/cli/main.py
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Envoie un prompt à un point de terminaison JSON-RPC A2A."
 
-#: src/iac_code/cli/main.py:781 src/iac_code/cli/main.py:951
-#: src/iac_code/cli/main.py:1004 src/iac_code/cli/main.py:1064
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1163
-#: src/iac_code/cli/main.py:1242 src/iac_code/cli/main.py:1299
-#: src/iac_code/cli/main.py:1355 src/iac_code/cli/main.py:1412
+#: src/iac_code/cli/main.py
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL du point de terminaison JSON-RPC A2A"
 
-#: src/iac_code/cli/main.py:782 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Spécification de route : name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:783
+#: src/iac_code/cli/main.py
 msgid "Named A2A route to call"
 msgstr "Route A2A nommée à appeler"
 
-#: src/iac_code/cli/main.py:784
+#: src/iac_code/cli/main.py
 msgid "Prompt to send"
 msgstr "Prompt à envoyer"
 
-#: src/iac_code/cli/main.py:785
+#: src/iac_code/cli/main.py
 msgid "Working directory metadata to send with the request"
 msgstr "Métadonnées du répertoire de travail à envoyer avec la requête"
 
-#: src/iac_code/cli/main.py:786
+#: src/iac_code/cli/main.py
 msgid "A2A context ID to continue"
 msgstr "ID de contexte A2A à poursuivre"
 
-#: src/iac_code/cli/main.py:787 src/iac_code/cli/main.py:882
-#: src/iac_code/cli/main.py:954 src/iac_code/cli/main.py:1011
-#: src/iac_code/cli/main.py:1066 src/iac_code/cli/main.py:1116
-#: src/iac_code/cli/main.py:1170 src/iac_code/cli/main.py:1245
-#: src/iac_code/cli/main.py:1303 src/iac_code/cli/main.py:1358
-#: src/iac_code/cli/main.py:1413
+#: src/iac_code/cli/main.py
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Jeton Bearer pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:788 src/iac_code/cli/main.py:883
-#: src/iac_code/cli/main.py:955 src/iac_code/cli/main.py:1012
-#: src/iac_code/cli/main.py:1067 src/iac_code/cli/main.py:1117
-#: src/iac_code/cli/main.py:1171 src/iac_code/cli/main.py:1246
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1359
-#: src/iac_code/cli/main.py:1414
+#: src/iac_code/cli/main.py
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Nom d'utilisateur d'authentification basique pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:789 src/iac_code/cli/main.py:884
-#: src/iac_code/cli/main.py:956 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1068 src/iac_code/cli/main.py:1118
-#: src/iac_code/cli/main.py:1172 src/iac_code/cli/main.py:1247
-#: src/iac_code/cli/main.py:1305 src/iac_code/cli/main.py:1360
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Mot de passe d'authentification basique pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:790 src/iac_code/cli/main.py:885
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1069 src/iac_code/cli/main.py:1119
-#: src/iac_code/cli/main.py:1173 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1306 src/iac_code/cli/main.py:1361
-#: src/iac_code/cli/main.py:1416
+#: src/iac_code/cli/main.py
 msgid "API key for A2A HTTP requests"
 msgstr "Clé d'API pour les requêtes HTTP A2A"
 
-#: src/iac_code/cli/main.py:791 src/iac_code/cli/main.py:886
-#: src/iac_code/cli/main.py:958 src/iac_code/cli/main.py:1015
-#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1120
-#: src/iac_code/cli/main.py:1174 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1307 src/iac_code/cli/main.py:1362
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py
 msgid "HTTP header name for A2A API key"
 msgstr "Nom de l'en-tête HTTP pour la clé d'API A2A"
 
-#: src/iac_code/cli/main.py:796 src/iac_code/cli/main.py:891
+#: src/iac_code/cli/main.py
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Secret utilisé pour vérifier l'A2A Agent Card"
 
-#: src/iac_code/cli/main.py:801 src/iac_code/cli/main.py:896
+#: src/iac_code/cli/main.py
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "URL JWKS distante utilisée pour vérifier l'A2A Agent Card"
 
-#: src/iac_code/cli/main.py:807 src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Exiger une signature valide de l'A2A Agent Card"
 
-#: src/iac_code/cli/main.py:809
+#: src/iac_code/cli/main.py
 msgid "A2A call timeout in seconds"
 msgstr "Délai d'expiration de l'appel A2A en secondes"
 
-#: src/iac_code/cli/main.py:810
+#: src/iac_code/cli/main.py
 msgid "Use A2A streaming message delivery"
 msgstr "Utiliser la diffusion en continu de messages A2A"
 
-#: src/iac_code/cli/main.py:878
+#: src/iac_code/cli/main.py
 msgid "Discover an A2A Agent Card."
 msgstr "Découvre une A2A Agent Card."
 
-#: src/iac_code/cli/main.py:881
+#: src/iac_code/cli/main.py
 msgid "A2A agent base URL"
 msgstr "URL de base de l'agent A2A"
 
-#: src/iac_code/cli/main.py:948
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task."
 msgstr "Récupère une tâche A2A."
 
-#: src/iac_code/cli/main.py:952 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1115 src/iac_code/cli/main.py:1164
-#: src/iac_code/cli/main.py:1243 src/iac_code/cli/main.py:1300
-#: src/iac_code/cli/main.py:1356
+#: src/iac_code/cli/main.py
 msgid "A2A task ID"
 msgstr "ID de tâche A2A"
 
-#: src/iac_code/cli/main.py:953
+#: src/iac_code/cli/main.py
 msgid "Maximum task history items to return"
 msgstr "Nombre maximal d'éléments d'historique de tâche à retourner"
 
-#: src/iac_code/cli/main.py:1001
+#: src/iac_code/cli/main.py
 msgid "List A2A tasks."
 msgstr "Liste les tâches A2A."
 
-#: src/iac_code/cli/main.py:1005
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A context ID"
 msgstr "Filtrer par ID de contexte A2A"
 
-#: src/iac_code/cli/main.py:1006
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A task state"
 msgstr "Filtrer par état de tâche A2A"
 
-#: src/iac_code/cli/main.py:1007
+#: src/iac_code/cli/main.py
 msgid "Maximum tasks to return"
 msgstr "Nombre maximal de tâches à retourner"
 
-#: src/iac_code/cli/main.py:1008 src/iac_code/cli/main.py:1302
+#: src/iac_code/cli/main.py
 msgid "Pagination token"
 msgstr "Jeton de pagination"
 
-#: src/iac_code/cli/main.py:1009
+#: src/iac_code/cli/main.py
 msgid "Include task artifacts"
 msgstr "Inclure les artefacts de tâche"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py
 msgid "Output format: table or json"
 msgstr "Format de sortie : table ou json"
 
-#: src/iac_code/cli/main.py:1061
+#: src/iac_code/cli/main.py
 msgid "Cancel an A2A task."
 msgstr "Annule une tâche A2A."
 
-#: src/iac_code/cli/main.py:1111
+#: src/iac_code/cli/main.py
 msgid "Subscribe to an A2A task event stream."
 msgstr "S'abonne à un flux d'événements de tâche A2A."
 
-#: src/iac_code/cli/main.py:1160
+#: src/iac_code/cli/main.py
 msgid "Create an A2A task push notification config."
 msgstr "Crée une configuration de notifications push de tâche A2A."
 
-#: src/iac_code/cli/main.py:1165 src/iac_code/cli/main.py:1244
-#: src/iac_code/cli/main.py:1357
+#: src/iac_code/cli/main.py
 msgid "Push config ID"
 msgstr "ID de configuration push"
 
-#: src/iac_code/cli/main.py:1166
+#: src/iac_code/cli/main.py
 msgid "Push callback URL"
 msgstr "URL de rappel push"
 
-#: src/iac_code/cli/main.py:1167
+#: src/iac_code/cli/main.py
 msgid "Notification verification token"
 msgstr "Jeton de vérification de notification"
 
-#: src/iac_code/cli/main.py:1168
+#: src/iac_code/cli/main.py
 msgid "Callback authentication scheme"
 msgstr "Schéma d'authentification du rappel"
 
-#: src/iac_code/cli/main.py:1169
+#: src/iac_code/cli/main.py
 msgid "Callback authentication credentials"
 msgstr "Identifiants d'authentification du rappel"
 
-#: src/iac_code/cli/main.py:1239
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task push notification config."
 msgstr "Récupère une configuration de notifications push de tâche A2A."
 
-#: src/iac_code/cli/main.py:1296
+#: src/iac_code/cli/main.py
 msgid "List A2A task push notification configs."
 msgstr "Liste les configurations de notifications push de tâches A2A."
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py
 msgid "Maximum configs to return"
 msgstr "Nombre maximal de configurations à retourner"
 
-#: src/iac_code/cli/main.py:1352
+#: src/iac_code/cli/main.py
 msgid "Delete an A2A task push notification config."
 msgstr "Supprime une configuration de notifications push de tâche A2A."
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Récupère une A2A Agent Card étendue authentifiée."
 
-#: src/iac_code/cli/main.py:1452
+#: src/iac_code/cli/main.py
 msgid "Preview A2A route resolution."
 msgstr "Aperçu de la résolution des routes A2A."
 
-#: src/iac_code/cli/main.py:1459
+#: src/iac_code/cli/main.py
 msgid "Route name to resolve"
 msgstr "Nom de route à résoudre"
 
-#: src/iac_code/cli/main.py:1460
+#: src/iac_code/cli/main.py
 msgid "Skill ID to resolve"
 msgstr "ID de compétence à résoudre"
 
-#: src/iac_code/cli/main.py:1461
+#: src/iac_code/cli/main.py
 msgid "Prompt text used for tag/name route matching"
 msgstr "Texte du prompt utilisé pour la correspondance des routes par tag/nom"
 
-#: src/iac_code/cli/main.py:1466
+#: src/iac_code/cli/main.py
 msgid "Directory for persisted A2A routes"
 msgstr "Répertoire pour les routes A2A persistées"
 
-#: src/iac_code/cli/main.py:1468
+#: src/iac_code/cli/main.py
 msgid "Save the provided routes as a route snapshot"
 msgstr "Enregistre les routes fournies sous forme d'instantané de routes"
 
-#: src/iac_code/commands/__init__.py:26
+#: src/iac_code/cli/update.py
+msgid "Check for updates without installing."
+msgstr "Vérifier les mises à jour sans installer."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "iac-code is already up to date (v{})."
+msgstr "iac-code est déjà à jour (v{})."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update available: v{} -> v{}"
+msgstr "Mise à jour disponible : v{} -> v{}"
+
+#: src/iac_code/cli/update.py src/iac_code/ui/banner.py
+#, python-brace-format
+msgid "Run {} to update."
+msgstr "Exécutez {} pour mettre à jour."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Updating iac-code from v{} to v{}..."
+msgstr "Mise à jour de iac-code de v{} vers v{}..."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed: {}"
+msgstr "La commande de mise à jour a échoué : {}"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed with exit code {}."
+msgstr "La commande de mise à jour a échoué avec le code de sortie {}."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Successfully updated to v{}!"
+msgstr "Mise à jour réussie vers v{} !"
+
+#: src/iac_code/commands/__init__.py
 msgid "Show available commands"
 msgstr "Afficher les commandes disponibles"
 
-#: src/iac_code/commands/__init__.py:35
+#: src/iac_code/commands/__init__.py
 msgid "Clear conversation history"
 msgstr "Effacer l’historique de conversation"
 
-#: src/iac_code/commands/__init__.py:43
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch model"
 msgstr "Afficher ou changer de modèle"
 
-#: src/iac_code/commands/__init__.py:52
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch thinking effort"
 msgstr "Afficher ou modifier l’effort de raisonnement"
 
-#: src/iac_code/commands/__init__.py:61
+#: src/iac_code/commands/__init__.py
 msgid "Compact conversation context"
 msgstr "Compacter le contexte de conversation"
 
-#: src/iac_code/commands/__init__.py:63
+#: src/iac_code/commands/__init__.py
 msgid "Compacting conversation"
 msgstr "Compactage de la conversation"
 
-#: src/iac_code/commands/__init__.py:70
+#: src/iac_code/commands/__init__.py
 msgid "Exit the application"
 msgstr "Quitter l’application"
 
-#: src/iac_code/commands/__init__.py:79
+#: src/iac_code/commands/__init__.py
 msgid "Authenticate with LLM provider"
 msgstr "S’authentifier auprès du fournisseur LLM"
 
-#: src/iac_code/commands/__init__.py:88
+#: src/iac_code/commands/__init__.py
 msgid "Toggle debug logging"
 msgstr "Activer ou désactiver la journalisation debug"
 
-#: src/iac_code/commands/__init__.py:97
+#: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"
 msgstr "Afficher et gérer les mémoires persistantes"
 
-#: src/iac_code/commands/__init__.py:99
+#: src/iac_code/commands/__init__.py
 msgid "[<name>|search <query>|delete <name>|help]"
 msgstr "[<nom>|search <requête>|delete <nom>|help]"
 
-#: src/iac_code/commands/__init__.py:106
+#: src/iac_code/commands/__init__.py
 msgid "Resume a previous session"
 msgstr "Reprendre une session précédente"
 
-#: src/iac_code/commands/__init__.py:108
+#: src/iac_code/commands/__init__.py
 msgid "[conversation id or search term]"
 msgstr "[identifiant de conversation ou terme de recherche]"
 
-#: src/iac_code/commands/__init__.py:115
+#: src/iac_code/commands/__init__.py
 msgid "Rename the current session"
 msgstr "Renommer la session actuelle"
 
-#: src/iac_code/commands/__init__.py:124
+#: src/iac_code/commands/__init__.py
 msgid "Manage skills"
 msgstr "Gérer les compétences"
 
-#: src/iac_code/commands/__init__.py:132
+#: src/iac_code/commands/__init__.py
 msgid "Show current session status"
 msgstr "Afficher l’état actuel de la session"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:1117
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Navigate"
 msgstr "Naviguer"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:538
-#: src/iac_code/commands/auth.py:570 src/iac_code/commands/auth.py:577
-#: src/iac_code/commands/auth.py:612 src/iac_code/commands/auth.py:619
-#: src/iac_code/commands/auth.py:640 src/iac_code/commands/auth.py:1117
-#: src/iac_code/commands/auth.py:1551 src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:536
-#: src/iac_code/commands/auth.py:538 src/iac_code/commands/auth.py:570
-#: src/iac_code/commands/auth.py:577 src/iac_code/commands/auth.py:612
-#: src/iac_code/commands/auth.py:619 src/iac_code/commands/auth.py:640
-#: src/iac_code/commands/auth.py:1117 src/iac_code/commands/auth.py:1443
-#: src/iac_code/commands/auth.py:1551
+#: src/iac_code/commands/auth.py
 msgid "Back"
 msgstr "Retour"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Keep"
 msgstr "Conserver"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Re-enter"
 msgstr "Saisir à nouveau"
 
-#: src/iac_code/commands/auth.py:749 src/iac_code/commands/auth.py:863
-#: src/iac_code/commands/auth.py:921 src/iac_code/commands/auth.py:929
-#: src/iac_code/commands/auth.py:956
+#: src/iac_code/commands/auth.py
 msgid " (current)"
 msgstr " (actuel)"
 
-#: src/iac_code/commands/auth.py:752
+#: src/iac_code/commands/auth.py
 msgid "Custom model..."
 msgstr "Modèle personnalisé…"
 
-#: src/iac_code/commands/auth.py:755
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select model for {provider}"
 msgstr "Sélectionner le modèle pour {provider}"
 
-#: src/iac_code/commands/auth.py:757
+#: src/iac_code/commands/auth.py
 msgid "Select model"
 msgstr "Sélectionner le modèle"
 
-#: src/iac_code/commands/auth.py:765
+#: src/iac_code/commands/auth.py
 msgid "Enter custom model name: "
 msgstr "Saisir le nom du modèle personnalisé : "
 
-#: src/iac_code/commands/auth.py:791
+#: src/iac_code/commands/auth.py
 msgid "Error: console not available"
 msgstr "Erreur : console indisponible"
 
-#: src/iac_code/commands/auth.py:820
+#: src/iac_code/commands/auth.py
 msgid "Configure LLM Provider"
 msgstr "Configurer le fournisseur LLM"
 
-#: src/iac_code/commands/auth.py:821
+#: src/iac_code/commands/auth.py
 msgid "Configure IaC Cloud Service"
 msgstr "Configurer le service cloud IaC"
 
-#: src/iac_code/commands/auth.py:823
+#: src/iac_code/commands/auth.py
 msgid "Select configuration type"
 msgstr "Sélectionner le type de configuration"
 
-#: src/iac_code/commands/auth.py:825 src/iac_code/commands/auth.py:981
-#: src/iac_code/commands/auth.py:997 src/iac_code/commands/auth.py:1076
-#: src/iac_code/commands/auth.py:1490 src/iac_code/commands/auth.py:1531
+#: src/iac_code/commands/auth.py
 msgid "Auth cancelled"
 msgstr "Authentification annulée"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:961
-#: src/iac_code/commands/auth.py:1051
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select provider — {group}"
 msgstr "Sélectionner le fournisseur — {group}"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:919
-#: src/iac_code/commands/auth.py:1036
+#: src/iac_code/commands/auth.py
 msgid "Third-party"
 msgstr "Tiers"
 
-#: src/iac_code/commands/auth.py:877
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider}"
 msgstr "{status} : {provider}"
 
-#: src/iac_code/commands/auth.py:878 src/iac_code/commands/auth.py:1029
+#: src/iac_code/commands/auth.py
 msgid "Configured"
 msgstr "Configuré"
 
-#: src/iac_code/commands/auth.py:933
+#: src/iac_code/commands/auth.py
 msgid "Select provider"
 msgstr "Sélectionner le fournisseur"
 
-#: src/iac_code/commands/auth.py:974
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Configure {provider}"
 msgstr "Configurer {provider}"
 
-#: src/iac_code/commands/auth.py:990
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Enter API key for {provider}"
 msgstr "Saisir la clé API pour {provider}"
 
-#: src/iac_code/commands/auth.py:1028
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider} / {model}"
 msgstr "{status} : {provider} / {model}"
 
-#: src/iac_code/commands/auth.py:1037 src/iac_code/commands/auth.py:1058
+#: src/iac_code/commands/auth.py
 msgid "Alibaba Cloud"
 msgstr "Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1038 src/iac_code/providers/registry.py:427
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "ZhiPu AI"
 msgstr "ZhiPu AI"
 
-#: src/iac_code/commands/auth.py:1039
+#: src/iac_code/commands/auth.py
 msgid "Kimi"
 msgstr "Kimi"
 
-#: src/iac_code/commands/auth.py:1040
+#: src/iac_code/commands/auth.py
 msgid "MiniMax"
 msgstr "MiniMax"
 
-#: src/iac_code/commands/auth.py:1041 src/iac_code/providers/registry.py:429
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Volcengine"
 msgstr "Volcengine"
 
-#: src/iac_code/commands/auth.py:1042
+#: src/iac_code/commands/auth.py
 msgid "SiliconFlow"
 msgstr "SiliconFlow"
 
-#: src/iac_code/commands/auth.py:1043 src/iac_code/providers/registry.py:420
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: src/iac_code/commands/auth.py:1044 src/iac_code/providers/registry.py:418
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: src/iac_code/commands/auth.py:1045 src/iac_code/providers/registry.py:419
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Anthropic"
 msgstr "Anthropic"
 
-#: src/iac_code/commands/auth.py:1046 src/iac_code/providers/registry.py:422
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
-#: src/iac_code/commands/auth.py:1047 src/iac_code/providers/registry.py:435
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Azure OpenAI"
 msgstr "Azure OpenAI"
 
-#: src/iac_code/commands/auth.py:1048 src/iac_code/providers/registry.py:434
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenRouter"
 msgstr "OpenRouter"
 
-#: src/iac_code/commands/auth.py:1049
+#: src/iac_code/commands/auth.py
 msgid "Local"
 msgstr "Local"
 
-#: src/iac_code/commands/auth.py:1050
+#: src/iac_code/commands/auth.py
 msgid "Compatible"
 msgstr "Compatible"
 
-#: src/iac_code/commands/auth.py:1067
+#: src/iac_code/commands/auth.py
 msgid "Select Cloud Provider"
 msgstr "Sélectionner le fournisseur cloud"
 
-#: src/iac_code/commands/auth.py:1083
+#: src/iac_code/commands/auth.py
 msgid "Credential"
 msgstr "Identifiants"
 
-#: src/iac_code/commands/auth.py:1084 src/iac_code/commands/auth.py:1199
-#: src/iac_code/commands/auth.py:1527 src/iac_code/commands/status.py:36
-#: src/iac_code/ui/renderer.py:455
+#: src/iac_code/commands/auth.py src/iac_code/commands/status.py
+#: src/iac_code/ui/renderer.py
 msgid "Region"
 msgstr "Région"
 
-#: src/iac_code/commands/auth.py:1086
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud"
 msgstr "Configurer Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1188
+#: src/iac_code/commands/auth.py
 msgid "Current configuration"
 msgstr "Configuration actuelle"
 
-#: src/iac_code/commands/auth.py:1190
+#: src/iac_code/commands/auth.py
 msgid "Mode"
 msgstr "Mode"
 
-#: src/iac_code/commands/auth.py:1196
+#: src/iac_code/commands/auth.py
 msgid "(not set)"
 msgstr "(non défini)"
 
-#: src/iac_code/commands/auth.py:1205
+#: src/iac_code/commands/auth.py
 msgid "AccessKey"
 msgstr "AccessKey"
 
-#: src/iac_code/commands/auth.py:1207 src/iac_code/commands/auth.py:1219
+#: src/iac_code/commands/auth.py
 msgid "STS Token"
 msgstr "Jeton STS"
 
-#: src/iac_code/commands/auth.py:1209
+#: src/iac_code/commands/auth.py
 msgid "RAM Role"
 msgstr "Rôle RAM"
 
-#: src/iac_code/commands/auth.py:1211
+#: src/iac_code/commands/auth.py
 msgid "OAuth Login (Browser)"
 msgstr "Connexion OAuth (navigateur)"
 
-#: src/iac_code/commands/auth.py:1217
+#: src/iac_code/commands/auth.py
 msgid "AccessKey ID"
 msgstr "ID AccessKey"
 
-#: src/iac_code/commands/auth.py:1218
+#: src/iac_code/commands/auth.py
 msgid "AccessKey Secret"
 msgstr "Secret AccessKey"
 
-#: src/iac_code/commands/auth.py:1220
+#: src/iac_code/commands/auth.py
 msgid "RAM Role ARN"
 msgstr "ARN du rôle RAM"
 
-#: src/iac_code/commands/auth.py:1221
+#: src/iac_code/commands/auth.py
 msgid "Session Name"
 msgstr "Nom de session"
 
-#: src/iac_code/commands/auth.py:1222
+#: src/iac_code/commands/auth.py
 msgid "OAuth Site Type"
 msgstr "Type de site OAuth"
 
-#: src/iac_code/commands/auth.py:1223
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token"
 msgstr "Jeton d'accès OAuth"
 
-#: src/iac_code/commands/auth.py:1224
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token"
 msgstr "Jeton de rafraîchissement OAuth"
 
-#: src/iac_code/commands/auth.py:1225
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token Expire"
 msgstr "Expiration du jeton d'accès OAuth"
 
-#: src/iac_code/commands/auth.py:1226
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token Expire"
 msgstr "Expiration du jeton de rafraîchissement OAuth"
 
-#: src/iac_code/commands/auth.py:1227
+#: src/iac_code/commands/auth.py
 msgid "STS Expiration"
 msgstr "Expiration STS"
 
-#: src/iac_code/commands/auth.py:1384
+#: src/iac_code/commands/auth.py
 msgid "China"
 msgstr "Chine"
 
-#: src/iac_code/commands/auth.py:1385
+#: src/iac_code/commands/auth.py
 msgid "International"
 msgstr "International"
 
-#: src/iac_code/commands/auth.py:1387
+#: src/iac_code/commands/auth.py
 msgid "Choose site type"
 msgstr "Choisir le type de site"
 
-#: src/iac_code/commands/auth.py:1402
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Alibaba Cloud OAuth login failed: {error}"
 msgstr "Échec de la connexion OAuth Alibaba Cloud : {error}"
 
-#: src/iac_code/commands/auth.py:1418
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud OAuth credentials saved"
 msgstr "Configuré : identifiants OAuth Alibaba Cloud enregistrés"
 
-#: src/iac_code/commands/auth.py:1430
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud credentials"
 msgstr "Configurer les identifiants Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1443
+#: src/iac_code/commands/auth.py
 msgid "Reconfigure credential"
 msgstr "Reconfigurer les identifiants"
 
-#: src/iac_code/commands/auth.py:1456
+#: src/iac_code/commands/auth.py
 msgid "Select credential type"
 msgstr "Sélectionner le type d’identifiants"
 
-#: src/iac_code/commands/auth.py:1512
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud credentials saved to ~/.iac-code"
 msgstr ""
 "Configured: Alibaba Cloud credentials saved to ~/.iac-codeConfigured: "
 "Alibaba Cloud credentials saved to ~/.iac-codeConfiguration effectuée : "
 "identifiants Alibaba Cloud enregistrés dans ~/.iac-code"
 
-#: src/iac_code/commands/auth.py:1519
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud region"
 msgstr "Configurer la région Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1545
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud region saved to ~/.iac-code"
 msgstr ""
 "Configured: Alibaba Cloud region saved to ~/.iac-codeConfigured: Alibaba "
 "Cloud region saved to ~/.iac-codeConfiguration effectuée : région Alibaba"
 " Cloud enregistrée dans ~/.iac-code"
 
-#: src/iac_code/commands/compact.py:12
+#: src/iac_code/commands/compact.py
 msgid "Compact command requires a context."
 msgstr "La commande compact nécessite un contexte."
 
-#: src/iac_code/commands/compact.py:16
+#: src/iac_code/commands/compact.py
 msgid "No active REPL."
 msgstr "Aucun REPL actif."
 
-#: src/iac_code/commands/compact.py:20
+#: src/iac_code/commands/compact.py
 msgid "No active agent loop."
 msgstr "Aucune boucle d’agent active."
 
-#: src/iac_code/commands/compact.py:35
+#: src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent_display} "
@@ -1036,108 +1024,107 @@ msgstr ""
 "Contexte compacté : {original} → {compacted} tokens (réduction "
 "{percent_display}). Utilisation du contexte : {usage_display}"
 
-#: src/iac_code/commands/debug.py:21
+#: src/iac_code/commands/debug.py
 msgid "Debug command requires a context."
 msgstr "La commande debug nécessite un contexte."
 
-#: src/iac_code/commands/debug.py:26
+#: src/iac_code/commands/debug.py
 msgid "No active session."
 msgstr "Aucune session active."
 
-#: src/iac_code/commands/effort.py:54 src/iac_code/commands/model.py:95
-#: src/iac_code/commands/model.py:99
+#: src/iac_code/commands/effort.py src/iac_code/commands/model.py
 msgid "No configured providers. Run /auth first."
 msgstr "Aucun fournisseur configuré. Exécutez d’abord /auth."
 
-#: src/iac_code/commands/effort.py:58
+#: src/iac_code/commands/effort.py
 msgid "No model selected. Run /model first."
 msgstr "Aucun modèle sélectionné. Exécutez d’abord /model."
 
-#: src/iac_code/commands/effort.py:66
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Model {model} does not support effort."
 msgstr "Le modèle {model} ne prend pas en charge l’effort de raisonnement."
 
-#: src/iac_code/commands/effort.py:80
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Invalid effort. Allowed: {labels}"
 msgstr "Effort de raisonnement invalide. Valeurs autorisées : {labels}"
 
-#: src/iac_code/commands/effort.py:85
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Current effort: {effort}"
 msgstr "Effort de raisonnement actuel : {effort}"
 
-#: src/iac_code/commands/effort.py:94
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Select effort for {model}"
 msgstr "Sélectionner l’effort pour {model}"
 
-#: src/iac_code/commands/effort.py:103 src/iac_code/commands/effort.py:107
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Kept effort as {effort}"
 msgstr "Effort de raisonnement conservé : {effort}"
 
-#: src/iac_code/commands/effort.py:116
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Effort switched to: {effort}"
 msgstr "Effort de raisonnement défini sur : {effort}"
 
-#: src/iac_code/commands/help.py:29
+#: src/iac_code/commands/help.py
 msgid "Commands:"
 msgstr "Commandes :"
 
-#: src/iac_code/commands/help.py:36
+#: src/iac_code/commands/help.py
 msgid "Shortcuts:"
 msgstr "Raccourcis :"
 
-#: src/iac_code/commands/help.py:39
+#: src/iac_code/commands/help.py
 msgid "Send message"
 msgstr "Envoyer le message"
 
-#: src/iac_code/commands/help.py:40
+#: src/iac_code/commands/help.py
 msgid "New line"
 msgstr "Nouvelle ligne"
 
-#: src/iac_code/commands/help.py:41
+#: src/iac_code/commands/help.py
 msgid "Show command suggestions"
 msgstr "Afficher les suggestions de commandes"
 
-#: src/iac_code/commands/help.py:42
+#: src/iac_code/commands/help.py
 msgid "Exit"
 msgstr "Quitter"
 
-#: src/iac_code/commands/memory.py:10
+#: src/iac_code/commands/memory.py
 msgid "Usage: /memory [<name>|search <query>|delete <name>|help]"
 msgstr "Utilisation : /memory [<nom>|search <requête>|delete <nom>|help]"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "Saved memories:"
 msgstr "Mémoires enregistrées :"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "No memories saved yet."
 msgstr "Aucune mémoire enregistrée pour le moment."
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "Matching memories:"
 msgstr "Mémoires correspondantes :"
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "No matching memories."
 msgstr "Aucune mémoire correspondante."
 
-#: src/iac_code/commands/memory.py:60 src/iac_code/commands/memory.py:75
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' not found."
 msgstr "Mémoire '{name}' introuvable."
 
-#: src/iac_code/commands/memory.py:64
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' deleted."
 msgstr "Mémoire '{name}' supprimée."
 
-#: src/iac_code/commands/model.py:57
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid ""
 "Model is managed by '{source}'. To change model, modify it in {source} or"
@@ -1146,183 +1133,181 @@ msgstr ""
 "Le modèle est géré par '{source}'. Pour changer le modèle, modifiez-le "
 "dans {source} ou changez de fournisseur via /auth."
 
-#: src/iac_code/commands/model.py:88 src/iac_code/commands/model.py:143
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Model switched to: {model}"
 msgstr "Modèle défini sur : {model}"
 
-#: src/iac_code/commands/model.py:92
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Current model: {model}"
 msgstr "Modèle actuel : {model}"
 
-#: src/iac_code/commands/model.py:118
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Kept model as {model}"
 msgstr "Modèle conservé : {model}"
 
-#: src/iac_code/commands/rename.py:16 src/iac_code/commands/rename.py:28
+#: src/iac_code/commands/rename.py
 msgid "Rename is only available in interactive mode."
 msgstr "Le renommage n'est disponible qu'en mode interactif."
 
-#: src/iac_code/commands/rename.py:31
+#: src/iac_code/commands/rename.py
 msgid "Rename cancelled"
 msgstr "Renommage annulé"
 
-#: src/iac_code/commands/resume.py:22
+#: src/iac_code/commands/resume.py
 msgid "Resume is only available in interactive mode."
 msgstr "/resume n’est disponible qu’en mode interactif."
 
-#: src/iac_code/commands/resume.py:28
+#: src/iac_code/commands/resume.py
 msgid "Resume is unavailable: session index not initialised."
 msgstr "Reprise indisponible : l’index des sessions n’est pas initialisé."
 
-#: src/iac_code/commands/resume.py:33 src/iac_code/commands/resume.py:36
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Session not found: {arg}"
 msgstr "Session introuvable : {arg}"
 
-#: src/iac_code/commands/resume.py:52 src/iac_code/commands/resume.py:68
+#: src/iac_code/commands/resume.py
 msgid "Resume cancelled"
 msgstr "Reprise annulée"
 
-#: src/iac_code/commands/resume.py:55
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Unable to resolve session: {arg}"
 msgstr "Impossible de résoudre la session : {arg}"
 
-#: src/iac_code/commands/skills.py:14
+#: src/iac_code/commands/skills.py
 msgid "Skills management is only available in interactive mode."
 msgstr "La gestion des compétences n'est disponible qu'en mode interactif."
 
-#: src/iac_code/commands/skills.py:25
+#: src/iac_code/commands/skills.py
 msgid "Skills update cancelled"
 msgstr "Mise à jour des compétences annulée"
 
-#: src/iac_code/commands/skills.py:29
+#: src/iac_code/commands/skills.py
 msgid "Skills updated"
 msgstr "Compétences mises à jour"
 
-#: src/iac_code/commands/status.py:19
+#: src/iac_code/commands/status.py
 msgid "Status command requires a context."
 msgstr "La commande status nécessite un contexte."
 
-#: src/iac_code/commands/status.py:22
+#: src/iac_code/commands/status.py
 msgid "Status command requires a REPL context."
 msgstr "La commande status nécessite un contexte REPL."
 
-#: src/iac_code/commands/status.py:24
+#: src/iac_code/commands/status.py
 msgid "Status is only available in interactive mode."
 msgstr "status n’est disponible qu’en mode interactif."
 
-#: src/iac_code/commands/status.py:33 src/iac_code/ui/banner.py:136
-#: src/iac_code/ui/banner.py:138
+#: src/iac_code/commands/status.py src/iac_code/ui/banner.py
 msgid "Session"
 msgstr "Session"
 
-#: src/iac_code/commands/status.py:34
+#: src/iac_code/commands/status.py
 msgid "Provider"
 msgstr "Fournisseur"
 
-#: src/iac_code/commands/status.py:34 src/iac_code/commands/status.py:35
-#: src/iac_code/commands/status.py:36
+#: src/iac_code/commands/status.py
 msgid "not configured"
 msgstr "non configuré"
 
-#: src/iac_code/commands/status.py:35
+#: src/iac_code/commands/status.py
 msgid "Model"
 msgstr "Modèle"
 
-#: src/iac_code/commands/status.py:37
+#: src/iac_code/commands/status.py
 msgid "CWD"
 msgstr "Répertoire courant"
 
-#: src/iac_code/commands/status.py:41
+#: src/iac_code/commands/status.py
 msgid "API Token Usage (recorded):"
 msgstr "Utilisation des tokens API (enregistrée) :"
 
-#: src/iac_code/commands/status.py:44
+#: src/iac_code/commands/status.py
 msgid "Input"
 msgstr "Entrée"
 
-#: src/iac_code/commands/status.py:45
+#: src/iac_code/commands/status.py
 msgid "Output"
 msgstr "Sortie"
 
-#: src/iac_code/commands/status.py:46
+#: src/iac_code/commands/status.py
 msgid "Cache read"
 msgstr "Lecture du cache"
 
-#: src/iac_code/commands/status.py:47
+#: src/iac_code/commands/status.py
 msgid "Total"
 msgstr "Total"
 
-#: src/iac_code/commands/status.py:50
+#: src/iac_code/commands/status.py
 msgid "No recorded API usage for this session yet."
 msgstr "Aucune utilisation d’API enregistrée pour cette session pour le moment."
 
-#: src/iac_code/commands/status.py:54
+#: src/iac_code/commands/status.py
 msgid "Turns"
 msgstr "Tours"
 
-#: src/iac_code/commands/status.py:55
+#: src/iac_code/commands/status.py
 msgid "Context"
 msgstr "Contexte"
 
-#: src/iac_code/commands/status.py:57
+#: src/iac_code/commands/status.py
 msgid "Session Status"
 msgstr "État de la session"
 
-#: src/iac_code/commands/status.py:73
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{session_id} (resumed)"
 msgstr "{session_id} (reprise)"
 
-#: src/iac_code/commands/status.py:81
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{percent} used ({total} / {window})"
 msgstr "{percent} utilisé ({total} / {window})"
 
 # Typer/Click built-in strings
-#: src/iac_code/i18n/__init__.py:51
+#: src/iac_code/i18n/__init__.py
 msgid "Options"
 msgstr "Options"
 
-#: src/iac_code/i18n/__init__.py:52
+#: src/iac_code/i18n/__init__.py
 msgid "Commands"
 msgstr "Commandes"
 
-#: src/iac_code/i18n/__init__.py:53
+#: src/iac_code/i18n/__init__.py
 msgid "Arguments"
 msgstr "Arguments"
 
-#: src/iac_code/i18n/__init__.py:54
+#: src/iac_code/i18n/__init__.py
 msgid "Show this message and exit."
 msgstr "Afficher ce message et quitter."
 
-#: src/iac_code/i18n/__init__.py:57
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "default: {default}"
 msgstr "par défaut : {default}"
 
-#: src/iac_code/i18n/__init__.py:58
+#: src/iac_code/i18n/__init__.py
 msgid "required"
 msgstr "obligatoire"
 
-#: src/iac_code/i18n/__init__.py:59
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "env var: {var}"
 msgstr "variable d’environnement : {var}"
 
-#: src/iac_code/i18n/__init__.py:60
+#: src/iac_code/i18n/__init__.py
 msgid "(dynamic)"
 msgstr "(dynamique)"
 
-#: src/iac_code/i18n/__init__.py:61
+#: src/iac_code/i18n/__init__.py
 msgid "Aborted!"
 msgstr "Interrompu !"
 
-#: src/iac_code/providers/manager.py:78
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Cannot determine provider for model: {model}. Run /auth to configure."
 msgstr ""
@@ -1331,12 +1316,12 @@ msgstr ""
 "configure.Impossible de déterminer le fournisseur pour le modèle : "
 "{model}. Exécutez /auth pour configurer."
 
-#: src/iac_code/providers/manager.py:95
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Unknown provider key: '{key}'. Run /auth to configure."
 msgstr "Clé de fournisseur inconnue : '{key}'. Exécutez /auth pour configurer."
 
-#: src/iac_code/providers/manager.py:100
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid ""
 "No API key configured for provider '{provider}' (model: {model}). Run "
@@ -1345,7 +1330,7 @@ msgstr ""
 "Aucune clé API configurée pour le fournisseur '{provider}' (modèle : "
 "{model}). Exécutez /auth pour configurer."
 
-#: src/iac_code/providers/openai_provider.py:307
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned no data. Please check that your API Base URL is correct "
@@ -1356,7 +1341,7 @@ msgstr ""
 "correcte (actuelle : {base_url}). De nombreux points de terminaison "
 "compatibles OpenAI exigent le suffixe /v1 (p. ex. {base_url}/v1)."
 
-#: src/iac_code/providers/openai_provider.py:348
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned an invalid response. Please check that your API Base URL is "
@@ -1367,83 +1352,83 @@ msgstr ""
 " correcte (actuelle : {base_url}). De nombreux points de terminaison "
 "compatibles OpenAI exigent le suffixe /v1 (p. ex. {base_url}/v1)."
 
-#: src/iac_code/providers/registry.py:416
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
 msgstr "Alibaba Cloud Bailian"
 
-#: src/iac_code/providers/registry.py:417
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian Token Plan"
 msgstr "Alibaba Cloud Bailian Token Plan"
 
-#: src/iac_code/providers/registry.py:421
+#: src/iac_code/providers/registry.py
 msgid "OpenAPI Compatible"
 msgstr "Compatible OpenAPI"
 
-#: src/iac_code/providers/registry.py:423
+#: src/iac_code/providers/registry.py
 msgid "Kimi (China)"
 msgstr "Kimi (Chine)"
 
-#: src/iac_code/providers/registry.py:424
+#: src/iac_code/providers/registry.py
 msgid "Kimi (International)"
 msgstr "Kimi (International)"
 
-#: src/iac_code/providers/registry.py:425
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (China)"
 msgstr "MiniMax (Chine)"
 
-#: src/iac_code/providers/registry.py:426
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (International)"
 msgstr "MiniMax (International)"
 
-#: src/iac_code/providers/registry.py:428
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI (International)"
 msgstr "ZhiPu AI (International)"
 
-#: src/iac_code/providers/registry.py:430
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (China)"
 msgstr "SiliconFlow (Chine)"
 
-#: src/iac_code/providers/registry.py:431
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (International)"
 msgstr "SiliconFlow (International)"
 
-#: src/iac_code/providers/registry.py:432
+#: src/iac_code/providers/registry.py
 msgid "Ollama (Local)"
 msgstr "Ollama (Local)"
 
-#: src/iac_code/providers/registry.py:433
+#: src/iac_code/providers/registry.py
 msgid "LM Studio (Local)"
 msgstr "LM Studio (Local)"
 
-#: src/iac_code/providers/registry.py:436
+#: src/iac_code/providers/registry.py
 msgid "ModelScope"
 msgstr "ModelScope"
 
-#: src/iac_code/providers/registry.py:437
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan"
 msgstr "Alibaba Cloud CodingPlan"
 
-#: src/iac_code/providers/registry.py:438
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan (International)"
 msgstr "Alibaba Cloud CodingPlan (International)"
 
-#: src/iac_code/providers/registry.py:439
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan"
 msgstr "ZhiPu AI CodingPlan"
 
-#: src/iac_code/providers/registry.py:440
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan (International)"
 msgstr "ZhiPu AI CodingPlan (International)"
 
-#: src/iac_code/providers/registry.py:441
+#: src/iac_code/providers/registry.py
 msgid "Volcengine CodingPlan"
 msgstr "Volcengine CodingPlan"
 
-#: src/iac_code/providers/registry.py:442
+#: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Compatible Anthropic"
 
-#: src/iac_code/services/qwenpaw_source.py:205
+#: src/iac_code/services/qwenpaw_source.py
 #, python-brace-format
 msgid ""
 "[QwenPaw mode] Unknown provider '{provider_id}'. iac-code does not "
@@ -1459,90 +1444,90 @@ msgstr ""
 "désactivez le mode QwenPaw (supprimez 'llm_source: qwenpaw' de "
 "settings.yml)."
 
-#: src/iac_code/services/session_metadata.py:52
+#: src/iac_code/services/session_metadata.py
 #, python-brace-format
 msgid "Session name must match {pattern}"
 msgstr "Le nom de session doit correspondre à {pattern}"
 
-#: src/iac_code/services/session_storage.py:241
+#: src/iac_code/services/session_storage.py
 #, python-brace-format
 msgid "Session name already exists in this project: {name}"
 msgstr "Le nom de session existe déjà dans ce projet : {name}"
 
-#: src/iac_code/services/permissions/loader.py:50
+#: src/iac_code/services/permissions/loader.py
 #, python-brace-format
 msgid "Invalid --permission-mode {!r}. Valid values: {}"
 msgstr "--permission-mode invalide : {!r}. Valeurs valides : {}"
 
-#: src/iac_code/services/permissions/pipeline.py:54
-#: src/iac_code/tools/base.py:199 src/iac_code/tools/bash/bash_tool.py:175
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Allow {}?"
 msgstr "Autoriser {} ?"
 
-#: src/iac_code/services/providers/aliyun.py:144
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
 msgstr "Le site OAuth Alibaba Cloud est manquant."
 
-#: src/iac_code/services/providers/aliyun.py:150
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth refresh token is missing."
 msgstr "Le jeton de rafraîchissement OAuth Alibaba Cloud est manquant."
 
-#: src/iac_code/services/providers/aliyun.py:158
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth access token is missing."
 msgstr "Le jeton d'accès OAuth Alibaba Cloud est manquant."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:83
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Run /auth and choose OAuth Login (Browser)."
 msgstr "Exécutez /auth et choisissez Connexion OAuth (navigateur)."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:106
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "Unknown Aliyun OAuth site: {site_type}"
 msgstr "Site OAuth Aliyun inconnu : {site_type}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:164
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Not found"
 msgstr "Introuvable"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:170
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "invalid state"
 msgstr "état invalide"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:171
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Invalid state"
 msgstr "État invalide"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:176
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "code not found"
 msgstr "code d'autorisation introuvable"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:177
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization code not found"
 msgstr "Code d'autorisation introuvable"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:181
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization successful. You can close this window."
 msgstr "Autorisation réussie. Vous pouvez fermer cette fenêtre."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:212
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "No available callback port in range {start}-{end}"
 msgstr "Aucun port de callback disponible dans la plage {start}-{end}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:227
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "OAuth login cancelled."
 msgstr "Connexion OAuth annulée."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:278
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Open in your browser:"
 msgstr "Ouvrir dans le navigateur :"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:299
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Waiting for browser authorization"
 msgstr "En attente de l'autorisation du navigateur"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:300
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "1. The browser may show official-cli; this is the Alibaba Cloud official "
 "CLI OAuth application."
@@ -1550,7 +1535,7 @@ msgstr ""
 "1. Le navigateur peut afficher official-cli ; il s'agit de l'application "
 "OAuth CLI officielle d'Alibaba Cloud."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:302
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "2. If assignment is required, assign the RAM user or RAM role that is "
 "signed in. User groups are not supported."
@@ -1559,7 +1544,7 @@ msgstr ""
 "RAM actuellement connecté. Les groupes d'utilisateurs ne sont pas pris en"
 " charge."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:306
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "3. After assignment, close the old authorization page and run OAuth Login"
 " (Browser) again. If it still fails, sign out of Alibaba Cloud and sign "
@@ -1569,7 +1554,7 @@ msgstr ""
 " Connexion OAuth (navigateur). Si l'échec persiste, déconnectez-vous "
 "d'Alibaba Cloud puis reconnectez-vous."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:310
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "4. STS credentials refresh when possible until Alibaba Cloud expires "
 "them. If refresh fails, run /auth again."
@@ -1578,11 +1563,11 @@ msgstr ""
 "leur expiration par Alibaba Cloud. Si l'actualisation échoue, exécutez de"
 " nouveau /auth."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:313
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Press Esc to cancel while waiting."
 msgstr "Appuyez sur Échap pour annuler l'attente."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:321
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "Timed out waiting for OAuth callback. If Alibaba Cloud asked you to "
 "assign the official-cli application, assign it to the exact RAM user or "
@@ -1598,26 +1583,26 @@ msgstr ""
 " si nécessaire, puis exécutez /auth pour choisir de nouveau Connexion "
 "OAuth (navigateur)."
 
-#: src/iac_code/skills/skill_tool.py:85 src/iac_code/ui/repl.py:842
+#: src/iac_code/skills/skill_tool.py src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Skill '{name}' is disabled. Run /skills to enable it."
 msgstr "La compétence « {name} » est désactivée. Exécutez /skills pour l'activer."
 
-#: src/iac_code/skills/skill_tool.py:137
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill '{name}' loaded (inline)."
 msgstr "Skill « {name} » chargé (inline)."
 
-#: src/iac_code/skills/skill_tool.py:221
+#: src/iac_code/skills/skill_tool.py
 msgid "Skill"
 msgstr "Skill"
 
-#: src/iac_code/skills/skill_tool.py:245
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill disabled: {name}"
 msgstr "Compétence désactivée : {name}"
 
-#: src/iac_code/skills/bundled/simplify.py:25
+#: src/iac_code/skills/bundled/simplify.py
 msgid ""
 "Review changed code for reuse, quality, and efficiency, then fix issues "
 "found."
@@ -1625,99 +1610,99 @@ msgstr ""
 "Examiner le code modifié pour la réutilisation, la qualité et "
 "l’efficacité, puis corriger les problèmes détectés."
 
-#: src/iac_code/tools/edit_file.py:116
+#: src/iac_code/tools/edit_file.py
 msgid "Edit"
 msgstr "Modifier"
 
-#: src/iac_code/tools/edit_file.py:118
+#: src/iac_code/tools/edit_file.py
 msgid "Create"
 msgstr "Créer"
 
-#: src/iac_code/tools/edit_file.py:119
+#: src/iac_code/tools/edit_file.py
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: src/iac_code/tools/edit_file.py:126
+#: src/iac_code/tools/edit_file.py
 #, python-brace-format
 msgid "Editing {path}"
 msgstr "Édition de {path}"
 
-#: src/iac_code/tools/edit_file.py:127
+#: src/iac_code/tools/edit_file.py
 msgid "Editing file..."
 msgstr "Édition du fichier…"
 
-#: src/iac_code/tools/glob.py:86 src/iac_code/tools/grep.py:237
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Found 0 files"
 msgstr "0 fichier trouvé"
 
-#: src/iac_code/tools/glob.py:89 src/iac_code/tools/grep.py:240
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Found {count} files"
 msgstr "{count} fichiers trouvés"
 
-#: src/iac_code/tools/glob.py:95 src/iac_code/tools/grep.py:246
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Search"
 msgstr "Recherche"
 
-#: src/iac_code/tools/glob.py:100
+#: src/iac_code/tools/glob.py
 #, python-brace-format
 msgid "Searching {pattern}"
 msgstr "Recherche de {pattern}"
 
-#: src/iac_code/tools/glob.py:101
+#: src/iac_code/tools/glob.py
 msgid "Searching files..."
 msgstr "Recherche de fichiers…"
 
-#: src/iac_code/tools/grep.py:251
+#: src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Searching for {pattern}"
 msgstr "Recherche de {pattern}"
 
-#: src/iac_code/tools/grep.py:252
+#: src/iac_code/tools/grep.py
 msgid "Searching content..."
 msgstr "Recherche dans le contenu…"
 
-#: src/iac_code/tools/list_files.py:82
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Found {count} items"
 msgstr "{count} éléments trouvés"
 
-#: src/iac_code/tools/list_files.py:88
+#: src/iac_code/tools/list_files.py
 msgid "List"
 msgstr "Liste"
 
-#: src/iac_code/tools/list_files.py:92
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Listing {path}"
 msgstr "Listage de {path}"
 
-#: src/iac_code/tools/list_files.py:93
+#: src/iac_code/tools/list_files.py
 msgid "Listing files..."
 msgstr "Listage des fichiers…"
 
-#: src/iac_code/tools/read_file.py:117
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Read {total} lines"
 msgstr "{total} lignes lues"
 
-#: src/iac_code/tools/read_file.py:120
+#: src/iac_code/tools/read_file.py
 msgid "Read"
 msgstr "Lecture"
 
-#: src/iac_code/tools/read_file.py:127
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Reading {path}"
 msgstr "Lecture de {path}"
 
-#: src/iac_code/tools/read_file.py:128
+#: src/iac_code/tools/read_file.py
 msgid "Reading file..."
 msgstr "Lecture du fichier…"
 
-#: src/iac_code/tools/web_fetch.py:94
+#: src/iac_code/tools/web_fetch.py
 msgid "URL cannot be empty."
 msgstr "L’URL ne peut pas être vide."
 
-#: src/iac_code/tools/web_fetch.py:100
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}"
 msgstr ""
@@ -1725,409 +1710,408 @@ msgstr ""
 " URL: missing scheme (e.g. http:// or https://). Got: {url}URL non valide"
 " : schéma manquant (p. ex. http:// ou https://). Obtenu : {url}"
 
-#: src/iac_code/tools/web_fetch.py:103
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing host/netloc. Got: {url}"
 msgstr "URL non valide : hôte ou emplacement réseau manquant. Obtenu : {url}"
 
-#: src/iac_code/tools/web_fetch.py:129
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "HTTP error {status}: {url}"
 msgstr "Erreur HTTP {status} : {url}"
 
-#: src/iac_code/tools/web_fetch.py:131
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Failed to fetch {url}: {error}"
 msgstr "Échec de la récupération de {url} : {error}"
 
-#: src/iac_code/tools/web_fetch.py:133
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Unexpected error fetching {url}: {error}"
 msgstr "Erreur inattendue lors de la récupération de {url} : {error}"
 
-#: src/iac_code/tools/web_fetch.py:147
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetched {chars} chars, {lines} lines"
 msgstr "{chars} caractères récupérés, {lines} lignes"
 
-#: src/iac_code/tools/web_fetch.py:159
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetch"
 msgstr "Récupération"
 
-#: src/iac_code/tools/web_fetch.py:165
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetching {url}"
 msgstr "Récupération de {url}"
 
-#: src/iac_code/tools/web_fetch.py:166
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetching web page..."
 msgstr "Récupération de la page web…"
 
-#: src/iac_code/tools/write_file.py:67
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Successfully wrote {lines} lines to {path}"
 msgstr "{lines} lignes écrites avec succès dans {path}"
 
-#: src/iac_code/tools/write_file.py:81
+#: src/iac_code/tools/write_file.py
 msgid "Write"
 msgstr "Écriture"
 
-#: src/iac_code/tools/write_file.py:88
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Writing {path}"
 msgstr "Écriture de {path}"
 
-#: src/iac_code/tools/write_file.py:89
+#: src/iac_code/tools/write_file.py
 msgid "Writing file..."
 msgstr "Écriture du fichier…"
 
-#: src/iac_code/tools/bash/bash_tool.py:81
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Command timed out after {timeout} seconds: {command}"
 msgstr "La commande a expiré après {timeout} secondes : {command}"
 
-#: src/iac_code/tools/bash/bash_tool.py:103
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Error executing command: {}"
 msgstr "Erreur lors de l'exécution de la commande : {}"
 
-#: src/iac_code/tools/bash/bash_tool.py:129
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "{count} more lines"
 msgstr "{count} lignes supplémentaires"
 
-#: src/iac_code/tools/bash/bash_tool.py:137
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Bash"
 msgstr "Bash"
 
-#: src/iac_code/tools/bash/bash_tool.py:143
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Running {cmd}"
 msgstr "Exécution de {cmd}"
 
-#: src/iac_code/tools/bash/bash_tool.py:144
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Running command..."
 msgstr "Exécution de la commande…"
 
-#: src/iac_code/tools/bash/command_parser.py:42
+#: src/iac_code/tools/bash/command_parser.py
 msgid "parse error"
 msgstr "Erreur d'analyse"
 
-#: src/iac_code/tools/bash/command_parser.py:46
+#: src/iac_code/tools/bash/command_parser.py
 msgid "unsupported shell construct"
 msgstr "Construction shell non prise en charge"
 
-#: src/iac_code/tools/bash/path_validation.py:111
+#: src/iac_code/tools/bash/path_validation.py
 #, python-brace-format
 msgid "path outside allowed directories: {}"
 msgstr "Chemin en dehors des répertoires autorisés : {}"
 
-#: src/iac_code/tools/bash/permissions.py:135
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s): {}"
 msgstr "Règle(s) de refus correspondante(s) : {}"
 
-#: src/iac_code/tools/bash/permissions.py:142
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Règle(s) de demande correspondante(s) : {}"
 
-#: src/iac_code/tools/bash/permissions.py:154
-#: src/iac_code/tools/bash/permissions.py:220
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched allow rule(s): {}"
 msgstr "Règle(s) d'autorisation correspondante(s) : {}"
 
-#: src/iac_code/tools/bash/permissions.py:162
+#: src/iac_code/tools/bash/permissions.py
 msgid "complex command requires confirmation"
 msgstr "La commande complexe nécessite une confirmation"
 
-#: src/iac_code/tools/bash/permissions.py:171
+#: src/iac_code/tools/bash/permissions.py
 msgid "sed in-place edit requires confirmation"
 msgstr "L'édition sed sur place nécessite une confirmation"
 
-#: src/iac_code/tools/bash/permissions.py:194
+#: src/iac_code/tools/bash/permissions.py
 msgid "command failed basic safety checks"
 msgstr "La commande n'a pas passé les vérifications de sécurité de base"
 
-#: src/iac_code/tools/bash/permissions.py:210
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s) on full command: {}"
 msgstr "Règle(s) de refus pour la commande complète : {}"
 
-#: src/iac_code/tools/bash/permissions.py:227
+#: src/iac_code/tools/bash/permissions.py
 msgid "command too complex to analyze"
 msgstr "Commande trop complexe pour être analysée"
 
-#: src/iac_code/tools/bash/permissions.py:229
+#: src/iac_code/tools/bash/permissions.py
 msgid "could not parse command"
 msgstr "Impossible d'analyser la commande"
 
-#: src/iac_code/tools/bash/permissions.py:245
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "too many subcommands (>{})"
 msgstr "Trop de sous-commandes (>{})"
 
-#: src/iac_code/tools/bash/permissions.py:258
+#: src/iac_code/tools/bash/permissions.py
 msgid "multiple cd commands in compound command"
 msgstr "Plusieurs commandes cd dans une commande composée"
 
-#: src/iac_code/tools/bash/permissions.py:271
+#: src/iac_code/tools/bash/permissions.py
 msgid "cd combined with git in compound command"
 msgstr "cd combiné avec git dans une commande composée"
 
-#: src/iac_code/tools/bash/safety_checks.py:151
+#: src/iac_code/tools/bash/safety_checks.py
 #, python-brace-format
 msgid "operation touches a sensitive path: {}"
 msgstr "L'opération touche un chemin sensible : {}"
 
-#: src/iac_code/tools/cloud/base_api.py:92
+#: src/iac_code/tools/cloud/base_api.py
 msgid "CloudAPI"
 msgstr "CloudAPI"
 
-#: src/iac_code/tools/cloud/base_api.py:116
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Calling {action}..."
 msgstr "Appel de {action}…"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:400
-#: src/iac_code/tools/cloud/base_api.py:123
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#: src/iac_code/tools/cloud/base_api.py
 msgid "Call succeeded"
 msgstr "Appel réussi"
 
-#: src/iac_code/tools/cloud/base_api.py:144
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Received response ({count} lines)"
 msgstr "Réponse reçue ({count} lignes)"
 
-#: src/iac_code/tools/cloud/base_stack.py:133
+#: src/iac_code/tools/cloud/base_stack.py
 msgid "CloudStack"
 msgstr "CloudStack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:117
-#: src/iac_code/tools/cloud/base_stack.py:150
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
+#: src/iac_code/tools/cloud/base_stack.py
 #, python-brace-format
 msgid "Running {action}..."
 msgstr "Exécution de {action}…"
 
-#: src/iac_code/tools/cloud/types.py:8
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_IN_PROGRESS"
 msgstr "CRÉATION EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:9
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_FAILED"
 msgstr "ÉCHEC DE LA CRÉATION"
 
-#: src/iac_code/tools/cloud/types.py:10
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_COMPLETE"
 msgstr "CRÉATION TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:11
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_IN_PROGRESS"
 msgstr "MISE À JOUR EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:12
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_FAILED"
 msgstr "ÉCHEC DE LA MISE À JOUR"
 
-#: src/iac_code/tools/cloud/types.py:13
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_COMPLETE"
 msgstr "MISE À JOUR TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:14
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_IN_PROGRESS"
 msgstr "SUPPRESSION EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:15
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_FAILED"
 msgstr "ÉCHEC DE LA SUPPRESSION"
 
-#: src/iac_code/tools/cloud/types.py:16
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_COMPLETE"
 msgstr "SUPPRESSION TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:17
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "ANNULATION DE CRÉATION EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:18
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_FAILED"
 msgstr "ÉCHEC DE L’ANNULATION DE CRÉATION"
 
-#: src/iac_code/tools/cloud/types.py:19
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_COMPLETE"
 msgstr "ANNULATION DE CRÉATION TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:20
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_IN_PROGRESS"
 msgstr "ANNULATION EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:21
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_FAILED"
 msgstr "ÉCHEC DE L’ANNULATION"
 
-#: src/iac_code/tools/cloud/types.py:22
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_COMPLETE"
 msgstr "ANNULATION TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:23
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_IN_PROGRESS"
 msgstr "VÉRIFICATION EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:24
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_FAILED"
 msgstr "ÉCHEC DE LA VÉRIFICATION"
 
-#: src/iac_code/tools/cloud/types.py:25
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_COMPLETE"
 msgstr "VÉRIFICATION TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:26
+#: src/iac_code/tools/cloud/types.py
 msgid "REVIEW_IN_PROGRESS"
 msgstr "EXAMEN EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:27
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_IN_PROGRESS"
 msgstr "IMPORT CRÉATION EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:28
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_FAILED"
 msgstr "ÉCHEC IMPORT CRÉATION"
 
-#: src/iac_code/tools/cloud/types.py:29
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_COMPLETE"
 msgstr "IMPORT CRÉATION TERMINÉ"
 
-#: src/iac_code/tools/cloud/types.py:30
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "ANNULATION IMPORT CRÉATION EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:31
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_FAILED"
 msgstr "ÉCHEC ANNULATION IMPORT CRÉATION"
 
-#: src/iac_code/tools/cloud/types.py:32
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_COMPLETE"
 msgstr "ANNULATION IMPORT CRÉATION TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:33
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_IN_PROGRESS"
 msgstr "IMPORT MISE À JOUR EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:34
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_FAILED"
 msgstr "ÉCHEC IMPORT MISE À JOUR"
 
-#: src/iac_code/tools/cloud/types.py:35
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_COMPLETE"
 msgstr "IMPORT MISE À JOUR TERMINÉ"
 
-#: src/iac_code/tools/cloud/types.py:36
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_IN_PROGRESS"
 msgstr "ANNULATION IMPORT MISE À JOUR EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:37
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_FAILED"
 msgstr "ÉCHEC ANNULATION IMPORT MISE À JOUR"
 
-#: src/iac_code/tools/cloud/types.py:38
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_COMPLETE"
 msgstr "ANNULATION IMPORT MISE À JOUR TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:40
+#: src/iac_code/tools/cloud/types.py
 msgid "INIT_COMPLETE"
 msgstr "INITIALISATION TERMINÉE"
 
-#: src/iac_code/tools/cloud/types.py:41
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_IN_PROGRESS"
 msgstr "IMPORT EN COURS"
 
-#: src/iac_code/tools/cloud/types.py:42
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_COMPLETE"
 msgstr "IMPORT TERMINÉ"
 
-#: src/iac_code/tools/cloud/types.py:43
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_FAILED"
 msgstr "ÉCHEC DE L’IMPORT"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:172
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 msgid "Aliyun API"
 msgstr "Aliyun API"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:399
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Appel réussi (RequestId : {request_id})"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:57
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "DocSearch"
 msgstr "DocSearch"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:70
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Searching docs for {keywords}..."
 msgstr "Recherche de documentation pour {keywords}…"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:71
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Searching docs..."
 msgstr "Recherche dans la documentation…"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:76
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "keywords cannot be empty."
 msgstr "Les mots-clés ne peuvent pas être vides."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:96
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "HTTP error {status} when searching docs."
 msgstr "Erreur HTTP {status} lors de la recherche dans la documentation."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:98
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Failed to search docs: {error}"
 msgstr "Échec de la recherche dans la documentation : {error}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:103
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Failed to parse search response as JSON."
 msgstr "Impossible d’analyser la réponse de recherche en JSON."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:106
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Search API returned failure."
 msgstr "L’API de recherche a signalé un échec."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:125
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "No documents found"
 msgstr "Aucun document trouvé"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:126
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "No documents found for keywords: {keywords}"
 msgstr "Aucun document pour les mots-clés : {keywords}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:141
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Found {count} documents (total {total})"
 msgstr "{count} documents trouvés (sur {total} au total)"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:143
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Use web_fetch tool to read full document content if needed."
 msgstr ""
 "Use web_fetch tool to read full document content if needed.Utilisez "
 "l’outil web_fetch pour lire le document en entier si nécessaire."
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack.py:143
+#: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:100
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:48
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template YAML syntax error: {}"
 msgstr "Erreur de syntaxe YAML dans le modèle : {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:60
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template YAML syntax error (line {line}, column {col}): {problem}\n"
@@ -2139,14 +2123,14 @@ msgstr ""
 "Contexte :\n"
 "{context}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:66
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template JSON syntax error (line {line}, column {col}): {msg}"
 msgstr ""
 "Erreur de syntaxe JSON dans le modèle (ligne {line}, colonne {col}) : "
 "{msg}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:85
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template {fmt} parse result is not an object (dict), please check the "
@@ -2155,7 +2139,7 @@ msgstr ""
 "Le résultat de l'analyse {fmt} du modèle n'est pas un objet (dict), "
 "veuillez vérifier le format du modèle"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:104
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"
@@ -2163,18 +2147,18 @@ msgstr ""
 "Le modèle ne contient pas ROSTemplateFormatVersion (les modèles ROS "
 "doivent inclure ce champ, ex. '2015-09-01')"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:110
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Template is missing Resources (ROS templates must include Resources)"
 msgstr ""
 "Le modèle ne contient pas Resources (les modèles ROS doivent inclure "
 "Resources)"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:112
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resources must be an object (dict), current type is {}"
 msgstr "Resources doit être un objet (dict), le type actuel est {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:117
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Resource '{name}' definition must be an object (dict), current type is "
@@ -2183,19 +2167,19 @@ msgstr ""
 "La définition de la ressource '{name}' doit être un objet (dict), le type"
 " actuel est {type}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:123
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' is missing the Type field"
 msgstr "La ressource '{name}' n'a pas le champ Type"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:129
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' has incorrect type '{wrong}', should be '{correct}'"
 msgstr ""
 "La ressource '{name}' a le type incorrect '{wrong}', devrait être "
 "'{correct}'"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:151
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template structure validation found the following issues, please fix and "
 "retry:"
@@ -2203,244 +2187,237 @@ msgstr ""
 "La validation de la structure du modèle a détecté les problèmes suivants,"
 " veuillez corriger et réessayer :"
 
-#: src/iac_code/ui/banner.py:42 src/iac_code/ui/banner.py:54
+#: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
 msgstr "Mise à jour disponible ! {} -> {}"
 
-#: src/iac_code/ui/banner.py:43
+#: src/iac_code/ui/banner.py
 msgid "Update command"
 msgstr "Commande de mise à jour"
 
-#: src/iac_code/ui/banner.py:46 src/iac_code/ui/banner.py:58
+#: src/iac_code/ui/banner.py
 msgid "Release notes"
 msgstr "Notes de version"
 
-#: src/iac_code/ui/banner.py:55
-#, python-brace-format
-msgid "Run {} to update."
-msgstr "Exécutez {} pour mettre à jour."
-
-#: src/iac_code/ui/banner.py:110
+#: src/iac_code/ui/banner.py
 msgid "Your AI-powered Infrastructure as Code assistant"
 msgstr "Votre assistant Infrastructure as Code assisté par IA"
 
-#: src/iac_code/ui/banner.py:144
+#: src/iac_code/ui/banner.py
 msgid "Welcome back"
 msgstr "Bon retour"
 
-#: src/iac_code/ui/banner.py:161
+#: src/iac_code/ui/banner.py
 msgid "Debug mode"
 msgstr "Mode debug"
 
-#: src/iac_code/ui/banner.py:162
+#: src/iac_code/ui/banner.py
 msgid "Log file"
 msgstr "Fichier journal"
 
-#: src/iac_code/ui/renderer.py:388 src/iac_code/ui/renderer.py:668
-#: src/iac_code/ui/renderer.py:1455
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Réflexion pendant {seconds:.1f}s"
 
-#: src/iac_code/ui/renderer.py:404 src/iac_code/ui/renderer.py:700
-#: src/iac_code/ui/renderer.py:1476
+#: src/iac_code/ui/renderer.py
 msgid "(ctrl+o to expand)"
 msgstr "(ctrl+o pour développer)"
 
-#: src/iac_code/ui/renderer.py:431
+#: src/iac_code/ui/renderer.py
 msgid "Resource"
 msgstr "Ressource"
 
-#: src/iac_code/ui/renderer.py:432
+#: src/iac_code/ui/renderer.py
 msgid "Type"
 msgstr "Type"
 
-#: src/iac_code/ui/renderer.py:433 src/iac_code/ui/renderer.py:456
+#: src/iac_code/ui/renderer.py
 msgid "Status"
 msgstr "État"
 
-#: src/iac_code/ui/renderer.py:454
+#: src/iac_code/ui/renderer.py
 msgid "Account ID"
 msgstr "Identifiant de compte"
 
-#: src/iac_code/ui/renderer.py:542
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Done ({child_count} tool uses{token_info}{elapsed})"
 msgstr "Terminé ({child_count} utilisations d’outil{token_info}{elapsed})"
 
-#: src/iac_code/ui/renderer.py:572
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "+ {count} more tool uses (ctrl+o to expand)"
 msgstr ""
 "+ {count} more tool uses (ctrl+o to expand)+ {count} utilisations d’outil"
 " supplémentaires (ctrl+o pour développer)"
 
-#: src/iac_code/ui/renderer.py:1177
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Context auto-compacted: {original} → {compacted} tokens"
 msgstr "Contexte compacté automatiquement : {original} → {compacted} tokens"
 
-#: src/iac_code/ui/renderer.py:1262
+#: src/iac_code/ui/renderer.py
 msgid "Operation cancelled."
 msgstr "Opération annulée."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "No API key configured."
 msgstr "Aucune clé API configurée."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "Please run /auth to set up your LLM provider and API key."
 msgstr "Exécutez /auth pour configurer votre fournisseur LLM et votre clé API."
 
-#: src/iac_code/ui/renderer.py:1272
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Erreur : {error}"
 
-#: src/iac_code/ui/renderer.py:1342
+#: src/iac_code/ui/renderer.py
 msgid "Allow this action?"
 msgstr "Autoriser cette action ?"
 
-#: src/iac_code/ui/renderer.py:1345
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow once"
 msgstr "Oui, autoriser une fois"
 
-#: src/iac_code/ui/renderer.py:1359
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Yes, always allow \"{rule}\" (this session)"
 msgstr "Oui, toujours autoriser \"{rule}\" (cette session)"
 
-#: src/iac_code/ui/renderer.py:1364
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow always for this tool"
 msgstr "Oui, toujours autoriser pour cet outil"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "No, reject once"
 msgstr "Non, refuser une fois"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "default"
 msgstr "par défaut"
 
-#: src/iac_code/ui/renderer.py:1374
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "No, always deny \"{rule}\" (this session)"
 msgstr "Non, toujours refuser \"{rule}\" (cette session)"
 
-#: src/iac_code/ui/renderer.py:1379
+#: src/iac_code/ui/renderer.py
 msgid "No, always reject this tool"
 msgstr "Non, toujours refuser cet outil"
 
-#: src/iac_code/ui/repl.py:424
+#: src/iac_code/ui/repl.py
 msgid "Press Ctrl+C again to exit."
 msgstr "Appuyez de nouveau sur Ctrl+C pour quitter."
 
-#: src/iac_code/ui/repl.py:449
+#: src/iac_code/ui/repl.py
 msgid "Interrupted."
 msgstr "Interrompu."
 
-#: src/iac_code/ui/repl.py:508
+#: src/iac_code/ui/repl.py
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/iac_code/ui/repl.py:510
+#: src/iac_code/ui/repl.py
 msgid "Run the shown update command and exit when it succeeds."
 msgstr "Exécute la commande de mise à jour affichée et quitte en cas de succès."
 
-#: src/iac_code/ui/repl.py:513
+#: src/iac_code/ui/repl.py
 msgid "Skip"
 msgstr "Ignorer"
 
-#: src/iac_code/ui/repl.py:515
+#: src/iac_code/ui/repl.py
 msgid "Continue with the current version for this session."
 msgstr "Continuer avec la version actuelle pour cette session."
 
-#: src/iac_code/ui/repl.py:518
+#: src/iac_code/ui/repl.py
 msgid "Skip until next version"
 msgstr "Ignorer jusqu’à la prochaine version"
 
-#: src/iac_code/ui/repl.py:520
+#: src/iac_code/ui/repl.py
 msgid "Hide this update until a newer version is available."
 msgstr ""
 "Masquer cette mise à jour jusqu’à ce qu’une version plus récente soit "
 "disponible."
 
-#: src/iac_code/ui/repl.py:539 src/iac_code/ui/repl.py:551
+#: src/iac_code/ui/repl.py
 msgid "Update command failed. Continuing with the current version."
 msgstr "La commande de mise à jour a échoué. La version actuelle sera conservée."
 
-#: src/iac_code/ui/repl.py:544
+#: src/iac_code/ui/repl.py
 msgid "Update completed. Restart iac-code to continue."
 msgstr "Mise à jour terminée. Redémarrez iac-code pour continuer."
 
-#: src/iac_code/ui/repl.py:582
+#: src/iac_code/ui/repl.py
 msgid "No image in clipboard."
 msgstr "Aucune image dans le presse-papiers."
 
-#: src/iac_code/ui/repl.py:768
+#: src/iac_code/ui/repl.py
 msgid "Usage: !<shell command>"
 msgstr "Utilisation : !<commande shell>"
 
-#: src/iac_code/ui/repl.py:775
+#: src/iac_code/ui/repl.py
 msgid "Shell command support is unavailable."
 msgstr "La prise en charge des commandes shell n'est pas disponible."
 
-#: src/iac_code/ui/repl.py:845
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown skill: ${name}. Type / to list commands and skills."
 msgstr ""
 "Compétence inconnue : ${name}. Tapez / pour lister les commandes et les "
 "compétences."
 
-#: src/iac_code/ui/repl.py:847
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown command: /{name}. Type /help for available commands."
 msgstr ""
 "Unknown command: /{name}. Type /help for available commands.Commande "
 "inconnue : /{name}. Saisissez /help pour la liste des commandes."
 
-#: src/iac_code/ui/repl.py:852
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "$ only invokes skills. Use /{name} instead."
 msgstr "$ n'invoque que des compétences. Utilisez plutôt /{name}."
 
-#: src/iac_code/ui/repl.py:874 src/iac_code/ui/repl.py:922
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command error: {error}"
 msgstr "Erreur de commande : {error}"
 
-#: src/iac_code/ui/repl.py:881
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command has no handler: {name}"
 msgstr "Aucun gestionnaire pour la commande : {name}"
 
-#: src/iac_code/ui/repl.py:1156
+#: src/iac_code/ui/repl.py
 msgid "Goodbye!"
 msgstr "Au revoir !"
 
-#: src/iac_code/ui/repl.py:1157
+#: src/iac_code/ui/repl.py
 msgid "Resume this session with:"
 msgstr "Pour reprendre cette session :"
 
-#: src/iac_code/ui/repl.py:1160
+#: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "ID de session"
 
-#: src/iac_code/ui/repl.py:1210 src/iac_code/ui/repl.py:1214
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Session not found: {session_id}"
 msgstr "Session introuvable : {session_id}"
 
-#: src/iac_code/ui/repl.py:1263
+#: src/iac_code/ui/repl.py
 msgid "Session name: "
 msgstr "Nom de session : "
 
-#: src/iac_code/ui/repl.py:1269
+#: src/iac_code/ui/repl.py
 msgid "Session name cannot be empty."
 msgstr "Le nom de session ne peut pas être vide."
 
-#: src/iac_code/ui/repl.py:1279
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "This session belongs to a different directory.\n"
@@ -2451,23 +2428,23 @@ msgstr ""
 "Pour la reprendre, exécutez :\n"
 "  {cmd}"
 
-#: src/iac_code/ui/repl.py:1283
+#: src/iac_code/ui/repl.py
 msgid "Multiple sessions match. Resume one by ID:"
 msgstr "Plusieurs sessions correspondent. Reprenez-en une par ID :"
 
-#: src/iac_code/ui/repl.py:1396
+#: src/iac_code/ui/repl.py
 msgid "This conversation is from a different directory."
 msgstr "Cette conversation provient d’un autre répertoire."
 
-#: src/iac_code/ui/repl.py:1398
+#: src/iac_code/ui/repl.py
 msgid "To resume, run:"
 msgstr "Pour reprendre, exécutez :"
 
-#: src/iac_code/ui/repl.py:1403
+#: src/iac_code/ui/repl.py
 msgid "(Command copied to clipboard)"
 msgstr "(Commande copiée dans le presse-papiers)"
 
-#: src/iac_code/ui/repl.py:1560
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "Current model {model} does not support image input. Use /model to switch "
@@ -2476,12 +2453,12 @@ msgstr ""
 "Le modèle actuel {model} ne prend pas en charge l’entrée d’image. "
 "Utilisez /model pour passer à un modèle compatible vision."
 
-#: src/iac_code/ui/repl.py:1569
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Image error: {err}"
 msgstr "Erreur d’image : {err}"
 
-#: src/iac_code/ui/repl.py:1586
+#: src/iac_code/ui/repl.py
 msgid ""
 "Failed to persist image to cache; it will only exist in memory for this "
 "turn."
@@ -2489,193 +2466,193 @@ msgstr ""
 "Impossible de persister l’image dans le cache ; elle n’existera qu’en "
 "mémoire pour ce tour."
 
-#: src/iac_code/ui/spinner.py:52
+#: src/iac_code/ui/spinner.py
 msgid "Processing"
 msgstr "Traitement"
 
-#: src/iac_code/ui/spinner.py:53
+#: src/iac_code/ui/spinner.py
 msgid "Working"
 msgstr "En cours"
 
-#: src/iac_code/ui/spinner.py:62
+#: src/iac_code/ui/spinner.py
 msgid "Thought"
 msgstr "Réflexion terminée"
 
-#: src/iac_code/ui/spinner.py:63
+#: src/iac_code/ui/spinner.py
 msgid "Processed"
 msgstr "Traité"
 
-#: src/iac_code/ui/spinner.py:64
+#: src/iac_code/ui/spinner.py
 msgid "Worked"
 msgstr "Terminé"
 
-#: src/iac_code/ui/transcript_view.py:158
+#: src/iac_code/ui/transcript_view.py
 msgid "Prompt:"
 msgstr "Prompt :"
 
-#: src/iac_code/ui/transcript_view.py:186
+#: src/iac_code/ui/transcript_view.py
 msgid "Showing transcript · ctrl+o to toggle"
 msgstr "Affichage de la transcription · ctrl+o pour basculer"
 
-#: src/iac_code/ui/components/fuzzy_picker.py:120
+#: src/iac_code/ui/components/fuzzy_picker.py
 msgid "No matches found"
 msgstr "Aucune correspondance"
 
-#: src/iac_code/ui/core/prompt_input.py:348
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Image in clipboard · ctrl+v to paste"
 msgstr "Image dans le presse-papiers · ctrl+v pour coller"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Fill"
 msgstr "Remplir"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Dismiss"
 msgstr "Fermer"
 
-#: src/iac_code/ui/dialogs/global_search.py:55
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "No matching content"
 msgstr "Aucun contenu correspondant"
 
-#: src/iac_code/ui/dialogs/global_search.py:61
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Search in Files"
 msgstr "Rechercher dans les fichiers"
 
-#: src/iac_code/ui/dialogs/global_search.py:62
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Type to search content..."
 msgstr "Saisissez du texte pour rechercher dans le contenu…"
 
-#: src/iac_code/ui/dialogs/global_search.py:63
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Enter search query"
 msgstr "Saisir la requête de recherche"
 
-#: src/iac_code/ui/dialogs/history_search.py:55
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Search Conversation History"
 msgstr "Rechercher dans l’historique de conversation"
 
-#: src/iac_code/ui/dialogs/history_search.py:56
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Type to search..."
 msgstr "Saisissez pour rechercher…"
 
-#: src/iac_code/ui/dialogs/history_search.py:57
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "No conversation history"
 msgstr "Aucun historique de conversation"
 
-#: src/iac_code/ui/dialogs/history_search.py:98
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Message Preview"
 msgstr "Aperçu du message"
 
-#: src/iac_code/ui/dialogs/quick_open.py:58
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Open File"
 msgstr "Ouvrir un fichier"
 
-#: src/iac_code/ui/dialogs/quick_open.py:59
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Type to search files..."
 msgstr "Saisissez pour rechercher des fichiers…"
 
-#: src/iac_code/ui/dialogs/quick_open.py:60
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "No matching files"
 msgstr "Aucun fichier correspondant"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:116
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Search..."
 msgstr "Rechercher…"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:374
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Resume Session"
 msgstr "Reprendre la session"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:384
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "No sessions found"
 msgstr "Aucune session trouvée"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:444
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show current dir"
 msgstr "afficher le répertoire actuel"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:446
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all projects"
 msgstr "afficher tous les projets"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:449
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all branches"
 msgstr "afficher toutes les branches"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:451
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "only show current branch"
 msgstr "afficher uniquement la branche actuelle"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:452
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "preview"
 msgstr "aperçu"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:453
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Type to search"
 msgstr "Saisir pour rechercher"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:454
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "cancel"
 msgstr "annuler"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:569
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} more line{s}"
 msgstr "{n} ligne{s} supplémentaire{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:583
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} message{s}"
 msgstr "{n} message{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:597
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "resume"
 msgstr "reprendre"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:601
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "back"
 msgstr "retour"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:606
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "scroll"
 msgstr "défiler"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:625
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "(empty session)"
 msgstr "(session vide)"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:745
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "just now"
 msgstr "à l’instant"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:748
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} minute{s} ago"
 msgstr "il y a {n} minute{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:751
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} hour{s} ago"
 msgstr "il y a {n} heure{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:753
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} day{s} ago"
 msgstr "il y a {n} jour{s}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:52
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Search skills..."
 msgstr "Rechercher des compétences..."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:159
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Skills"
 msgstr "Compétences"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:161
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "{current} of {total}"
 msgstr "{current} sur {total}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:165
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid ""
 "{count} skills - Space to toggle, Enter to save, Tab to sort, Esc to "
@@ -2684,90 +2661,90 @@ msgstr ""
 "{count} compétences - Espace pour activer/désactiver, Entrée pour "
 "enregistrer, Tab pour trier, Échap pour annuler"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:171
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "Sort: {mode}"
 msgstr "Tri : {mode}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:176
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "No skills found"
 msgstr "Aucune compétence trouvée"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:245
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Bundled skills cannot be disabled."
 msgstr "Les compétences intégrées ne peuvent pas être désactivées."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "on"
 msgstr "activée"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "off"
 msgstr "désactivée"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:265
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "locked"
 msgstr "verrouillée"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:268
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "matched description"
 msgstr "correspond à la description"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:277
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "source"
 msgstr "source"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:279
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "size"
 msgstr "taille"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:280
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "name"
 msgstr "nom"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:285
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "bundled"
 msgstr "intégrée"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:287
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "project"
 msgstr "projet"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:289
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "user"
 msgstr "utilisateur"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:296
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count}k tokens"
 msgstr "~{count}k jetons"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:297
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count} tokens"
 msgstr "~{count} jetons"
 
-#: src/iac_code/ui/suggestions/command_provider.py:79
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Search saved memories"
 msgstr "Rechercher dans les mémoires enregistrées"
 
-#: src/iac_code/ui/suggestions/command_provider.py:80
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Delete a saved memory"
 msgstr "Supprimer une mémoire enregistrée"
 
-#: src/iac_code/ui/suggestions/command_provider.py:81
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Show memory command help"
 msgstr "Afficher l'aide de la commande memory"
 
-#: src/iac_code/ui/suggestions/command_provider.py:116
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Saved memory"
 msgstr "Mémoire enregistrée"
 
-#: src/iac_code/utils/platform.py:39
+#: src/iac_code/utils/platform.py
 msgid "iac-code on Windows requires Git for Windows."
 msgstr "iac-code sous Windows nécessite Git for Windows."
 
-#: src/iac_code/utils/platform.py:41
+#: src/iac_code/utils/platform.py
 msgid ""
 "If installed but not on PATH, set IAC_CODE_GIT_BASH_PATH environment "
 "variable."
@@ -2775,15 +2752,15 @@ msgstr ""
 "S'il est installé mais absent du PATH, définissez la variable "
 "d'environnement IAC_CODE_GIT_BASH_PATH."
 
-#: src/iac_code/utils/platform.py:44
+#: src/iac_code/utils/platform.py
 msgid "To install:"
 msgstr "Pour installer :"
 
-#: src/iac_code/utils/platform.py:47
+#: src/iac_code/utils/platform.py
 msgid "  Option 1 - winget (requires access to github.com):"
 msgstr "  Option 1 - winget (nécessite l'accès à github.com) :"
 
-#: src/iac_code/utils/platform.py:52
+#: src/iac_code/utils/platform.py
 msgid ""
 "  Option 2 - if you cannot reach github.com, run this to install via "
 "npmmirror:"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 13:32+0800\n"
+"POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -17,12 +17,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/iac_code/config.py:164
+#: src/iac_code/config.py
 #, python-brace-format
 msgid "Invalid IAC_CODE_PROVIDER value: {!r}. Valid values (case-insensitive): {}"
 msgstr "無効な IAC_CODE_PROVIDER 値: {!r}。有効な値 (大文字と小文字を区別しません): {}"
 
-#: src/iac_code/a2a/transports/base.py:175
+#: src/iac_code/a2a/transports/base.py
 msgid ""
 "Unix domain socket transport is not supported on Windows. Use --transport"
 " http or --transport stdio instead."
@@ -30,54 +30,53 @@ msgstr ""
 "Unix ドメインソケットトランスポートは Windows ではサポートされていません。--transport http または "
 "--transport stdio を使用してください。"
 
-#: src/iac_code/acp/server.py:413 src/iac_code/acp/server.py:429
-#: src/iac_code/acp/server.py:456
+#: src/iac_code/acp/server.py
 msgid "Session not found"
 msgstr "セッションが見つかりません"
 
-#: src/iac_code/acp/server.py:416
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session name is ambiguous. Candidates: {candidates}"
 msgstr "セッション名があいまいです。候補: {candidates}"
 
-#: src/iac_code/acp/server.py:434 src/iac_code/acp/server.py:708
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session belongs to another project. Run: {hint}"
 msgstr "セッションは別のプロジェクトに属しています。実行: {hint}"
 
-#: src/iac_code/acp/slash_registry.py:46
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Command '/{cmd_name}' is not supported over ACP. Supported commands: "
 "{supported}"
 msgstr "コマンド '/{cmd_name}' は ACP 上ではサポートされていません。サポートされているコマンド：{supported}"
 
-#: src/iac_code/acp/slash_registry.py:62
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Command '/{cmd_name}' handler not implemented."
 msgstr "コマンド '/{cmd_name}' のハンドラーは未実装です。"
 
-#: src/iac_code/acp/slash_registry.py:74
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Compaction failed: {error}"
 msgstr "圧縮に失敗しました：{error}"
 
-#: src/iac_code/acp/slash_registry.py:77 src/iac_code/commands/compact.py:24
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Nothing to compact: conversation is empty."
 msgstr "圧縮できる内容がありません：会話が空です。"
 
-#: src/iac_code/acp/slash_registry.py:80 src/iac_code/commands/compact.py:27
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Conversation too short to compact: all messages are within the recent "
 "{turns}-turn preservation window."
 msgstr "会話が短すぎて圧縮できません：すべてのメッセージが直近 {turns} ターンの保持ウィンドウ内にあります。"
 
-#: src/iac_code/acp/slash_registry.py:84 src/iac_code/commands/compact.py:30
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Compaction failed. See logs for details."
 msgstr "圧縮に失敗しました。詳細はログをご確認ください。"
 
-#: src/iac_code/acp/slash_registry.py:89
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent} reduction)."
@@ -86,123 +85,121 @@ msgstr ""
 "コンテキストを圧縮しました：{original} → {compacted} tokens（{percent} 削減）。 "
 "コンテキスト使用量：{usage}"
 
-#: src/iac_code/acp/slash_registry.py:103
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Clear failed: {error}"
 msgstr "クリアに失敗しました：{error}"
 
-#: src/iac_code/acp/slash_registry.py:104
+#: src/iac_code/acp/slash_registry.py
 msgid "Conversation history cleared."
 msgstr "会話履歴をクリアしました。"
 
-#: src/iac_code/acp/slash_registry.py:120 src/iac_code/commands/debug.py:34
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging is on. Log file: {path}"
 msgstr "デバッグログはオンです。ログファイル：{path}"
 
-#: src/iac_code/acp/slash_registry.py:121 src/iac_code/commands/debug.py:35
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging is off."
 msgstr "デバッグログはオフです。"
 
-#: src/iac_code/acp/slash_registry.py:125 src/iac_code/commands/debug.py:39
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging enabled. Log file: {path}"
 msgstr "デバッグログを有効にしました。ログファイル：{path}"
 
-#: src/iac_code/acp/slash_registry.py:129 src/iac_code/commands/debug.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging disabled."
 msgstr "デバッグログを無効にしました。"
 
-#: src/iac_code/acp/slash_registry.py:131 src/iac_code/commands/debug.py:45
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Usage: /debug [on|off]"
 msgstr "使用方法：/debug [on|off]"
 
-#: src/iac_code/acp/slash_registry.py:136 src/iac_code/commands/memory.py:84
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/memory.py
 msgid "Memory manager is unavailable."
 msgstr "メモリマネージャーを利用できません。"
 
-#: src/iac_code/acp/slash_registry.py:146 src/iac_code/commands/rename.py:21
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 msgid "Usage: /rename <name>"
 msgstr "使用法: /rename <名前>"
 
-#: src/iac_code/acp/slash_registry.py:152
+#: src/iac_code/acp/slash_registry.py
 msgid "Rename is only available after a session is created."
 msgstr "セッション作成後にのみ名前を変更できます。"
 
-#: src/iac_code/acp/slash_registry.py:163 src/iac_code/commands/rename.py:42
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Session is already named {name}"
 msgstr "セッション名はすでに {name} です"
 
-#: src/iac_code/acp/slash_registry.py:164 src/iac_code/commands/rename.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Renamed session to {name}"
 msgstr "セッション名を {name} に変更しました"
 
-#: src/iac_code/agent/agent_loop.py:413 src/iac_code/agent/agent_loop.py:428
-#: src/iac_code/ui/repl.py:813 src/iac_code/ui/repl.py:827
+#: src/iac_code/agent/agent_loop.py src/iac_code/ui/repl.py
 msgid "Permission denied."
 msgstr "権限が拒否されました。"
 
-#: src/iac_code/agent/agent_tool.py:266
+#: src/iac_code/agent/agent_tool.py
 #, python-brace-format
 msgid "Done ({tool_count} tool uses · {token_display} tokens)"
 msgstr "完了（ツール使用 {tool_count} 回 · {token_display} tokens）"
 
-#: src/iac_code/agent/agent_tool.py:276
+#: src/iac_code/agent/agent_tool.py
 msgid "Explore"
 msgstr "探索"
 
-#: src/iac_code/agent/agent_tool.py:277
+#: src/iac_code/agent/agent_tool.py
 msgid "Plan"
 msgstr "計画"
 
-#: src/iac_code/agent/agent_tool.py:278 src/iac_code/agent/agent_tool.py:279
-#: src/iac_code/agent/agent_tool.py:280
+#: src/iac_code/agent/agent_tool.py
 msgid "Agent"
 msgstr "エージェント"
 
-#: src/iac_code/cli/headless.py:50
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool started: {}"
 msgstr "ツール開始: {}"
 
-#: src/iac_code/cli/headless.py:53
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool failed: {}"
 msgstr "ツール失敗: {}"
 
-#: src/iac_code/cli/headless.py:55
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool finished: {}"
 msgstr "ツール完了: {}"
 
-#: src/iac_code/cli/headless.py:59
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool failed: {}"
 msgstr "子ツール失敗: {}"
 
-#: src/iac_code/cli/headless.py:61
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool finished: {}"
 msgstr "子ツール完了: {}"
 
-#: src/iac_code/cli/headless.py:63
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool started: {}"
 msgstr "子ツール開始: {}"
 
-#: src/iac_code/cli/headless.py:65
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack {}: {} ({:.1f}%)"
 msgstr "スタック {}: {} ({:.1f}%)"
 
-#: src/iac_code/cli/headless.py:71
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack group {}: {} ({}%)"
 msgstr "スタックグループ {}: {} ({}%)"
 
-#: src/iac_code/cli/headless.py:110
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -221,25 +218,25 @@ msgstr ""
 "  ドキュメント：https://aliyun.github.io/iac-"
 "code/ja/docs/configuration/authentication\n"
 
-#: src/iac_code/cli/install_git_bash.py:40
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git Bash is already installed at {}"
 msgstr "Git Bash は既に {} にインストールされています"
 
-#: src/iac_code/cli/install_git_bash.py:43
+#: src/iac_code/cli/install_git_bash.py
 msgid "Installing Git for Windows via npmmirror..."
 msgstr "npmmirror 経由で Git for Windows をインストール中..."
 
-#: src/iac_code/cli/install_git_bash.py:59
+#: src/iac_code/cli/install_git_bash.py
 msgid "powershell.exe was not found on PATH; cannot run installer."
 msgstr "PATH に powershell.exe が見つかりません。インストーラーを実行できません。"
 
-#: src/iac_code/cli/install_git_bash.py:66
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Installation failed (PowerShell exited with code {})"
 msgstr "インストールに失敗しました（PowerShell 終了コード {}）"
 
-#: src/iac_code/cli/install_git_bash.py:77
+#: src/iac_code/cli/install_git_bash.py
 msgid ""
 "Installer exited but bash.exe was not found in common locations; UAC may "
 "have been cancelled or the installer used a non-standard path."
@@ -247,129 +244,131 @@ msgstr ""
 "インストーラーは終了しましたが、一般的な場所に bash.exe が見つかりませんでした。UAC "
 "がキャンセルされたか、インストーラーが標準外のパスを使用した可能性があります。"
 
-#: src/iac_code/cli/install_git_bash.py:84
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git for Windows installed at {}"
 msgstr "Git for Windows を {} にインストールしました"
 
-#: src/iac_code/cli/main.py:33 src/iac_code/commands/help.py:26
+#: src/iac_code/cli/main.py src/iac_code/commands/help.py
 msgid "AI-powered infrastructure orchestration tool"
 msgstr "AI 駆動のインフラストラクチャ・オーケストレーションツール"
 
-#: src/iac_code/cli/main.py:41
+#: src/iac_code/cli/main.py
 msgid "Use iac-code as an A2A client."
 msgstr "iac-code を A2A クライアントとして使用します。"
 
-#: src/iac_code/cli/main.py:54
+#: src/iac_code/cli/main.py
 msgid "Install Git for Windows via the npmmirror mirror (Windows only)."
 msgstr "npmmirror ミラー経由で Git for Windows をインストールします（Windows 専用）。"
 
-#: src/iac_code/cli/main.py:61
+#: src/iac_code/cli/main.py
+msgid "Update iac-code to the latest version."
+msgstr "iac-code を最新バージョンに更新します。"
+
+#: src/iac_code/cli/main.py
 msgid "YAML config file containing A2A client options"
 msgstr "A2A クライアントオプションを含む YAML 設定ファイル"
 
-#: src/iac_code/cli/main.py:68 src/iac_code/cli/main.py:1501
-#: src/iac_code/cli/main.py:1862 src/iac_code/cli/main.py:1901
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
 msgstr "A2A クライアントの依存関係が不足しています。次のコマンドでインストールしてください: pip install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:82
+#: src/iac_code/cli/main.py
 msgid "LLM model to use"
 msgstr "使用する LLM モデル"
 
-#: src/iac_code/cli/main.py:83
+#: src/iac_code/cli/main.py
 msgid "Non-interactive mode: run a single prompt and exit"
 msgstr "非対話モード：単一のプロンプトを実行して終了します"
 
-#: src/iac_code/cli/main.py:84
+#: src/iac_code/cli/main.py
 msgid "Output format: text, json, stream-json"
 msgstr "出力形式：text、json、stream-json"
 
-#: src/iac_code/cli/main.py:85
+#: src/iac_code/cli/main.py
 msgid "Maximum agent turns in headless mode"
 msgstr "ヘッドレスモードでの最大エージェンターン数"
 
-#: src/iac_code/cli/main.py:86 src/iac_code/cli/main.py:366
-#: src/iac_code/cli/main.py:591
+#: src/iac_code/cli/main.py
 msgid "Enable debug logging"
 msgstr "デバッグログを有効にする"
 
-#: src/iac_code/cli/main.py:87
+#: src/iac_code/cli/main.py
 msgid "Show headless progress on stderr"
 msgstr "ヘッドレス進行状況を stderr に表示"
 
-#: src/iac_code/cli/main.py:88
+#: src/iac_code/cli/main.py
 msgid "Show version and exit"
 msgstr "バージョンを表示して終了する"
 
-#: src/iac_code/cli/main.py:89
+#: src/iac_code/cli/main.py
 msgid "Resume a session by ID or name"
 msgstr "ID または名前でセッションを再開"
 
-#: src/iac_code/cli/main.py:90
+#: src/iac_code/cli/main.py
 msgid "Resume the most recent session"
 msgstr "直近のセッションを再開する"
 
-#: src/iac_code/cli/main.py:97 src/iac_code/i18n/__init__.py:55
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid "Install completion for the current shell."
 msgstr "現在の shell に補完をインストールします。"
 
-#: src/iac_code/cli/main.py:105 src/iac_code/i18n/__init__.py:56
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid ""
 "Show completion for the current shell, to copy it or customize the "
 "installation."
 msgstr "現在の shell 向けの補完スクリプトを表示します。コピーしたり、インストールをカスタマイズしたりできます。"
 
-#: src/iac_code/cli/main.py:110
+#: src/iac_code/cli/main.py
 msgid ""
 "Comma-separated tool permission patterns to allow, e.g. 'bash(git "
 "*),write_file'"
 msgstr "許可するツール権限パターン（カンマ区切り）、例: 'bash(git *),write_file'*),write_file'"
 
-#: src/iac_code/cli/main.py:115
+#: src/iac_code/cli/main.py
 msgid "Comma-separated tool permission patterns to deny"
 msgstr "拒否するツール権限パターン（カンマ区切り）"
 
-#: src/iac_code/cli/main.py:120
+#: src/iac_code/cli/main.py
 msgid "Permission mode: default, accept_edits, bypass_permissions, dont_ask"
 msgstr "権限モード: default, accept_edits, bypass_permissions, dont_ask"
 
-#: src/iac_code/cli/main.py:151
+#: src/iac_code/cli/main.py
 msgid "Error: --resume and --continue cannot be used together."
 msgstr "エラー：--resume と --continue は同時に使用できません。"
 
-#: src/iac_code/cli/main.py:163
+#: src/iac_code/cli/main.py
 #, python-brace-format
 msgid "Invalid --output-format '{}'. Valid values: {}"
 msgstr "無効な --output-format '{}' です。有効な値: {}"
 
-#: src/iac_code/cli/main.py:361
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an ACP server."
 msgstr "iac-code を ACP サーバーとして実行します。"
 
-#: src/iac_code/cli/main.py:363
+#: src/iac_code/cli/main.py
 msgid "Transport type: stdio or http"
 msgstr "トランスポートの種類：stdio または http"
 
-#: src/iac_code/cli/main.py:364
+#: src/iac_code/cli/main.py
 msgid "HTTP server port"
 msgstr "HTTP サーバーのポート"
 
-#: src/iac_code/cli/main.py:365 src/iac_code/cli/main.py:581
+#: src/iac_code/cli/main.py
 msgid "HTTP server host"
 msgstr "HTTP サーバーのホスト"
 
-#: src/iac_code/cli/main.py:577
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an A2A 1.0 server."
 msgstr "iac-code を A2A 1.0 サーバーとして実行します。"
 
-#: src/iac_code/cli/main.py:580
+#: src/iac_code/cli/main.py
 msgid "YAML config file for A2A server options"
 msgstr "A2A サーバーオプション用の YAML 設定ファイル"
 
-#: src/iac_code/cli/main.py:584
+#: src/iac_code/cli/main.py
 msgid ""
 "HTTP server port. 41242 is the iac-code default inspired by Gemini CLI, "
 "not a registered A2A port."
@@ -377,629 +376,618 @@ msgstr ""
 "HTTP サーバーポート。41242 は Gemini CLI に触発された iac-code のデフォルトで、登録済みの A2A "
 "ポートではありません。"
 
-#: src/iac_code/cli/main.py:589
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc, or "
 "redis-streams"
 msgstr "A2A トランスポート: http、stdio、unix、websocket、grpc、grpc-jsonrpc、または redis-streams"
 
-#: src/iac_code/cli/main.py:595
+#: src/iac_code/cli/main.py
 msgid ""
 "Expose A2A thinking signal types; repeat for multiple. Values: raw-"
 "thinking, tool-trace."
 msgstr "A2A thinking 信号タイプを公開します。複数指定するには繰り返します。値：raw-thinking、tool-trace。"
 
-#: src/iac_code/cli/main.py:646
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
 msgstr "A2A サーバーの依存関係が不足しています。次のコマンドでインストールしてください: pip install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:778
+#: src/iac_code/cli/main.py
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "A2A JSON-RPC エンドポイントにプロンプトを送信します。"
 
-#: src/iac_code/cli/main.py:781 src/iac_code/cli/main.py:951
-#: src/iac_code/cli/main.py:1004 src/iac_code/cli/main.py:1064
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1163
-#: src/iac_code/cli/main.py:1242 src/iac_code/cli/main.py:1299
-#: src/iac_code/cli/main.py:1355 src/iac_code/cli/main.py:1412
+#: src/iac_code/cli/main.py
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "A2A JSON-RPC エンドポイント URL"
 
-#: src/iac_code/cli/main.py:782 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "ルート仕様: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:783
+#: src/iac_code/cli/main.py
 msgid "Named A2A route to call"
 msgstr "呼び出す名前付き A2A ルート"
 
-#: src/iac_code/cli/main.py:784
+#: src/iac_code/cli/main.py
 msgid "Prompt to send"
 msgstr "送信するプロンプト"
 
-#: src/iac_code/cli/main.py:785
+#: src/iac_code/cli/main.py
 msgid "Working directory metadata to send with the request"
 msgstr "リクエストと共に送信する作業ディレクトリのメタデータ"
 
-#: src/iac_code/cli/main.py:786
+#: src/iac_code/cli/main.py
 msgid "A2A context ID to continue"
 msgstr "継続する A2A コンテキスト ID"
 
-#: src/iac_code/cli/main.py:787 src/iac_code/cli/main.py:882
-#: src/iac_code/cli/main.py:954 src/iac_code/cli/main.py:1011
-#: src/iac_code/cli/main.py:1066 src/iac_code/cli/main.py:1116
-#: src/iac_code/cli/main.py:1170 src/iac_code/cli/main.py:1245
-#: src/iac_code/cli/main.py:1303 src/iac_code/cli/main.py:1358
-#: src/iac_code/cli/main.py:1413
+#: src/iac_code/cli/main.py
 msgid "Bearer token for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の Bearer トークン"
 
-#: src/iac_code/cli/main.py:788 src/iac_code/cli/main.py:883
-#: src/iac_code/cli/main.py:955 src/iac_code/cli/main.py:1012
-#: src/iac_code/cli/main.py:1067 src/iac_code/cli/main.py:1117
-#: src/iac_code/cli/main.py:1171 src/iac_code/cli/main.py:1246
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1359
-#: src/iac_code/cli/main.py:1414
+#: src/iac_code/cli/main.py
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の Basic 認証ユーザー名"
 
-#: src/iac_code/cli/main.py:789 src/iac_code/cli/main.py:884
-#: src/iac_code/cli/main.py:956 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1068 src/iac_code/cli/main.py:1118
-#: src/iac_code/cli/main.py:1172 src/iac_code/cli/main.py:1247
-#: src/iac_code/cli/main.py:1305 src/iac_code/cli/main.py:1360
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の Basic 認証パスワード"
 
-#: src/iac_code/cli/main.py:790 src/iac_code/cli/main.py:885
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1069 src/iac_code/cli/main.py:1119
-#: src/iac_code/cli/main.py:1173 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1306 src/iac_code/cli/main.py:1361
-#: src/iac_code/cli/main.py:1416
+#: src/iac_code/cli/main.py
 msgid "API key for A2A HTTP requests"
 msgstr "A2A HTTP リクエスト用の API キー"
 
-#: src/iac_code/cli/main.py:791 src/iac_code/cli/main.py:886
-#: src/iac_code/cli/main.py:958 src/iac_code/cli/main.py:1015
-#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1120
-#: src/iac_code/cli/main.py:1174 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1307 src/iac_code/cli/main.py:1362
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py
 msgid "HTTP header name for A2A API key"
 msgstr "A2A API キー用の HTTP ヘッダー名"
 
-#: src/iac_code/cli/main.py:796 src/iac_code/cli/main.py:891
+#: src/iac_code/cli/main.py
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "A2A Agent Card の検証に使用するシークレット"
 
-#: src/iac_code/cli/main.py:801 src/iac_code/cli/main.py:896
+#: src/iac_code/cli/main.py
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "A2A Agent Card の検証に使用するリモート JWKS URL"
 
-#: src/iac_code/cli/main.py:807 src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py
 msgid "Require a valid A2A Agent Card signature"
 msgstr "有効な A2A Agent Card 署名を要求します"
 
-#: src/iac_code/cli/main.py:809
+#: src/iac_code/cli/main.py
 msgid "A2A call timeout in seconds"
 msgstr "A2A 呼び出しのタイムアウト（秒）"
 
-#: src/iac_code/cli/main.py:810
+#: src/iac_code/cli/main.py
 msgid "Use A2A streaming message delivery"
 msgstr "A2A ストリーミングメッセージ配信を使用します"
 
-#: src/iac_code/cli/main.py:878
+#: src/iac_code/cli/main.py
 msgid "Discover an A2A Agent Card."
 msgstr "A2A Agent Card を検出します。"
 
-#: src/iac_code/cli/main.py:881
+#: src/iac_code/cli/main.py
 msgid "A2A agent base URL"
 msgstr "A2A エージェントのベース URL"
 
-#: src/iac_code/cli/main.py:948
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task."
 msgstr "A2A タスクを取得します。"
 
-#: src/iac_code/cli/main.py:952 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1115 src/iac_code/cli/main.py:1164
-#: src/iac_code/cli/main.py:1243 src/iac_code/cli/main.py:1300
-#: src/iac_code/cli/main.py:1356
+#: src/iac_code/cli/main.py
 msgid "A2A task ID"
 msgstr "A2A タスク ID"
 
-#: src/iac_code/cli/main.py:953
+#: src/iac_code/cli/main.py
 msgid "Maximum task history items to return"
 msgstr "返却するタスク履歴項目の最大数"
 
-#: src/iac_code/cli/main.py:1001
+#: src/iac_code/cli/main.py
 msgid "List A2A tasks."
 msgstr "A2A タスクを一覧表示します。"
 
-#: src/iac_code/cli/main.py:1005
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A context ID"
 msgstr "A2A コンテキスト ID でフィルタリングします"
 
-#: src/iac_code/cli/main.py:1006
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A task state"
 msgstr "A2A タスク状態でフィルタリングします"
 
-#: src/iac_code/cli/main.py:1007
+#: src/iac_code/cli/main.py
 msgid "Maximum tasks to return"
 msgstr "返却するタスクの最大数"
 
-#: src/iac_code/cli/main.py:1008 src/iac_code/cli/main.py:1302
+#: src/iac_code/cli/main.py
 msgid "Pagination token"
 msgstr "ページネーショントークン"
 
-#: src/iac_code/cli/main.py:1009
+#: src/iac_code/cli/main.py
 msgid "Include task artifacts"
 msgstr "タスクアーティファクトを含めます"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py
 msgid "Output format: table or json"
 msgstr "出力形式: table または json"
 
-#: src/iac_code/cli/main.py:1061
+#: src/iac_code/cli/main.py
 msgid "Cancel an A2A task."
 msgstr "A2A タスクをキャンセルします。"
 
-#: src/iac_code/cli/main.py:1111
+#: src/iac_code/cli/main.py
 msgid "Subscribe to an A2A task event stream."
 msgstr "A2A タスクのイベントストリームを購読します。"
 
-#: src/iac_code/cli/main.py:1160
+#: src/iac_code/cli/main.py
 msgid "Create an A2A task push notification config."
 msgstr "A2A タスクプッシュ通知設定を作成します。"
 
-#: src/iac_code/cli/main.py:1165 src/iac_code/cli/main.py:1244
-#: src/iac_code/cli/main.py:1357
+#: src/iac_code/cli/main.py
 msgid "Push config ID"
 msgstr "プッシュ設定 ID"
 
-#: src/iac_code/cli/main.py:1166
+#: src/iac_code/cli/main.py
 msgid "Push callback URL"
 msgstr "プッシュコールバック URL"
 
-#: src/iac_code/cli/main.py:1167
+#: src/iac_code/cli/main.py
 msgid "Notification verification token"
 msgstr "通知検証トークン"
 
-#: src/iac_code/cli/main.py:1168
+#: src/iac_code/cli/main.py
 msgid "Callback authentication scheme"
 msgstr "コールバック認証方式"
 
-#: src/iac_code/cli/main.py:1169
+#: src/iac_code/cli/main.py
 msgid "Callback authentication credentials"
 msgstr "コールバック認証資格情報"
 
-#: src/iac_code/cli/main.py:1239
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task push notification config."
 msgstr "A2A タスクプッシュ通知設定を取得します。"
 
-#: src/iac_code/cli/main.py:1296
+#: src/iac_code/cli/main.py
 msgid "List A2A task push notification configs."
 msgstr "A2A タスクプッシュ通知設定を一覧表示します。"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py
 msgid "Maximum configs to return"
 msgstr "返却する設定の最大数"
 
-#: src/iac_code/cli/main.py:1352
+#: src/iac_code/cli/main.py
 msgid "Delete an A2A task push notification config."
 msgstr "A2A タスクプッシュ通知設定を削除します。"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "認証済みの拡張 A2A Agent Card を取得します。"
 
-#: src/iac_code/cli/main.py:1452
+#: src/iac_code/cli/main.py
 msgid "Preview A2A route resolution."
 msgstr "A2A ルート解決をプレビューします。"
 
-#: src/iac_code/cli/main.py:1459
+#: src/iac_code/cli/main.py
 msgid "Route name to resolve"
 msgstr "解決するルート名"
 
-#: src/iac_code/cli/main.py:1460
+#: src/iac_code/cli/main.py
 msgid "Skill ID to resolve"
 msgstr "解決するスキル ID"
 
-#: src/iac_code/cli/main.py:1461
+#: src/iac_code/cli/main.py
 msgid "Prompt text used for tag/name route matching"
 msgstr "タグ/名前ルートのマッチングに使用するプロンプトテキスト"
 
-#: src/iac_code/cli/main.py:1466
+#: src/iac_code/cli/main.py
 msgid "Directory for persisted A2A routes"
 msgstr "永続化された A2A ルート用のディレクトリ"
 
-#: src/iac_code/cli/main.py:1468
+#: src/iac_code/cli/main.py
 msgid "Save the provided routes as a route snapshot"
 msgstr "指定されたルートをルートスナップショットとして保存します"
 
-#: src/iac_code/commands/__init__.py:26
+#: src/iac_code/cli/update.py
+msgid "Check for updates without installing."
+msgstr "インストールせずに更新を確認します。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "iac-code is already up to date (v{})."
+msgstr "iac-code はすでに最新です (v{})。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update available: v{} -> v{}"
+msgstr "更新があります: v{} -> v{}"
+
+#: src/iac_code/cli/update.py src/iac_code/ui/banner.py
+#, python-brace-format
+msgid "Run {} to update."
+msgstr "更新するには {} を実行してください。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Updating iac-code from v{} to v{}..."
+msgstr "iac-code を v{} から v{} に更新しています..."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed: {}"
+msgstr "更新コマンドに失敗しました: {}"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed with exit code {}."
+msgstr "更新コマンドが終了コード {} で失敗しました。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Successfully updated to v{}!"
+msgstr "v{} への更新に成功しました!"
+
+#: src/iac_code/commands/__init__.py
 msgid "Show available commands"
 msgstr "利用可能なコマンドを表示します"
 
-#: src/iac_code/commands/__init__.py:35
+#: src/iac_code/commands/__init__.py
 msgid "Clear conversation history"
 msgstr "会話履歴をクリアします"
 
-#: src/iac_code/commands/__init__.py:43
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch model"
 msgstr "モデルを表示または切り替えます"
 
-#: src/iac_code/commands/__init__.py:52
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch thinking effort"
 msgstr "思考の負荷（effort）を表示または切り替えます"
 
-#: src/iac_code/commands/__init__.py:61
+#: src/iac_code/commands/__init__.py
 msgid "Compact conversation context"
 msgstr "会話コンテキストを圧縮します"
 
-#: src/iac_code/commands/__init__.py:63
+#: src/iac_code/commands/__init__.py
 msgid "Compacting conversation"
 msgstr "会話を圧縮しています"
 
-#: src/iac_code/commands/__init__.py:70
+#: src/iac_code/commands/__init__.py
 msgid "Exit the application"
 msgstr "アプリケーションを終了します"
 
-#: src/iac_code/commands/__init__.py:79
+#: src/iac_code/commands/__init__.py
 msgid "Authenticate with LLM provider"
 msgstr "LLM プロバイダーで認証を行います"
 
-#: src/iac_code/commands/__init__.py:88
+#: src/iac_code/commands/__init__.py
 msgid "Toggle debug logging"
 msgstr "デバッグログのオン／オフを切り替えます"
 
-#: src/iac_code/commands/__init__.py:97
+#: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"
 msgstr "永続メモリを表示および管理"
 
-#: src/iac_code/commands/__init__.py:99
+#: src/iac_code/commands/__init__.py
 msgid "[<name>|search <query>|delete <name>|help]"
 msgstr "[<名前>|search <検索語>|delete <名前>|help]"
 
-#: src/iac_code/commands/__init__.py:106
+#: src/iac_code/commands/__init__.py
 msgid "Resume a previous session"
 msgstr "以前のセッションを再開します"
 
-#: src/iac_code/commands/__init__.py:108
+#: src/iac_code/commands/__init__.py
 msgid "[conversation id or search term]"
 msgstr "[会話 ID または検索語]"
 
-#: src/iac_code/commands/__init__.py:115
+#: src/iac_code/commands/__init__.py
 msgid "Rename the current session"
 msgstr "現在のセッション名を変更"
 
-#: src/iac_code/commands/__init__.py:124
+#: src/iac_code/commands/__init__.py
 msgid "Manage skills"
 msgstr "スキルを管理"
 
-#: src/iac_code/commands/__init__.py:132
+#: src/iac_code/commands/__init__.py
 msgid "Show current session status"
 msgstr "現在のセッション状態を表示"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:1117
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Navigate"
 msgstr "移動"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:538
-#: src/iac_code/commands/auth.py:570 src/iac_code/commands/auth.py:577
-#: src/iac_code/commands/auth.py:612 src/iac_code/commands/auth.py:619
-#: src/iac_code/commands/auth.py:640 src/iac_code/commands/auth.py:1117
-#: src/iac_code/commands/auth.py:1551 src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Confirm"
 msgstr "確認"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:536
-#: src/iac_code/commands/auth.py:538 src/iac_code/commands/auth.py:570
-#: src/iac_code/commands/auth.py:577 src/iac_code/commands/auth.py:612
-#: src/iac_code/commands/auth.py:619 src/iac_code/commands/auth.py:640
-#: src/iac_code/commands/auth.py:1117 src/iac_code/commands/auth.py:1443
-#: src/iac_code/commands/auth.py:1551
+#: src/iac_code/commands/auth.py
 msgid "Back"
 msgstr "戻る"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Keep"
 msgstr "維持"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Re-enter"
 msgstr "再入力"
 
-#: src/iac_code/commands/auth.py:749 src/iac_code/commands/auth.py:863
-#: src/iac_code/commands/auth.py:921 src/iac_code/commands/auth.py:929
-#: src/iac_code/commands/auth.py:956
+#: src/iac_code/commands/auth.py
 msgid " (current)"
 msgstr " （現在）"
 
-#: src/iac_code/commands/auth.py:752
+#: src/iac_code/commands/auth.py
 msgid "Custom model..."
 msgstr "カスタムモデル…"
 
-#: src/iac_code/commands/auth.py:755
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select model for {provider}"
 msgstr "{provider} のモデルを選択してください"
 
-#: src/iac_code/commands/auth.py:757
+#: src/iac_code/commands/auth.py
 msgid "Select model"
 msgstr "モデルを選択"
 
-#: src/iac_code/commands/auth.py:765
+#: src/iac_code/commands/auth.py
 msgid "Enter custom model name: "
 msgstr "カスタムモデル名を入力してください："
 
-#: src/iac_code/commands/auth.py:791
+#: src/iac_code/commands/auth.py
 msgid "Error: console not available"
 msgstr "エラー：コンソールを使用できません"
 
-#: src/iac_code/commands/auth.py:820
+#: src/iac_code/commands/auth.py
 msgid "Configure LLM Provider"
 msgstr "LLM プロバイダーを設定"
 
-#: src/iac_code/commands/auth.py:821
+#: src/iac_code/commands/auth.py
 msgid "Configure IaC Cloud Service"
 msgstr "IaC クラウドサービスを設定"
 
-#: src/iac_code/commands/auth.py:823
+#: src/iac_code/commands/auth.py
 msgid "Select configuration type"
 msgstr "設定の種類を選択"
 
-#: src/iac_code/commands/auth.py:825 src/iac_code/commands/auth.py:981
-#: src/iac_code/commands/auth.py:997 src/iac_code/commands/auth.py:1076
-#: src/iac_code/commands/auth.py:1490 src/iac_code/commands/auth.py:1531
+#: src/iac_code/commands/auth.py
 msgid "Auth cancelled"
 msgstr "認証をキャンセルしました"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:961
-#: src/iac_code/commands/auth.py:1051
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select provider — {group}"
 msgstr "プロバイダーを選択 — {group}"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:919
-#: src/iac_code/commands/auth.py:1036
+#: src/iac_code/commands/auth.py
 msgid "Third-party"
 msgstr "サードパーティ"
 
-#: src/iac_code/commands/auth.py:877
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider}"
 msgstr "{status}：{provider}"
 
-#: src/iac_code/commands/auth.py:878 src/iac_code/commands/auth.py:1029
+#: src/iac_code/commands/auth.py
 msgid "Configured"
 msgstr "設定済み"
 
-#: src/iac_code/commands/auth.py:933
+#: src/iac_code/commands/auth.py
 msgid "Select provider"
 msgstr "プロバイダーを選択"
 
-#: src/iac_code/commands/auth.py:974
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Configure {provider}"
 msgstr "{provider} を設定"
 
-#: src/iac_code/commands/auth.py:990
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Enter API key for {provider}"
 msgstr "{provider} の API key を入力してください"
 
-#: src/iac_code/commands/auth.py:1028
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider} / {model}"
 msgstr "{status}：{provider} / {model}"
 
-#: src/iac_code/commands/auth.py:1037 src/iac_code/commands/auth.py:1058
+#: src/iac_code/commands/auth.py
 msgid "Alibaba Cloud"
 msgstr "Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1038 src/iac_code/providers/registry.py:427
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "ZhiPu AI"
 msgstr "ZhiPu AI"
 
-#: src/iac_code/commands/auth.py:1039
+#: src/iac_code/commands/auth.py
 msgid "Kimi"
 msgstr "Kimi"
 
-#: src/iac_code/commands/auth.py:1040
+#: src/iac_code/commands/auth.py
 msgid "MiniMax"
 msgstr "MiniMax"
 
-#: src/iac_code/commands/auth.py:1041 src/iac_code/providers/registry.py:429
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Volcengine"
 msgstr "Volcengine"
 
-#: src/iac_code/commands/auth.py:1042
+#: src/iac_code/commands/auth.py
 msgid "SiliconFlow"
 msgstr "SiliconFlow"
 
-#: src/iac_code/commands/auth.py:1043 src/iac_code/providers/registry.py:420
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: src/iac_code/commands/auth.py:1044 src/iac_code/providers/registry.py:418
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: src/iac_code/commands/auth.py:1045 src/iac_code/providers/registry.py:419
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Anthropic"
 msgstr "Anthropic"
 
-#: src/iac_code/commands/auth.py:1046 src/iac_code/providers/registry.py:422
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
-#: src/iac_code/commands/auth.py:1047 src/iac_code/providers/registry.py:435
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Azure OpenAI"
 msgstr "Azure OpenAI"
 
-#: src/iac_code/commands/auth.py:1048 src/iac_code/providers/registry.py:434
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenRouter"
 msgstr "OpenRouter"
 
-#: src/iac_code/commands/auth.py:1049
+#: src/iac_code/commands/auth.py
 msgid "Local"
 msgstr "ローカル"
 
-#: src/iac_code/commands/auth.py:1050
+#: src/iac_code/commands/auth.py
 msgid "Compatible"
 msgstr "互換モード"
 
-#: src/iac_code/commands/auth.py:1067
+#: src/iac_code/commands/auth.py
 msgid "Select Cloud Provider"
 msgstr "クラウドプロバイダーを選択"
 
-#: src/iac_code/commands/auth.py:1083
+#: src/iac_code/commands/auth.py
 msgid "Credential"
 msgstr "クレデンシャル"
 
-#: src/iac_code/commands/auth.py:1084 src/iac_code/commands/auth.py:1199
-#: src/iac_code/commands/auth.py:1527 src/iac_code/commands/status.py:36
-#: src/iac_code/ui/renderer.py:455
+#: src/iac_code/commands/auth.py src/iac_code/commands/status.py
+#: src/iac_code/ui/renderer.py
 msgid "Region"
 msgstr "リージョン"
 
-#: src/iac_code/commands/auth.py:1086
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud"
 msgstr "Alibaba Cloud を設定"
 
-#: src/iac_code/commands/auth.py:1188
+#: src/iac_code/commands/auth.py
 msgid "Current configuration"
 msgstr "現在の設定"
 
-#: src/iac_code/commands/auth.py:1190
+#: src/iac_code/commands/auth.py
 msgid "Mode"
 msgstr "モード"
 
-#: src/iac_code/commands/auth.py:1196
+#: src/iac_code/commands/auth.py
 msgid "(not set)"
 msgstr "（未設定）"
 
-#: src/iac_code/commands/auth.py:1205
+#: src/iac_code/commands/auth.py
 msgid "AccessKey"
 msgstr "AccessKey"
 
-#: src/iac_code/commands/auth.py:1207 src/iac_code/commands/auth.py:1219
+#: src/iac_code/commands/auth.py
 msgid "STS Token"
 msgstr "STS トークン"
 
-#: src/iac_code/commands/auth.py:1209
+#: src/iac_code/commands/auth.py
 msgid "RAM Role"
 msgstr "RAM ロール"
 
-#: src/iac_code/commands/auth.py:1211
+#: src/iac_code/commands/auth.py
 msgid "OAuth Login (Browser)"
 msgstr "OAuth ログイン（ブラウザー）"
 
-#: src/iac_code/commands/auth.py:1217
+#: src/iac_code/commands/auth.py
 msgid "AccessKey ID"
 msgstr "AccessKey ID"
 
-#: src/iac_code/commands/auth.py:1218
+#: src/iac_code/commands/auth.py
 msgid "AccessKey Secret"
 msgstr "AccessKey シークレット"
 
-#: src/iac_code/commands/auth.py:1220
+#: src/iac_code/commands/auth.py
 msgid "RAM Role ARN"
 msgstr "RAM ロール ARN"
 
-#: src/iac_code/commands/auth.py:1221
+#: src/iac_code/commands/auth.py
 msgid "Session Name"
 msgstr "セッション名"
 
-#: src/iac_code/commands/auth.py:1222
+#: src/iac_code/commands/auth.py
 msgid "OAuth Site Type"
 msgstr "OAuth サイトタイプ"
 
-#: src/iac_code/commands/auth.py:1223
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token"
 msgstr "OAuth アクセストークン"
 
-#: src/iac_code/commands/auth.py:1224
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token"
 msgstr "OAuth リフレッシュトークン"
 
-#: src/iac_code/commands/auth.py:1225
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token Expire"
 msgstr "OAuth アクセストークンの有効期限"
 
-#: src/iac_code/commands/auth.py:1226
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token Expire"
 msgstr "OAuth リフレッシュトークンの有効期限"
 
-#: src/iac_code/commands/auth.py:1227
+#: src/iac_code/commands/auth.py
 msgid "STS Expiration"
 msgstr "STS 有効期限"
 
-#: src/iac_code/commands/auth.py:1384
+#: src/iac_code/commands/auth.py
 msgid "China"
 msgstr "中国"
 
-#: src/iac_code/commands/auth.py:1385
+#: src/iac_code/commands/auth.py
 msgid "International"
 msgstr "国際"
 
-#: src/iac_code/commands/auth.py:1387
+#: src/iac_code/commands/auth.py
 msgid "Choose site type"
 msgstr "サイトタイプを選択"
 
-#: src/iac_code/commands/auth.py:1402
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Alibaba Cloud OAuth login failed: {error}"
 msgstr "Alibaba Cloud OAuth ログインに失敗しました: {error}"
 
-#: src/iac_code/commands/auth.py:1418
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud OAuth credentials saved"
 msgstr "設定完了: Alibaba Cloud OAuth 認証情報を保存しました"
 
-#: src/iac_code/commands/auth.py:1430
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud credentials"
 msgstr "Alibaba Cloud のクレデンシャルを設定"
 
-#: src/iac_code/commands/auth.py:1443
+#: src/iac_code/commands/auth.py
 msgid "Reconfigure credential"
 msgstr "クレデンシャルを再設定"
 
-#: src/iac_code/commands/auth.py:1456
+#: src/iac_code/commands/auth.py
 msgid "Select credential type"
 msgstr "クレデンシャルの種類を選択"
 
-#: src/iac_code/commands/auth.py:1512
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud credentials saved to ~/.iac-code"
 msgstr ""
 "Configured: Alibaba Cloud credentials saved to ~/.iac-code設定しました：Alibaba "
 "Cloud のクレデンシャルを ~/.iac-code に保存しました"
 
-#: src/iac_code/commands/auth.py:1519
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud region"
 msgstr "Alibaba Cloud のリージョンを設定"
 
-#: src/iac_code/commands/auth.py:1545
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud region saved to ~/.iac-code"
 msgstr "設定しました：Alibaba Cloud のリージョンを ~/.iac-code に保存しました"
 
-#: src/iac_code/commands/compact.py:12
+#: src/iac_code/commands/compact.py
 msgid "Compact command requires a context."
 msgstr "compact コマンドにはコンテキストが必要です。"
 
-#: src/iac_code/commands/compact.py:16
+#: src/iac_code/commands/compact.py
 msgid "No active REPL."
 msgstr "アクティブな REPL がありません。"
 
-#: src/iac_code/commands/compact.py:20
+#: src/iac_code/commands/compact.py
 msgid "No active agent loop."
 msgstr "アクティブなエージェントループがありません。"
 
-#: src/iac_code/commands/compact.py:35
+#: src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent_display} "
@@ -1008,108 +996,107 @@ msgstr ""
 "コンテキストを圧縮しました：{original} → {compacted} tokens（{percent_display} 削減）。 "
 "コンテキスト使用量：{usage_display}"
 
-#: src/iac_code/commands/debug.py:21
+#: src/iac_code/commands/debug.py
 msgid "Debug command requires a context."
 msgstr "debug コマンドにはコンテキストが必要です。"
 
-#: src/iac_code/commands/debug.py:26
+#: src/iac_code/commands/debug.py
 msgid "No active session."
 msgstr "アクティブなセッションがありません。"
 
-#: src/iac_code/commands/effort.py:54 src/iac_code/commands/model.py:95
-#: src/iac_code/commands/model.py:99
+#: src/iac_code/commands/effort.py src/iac_code/commands/model.py
 msgid "No configured providers. Run /auth first."
 msgstr "設定済みのプロバイダーがありません。先に /auth を実行してください。"
 
-#: src/iac_code/commands/effort.py:58
+#: src/iac_code/commands/effort.py
 msgid "No model selected. Run /model first."
 msgstr "モデルが選択されていません。先に /model を実行してください。"
 
-#: src/iac_code/commands/effort.py:66
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Model {model} does not support effort."
 msgstr "モデル {model} は effort（思考の負荷）をサポートしていません。"
 
-#: src/iac_code/commands/effort.py:80
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Invalid effort. Allowed: {labels}"
 msgstr "無効な effort です。許可される値：{labels}"
 
-#: src/iac_code/commands/effort.py:85
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Current effort: {effort}"
 msgstr "現在の effort：{effort}"
 
-#: src/iac_code/commands/effort.py:94
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Select effort for {model}"
 msgstr "{model} の effort を選択してください"
 
-#: src/iac_code/commands/effort.py:103 src/iac_code/commands/effort.py:107
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Kept effort as {effort}"
 msgstr "effort を {effort} のままにしました"
 
-#: src/iac_code/commands/effort.py:116
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Effort switched to: {effort}"
 msgstr "effort を {effort} に切り替えました"
 
-#: src/iac_code/commands/help.py:29
+#: src/iac_code/commands/help.py
 msgid "Commands:"
 msgstr "コマンド："
 
-#: src/iac_code/commands/help.py:36
+#: src/iac_code/commands/help.py
 msgid "Shortcuts:"
 msgstr "ショートカット："
 
-#: src/iac_code/commands/help.py:39
+#: src/iac_code/commands/help.py
 msgid "Send message"
 msgstr "メッセージを送信"
 
-#: src/iac_code/commands/help.py:40
+#: src/iac_code/commands/help.py
 msgid "New line"
 msgstr "改行"
 
-#: src/iac_code/commands/help.py:41
+#: src/iac_code/commands/help.py
 msgid "Show command suggestions"
 msgstr "コマンド候補を表示"
 
-#: src/iac_code/commands/help.py:42
+#: src/iac_code/commands/help.py
 msgid "Exit"
 msgstr "終了"
 
-#: src/iac_code/commands/memory.py:10
+#: src/iac_code/commands/memory.py
 msgid "Usage: /memory [<name>|search <query>|delete <name>|help]"
 msgstr "使用法: /memory [<名前>|search <検索語>|delete <名前>|help]"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "Saved memories:"
 msgstr "保存済みメモリ:"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "No memories saved yet."
 msgstr "保存済みメモリはまだありません。"
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "Matching memories:"
 msgstr "一致するメモリ:"
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "No matching memories."
 msgstr "一致するメモリはありません。"
 
-#: src/iac_code/commands/memory.py:60 src/iac_code/commands/memory.py:75
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' not found."
 msgstr "メモリ '{name}' が見つかりません。"
 
-#: src/iac_code/commands/memory.py:64
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' deleted."
 msgstr "メモリ '{name}' を削除しました。"
 
-#: src/iac_code/commands/model.py:57
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid ""
 "Model is managed by '{source}'. To change model, modify it in {source} or"
@@ -1118,202 +1105,200 @@ msgstr ""
 "モデルは '{source}' によって管理されています。モデルを変更するには {source} で調整するか、/auth "
 "で別のプロバイダーに切り替えてください。"
 
-#: src/iac_code/commands/model.py:88 src/iac_code/commands/model.py:143
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Model switched to: {model}"
 msgstr "モデルを {model} に切り替えました"
 
-#: src/iac_code/commands/model.py:92
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Current model: {model}"
 msgstr "現在のモデル：{model}"
 
-#: src/iac_code/commands/model.py:118
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Kept model as {model}"
 msgstr "モデルを {model} のままにしました"
 
-#: src/iac_code/commands/rename.py:16 src/iac_code/commands/rename.py:28
+#: src/iac_code/commands/rename.py
 msgid "Rename is only available in interactive mode."
 msgstr "名前の変更は対話モードでのみ使用できます。"
 
-#: src/iac_code/commands/rename.py:31
+#: src/iac_code/commands/rename.py
 msgid "Rename cancelled"
 msgstr "名前の変更をキャンセルしました"
 
-#: src/iac_code/commands/resume.py:22
+#: src/iac_code/commands/resume.py
 msgid "Resume is only available in interactive mode."
 msgstr "resume は対話モードでのみ利用できます。"
 
-#: src/iac_code/commands/resume.py:28
+#: src/iac_code/commands/resume.py
 msgid "Resume is unavailable: session index not initialised."
 msgstr "resume を使用できません：セッション索引が初期化されていません。"
 
-#: src/iac_code/commands/resume.py:33 src/iac_code/commands/resume.py:36
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Session not found: {arg}"
 msgstr "セッションが見つかりません：{arg}"
 
-#: src/iac_code/commands/resume.py:52 src/iac_code/commands/resume.py:68
+#: src/iac_code/commands/resume.py
 msgid "Resume cancelled"
 msgstr "resume をキャンセルしました"
 
-#: src/iac_code/commands/resume.py:55
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Unable to resolve session: {arg}"
 msgstr "セッションを解決できません: {arg}"
 
-#: src/iac_code/commands/skills.py:14
+#: src/iac_code/commands/skills.py
 msgid "Skills management is only available in interactive mode."
 msgstr "スキル管理は対話モードでのみ使用できます。"
 
-#: src/iac_code/commands/skills.py:25
+#: src/iac_code/commands/skills.py
 msgid "Skills update cancelled"
 msgstr "スキル更新をキャンセルしました"
 
-#: src/iac_code/commands/skills.py:29
+#: src/iac_code/commands/skills.py
 msgid "Skills updated"
 msgstr "スキルを更新しました"
 
-#: src/iac_code/commands/status.py:19
+#: src/iac_code/commands/status.py
 msgid "Status command requires a context."
 msgstr "status コマンドにはコンテキストが必要です。"
 
-#: src/iac_code/commands/status.py:22
+#: src/iac_code/commands/status.py
 msgid "Status command requires a REPL context."
 msgstr "status コマンドには REPL コンテキストが必要です。"
 
-#: src/iac_code/commands/status.py:24
+#: src/iac_code/commands/status.py
 msgid "Status is only available in interactive mode."
 msgstr "status は対話モードでのみ利用できます。"
 
-#: src/iac_code/commands/status.py:33 src/iac_code/ui/banner.py:136
-#: src/iac_code/ui/banner.py:138
+#: src/iac_code/commands/status.py src/iac_code/ui/banner.py
 msgid "Session"
 msgstr "セッション"
 
-#: src/iac_code/commands/status.py:34
+#: src/iac_code/commands/status.py
 msgid "Provider"
 msgstr "プロバイダー"
 
-#: src/iac_code/commands/status.py:34 src/iac_code/commands/status.py:35
-#: src/iac_code/commands/status.py:36
+#: src/iac_code/commands/status.py
 msgid "not configured"
 msgstr "未設定"
 
-#: src/iac_code/commands/status.py:35
+#: src/iac_code/commands/status.py
 msgid "Model"
 msgstr "モデル"
 
-#: src/iac_code/commands/status.py:37
+#: src/iac_code/commands/status.py
 msgid "CWD"
 msgstr "現在のディレクトリ"
 
-#: src/iac_code/commands/status.py:41
+#: src/iac_code/commands/status.py
 msgid "API Token Usage (recorded):"
 msgstr "API トークン使用量（記録済み）："
 
-#: src/iac_code/commands/status.py:44
+#: src/iac_code/commands/status.py
 msgid "Input"
 msgstr "入力"
 
-#: src/iac_code/commands/status.py:45
+#: src/iac_code/commands/status.py
 msgid "Output"
 msgstr "出力"
 
-#: src/iac_code/commands/status.py:46
+#: src/iac_code/commands/status.py
 msgid "Cache read"
 msgstr "キャッシュ読み取り"
 
-#: src/iac_code/commands/status.py:47
+#: src/iac_code/commands/status.py
 msgid "Total"
 msgstr "合計"
 
-#: src/iac_code/commands/status.py:50
+#: src/iac_code/commands/status.py
 msgid "No recorded API usage for this session yet."
 msgstr "このセッションにはまだ記録済みの API 使用量がありません。"
 
-#: src/iac_code/commands/status.py:54
+#: src/iac_code/commands/status.py
 msgid "Turns"
 msgstr "ターン"
 
-#: src/iac_code/commands/status.py:55
+#: src/iac_code/commands/status.py
 msgid "Context"
 msgstr "コンテキスト"
 
-#: src/iac_code/commands/status.py:57
+#: src/iac_code/commands/status.py
 msgid "Session Status"
 msgstr "セッション状態"
 
-#: src/iac_code/commands/status.py:73
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{session_id} (resumed)"
 msgstr "{session_id}（再開済み）"
 
-#: src/iac_code/commands/status.py:81
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{percent} used ({total} / {window})"
 msgstr "{percent} 使用済み（{total} / {window}）"
 
 # Typer/Click built-in strings
-#: src/iac_code/i18n/__init__.py:51
+#: src/iac_code/i18n/__init__.py
 msgid "Options"
 msgstr "オプション"
 
-#: src/iac_code/i18n/__init__.py:52
+#: src/iac_code/i18n/__init__.py
 msgid "Commands"
 msgstr "コマンド"
 
-#: src/iac_code/i18n/__init__.py:53
+#: src/iac_code/i18n/__init__.py
 msgid "Arguments"
 msgstr "引数"
 
-#: src/iac_code/i18n/__init__.py:54
+#: src/iac_code/i18n/__init__.py
 msgid "Show this message and exit."
 msgstr "このメッセージを表示して終了します。"
 
-#: src/iac_code/i18n/__init__.py:57
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "default: {default}"
 msgstr "既定値：{default}"
 
-#: src/iac_code/i18n/__init__.py:58
+#: src/iac_code/i18n/__init__.py
 msgid "required"
 msgstr "必須"
 
-#: src/iac_code/i18n/__init__.py:59
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "env var: {var}"
 msgstr "環境変数：{var}"
 
-#: src/iac_code/i18n/__init__.py:60
+#: src/iac_code/i18n/__init__.py
 msgid "(dynamic)"
 msgstr "（動的）"
 
-#: src/iac_code/i18n/__init__.py:61
+#: src/iac_code/i18n/__init__.py
 msgid "Aborted!"
 msgstr "中断しました。"
 
-#: src/iac_code/providers/manager.py:78
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Cannot determine provider for model: {model}. Run /auth to configure."
 msgstr ""
 "Cannot determine provider for model: {model}. Run /auth to configure.モデル "
 "{model} のプロバイダーを特定できません。/auth を実行して設定してください。"
 
-#: src/iac_code/providers/manager.py:95
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Unknown provider key: '{key}'. Run /auth to configure."
 msgstr "不明なプロバイダーキー：'{key}'。/auth を実行して設定してください。"
 
-#: src/iac_code/providers/manager.py:100
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid ""
 "No API key configured for provider '{provider}' (model: {model}). Run "
 "/auth to configure."
 msgstr "プロバイダー '{provider}' の API キーが設定されていません（モデル: {model}）。/auth を実行して設定してください。"
 
-#: src/iac_code/providers/openai_provider.py:307
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned no data. Please check that your API Base URL is correct "
@@ -1323,7 +1308,7 @@ msgstr ""
 "API からデータが返りませんでした。API Base URL が正しいか確認してください（現在：{base_url}）。 多くの OpenAI "
 "互換エンドポイントでは /v1 接尾辞が必要です（例：{base_url}/v1）。"
 
-#: src/iac_code/providers/openai_provider.py:348
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned an invalid response. Please check that your API Base URL is "
@@ -1333,83 +1318,83 @@ msgstr ""
 "API から無効な応答が返りました。API Base URL が正しいか確認してください（現在：{base_url}）。 多くの OpenAI "
 "互換エンドポイントでは /v1 接尾辞が必要です（例：{base_url}/v1）。"
 
-#: src/iac_code/providers/registry.py:416
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
 msgstr "Alibaba Cloud 百錬"
 
-#: src/iac_code/providers/registry.py:417
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian Token Plan"
 msgstr "Alibaba Cloud 百錬 Token Plan"
 
-#: src/iac_code/providers/registry.py:421
+#: src/iac_code/providers/registry.py
 msgid "OpenAPI Compatible"
 msgstr "OpenAPI 互換"
 
-#: src/iac_code/providers/registry.py:423
+#: src/iac_code/providers/registry.py
 msgid "Kimi (China)"
 msgstr "Kimi（中国版）"
 
-#: src/iac_code/providers/registry.py:424
+#: src/iac_code/providers/registry.py
 msgid "Kimi (International)"
 msgstr "Kimi（国際版）"
 
-#: src/iac_code/providers/registry.py:425
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (China)"
 msgstr "MiniMax（中国版）"
 
-#: src/iac_code/providers/registry.py:426
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (International)"
 msgstr "MiniMax（国際版）"
 
-#: src/iac_code/providers/registry.py:428
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI (International)"
 msgstr "ZhiPu AI（国際版）"
 
-#: src/iac_code/providers/registry.py:430
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (China)"
 msgstr "SiliconFlow（中国版）"
 
-#: src/iac_code/providers/registry.py:431
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (International)"
 msgstr "SiliconFlow（国際版）"
 
-#: src/iac_code/providers/registry.py:432
+#: src/iac_code/providers/registry.py
 msgid "Ollama (Local)"
 msgstr "Ollama（ローカル）"
 
-#: src/iac_code/providers/registry.py:433
+#: src/iac_code/providers/registry.py
 msgid "LM Studio (Local)"
 msgstr "LM Studio（ローカル）"
 
-#: src/iac_code/providers/registry.py:436
+#: src/iac_code/providers/registry.py
 msgid "ModelScope"
 msgstr "ModelScope"
 
-#: src/iac_code/providers/registry.py:437
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan"
 msgstr "Alibaba Cloud CodingPlan"
 
-#: src/iac_code/providers/registry.py:438
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan (International)"
 msgstr "Alibaba Cloud CodingPlan（国際版）"
 
-#: src/iac_code/providers/registry.py:439
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan"
 msgstr "ZhiPu AI CodingPlan"
 
-#: src/iac_code/providers/registry.py:440
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan (International)"
 msgstr "ZhiPu AI CodingPlan（国際版）"
 
-#: src/iac_code/providers/registry.py:441
+#: src/iac_code/providers/registry.py
 msgid "Volcengine CodingPlan"
 msgstr "Volcengine CodingPlan"
 
-#: src/iac_code/providers/registry.py:442
+#: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Anthropic 互換"
 
-#: src/iac_code/services/qwenpaw_source.py:205
+#: src/iac_code/services/qwenpaw_source.py
 #, python-brace-format
 msgid ""
 "[QwenPaw mode] Unknown provider '{provider_id}'. iac-code does not "
@@ -1424,90 +1409,90 @@ msgstr ""
 "対処法：QwenPaw でサポートされているプロバイダーに切り替えるか、QwenPaw モードを無効にしてください（settings.yml から"
 " 'llm_source: qwenpaw' を削除）。"
 
-#: src/iac_code/services/session_metadata.py:52
+#: src/iac_code/services/session_metadata.py
 #, python-brace-format
 msgid "Session name must match {pattern}"
 msgstr "セッション名は {pattern} に一致する必要があります"
 
-#: src/iac_code/services/session_storage.py:241
+#: src/iac_code/services/session_storage.py
 #, python-brace-format
 msgid "Session name already exists in this project: {name}"
 msgstr "このプロジェクトにはセッション名がすでに存在します: {name}"
 
-#: src/iac_code/services/permissions/loader.py:50
+#: src/iac_code/services/permissions/loader.py
 #, python-brace-format
 msgid "Invalid --permission-mode {!r}. Valid values: {}"
 msgstr "無効な --permission-mode {!r} です。有効な値: {}"
 
-#: src/iac_code/services/permissions/pipeline.py:54
-#: src/iac_code/tools/base.py:199 src/iac_code/tools/bash/bash_tool.py:175
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Allow {}?"
 msgstr "{} を許可しますか？"
 
-#: src/iac_code/services/providers/aliyun.py:144
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
 msgstr "Alibaba Cloud OAuth サイトがありません。"
 
-#: src/iac_code/services/providers/aliyun.py:150
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth refresh token is missing."
 msgstr "Alibaba Cloud OAuth リフレッシュトークンがありません。"
 
-#: src/iac_code/services/providers/aliyun.py:158
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth access token is missing."
 msgstr "Alibaba Cloud OAuth アクセストークンがありません。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:83
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Run /auth and choose OAuth Login (Browser)."
 msgstr "/auth を実行し、OAuth ログイン（ブラウザー）を選択してください。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:106
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "Unknown Aliyun OAuth site: {site_type}"
 msgstr "不明な Aliyun OAuth サイト: {site_type}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:164
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Not found"
 msgstr "見つかりません"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:170
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "invalid state"
 msgstr "無効な状態"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:171
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Invalid state"
 msgstr "無効な状態"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:176
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "code not found"
 msgstr "認可コードが見つかりません"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:177
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization code not found"
 msgstr "認可コードが見つかりません"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:181
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization successful. You can close this window."
 msgstr "認可に成功しました。このウィンドウを閉じてもかまいません。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:212
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "No available callback port in range {start}-{end}"
 msgstr "{start}-{end} の範囲に利用可能なコールバックポートがありません"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:227
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "OAuth login cancelled."
 msgstr "OAuth ログインをキャンセルしました。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:278
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Open in your browser:"
 msgstr "ブラウザーで開く:"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:299
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Waiting for browser authorization"
 msgstr "ブラウザー認可を待機しています"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:300
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "1. The browser may show official-cli; this is the Alibaba Cloud official "
 "CLI OAuth application."
@@ -1515,13 +1500,13 @@ msgstr ""
 "1. ブラウザーに official-cli と表示される場合があります。これは Alibaba Cloud 公式 CLI OAuth "
 "アプリケーションです。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:302
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "2. If assignment is required, assign the RAM user or RAM role that is "
 "signed in. User groups are not supported."
 msgstr "2. 割り当てが必要な場合は、サインイン中の RAM ユーザーまたは RAM ロールを割り当ててください。ユーザーグループはサポートされていません。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:306
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "3. After assignment, close the old authorization page and run OAuth Login"
 " (Browser) again. If it still fails, sign out of Alibaba Cloud and sign "
@@ -1530,7 +1515,7 @@ msgstr ""
 "3. 割り当て後、古い認可ページを閉じて OAuth ログイン（ブラウザー）を再実行してください。それでも失敗する場合は、Alibaba "
 "Cloud からサインアウトして再度サインインしてください。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:310
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "4. STS credentials refresh when possible until Alibaba Cloud expires "
 "them. If refresh fails, run /auth again."
@@ -1538,11 +1523,11 @@ msgstr ""
 "4. STS 認証情報は Alibaba Cloud が期限切れにするまで可能な場合に更新されます。更新に失敗した場合は、/auth "
 "を再実行してください。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:313
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Press Esc to cancel while waiting."
 msgstr "Esc を押すと待機をキャンセルできます。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:321
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "Timed out waiting for OAuth callback. If Alibaba Cloud asked you to "
 "assign the official-cli application, assign it to the exact RAM user or "
@@ -1555,531 +1540,530 @@ msgstr ""
 "ロールに割り当ててください。ユーザーグループはサポートされていません。その後、古い認可ページを閉じ、必要に応じて Alibaba Cloud "
 "からサインアウトしてサインインし直し、/auth を実行して OAuth ログイン（ブラウザー）を再度選択してください。"
 
-#: src/iac_code/skills/skill_tool.py:85 src/iac_code/ui/repl.py:842
+#: src/iac_code/skills/skill_tool.py src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Skill '{name}' is disabled. Run /skills to enable it."
 msgstr "スキル「{name}」は無効です。有効にするには /skills を実行してください。"
 
-#: src/iac_code/skills/skill_tool.py:137
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill '{name}' loaded (inline)."
 msgstr "スキル '{name}' を読み込みました（インライン）。"
 
-#: src/iac_code/skills/skill_tool.py:221
+#: src/iac_code/skills/skill_tool.py
 msgid "Skill"
 msgstr "スキル"
 
-#: src/iac_code/skills/skill_tool.py:245
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill disabled: {name}"
 msgstr "スキルが無効です: {name}"
 
-#: src/iac_code/skills/bundled/simplify.py:25
+#: src/iac_code/skills/bundled/simplify.py
 msgid ""
 "Review changed code for reuse, quality, and efficiency, then fix issues "
 "found."
 msgstr "変更されたコードの再利用性、品質、効率を確認し、見つかった問題を修正してください。"
 
-#: src/iac_code/tools/edit_file.py:116
+#: src/iac_code/tools/edit_file.py
 msgid "Edit"
 msgstr "編集"
 
-#: src/iac_code/tools/edit_file.py:118
+#: src/iac_code/tools/edit_file.py
 msgid "Create"
 msgstr "作成"
 
-#: src/iac_code/tools/edit_file.py:119
+#: src/iac_code/tools/edit_file.py
 msgid "Update"
 msgstr "更新"
 
-#: src/iac_code/tools/edit_file.py:126
+#: src/iac_code/tools/edit_file.py
 #, python-brace-format
 msgid "Editing {path}"
 msgstr "{path} を編集中"
 
-#: src/iac_code/tools/edit_file.py:127
+#: src/iac_code/tools/edit_file.py
 msgid "Editing file..."
 msgstr "ファイルを編集中…"
 
-#: src/iac_code/tools/glob.py:86 src/iac_code/tools/grep.py:237
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Found 0 files"
 msgstr "ファイルが 0 件見つかりました"
 
-#: src/iac_code/tools/glob.py:89 src/iac_code/tools/grep.py:240
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Found {count} files"
 msgstr "{count} 件のファイルが見つかりました"
 
-#: src/iac_code/tools/glob.py:95 src/iac_code/tools/grep.py:246
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Search"
 msgstr "検索"
 
-#: src/iac_code/tools/glob.py:100
+#: src/iac_code/tools/glob.py
 #, python-brace-format
 msgid "Searching {pattern}"
 msgstr "{pattern} を検索中"
 
-#: src/iac_code/tools/glob.py:101
+#: src/iac_code/tools/glob.py
 msgid "Searching files..."
 msgstr "ファイルを検索しています…"
 
-#: src/iac_code/tools/grep.py:251
+#: src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Searching for {pattern}"
 msgstr "{pattern} を検索中"
 
-#: src/iac_code/tools/grep.py:252
+#: src/iac_code/tools/grep.py
 msgid "Searching content..."
 msgstr "内容を検索しています…"
 
-#: src/iac_code/tools/list_files.py:82
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Found {count} items"
 msgstr "{count} 件見つかりました"
 
-#: src/iac_code/tools/list_files.py:88
+#: src/iac_code/tools/list_files.py
 msgid "List"
 msgstr "一覧"
 
-#: src/iac_code/tools/list_files.py:92
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Listing {path}"
 msgstr "{path} を一覧表示中"
 
-#: src/iac_code/tools/list_files.py:93
+#: src/iac_code/tools/list_files.py
 msgid "Listing files..."
 msgstr "ファイルを一覧表示しています…"
 
-#: src/iac_code/tools/read_file.py:117
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Read {total} lines"
 msgstr "{total} 行読み取りました"
 
-#: src/iac_code/tools/read_file.py:120
+#: src/iac_code/tools/read_file.py
 msgid "Read"
 msgstr "読み取り"
 
-#: src/iac_code/tools/read_file.py:127
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Reading {path}"
 msgstr "{path} を読み取り中"
 
-#: src/iac_code/tools/read_file.py:128
+#: src/iac_code/tools/read_file.py
 msgid "Reading file..."
 msgstr "ファイルを読み取り中…"
 
-#: src/iac_code/tools/web_fetch.py:94
+#: src/iac_code/tools/web_fetch.py
 msgid "URL cannot be empty."
 msgstr "URL を空にすることはできません。"
 
-#: src/iac_code/tools/web_fetch.py:100
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}"
 msgstr ""
 "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}無効な "
 "URL：スキームがありません（例：http:// または https://）。値：{url}"
 
-#: src/iac_code/tools/web_fetch.py:103
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing host/netloc. Got: {url}"
 msgstr "無効な URL：ホスト／ネットロケーションがありません。値：{url}"
 
-#: src/iac_code/tools/web_fetch.py:129
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "HTTP error {status}: {url}"
 msgstr "HTTP エラー {status}：{url}"
 
-#: src/iac_code/tools/web_fetch.py:131
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Failed to fetch {url}: {error}"
 msgstr "{url} の取得に失敗しました：{error}"
 
-#: src/iac_code/tools/web_fetch.py:133
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Unexpected error fetching {url}: {error}"
 msgstr "{url} の取得中に予期しないエラーが発生しました：{error}"
 
-#: src/iac_code/tools/web_fetch.py:147
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetched {chars} chars, {lines} lines"
 msgstr "{chars} 文字、{lines} 行を取得しました"
 
-#: src/iac_code/tools/web_fetch.py:159
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetch"
 msgstr "取得"
 
-#: src/iac_code/tools/web_fetch.py:165
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetching {url}"
 msgstr "{url} を取得中"
 
-#: src/iac_code/tools/web_fetch.py:166
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetching web page..."
 msgstr "ウェブページを取得しています…"
 
-#: src/iac_code/tools/write_file.py:67
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Successfully wrote {lines} lines to {path}"
 msgstr "{path} へ {lines} 行の書き込みに成功しました"
 
-#: src/iac_code/tools/write_file.py:81
+#: src/iac_code/tools/write_file.py
 msgid "Write"
 msgstr "書き込み"
 
-#: src/iac_code/tools/write_file.py:88
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Writing {path}"
 msgstr "{path} を書き込み中"
 
-#: src/iac_code/tools/write_file.py:89
+#: src/iac_code/tools/write_file.py
 msgid "Writing file..."
 msgstr "ファイルを書き込み中…"
 
-#: src/iac_code/tools/bash/bash_tool.py:81
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Command timed out after {timeout} seconds: {command}"
 msgstr "コマンドが {timeout} 秒後にタイムアウトしました: {command}"
 
-#: src/iac_code/tools/bash/bash_tool.py:103
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Error executing command: {}"
 msgstr "コマンドの実行エラー: {}"
 
-#: src/iac_code/tools/bash/bash_tool.py:129
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "{count} more lines"
 msgstr "あと {count} 行"
 
-#: src/iac_code/tools/bash/bash_tool.py:137
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Bash"
 msgstr "Bash"
 
-#: src/iac_code/tools/bash/bash_tool.py:143
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Running {cmd}"
 msgstr "{cmd} を実行中"
 
-#: src/iac_code/tools/bash/bash_tool.py:144
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Running command..."
 msgstr "コマンドを実行しています…"
 
-#: src/iac_code/tools/bash/command_parser.py:42
+#: src/iac_code/tools/bash/command_parser.py
 msgid "parse error"
 msgstr "解析エラー"
 
-#: src/iac_code/tools/bash/command_parser.py:46
+#: src/iac_code/tools/bash/command_parser.py
 msgid "unsupported shell construct"
 msgstr "サポートされていないシェル構文"
 
-#: src/iac_code/tools/bash/path_validation.py:111
+#: src/iac_code/tools/bash/path_validation.py
 #, python-brace-format
 msgid "path outside allowed directories: {}"
 msgstr "許可されたディレクトリの外のパス: {}"
 
-#: src/iac_code/tools/bash/permissions.py:135
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s): {}"
 msgstr "一致した拒否ルール: {}"
 
-#: src/iac_code/tools/bash/permissions.py:142
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "一致した確認ルール: {}"
 
-#: src/iac_code/tools/bash/permissions.py:154
-#: src/iac_code/tools/bash/permissions.py:220
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched allow rule(s): {}"
 msgstr "一致した許可ルール: {}"
 
-#: src/iac_code/tools/bash/permissions.py:162
+#: src/iac_code/tools/bash/permissions.py
 msgid "complex command requires confirmation"
 msgstr "複雑なコマンドは確認が必要です"
 
-#: src/iac_code/tools/bash/permissions.py:171
+#: src/iac_code/tools/bash/permissions.py
 msgid "sed in-place edit requires confirmation"
 msgstr "sed のインプレース編集には確認が必要です"
 
-#: src/iac_code/tools/bash/permissions.py:194
+#: src/iac_code/tools/bash/permissions.py
 msgid "command failed basic safety checks"
 msgstr "コマンドが基本的な安全性チェックに失敗しました"
 
-#: src/iac_code/tools/bash/permissions.py:210
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s) on full command: {}"
 msgstr "完全なコマンドに一致した拒否ルール: {}"
 
-#: src/iac_code/tools/bash/permissions.py:227
+#: src/iac_code/tools/bash/permissions.py
 msgid "command too complex to analyze"
 msgstr "コマンドが複雑すぎて分析できません"
 
-#: src/iac_code/tools/bash/permissions.py:229
+#: src/iac_code/tools/bash/permissions.py
 msgid "could not parse command"
 msgstr "コマンドを解析できませんでした"
 
-#: src/iac_code/tools/bash/permissions.py:245
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "too many subcommands (>{})"
 msgstr "サブコマンドが多すぎます (>{})"
 
-#: src/iac_code/tools/bash/permissions.py:258
+#: src/iac_code/tools/bash/permissions.py
 msgid "multiple cd commands in compound command"
 msgstr "複合コマンド内に複数の cd コマンドがあります"
 
-#: src/iac_code/tools/bash/permissions.py:271
+#: src/iac_code/tools/bash/permissions.py
 msgid "cd combined with git in compound command"
 msgstr "複合コマンド内で cd と git が組み合わされています"
 
-#: src/iac_code/tools/bash/safety_checks.py:151
+#: src/iac_code/tools/bash/safety_checks.py
 #, python-brace-format
 msgid "operation touches a sensitive path: {}"
 msgstr "操作が機密パスに影響します: {}"
 
-#: src/iac_code/tools/cloud/base_api.py:92
+#: src/iac_code/tools/cloud/base_api.py
 msgid "CloudAPI"
 msgstr "CloudAPI"
 
-#: src/iac_code/tools/cloud/base_api.py:116
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Calling {action}..."
 msgstr "{action} を呼び出しています…"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:400
-#: src/iac_code/tools/cloud/base_api.py:123
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#: src/iac_code/tools/cloud/base_api.py
 msgid "Call succeeded"
 msgstr "呼び出しに成功しました"
 
-#: src/iac_code/tools/cloud/base_api.py:144
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Received response ({count} lines)"
 msgstr "応答を受信しました（{count} 行）"
 
-#: src/iac_code/tools/cloud/base_stack.py:133
+#: src/iac_code/tools/cloud/base_stack.py
 msgid "CloudStack"
 msgstr "CloudStack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:117
-#: src/iac_code/tools/cloud/base_stack.py:150
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
+#: src/iac_code/tools/cloud/base_stack.py
 #, python-brace-format
 msgid "Running {action}..."
 msgstr "{action} を実行中…"
 
-#: src/iac_code/tools/cloud/types.py:8
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_IN_PROGRESS"
 msgstr "作成進行中"
 
-#: src/iac_code/tools/cloud/types.py:9
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_FAILED"
 msgstr "作成失敗"
 
-#: src/iac_code/tools/cloud/types.py:10
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_COMPLETE"
 msgstr "作成完了"
 
-#: src/iac_code/tools/cloud/types.py:11
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_IN_PROGRESS"
 msgstr "更新進行中"
 
-#: src/iac_code/tools/cloud/types.py:12
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_FAILED"
 msgstr "更新失敗"
 
-#: src/iac_code/tools/cloud/types.py:13
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_COMPLETE"
 msgstr "更新完了"
 
-#: src/iac_code/tools/cloud/types.py:14
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_IN_PROGRESS"
 msgstr "削除進行中"
 
-#: src/iac_code/tools/cloud/types.py:15
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_FAILED"
 msgstr "削除失敗"
 
-#: src/iac_code/tools/cloud/types.py:16
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_COMPLETE"
 msgstr "削除完了"
 
-#: src/iac_code/tools/cloud/types.py:17
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "作成ロールバック進行中"
 
-#: src/iac_code/tools/cloud/types.py:18
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_FAILED"
 msgstr "作成ロールバック失敗"
 
-#: src/iac_code/tools/cloud/types.py:19
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_COMPLETE"
 msgstr "作成ロールバック完了"
 
-#: src/iac_code/tools/cloud/types.py:20
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_IN_PROGRESS"
 msgstr "ロールバック進行中"
 
-#: src/iac_code/tools/cloud/types.py:21
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_FAILED"
 msgstr "ロールバック失敗"
 
-#: src/iac_code/tools/cloud/types.py:22
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_COMPLETE"
 msgstr "ロールバック完了"
 
-#: src/iac_code/tools/cloud/types.py:23
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_IN_PROGRESS"
 msgstr "チェック進行中"
 
-#: src/iac_code/tools/cloud/types.py:24
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_FAILED"
 msgstr "チェック失敗"
 
-#: src/iac_code/tools/cloud/types.py:25
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_COMPLETE"
 msgstr "チェック完了"
 
-#: src/iac_code/tools/cloud/types.py:26
+#: src/iac_code/tools/cloud/types.py
 msgid "REVIEW_IN_PROGRESS"
 msgstr "レビュー進行中"
 
-#: src/iac_code/tools/cloud/types.py:27
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_IN_PROGRESS"
 msgstr "インポート作成進行中"
 
-#: src/iac_code/tools/cloud/types.py:28
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_FAILED"
 msgstr "インポート作成失敗"
 
-#: src/iac_code/tools/cloud/types.py:29
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_COMPLETE"
 msgstr "インポート作成完了"
 
-#: src/iac_code/tools/cloud/types.py:30
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "インポート作成ロールバック進行中"
 
-#: src/iac_code/tools/cloud/types.py:31
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_FAILED"
 msgstr "インポート作成ロールバック失敗"
 
-#: src/iac_code/tools/cloud/types.py:32
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_COMPLETE"
 msgstr "インポート作成ロールバック完了"
 
-#: src/iac_code/tools/cloud/types.py:33
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_IN_PROGRESS"
 msgstr "インポート更新進行中"
 
-#: src/iac_code/tools/cloud/types.py:34
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_FAILED"
 msgstr "インポート更新失敗"
 
-#: src/iac_code/tools/cloud/types.py:35
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_COMPLETE"
 msgstr "インポート更新完了"
 
-#: src/iac_code/tools/cloud/types.py:36
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_IN_PROGRESS"
 msgstr "インポート更新ロールバック進行中"
 
-#: src/iac_code/tools/cloud/types.py:37
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_FAILED"
 msgstr "インポート更新ロールバック失敗"
 
-#: src/iac_code/tools/cloud/types.py:38
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_COMPLETE"
 msgstr "インポート更新ロールバック完了"
 
-#: src/iac_code/tools/cloud/types.py:40
+#: src/iac_code/tools/cloud/types.py
 msgid "INIT_COMPLETE"
 msgstr "初期化完了"
 
-#: src/iac_code/tools/cloud/types.py:41
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_IN_PROGRESS"
 msgstr "インポート進行中"
 
-#: src/iac_code/tools/cloud/types.py:42
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_COMPLETE"
 msgstr "インポート完了"
 
-#: src/iac_code/tools/cloud/types.py:43
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_FAILED"
 msgstr "インポート失敗"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:172
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 msgid "Aliyun API"
 msgstr "Aliyun API"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:399
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "呼び出しに成功しました（RequestId: {request_id}）"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:57
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "DocSearch"
 msgstr "DocSearch"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:70
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Searching docs for {keywords}..."
 msgstr "{keywords} に関するドキュメントを検索しています…"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:71
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Searching docs..."
 msgstr "ドキュメントを検索しています…"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:76
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "keywords cannot be empty."
 msgstr "キーワードを空にすることはできません。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:96
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "HTTP error {status} when searching docs."
 msgstr "ドキュメント検索中に HTTP エラー {status} が発生しました。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:98
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Failed to search docs: {error}"
 msgstr "ドキュメントの検索に失敗しました：{error}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:103
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Failed to parse search response as JSON."
 msgstr "検索結果の JSON 解析に失敗しました。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:106
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Search API returned failure."
 msgstr "Search API が失敗を返しました。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:125
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "No documents found"
 msgstr "ドキュメントが見つかりません"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:126
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "No documents found for keywords: {keywords}"
 msgstr "キーワード {keywords} に一致するドキュメントが見つかりません"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:141
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Found {count} documents (total {total})"
 msgstr "{count} 件のドキュメントが見つかりました（合計 {total} 件）"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:143
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Use web_fetch tool to read full document content if needed."
 msgstr "必要に応じて web_fetch ツールで全文を取得してください。"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack.py:143
+#: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS スタック"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:100
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:48
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template YAML syntax error: {}"
 msgstr "テンプレートの YAML 構文エラー: {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:60
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template YAML syntax error (line {line}, column {col}): {problem}\n"
@@ -2090,19 +2074,19 @@ msgstr ""
 "コンテキスト:\n"
 "{context}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:66
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template JSON syntax error (line {line}, column {col}): {msg}"
 msgstr "テンプレートの JSON 構文エラー（{line} 行目、{col} 列目）: {msg}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:85
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template {fmt} parse result is not an object (dict), please check the "
 "template format"
 msgstr "テンプレートの {fmt} 解析結果がオブジェクト（dict）ではありません。テンプレートの形式を確認してください"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:104
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"
@@ -2110,270 +2094,263 @@ msgstr ""
 "テンプレートに ROSTemplateFormatVersion がありません（ROS テンプレートにはこのフィールドが必須です。例: "
 "'2015-09-01'）"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:110
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Template is missing Resources (ROS templates must include Resources)"
 msgstr "テンプレートに Resources がありません（ROS テンプレートには Resources が必須です）"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:112
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resources must be an object (dict), current type is {}"
 msgstr "Resources はオブジェクト（dict）でなければなりません。現在の型は {} です"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:117
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Resource '{name}' definition must be an object (dict), current type is "
 "{type}"
 msgstr "リソース '{name}' の定義はオブジェクト（dict）でなければなりません。現在の型は {type} です"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:123
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' is missing the Type field"
 msgstr "リソース '{name}' に Type フィールドがありません"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:129
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' has incorrect type '{wrong}', should be '{correct}'"
 msgstr "リソース '{name}' の型 '{wrong}' が正しくありません。'{correct}' に変更してください"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:151
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template structure validation found the following issues, please fix and "
 "retry:"
 msgstr "テンプレート構造の検証で以下の問題が見つかりました。修正して再試行してください:"
 
-#: src/iac_code/ui/banner.py:42 src/iac_code/ui/banner.py:54
+#: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
 msgstr "更新があります！{} -> {}"
 
-#: src/iac_code/ui/banner.py:43
+#: src/iac_code/ui/banner.py
 msgid "Update command"
 msgstr "更新コマンド"
 
-#: src/iac_code/ui/banner.py:46 src/iac_code/ui/banner.py:58
+#: src/iac_code/ui/banner.py
 msgid "Release notes"
 msgstr "リリースノート"
 
-#: src/iac_code/ui/banner.py:55
-#, python-brace-format
-msgid "Run {} to update."
-msgstr "更新するには {} を実行してください。"
-
-#: src/iac_code/ui/banner.py:110
+#: src/iac_code/ui/banner.py
 msgid "Your AI-powered Infrastructure as Code assistant"
 msgstr "あなたの AI 駆動の Infrastructure as Code アシスタントです"
 
-#: src/iac_code/ui/banner.py:144
+#: src/iac_code/ui/banner.py
 msgid "Welcome back"
 msgstr "おかえりなさい"
 
-#: src/iac_code/ui/banner.py:161
+#: src/iac_code/ui/banner.py
 msgid "Debug mode"
 msgstr "デバッグモード"
 
-#: src/iac_code/ui/banner.py:162
+#: src/iac_code/ui/banner.py
 msgid "Log file"
 msgstr "ログファイル"
 
-#: src/iac_code/ui/renderer.py:388 src/iac_code/ui/renderer.py:668
-#: src/iac_code/ui/renderer.py:1455
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "{seconds:.1f} 秒考えました"
 
-#: src/iac_code/ui/renderer.py:404 src/iac_code/ui/renderer.py:700
-#: src/iac_code/ui/renderer.py:1476
+#: src/iac_code/ui/renderer.py
 msgid "(ctrl+o to expand)"
 msgstr "（ctrl+o で展開）"
 
-#: src/iac_code/ui/renderer.py:431
+#: src/iac_code/ui/renderer.py
 msgid "Resource"
 msgstr "リソース"
 
-#: src/iac_code/ui/renderer.py:432
+#: src/iac_code/ui/renderer.py
 msgid "Type"
 msgstr "種類"
 
-#: src/iac_code/ui/renderer.py:433 src/iac_code/ui/renderer.py:456
+#: src/iac_code/ui/renderer.py
 msgid "Status"
 msgstr "状態"
 
-#: src/iac_code/ui/renderer.py:454
+#: src/iac_code/ui/renderer.py
 msgid "Account ID"
 msgstr "アカウント ID"
 
-#: src/iac_code/ui/renderer.py:542
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Done ({child_count} tool uses{token_info}{elapsed})"
 msgstr "完了（ツール使用 {child_count} 回{token_info}{elapsed}）"
 
-#: src/iac_code/ui/renderer.py:572
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "+ {count} more tool uses (ctrl+o to expand)"
 msgstr "+ ツール使用がさらに {count} 回（ctrl+o で展開）"
 
-#: src/iac_code/ui/renderer.py:1177
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Context auto-compacted: {original} → {compacted} tokens"
 msgstr "コンテキストを自動圧縮しました：{original} → {compacted} tokens"
 
-#: src/iac_code/ui/renderer.py:1262
+#: src/iac_code/ui/renderer.py
 msgid "Operation cancelled."
 msgstr "操作をキャンセルしました。"
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "No API key configured."
 msgstr "API key が設定されていません。"
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "Please run /auth to set up your LLM provider and API key."
 msgstr "/auth を実行して LLM プロバイダーと API key を設定してください。"
 
-#: src/iac_code/ui/renderer.py:1272
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "エラー：{error}"
 
-#: src/iac_code/ui/renderer.py:1342
+#: src/iac_code/ui/renderer.py
 msgid "Allow this action?"
 msgstr "この操作を許可しますか？"
 
-#: src/iac_code/ui/renderer.py:1345
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow once"
 msgstr "はい、今回のみ許可"
 
-#: src/iac_code/ui/renderer.py:1359
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Yes, always allow \"{rule}\" (this session)"
 msgstr "はい、\"{rule}\" を常に許可（このセッション）"
 
-#: src/iac_code/ui/renderer.py:1364
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow always for this tool"
 msgstr "はい、このツールは常に許可"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "No, reject once"
 msgstr "いいえ、今回は拒否"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "default"
 msgstr "既定"
 
-#: src/iac_code/ui/renderer.py:1374
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "No, always deny \"{rule}\" (this session)"
 msgstr "いいえ、常に \"{rule}\" を拒否（このセッション）"
 
-#: src/iac_code/ui/renderer.py:1379
+#: src/iac_code/ui/renderer.py
 msgid "No, always reject this tool"
 msgstr "いいえ、このツールは常に拒否"
 
-#: src/iac_code/ui/repl.py:424
+#: src/iac_code/ui/repl.py
 msgid "Press Ctrl+C again to exit."
 msgstr "終了するには Ctrl+C をもう一度押してください。"
 
-#: src/iac_code/ui/repl.py:449
+#: src/iac_code/ui/repl.py
 msgid "Interrupted."
 msgstr "中断しました。"
 
-#: src/iac_code/ui/repl.py:508
+#: src/iac_code/ui/repl.py
 msgid "Update now"
 msgstr "今すぐ更新"
 
-#: src/iac_code/ui/repl.py:510
+#: src/iac_code/ui/repl.py
 msgid "Run the shown update command and exit when it succeeds."
 msgstr "表示された更新コマンドを実行し、成功したら終了します。"
 
-#: src/iac_code/ui/repl.py:513
+#: src/iac_code/ui/repl.py
 msgid "Skip"
 msgstr "スキップ"
 
-#: src/iac_code/ui/repl.py:515
+#: src/iac_code/ui/repl.py
 msgid "Continue with the current version for this session."
 msgstr "このセッションでは現在のバージョンを使い続けます。"
 
-#: src/iac_code/ui/repl.py:518
+#: src/iac_code/ui/repl.py
 msgid "Skip until next version"
 msgstr "次のバージョンまでスキップ"
 
-#: src/iac_code/ui/repl.py:520
+#: src/iac_code/ui/repl.py
 msgid "Hide this update until a newer version is available."
 msgstr "より新しいバージョンが利用可能になるまで、この更新を非表示にします。"
 
-#: src/iac_code/ui/repl.py:539 src/iac_code/ui/repl.py:551
+#: src/iac_code/ui/repl.py
 msgid "Update command failed. Continuing with the current version."
 msgstr "更新コマンドに失敗しました。現在のバージョンで続行します。"
 
-#: src/iac_code/ui/repl.py:544
+#: src/iac_code/ui/repl.py
 msgid "Update completed. Restart iac-code to continue."
 msgstr "更新が完了しました。続行するには iac-code を再起動してください。"
 
-#: src/iac_code/ui/repl.py:582
+#: src/iac_code/ui/repl.py
 msgid "No image in clipboard."
 msgstr "クリップボードに画像がありません。"
 
-#: src/iac_code/ui/repl.py:768
+#: src/iac_code/ui/repl.py
 msgid "Usage: !<shell command>"
 msgstr "使用方法: !<shell command>"
 
-#: src/iac_code/ui/repl.py:775
+#: src/iac_code/ui/repl.py
 msgid "Shell command support is unavailable."
 msgstr "シェルコマンドのサポートは利用できません。"
 
-#: src/iac_code/ui/repl.py:845
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown skill: ${name}. Type / to list commands and skills."
 msgstr "不明なスキル: ${name}。/ を入力するとコマンドとスキルを一覧表示します。"
 
-#: src/iac_code/ui/repl.py:847
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown command: /{name}. Type /help for available commands."
 msgstr ""
 "Unknown command: /{name}. Type /help for available "
 "commands.不明なコマンドです：/{name}。利用可能なコマンドは /help を入力してください。"
 
-#: src/iac_code/ui/repl.py:852
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "$ only invokes skills. Use /{name} instead."
 msgstr "$ はスキルのみを呼び出します。代わりに /{name} を使用してください。"
 
-#: src/iac_code/ui/repl.py:874 src/iac_code/ui/repl.py:922
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command error: {error}"
 msgstr "コマンドエラー：{error}"
 
-#: src/iac_code/ui/repl.py:881
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command has no handler: {name}"
 msgstr "ハンドラーがないコマンドです：{name}"
 
-#: src/iac_code/ui/repl.py:1156
+#: src/iac_code/ui/repl.py
 msgid "Goodbye!"
 msgstr "さようなら。"
 
-#: src/iac_code/ui/repl.py:1157
+#: src/iac_code/ui/repl.py
 msgid "Resume this session with:"
 msgstr "このセッションを再開するには次を実行してください："
 
-#: src/iac_code/ui/repl.py:1160
+#: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "セッション ID"
 
-#: src/iac_code/ui/repl.py:1210 src/iac_code/ui/repl.py:1214
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Session not found: {session_id}"
 msgstr "セッションが見つかりません：{session_id}"
 
-#: src/iac_code/ui/repl.py:1263
+#: src/iac_code/ui/repl.py
 msgid "Session name: "
 msgstr "セッション名: "
 
-#: src/iac_code/ui/repl.py:1269
+#: src/iac_code/ui/repl.py
 msgid "Session name cannot be empty."
 msgstr "セッション名は空にできません。"
 
-#: src/iac_code/ui/repl.py:1279
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "This session belongs to a different directory.\n"
@@ -2384,331 +2361,331 @@ msgstr ""
 "再開するには次を実行してください：\n"
 "  {cmd}"
 
-#: src/iac_code/ui/repl.py:1283
+#: src/iac_code/ui/repl.py
 msgid "Multiple sessions match. Resume one by ID:"
 msgstr "複数のセッションが一致しました。ID でいずれかを再開してください:"
 
-#: src/iac_code/ui/repl.py:1396
+#: src/iac_code/ui/repl.py
 msgid "This conversation is from a different directory."
 msgstr "この会話は別のディレクトリ由来です。"
 
-#: src/iac_code/ui/repl.py:1398
+#: src/iac_code/ui/repl.py
 msgid "To resume, run:"
 msgstr "再開するには次を実行してください："
 
-#: src/iac_code/ui/repl.py:1403
+#: src/iac_code/ui/repl.py
 msgid "(Command copied to clipboard)"
 msgstr "（コマンドをクリップボードにコピーしました）"
 
-#: src/iac_code/ui/repl.py:1560
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "Current model {model} does not support image input. Use /model to switch "
 "to a vision-capable model."
 msgstr "現在のモデル {model} は画像入力をサポートしていません。/model を使用してビジョン対応モデルに切り替えてください。"
 
-#: src/iac_code/ui/repl.py:1569
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Image error: {err}"
 msgstr "画像エラー：{err}"
 
-#: src/iac_code/ui/repl.py:1586
+#: src/iac_code/ui/repl.py
 msgid ""
 "Failed to persist image to cache; it will only exist in memory for this "
 "turn."
 msgstr "画像をキャッシュに保存できませんでした。このターンの間、メモリ上にのみ存在します。"
 
-#: src/iac_code/ui/spinner.py:52
+#: src/iac_code/ui/spinner.py
 msgid "Processing"
 msgstr "処理中"
 
-#: src/iac_code/ui/spinner.py:53
+#: src/iac_code/ui/spinner.py
 msgid "Working"
 msgstr "作業中"
 
-#: src/iac_code/ui/spinner.py:62
+#: src/iac_code/ui/spinner.py
 msgid "Thought"
 msgstr "思考しました"
 
-#: src/iac_code/ui/spinner.py:63
+#: src/iac_code/ui/spinner.py
 msgid "Processed"
 msgstr "処理しました"
 
-#: src/iac_code/ui/spinner.py:64
+#: src/iac_code/ui/spinner.py
 msgid "Worked"
 msgstr "作業しました"
 
-#: src/iac_code/ui/transcript_view.py:158
+#: src/iac_code/ui/transcript_view.py
 msgid "Prompt:"
 msgstr "プロンプト："
 
-#: src/iac_code/ui/transcript_view.py:186
+#: src/iac_code/ui/transcript_view.py
 msgid "Showing transcript · ctrl+o to toggle"
 msgstr "トランスクリプトを表示中 · ctrl+o で切り替え"
 
-#: src/iac_code/ui/components/fuzzy_picker.py:120
+#: src/iac_code/ui/components/fuzzy_picker.py
 msgid "No matches found"
 msgstr "一致する項目がありません"
 
-#: src/iac_code/ui/core/prompt_input.py:348
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Image in clipboard · ctrl+v to paste"
 msgstr "クリップボードに画像 · ctrl+v で貼り付け"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Fill"
 msgstr "入力"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Dismiss"
 msgstr "閉じる"
 
-#: src/iac_code/ui/dialogs/global_search.py:55
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "No matching content"
 msgstr "一致する内容がありません"
 
-#: src/iac_code/ui/dialogs/global_search.py:61
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Search in Files"
 msgstr "ファイル内を検索"
 
-#: src/iac_code/ui/dialogs/global_search.py:62
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Type to search content..."
 msgstr "入力して内容を検索…"
 
-#: src/iac_code/ui/dialogs/global_search.py:63
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Enter search query"
 msgstr "検索クエリを入力"
 
-#: src/iac_code/ui/dialogs/history_search.py:55
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Search Conversation History"
 msgstr "会話履歴を検索"
 
-#: src/iac_code/ui/dialogs/history_search.py:56
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Type to search..."
 msgstr "入力して検索…"
 
-#: src/iac_code/ui/dialogs/history_search.py:57
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "No conversation history"
 msgstr "会話履歴がありません"
 
-#: src/iac_code/ui/dialogs/history_search.py:98
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Message Preview"
 msgstr "メッセージのプレビュー"
 
-#: src/iac_code/ui/dialogs/quick_open.py:58
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Open File"
 msgstr "ファイルを開く"
 
-#: src/iac_code/ui/dialogs/quick_open.py:59
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Type to search files..."
 msgstr "入力してファイルを検索…"
 
-#: src/iac_code/ui/dialogs/quick_open.py:60
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "No matching files"
 msgstr "一致するファイルがありません"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:116
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Search..."
 msgstr "検索…"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:374
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Resume Session"
 msgstr "セッションを再開"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:384
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "No sessions found"
 msgstr "セッションが見つかりません"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:444
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show current dir"
 msgstr "現在のディレクトリのみ表示"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:446
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all projects"
 msgstr "すべてのプロジェクトを表示"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:449
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all branches"
 msgstr "すべてのブランチを表示"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:451
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "only show current branch"
 msgstr "現在のブランチのみ表示"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:452
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "preview"
 msgstr "プレビュー"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:453
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Type to search"
 msgstr "入力して検索"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:454
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "cancel"
 msgstr "キャンセル"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:569
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} more line{s}"
 msgstr "あと {n} 行{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:583
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} message{s}"
 msgstr "{n} 件のメッセージ{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:597
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "resume"
 msgstr "再開"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:601
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "back"
 msgstr "戻る"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:606
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "scroll"
 msgstr "スクロール"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:625
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "(empty session)"
 msgstr "（空のセッション）"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:745
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "just now"
 msgstr "たった今"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:748
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} minute{s} ago"
 msgstr "{n} 分{s}前"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:751
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} hour{s} ago"
 msgstr "{n} 時間{s}前"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:753
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} day{s} ago"
 msgstr "{n} 日{s}前"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:52
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Search skills..."
 msgstr "スキルを検索..."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:159
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Skills"
 msgstr "スキル"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:161
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "{current} of {total}"
 msgstr "{total} 件中 {current}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:165
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid ""
 "{count} skills - Space to toggle, Enter to save, Tab to sort, Esc to "
 "cancel"
 msgstr "{count} 個のスキル - Space で切り替え、Enter で保存、Tab で並べ替え、Esc でキャンセル"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:171
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "Sort: {mode}"
 msgstr "並べ替え: {mode}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:176
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "No skills found"
 msgstr "スキルが見つかりません"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:245
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Bundled skills cannot be disabled."
 msgstr "バンドルスキルは無効にできません。"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "on"
 msgstr "有効"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "off"
 msgstr "無効"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:265
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "locked"
 msgstr "ロック済み"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:268
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "matched description"
 msgstr "説明に一致"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:277
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "source"
 msgstr "提供元"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:279
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "size"
 msgstr "サイズ"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:280
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "name"
 msgstr "名前"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:285
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "bundled"
 msgstr "バンドル"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:287
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "project"
 msgstr "プロジェクト"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:289
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "user"
 msgstr "ユーザー"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:296
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count}k tokens"
 msgstr "約{count}kトークン"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:297
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count} tokens"
 msgstr "約{count}トークン"
 
-#: src/iac_code/ui/suggestions/command_provider.py:79
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Search saved memories"
 msgstr "保存済みメモリを検索"
 
-#: src/iac_code/ui/suggestions/command_provider.py:80
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Delete a saved memory"
 msgstr "保存済みメモリを削除"
 
-#: src/iac_code/ui/suggestions/command_provider.py:81
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Show memory command help"
 msgstr "memory コマンドのヘルプを表示"
 
-#: src/iac_code/ui/suggestions/command_provider.py:116
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Saved memory"
 msgstr "保存済みメモリ"
 
-#: src/iac_code/utils/platform.py:39
+#: src/iac_code/utils/platform.py
 msgid "iac-code on Windows requires Git for Windows."
 msgstr "iac-code を Windows で使用するには Git for Windows が必要です。"
 
-#: src/iac_code/utils/platform.py:41
+#: src/iac_code/utils/platform.py
 msgid ""
 "If installed but not on PATH, set IAC_CODE_GIT_BASH_PATH environment "
 "variable."
 msgstr "インストール済みで PATH に含まれていない場合は、IAC_CODE_GIT_BASH_PATH 環境変数を設定してください。"
 
-#: src/iac_code/utils/platform.py:44
+#: src/iac_code/utils/platform.py
 msgid "To install:"
 msgstr "インストール方法："
 
-#: src/iac_code/utils/platform.py:47
+#: src/iac_code/utils/platform.py
 msgid "  Option 1 - winget (requires access to github.com):"
 msgstr "  方法 1 - winget（github.com へのアクセスが必要）："
 
-#: src/iac_code/utils/platform.py:52
+#: src/iac_code/utils/platform.py
 msgid ""
 "  Option 2 - if you cannot reach github.com, run this to install via "
 "npmmirror:"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 13:32+0800\n"
+"POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
 "Last-Translator: \n"
 "Language: pt\n"
@@ -17,14 +17,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/iac_code/config.py:164
+#: src/iac_code/config.py
 #, python-brace-format
 msgid "Invalid IAC_CODE_PROVIDER value: {!r}. Valid values (case-insensitive): {}"
 msgstr ""
 "Valor inválido de IAC_CODE_PROVIDER: {!r}. Valores válidos (sem "
 "diferenciar maiúsculas de minúsculas): {}"
 
-#: src/iac_code/a2a/transports/base.py:175
+#: src/iac_code/a2a/transports/base.py
 msgid ""
 "Unix domain socket transport is not supported on Windows. Use --transport"
 " http or --transport stdio instead."
@@ -32,22 +32,21 @@ msgstr ""
 "O transporte de socket de domínio Unix não é suportado no Windows. Use "
 "--transport http ou --transport stdio."
 
-#: src/iac_code/acp/server.py:413 src/iac_code/acp/server.py:429
-#: src/iac_code/acp/server.py:456
+#: src/iac_code/acp/server.py
 msgid "Session not found"
 msgstr "Sessão não encontrada"
 
-#: src/iac_code/acp/server.py:416
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session name is ambiguous. Candidates: {candidates}"
 msgstr "O nome da sessão é ambíguo. Candidatas: {candidates}"
 
-#: src/iac_code/acp/server.py:434 src/iac_code/acp/server.py:708
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session belongs to another project. Run: {hint}"
 msgstr "A sessão pertence a outro projeto. Execute: {hint}"
 
-#: src/iac_code/acp/slash_registry.py:46
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Command '/{cmd_name}' is not supported over ACP. Supported commands: "
@@ -56,21 +55,21 @@ msgstr ""
 "O comando '/{cmd_name}' não é compatível com ACP. Comandos compatíveis: "
 "{supported}"
 
-#: src/iac_code/acp/slash_registry.py:62
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Command '/{cmd_name}' handler not implemented."
 msgstr "Tratador do comando '/{cmd_name}' não implementado."
 
-#: src/iac_code/acp/slash_registry.py:74
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Compaction failed: {error}"
 msgstr "Falha ao compactar: {error}"
 
-#: src/iac_code/acp/slash_registry.py:77 src/iac_code/commands/compact.py:24
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Nothing to compact: conversation is empty."
 msgstr "Nada para compactar: a conversa está vazia."
 
-#: src/iac_code/acp/slash_registry.py:80 src/iac_code/commands/compact.py:27
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Conversation too short to compact: all messages are within the recent "
@@ -79,11 +78,11 @@ msgstr ""
 "Conversa curta demais para compactar: todas as mensagens estão na janela "
 "de preservação das últimas {turns} interações."
 
-#: src/iac_code/acp/slash_registry.py:84 src/iac_code/commands/compact.py:30
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Compaction failed. See logs for details."
 msgstr "Falha na compactação. Consulte os logs para detalhes."
 
-#: src/iac_code/acp/slash_registry.py:89
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent} reduction)."
@@ -92,123 +91,121 @@ msgstr ""
 "Contexto compactado: {original} → {compacted} tokens (redução de "
 "{percent}). Uso do contexto: {usage}"
 
-#: src/iac_code/acp/slash_registry.py:103
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Clear failed: {error}"
 msgstr "Falha ao limpar: {error}"
 
-#: src/iac_code/acp/slash_registry.py:104
+#: src/iac_code/acp/slash_registry.py
 msgid "Conversation history cleared."
 msgstr "Histórico da conversa limpo."
 
-#: src/iac_code/acp/slash_registry.py:120 src/iac_code/commands/debug.py:34
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging is on. Log file: {path}"
 msgstr "Debug ativado. Arquivo de log: {path}"
 
-#: src/iac_code/acp/slash_registry.py:121 src/iac_code/commands/debug.py:35
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging is off."
 msgstr "Debug desativado."
 
-#: src/iac_code/acp/slash_registry.py:125 src/iac_code/commands/debug.py:39
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging enabled. Log file: {path}"
 msgstr "Debug ativado. Arquivo de log: {path}"
 
-#: src/iac_code/acp/slash_registry.py:129 src/iac_code/commands/debug.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging disabled."
 msgstr "Debug desativado."
 
-#: src/iac_code/acp/slash_registry.py:131 src/iac_code/commands/debug.py:45
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Usage: /debug [on|off]"
 msgstr "Uso: /debug [on|off]"
 
-#: src/iac_code/acp/slash_registry.py:136 src/iac_code/commands/memory.py:84
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/memory.py
 msgid "Memory manager is unavailable."
 msgstr "O gerenciador de memória está indisponível."
 
-#: src/iac_code/acp/slash_registry.py:146 src/iac_code/commands/rename.py:21
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 msgid "Usage: /rename <name>"
 msgstr "Uso: /rename <nome>"
 
-#: src/iac_code/acp/slash_registry.py:152
+#: src/iac_code/acp/slash_registry.py
 msgid "Rename is only available after a session is created."
 msgstr "Renomear só fica disponível depois que uma sessão é criada."
 
-#: src/iac_code/acp/slash_registry.py:163 src/iac_code/commands/rename.py:42
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Session is already named {name}"
 msgstr "A sessão já se chama {name}"
 
-#: src/iac_code/acp/slash_registry.py:164 src/iac_code/commands/rename.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Renamed session to {name}"
 msgstr "Sessão renomeada para {name}"
 
-#: src/iac_code/agent/agent_loop.py:413 src/iac_code/agent/agent_loop.py:428
-#: src/iac_code/ui/repl.py:813 src/iac_code/ui/repl.py:827
+#: src/iac_code/agent/agent_loop.py src/iac_code/ui/repl.py
 msgid "Permission denied."
 msgstr "Permissão negada."
 
-#: src/iac_code/agent/agent_tool.py:266
+#: src/iac_code/agent/agent_tool.py
 #, python-brace-format
 msgid "Done ({tool_count} tool uses · {token_display} tokens)"
 msgstr "Concluído ({tool_count} usos de ferramenta · {token_display} tokens)"
 
-#: src/iac_code/agent/agent_tool.py:276
+#: src/iac_code/agent/agent_tool.py
 msgid "Explore"
 msgstr "Explorar"
 
-#: src/iac_code/agent/agent_tool.py:277
+#: src/iac_code/agent/agent_tool.py
 msgid "Plan"
 msgstr "Planejar"
 
-#: src/iac_code/agent/agent_tool.py:278 src/iac_code/agent/agent_tool.py:279
-#: src/iac_code/agent/agent_tool.py:280
+#: src/iac_code/agent/agent_tool.py
 msgid "Agent"
 msgstr "Agent"
 
-#: src/iac_code/cli/headless.py:50
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool started: {}"
 msgstr "Ferramenta iniciada: {}"
 
-#: src/iac_code/cli/headless.py:53
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool failed: {}"
 msgstr "Ferramenta falhou: {}"
 
-#: src/iac_code/cli/headless.py:55
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool finished: {}"
 msgstr "Ferramenta concluída: {}"
 
-#: src/iac_code/cli/headless.py:59
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool failed: {}"
 msgstr "Ferramenta filha falhou: {}"
 
-#: src/iac_code/cli/headless.py:61
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool finished: {}"
 msgstr "Ferramenta filha concluída: {}"
 
-#: src/iac_code/cli/headless.py:63
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool started: {}"
 msgstr "Ferramenta filha iniciada: {}"
 
-#: src/iac_code/cli/headless.py:65
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack {}: {} ({:.1f}%)"
 msgstr "Pilha {}: {} ({:.1f}%)"
 
-#: src/iac_code/cli/headless.py:71
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack group {}: {} ({}%)"
 msgstr "Grupo de pilhas {}: {} ({}%)"
 
-#: src/iac_code/cli/headless.py:110
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -227,27 +224,27 @@ msgstr ""
 "  Documentação: https://aliyun.github.io/iac-"
 "code/pt/docs/configuration/authentication\n"
 
-#: src/iac_code/cli/install_git_bash.py:40
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git Bash is already installed at {}"
 msgstr "Git Bash já está instalado em {}"
 
-#: src/iac_code/cli/install_git_bash.py:43
+#: src/iac_code/cli/install_git_bash.py
 msgid "Installing Git for Windows via npmmirror..."
 msgstr "Instalando Git for Windows via npmmirror..."
 
-#: src/iac_code/cli/install_git_bash.py:59
+#: src/iac_code/cli/install_git_bash.py
 msgid "powershell.exe was not found on PATH; cannot run installer."
 msgstr ""
 "powershell.exe não foi encontrado no PATH; não é possível executar o "
 "instalador."
 
-#: src/iac_code/cli/install_git_bash.py:66
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Installation failed (PowerShell exited with code {})"
 msgstr "A instalação falhou (PowerShell saiu com código {})"
 
-#: src/iac_code/cli/install_git_bash.py:77
+#: src/iac_code/cli/install_git_bash.py
 msgid ""
 "Installer exited but bash.exe was not found in common locations; UAC may "
 "have been cancelled or the installer used a non-standard path."
@@ -255,29 +252,32 @@ msgstr ""
 "O instalador encerrou mas bash.exe não foi encontrado em locais comuns; "
 "UAC pode ter sido cancelado ou o instalador usou um caminho não padrão."
 
-#: src/iac_code/cli/install_git_bash.py:84
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git for Windows installed at {}"
 msgstr "Git for Windows instalado em {}"
 
-#: src/iac_code/cli/main.py:33 src/iac_code/commands/help.py:26
+#: src/iac_code/cli/main.py src/iac_code/commands/help.py
 msgid "AI-powered infrastructure orchestration tool"
 msgstr "Ferramenta de orquestração de infraestrutura com IA"
 
-#: src/iac_code/cli/main.py:41
+#: src/iac_code/cli/main.py
 msgid "Use iac-code as an A2A client."
 msgstr "Usa o iac-code como cliente A2A."
 
-#: src/iac_code/cli/main.py:54
+#: src/iac_code/cli/main.py
 msgid "Install Git for Windows via the npmmirror mirror (Windows only)."
 msgstr "Instalar Git for Windows pelo espelho npmmirror (somente Windows)."
 
-#: src/iac_code/cli/main.py:61
+#: src/iac_code/cli/main.py
+msgid "Update iac-code to the latest version."
+msgstr "Atualizar o iac-code para a versão mais recente."
+
+#: src/iac_code/cli/main.py
 msgid "YAML config file containing A2A client options"
 msgstr "Arquivo de configuração YAML com opções do cliente A2A"
 
-#: src/iac_code/cli/main.py:68 src/iac_code/cli/main.py:1501
-#: src/iac_code/cli/main.py:1862 src/iac_code/cli/main.py:1901
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -285,48 +285,47 @@ msgstr ""
 "As dependências do cliente A2A estão ausentes. Instale com: pip install "
 "'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:82
+#: src/iac_code/cli/main.py
 msgid "LLM model to use"
 msgstr "Modelo LLM a utilizar"
 
-#: src/iac_code/cli/main.py:83
+#: src/iac_code/cli/main.py
 msgid "Non-interactive mode: run a single prompt and exit"
 msgstr "Modo não interativo: executa um único prompt e encerra"
 
-#: src/iac_code/cli/main.py:84
+#: src/iac_code/cli/main.py
 msgid "Output format: text, json, stream-json"
 msgstr "Formato de saída: text, json, stream-json"
 
-#: src/iac_code/cli/main.py:85
+#: src/iac_code/cli/main.py
 msgid "Maximum agent turns in headless mode"
 msgstr "Número máximo de passos do agent em modo headless"
 
-#: src/iac_code/cli/main.py:86 src/iac_code/cli/main.py:366
-#: src/iac_code/cli/main.py:591
+#: src/iac_code/cli/main.py
 msgid "Enable debug logging"
 msgstr "Ativar debug"
 
-#: src/iac_code/cli/main.py:87
+#: src/iac_code/cli/main.py
 msgid "Show headless progress on stderr"
 msgstr "Mostrar progresso do modo headless no stderr"
 
-#: src/iac_code/cli/main.py:88
+#: src/iac_code/cli/main.py
 msgid "Show version and exit"
 msgstr "Mostrar versão e sair"
 
-#: src/iac_code/cli/main.py:89
+#: src/iac_code/cli/main.py
 msgid "Resume a session by ID or name"
 msgstr "Retomar uma sessão por ID ou nome"
 
-#: src/iac_code/cli/main.py:90
+#: src/iac_code/cli/main.py
 msgid "Resume the most recent session"
 msgstr "Retomar a sessão mais recente"
 
-#: src/iac_code/cli/main.py:97 src/iac_code/i18n/__init__.py:55
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid "Install completion for the current shell."
 msgstr "Instalar completion para o shell atual."
 
-#: src/iac_code/cli/main.py:105 src/iac_code/i18n/__init__.py:56
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid ""
 "Show completion for the current shell, to copy it or customize the "
 "installation."
@@ -334,7 +333,7 @@ msgstr ""
 "Exibir o completion do shell atual, para copiar ou personalizar a "
 "instalação."
 
-#: src/iac_code/cli/main.py:110
+#: src/iac_code/cli/main.py
 msgid ""
 "Comma-separated tool permission patterns to allow, e.g. 'bash(git "
 "*),write_file'"
@@ -342,48 +341,48 @@ msgstr ""
 "Padrões de permissão de ferramentas a permitir (separados por vírgula), "
 "ex. 'bash(git *),write_file'*),write_file'"
 
-#: src/iac_code/cli/main.py:115
+#: src/iac_code/cli/main.py
 msgid "Comma-separated tool permission patterns to deny"
 msgstr "Padrões de permissão de ferramentas a negar (separados por vírgula)"
 
-#: src/iac_code/cli/main.py:120
+#: src/iac_code/cli/main.py
 msgid "Permission mode: default, accept_edits, bypass_permissions, dont_ask"
 msgstr "Modo de permissão: default, accept_edits, bypass_permissions, dont_ask"
 
-#: src/iac_code/cli/main.py:151
+#: src/iac_code/cli/main.py
 msgid "Error: --resume and --continue cannot be used together."
 msgstr "Erro: --resume e --continue não podem ser usados juntos."
 
-#: src/iac_code/cli/main.py:163
+#: src/iac_code/cli/main.py
 #, python-brace-format
 msgid "Invalid --output-format '{}'. Valid values: {}"
 msgstr "--output-format inválido '{}'. Valores válidos: {}"
 
-#: src/iac_code/cli/main.py:361
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an ACP server."
 msgstr "Executar o iac-code como servidor ACP."
 
-#: src/iac_code/cli/main.py:363
+#: src/iac_code/cli/main.py
 msgid "Transport type: stdio or http"
 msgstr "Tipo de transporte: stdio ou http"
 
-#: src/iac_code/cli/main.py:364
+#: src/iac_code/cli/main.py
 msgid "HTTP server port"
 msgstr "Porta do servidor HTTP"
 
-#: src/iac_code/cli/main.py:365 src/iac_code/cli/main.py:581
+#: src/iac_code/cli/main.py
 msgid "HTTP server host"
 msgstr "Host do servidor HTTP"
 
-#: src/iac_code/cli/main.py:577
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an A2A 1.0 server."
 msgstr "Executa o iac-code como servidor A2A 1.0."
 
-#: src/iac_code/cli/main.py:580
+#: src/iac_code/cli/main.py
 msgid "YAML config file for A2A server options"
 msgstr "Arquivo de configuração YAML para opções do servidor A2A"
 
-#: src/iac_code/cli/main.py:584
+#: src/iac_code/cli/main.py
 msgid ""
 "HTTP server port. 41242 is the iac-code default inspired by Gemini CLI, "
 "not a registered A2A port."
@@ -391,7 +390,7 @@ msgstr ""
 "Porta do servidor HTTP. 41242 é o padrão do iac-code inspirado no Gemini "
 "CLI, não uma porta A2A registrada."
 
-#: src/iac_code/cli/main.py:589
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc, or "
 "redis-streams"
@@ -399,7 +398,7 @@ msgstr ""
 "Transporte A2A: http, stdio, unix, websocket, grpc, grpc-jsonrpc ou "
 "redis-streams"
 
-#: src/iac_code/cli/main.py:595
+#: src/iac_code/cli/main.py
 msgid ""
 "Expose A2A thinking signal types; repeat for multiple. Values: raw-"
 "thinking, tool-trace."
@@ -407,7 +406,7 @@ msgstr ""
 "Expõe tipos de sinal de thinking A2A; repita para múltiplos. Valores: "
 "raw-thinking, tool-trace."
 
-#: src/iac_code/cli/main.py:646
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
@@ -415,609 +414,598 @@ msgstr ""
 "As dependências do servidor A2A estão ausentes. Instale com: pip install "
 "'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:778
+#: src/iac_code/cli/main.py
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "Envia um prompt para um endpoint JSON-RPC A2A."
 
-#: src/iac_code/cli/main.py:781 src/iac_code/cli/main.py:951
-#: src/iac_code/cli/main.py:1004 src/iac_code/cli/main.py:1064
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1163
-#: src/iac_code/cli/main.py:1242 src/iac_code/cli/main.py:1299
-#: src/iac_code/cli/main.py:1355 src/iac_code/cli/main.py:1412
+#: src/iac_code/cli/main.py
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "URL do endpoint JSON-RPC A2A"
 
-#: src/iac_code/cli/main.py:782 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "Especificação de rota: name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:783
+#: src/iac_code/cli/main.py
 msgid "Named A2A route to call"
 msgstr "Rota A2A nomeada a chamar"
 
-#: src/iac_code/cli/main.py:784
+#: src/iac_code/cli/main.py
 msgid "Prompt to send"
 msgstr "Prompt para enviar"
 
-#: src/iac_code/cli/main.py:785
+#: src/iac_code/cli/main.py
 msgid "Working directory metadata to send with the request"
 msgstr "Metadados do diretório de trabalho a enviar com a requisição"
 
-#: src/iac_code/cli/main.py:786
+#: src/iac_code/cli/main.py
 msgid "A2A context ID to continue"
 msgstr "ID de contexto A2A para continuar"
 
-#: src/iac_code/cli/main.py:787 src/iac_code/cli/main.py:882
-#: src/iac_code/cli/main.py:954 src/iac_code/cli/main.py:1011
-#: src/iac_code/cli/main.py:1066 src/iac_code/cli/main.py:1116
-#: src/iac_code/cli/main.py:1170 src/iac_code/cli/main.py:1245
-#: src/iac_code/cli/main.py:1303 src/iac_code/cli/main.py:1358
-#: src/iac_code/cli/main.py:1413
+#: src/iac_code/cli/main.py
 msgid "Bearer token for A2A HTTP requests"
 msgstr "Token Bearer para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:788 src/iac_code/cli/main.py:883
-#: src/iac_code/cli/main.py:955 src/iac_code/cli/main.py:1012
-#: src/iac_code/cli/main.py:1067 src/iac_code/cli/main.py:1117
-#: src/iac_code/cli/main.py:1171 src/iac_code/cli/main.py:1246
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1359
-#: src/iac_code/cli/main.py:1414
+#: src/iac_code/cli/main.py
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "Nome de usuário de autenticação básica para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:789 src/iac_code/cli/main.py:884
-#: src/iac_code/cli/main.py:956 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1068 src/iac_code/cli/main.py:1118
-#: src/iac_code/cli/main.py:1172 src/iac_code/cli/main.py:1247
-#: src/iac_code/cli/main.py:1305 src/iac_code/cli/main.py:1360
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "Senha de autenticação básica para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:790 src/iac_code/cli/main.py:885
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1069 src/iac_code/cli/main.py:1119
-#: src/iac_code/cli/main.py:1173 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1306 src/iac_code/cli/main.py:1361
-#: src/iac_code/cli/main.py:1416
+#: src/iac_code/cli/main.py
 msgid "API key for A2A HTTP requests"
 msgstr "Chave de API para requisições HTTP A2A"
 
-#: src/iac_code/cli/main.py:791 src/iac_code/cli/main.py:886
-#: src/iac_code/cli/main.py:958 src/iac_code/cli/main.py:1015
-#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1120
-#: src/iac_code/cli/main.py:1174 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1307 src/iac_code/cli/main.py:1362
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py
 msgid "HTTP header name for A2A API key"
 msgstr "Nome do cabeçalho HTTP para a chave de API A2A"
 
-#: src/iac_code/cli/main.py:796 src/iac_code/cli/main.py:891
+#: src/iac_code/cli/main.py
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "Segredo usado para verificar o A2A Agent Card"
 
-#: src/iac_code/cli/main.py:801 src/iac_code/cli/main.py:896
+#: src/iac_code/cli/main.py
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "URL JWKS remota usada para verificar o A2A Agent Card"
 
-#: src/iac_code/cli/main.py:807 src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py
 msgid "Require a valid A2A Agent Card signature"
 msgstr "Exigir uma assinatura válida do A2A Agent Card"
 
-#: src/iac_code/cli/main.py:809
+#: src/iac_code/cli/main.py
 msgid "A2A call timeout in seconds"
 msgstr "Tempo limite da chamada A2A em segundos"
 
-#: src/iac_code/cli/main.py:810
+#: src/iac_code/cli/main.py
 msgid "Use A2A streaming message delivery"
 msgstr "Usar entrega de mensagens em streaming A2A"
 
-#: src/iac_code/cli/main.py:878
+#: src/iac_code/cli/main.py
 msgid "Discover an A2A Agent Card."
 msgstr "Descobre um A2A Agent Card."
 
-#: src/iac_code/cli/main.py:881
+#: src/iac_code/cli/main.py
 msgid "A2A agent base URL"
 msgstr "URL base do agente A2A"
 
-#: src/iac_code/cli/main.py:948
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task."
 msgstr "Obtém uma tarefa A2A."
 
-#: src/iac_code/cli/main.py:952 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1115 src/iac_code/cli/main.py:1164
-#: src/iac_code/cli/main.py:1243 src/iac_code/cli/main.py:1300
-#: src/iac_code/cli/main.py:1356
+#: src/iac_code/cli/main.py
 msgid "A2A task ID"
 msgstr "ID da tarefa A2A"
 
-#: src/iac_code/cli/main.py:953
+#: src/iac_code/cli/main.py
 msgid "Maximum task history items to return"
 msgstr "Número máximo de itens do histórico de tarefas a retornar"
 
-#: src/iac_code/cli/main.py:1001
+#: src/iac_code/cli/main.py
 msgid "List A2A tasks."
 msgstr "Lista as tarefas A2A."
 
-#: src/iac_code/cli/main.py:1005
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A context ID"
 msgstr "Filtrar por ID de contexto A2A"
 
-#: src/iac_code/cli/main.py:1006
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A task state"
 msgstr "Filtrar por estado de tarefa A2A"
 
-#: src/iac_code/cli/main.py:1007
+#: src/iac_code/cli/main.py
 msgid "Maximum tasks to return"
 msgstr "Número máximo de tarefas a retornar"
 
-#: src/iac_code/cli/main.py:1008 src/iac_code/cli/main.py:1302
+#: src/iac_code/cli/main.py
 msgid "Pagination token"
 msgstr "Token de paginação"
 
-#: src/iac_code/cli/main.py:1009
+#: src/iac_code/cli/main.py
 msgid "Include task artifacts"
 msgstr "Incluir artefatos de tarefa"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py
 msgid "Output format: table or json"
 msgstr "Formato de saída: table ou json"
 
-#: src/iac_code/cli/main.py:1061
+#: src/iac_code/cli/main.py
 msgid "Cancel an A2A task."
 msgstr "Cancela uma tarefa A2A."
 
-#: src/iac_code/cli/main.py:1111
+#: src/iac_code/cli/main.py
 msgid "Subscribe to an A2A task event stream."
 msgstr "Assina um fluxo de eventos de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1160
+#: src/iac_code/cli/main.py
 msgid "Create an A2A task push notification config."
 msgstr "Cria uma configuração de notificação push de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1165 src/iac_code/cli/main.py:1244
-#: src/iac_code/cli/main.py:1357
+#: src/iac_code/cli/main.py
 msgid "Push config ID"
 msgstr "ID da configuração push"
 
-#: src/iac_code/cli/main.py:1166
+#: src/iac_code/cli/main.py
 msgid "Push callback URL"
 msgstr "URL de callback push"
 
-#: src/iac_code/cli/main.py:1167
+#: src/iac_code/cli/main.py
 msgid "Notification verification token"
 msgstr "Token de verificação de notificação"
 
-#: src/iac_code/cli/main.py:1168
+#: src/iac_code/cli/main.py
 msgid "Callback authentication scheme"
 msgstr "Esquema de autenticação de callback"
 
-#: src/iac_code/cli/main.py:1169
+#: src/iac_code/cli/main.py
 msgid "Callback authentication credentials"
 msgstr "Credenciais de autenticação de callback"
 
-#: src/iac_code/cli/main.py:1239
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task push notification config."
 msgstr "Obtém uma configuração de notificação push de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1296
+#: src/iac_code/cli/main.py
 msgid "List A2A task push notification configs."
 msgstr "Lista as configurações de notificação push de tarefas A2A."
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py
 msgid "Maximum configs to return"
 msgstr "Número máximo de configurações a retornar"
 
-#: src/iac_code/cli/main.py:1352
+#: src/iac_code/cli/main.py
 msgid "Delete an A2A task push notification config."
 msgstr "Exclui uma configuração de notificação push de tarefa A2A."
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "Obtém um A2A Agent Card estendido autenticado."
 
-#: src/iac_code/cli/main.py:1452
+#: src/iac_code/cli/main.py
 msgid "Preview A2A route resolution."
 msgstr "Pré-visualização da resolução de rotas A2A."
 
-#: src/iac_code/cli/main.py:1459
+#: src/iac_code/cli/main.py
 msgid "Route name to resolve"
 msgstr "Nome da rota a resolver"
 
-#: src/iac_code/cli/main.py:1460
+#: src/iac_code/cli/main.py
 msgid "Skill ID to resolve"
 msgstr "ID da habilidade a resolver"
 
-#: src/iac_code/cli/main.py:1461
+#: src/iac_code/cli/main.py
 msgid "Prompt text used for tag/name route matching"
 msgstr "Texto do prompt usado para correspondência de rotas por tag/nome"
 
-#: src/iac_code/cli/main.py:1466
+#: src/iac_code/cli/main.py
 msgid "Directory for persisted A2A routes"
 msgstr "Diretório para rotas A2A persistidas"
 
-#: src/iac_code/cli/main.py:1468
+#: src/iac_code/cli/main.py
 msgid "Save the provided routes as a route snapshot"
 msgstr "Salva as rotas fornecidas como um snapshot de rotas"
 
-#: src/iac_code/commands/__init__.py:26
+#: src/iac_code/cli/update.py
+msgid "Check for updates without installing."
+msgstr "Verificar atualizações sem instalar."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "iac-code is already up to date (v{})."
+msgstr "O iac-code já está atualizado (v{})."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update available: v{} -> v{}"
+msgstr "Atualização disponível: v{} -> v{}"
+
+#: src/iac_code/cli/update.py src/iac_code/ui/banner.py
+#, python-brace-format
+msgid "Run {} to update."
+msgstr "Execute {} para atualizar."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Updating iac-code from v{} to v{}..."
+msgstr "Atualizando o iac-code de v{} para v{}..."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed: {}"
+msgstr "Falha no comando de atualização: {}"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed with exit code {}."
+msgstr "O comando de atualização falhou com código de saída {}."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Successfully updated to v{}!"
+msgstr "Atualizado com sucesso para v{}!"
+
+#: src/iac_code/commands/__init__.py
 msgid "Show available commands"
 msgstr "Mostrar comandos disponíveis"
 
-#: src/iac_code/commands/__init__.py:35
+#: src/iac_code/commands/__init__.py
 msgid "Clear conversation history"
 msgstr "Limpar histórico da conversa"
 
-#: src/iac_code/commands/__init__.py:43
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch model"
 msgstr "Exibir ou trocar modelo"
 
-#: src/iac_code/commands/__init__.py:52
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch thinking effort"
 msgstr "Exibir ou alterar o nível de esforço de raciocínio"
 
-#: src/iac_code/commands/__init__.py:61
+#: src/iac_code/commands/__init__.py
 msgid "Compact conversation context"
 msgstr "Compactar contexto da conversa"
 
-#: src/iac_code/commands/__init__.py:63
+#: src/iac_code/commands/__init__.py
 msgid "Compacting conversation"
 msgstr "Compactando conversa"
 
-#: src/iac_code/commands/__init__.py:70
+#: src/iac_code/commands/__init__.py
 msgid "Exit the application"
 msgstr "Encerrar o aplicativo"
 
-#: src/iac_code/commands/__init__.py:79
+#: src/iac_code/commands/__init__.py
 msgid "Authenticate with LLM provider"
 msgstr "Autenticar com o provedor LLM"
 
-#: src/iac_code/commands/__init__.py:88
+#: src/iac_code/commands/__init__.py
 msgid "Toggle debug logging"
 msgstr "Alternar debug"
 
-#: src/iac_code/commands/__init__.py:97
+#: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"
 msgstr "Ver e gerenciar memórias persistentes"
 
-#: src/iac_code/commands/__init__.py:99
+#: src/iac_code/commands/__init__.py
 msgid "[<name>|search <query>|delete <name>|help]"
 msgstr "[<nome>|search <consulta>|delete <nome>|help]"
 
-#: src/iac_code/commands/__init__.py:106
+#: src/iac_code/commands/__init__.py
 msgid "Resume a previous session"
 msgstr "Retomar uma sessão anterior"
 
-#: src/iac_code/commands/__init__.py:108
+#: src/iac_code/commands/__init__.py
 msgid "[conversation id or search term]"
 msgstr "[ID da conversa ou termo de busca]"
 
-#: src/iac_code/commands/__init__.py:115
+#: src/iac_code/commands/__init__.py
 msgid "Rename the current session"
 msgstr "Renomear a sessão atual"
 
-#: src/iac_code/commands/__init__.py:124
+#: src/iac_code/commands/__init__.py
 msgid "Manage skills"
 msgstr "Gerenciar habilidades"
 
-#: src/iac_code/commands/__init__.py:132
+#: src/iac_code/commands/__init__.py
 msgid "Show current session status"
 msgstr "Mostrar o status atual da sessão"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:1117
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Navigate"
 msgstr "Navegar"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:538
-#: src/iac_code/commands/auth.py:570 src/iac_code/commands/auth.py:577
-#: src/iac_code/commands/auth.py:612 src/iac_code/commands/auth.py:619
-#: src/iac_code/commands/auth.py:640 src/iac_code/commands/auth.py:1117
-#: src/iac_code/commands/auth.py:1551 src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:536
-#: src/iac_code/commands/auth.py:538 src/iac_code/commands/auth.py:570
-#: src/iac_code/commands/auth.py:577 src/iac_code/commands/auth.py:612
-#: src/iac_code/commands/auth.py:619 src/iac_code/commands/auth.py:640
-#: src/iac_code/commands/auth.py:1117 src/iac_code/commands/auth.py:1443
-#: src/iac_code/commands/auth.py:1551
+#: src/iac_code/commands/auth.py
 msgid "Back"
 msgstr "Voltar"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Keep"
 msgstr "Manter"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Re-enter"
 msgstr "Digitar novamente"
 
-#: src/iac_code/commands/auth.py:749 src/iac_code/commands/auth.py:863
-#: src/iac_code/commands/auth.py:921 src/iac_code/commands/auth.py:929
-#: src/iac_code/commands/auth.py:956
+#: src/iac_code/commands/auth.py
 msgid " (current)"
 msgstr " (atual)"
 
-#: src/iac_code/commands/auth.py:752
+#: src/iac_code/commands/auth.py
 msgid "Custom model..."
 msgstr "Modelo personalizado..."
 
-#: src/iac_code/commands/auth.py:755
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select model for {provider}"
 msgstr "Selecionar modelo para {provider}"
 
-#: src/iac_code/commands/auth.py:757
+#: src/iac_code/commands/auth.py
 msgid "Select model"
 msgstr "Selecionar modelo"
 
-#: src/iac_code/commands/auth.py:765
+#: src/iac_code/commands/auth.py
 msgid "Enter custom model name: "
 msgstr "Informe o nome do modelo personalizado: "
 
-#: src/iac_code/commands/auth.py:791
+#: src/iac_code/commands/auth.py
 msgid "Error: console not available"
 msgstr "Erro: console indisponível"
 
-#: src/iac_code/commands/auth.py:820
+#: src/iac_code/commands/auth.py
 msgid "Configure LLM Provider"
 msgstr "Configurar provedor LLM"
 
-#: src/iac_code/commands/auth.py:821
+#: src/iac_code/commands/auth.py
 msgid "Configure IaC Cloud Service"
 msgstr "Configurar serviço de nuvem IaC"
 
-#: src/iac_code/commands/auth.py:823
+#: src/iac_code/commands/auth.py
 msgid "Select configuration type"
 msgstr "Selecionar tipo de configuração"
 
-#: src/iac_code/commands/auth.py:825 src/iac_code/commands/auth.py:981
-#: src/iac_code/commands/auth.py:997 src/iac_code/commands/auth.py:1076
-#: src/iac_code/commands/auth.py:1490 src/iac_code/commands/auth.py:1531
+#: src/iac_code/commands/auth.py
 msgid "Auth cancelled"
 msgstr "Autenticação cancelada"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:961
-#: src/iac_code/commands/auth.py:1051
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select provider — {group}"
 msgstr "Selecionar provedor — {group}"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:919
-#: src/iac_code/commands/auth.py:1036
+#: src/iac_code/commands/auth.py
 msgid "Third-party"
 msgstr "Terceiros"
 
-#: src/iac_code/commands/auth.py:877
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider}"
 msgstr "{status}: {provider}"
 
-#: src/iac_code/commands/auth.py:878 src/iac_code/commands/auth.py:1029
+#: src/iac_code/commands/auth.py
 msgid "Configured"
 msgstr "Configurado"
 
-#: src/iac_code/commands/auth.py:933
+#: src/iac_code/commands/auth.py
 msgid "Select provider"
 msgstr "Selecionar provedor"
 
-#: src/iac_code/commands/auth.py:974
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Configure {provider}"
 msgstr "Configurar {provider}"
 
-#: src/iac_code/commands/auth.py:990
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Enter API key for {provider}"
 msgstr "Informe a API key para {provider}"
 
-#: src/iac_code/commands/auth.py:1028
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider} / {model}"
 msgstr "{status}: {provider} / {model}"
 
-#: src/iac_code/commands/auth.py:1037 src/iac_code/commands/auth.py:1058
+#: src/iac_code/commands/auth.py
 msgid "Alibaba Cloud"
 msgstr "Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1038 src/iac_code/providers/registry.py:427
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "ZhiPu AI"
 msgstr "ZhiPu AI"
 
-#: src/iac_code/commands/auth.py:1039
+#: src/iac_code/commands/auth.py
 msgid "Kimi"
 msgstr "Kimi"
 
-#: src/iac_code/commands/auth.py:1040
+#: src/iac_code/commands/auth.py
 msgid "MiniMax"
 msgstr "MiniMax"
 
-#: src/iac_code/commands/auth.py:1041 src/iac_code/providers/registry.py:429
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Volcengine"
 msgstr "Volcengine"
 
-#: src/iac_code/commands/auth.py:1042
+#: src/iac_code/commands/auth.py
 msgid "SiliconFlow"
 msgstr "SiliconFlow"
 
-#: src/iac_code/commands/auth.py:1043 src/iac_code/providers/registry.py:420
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: src/iac_code/commands/auth.py:1044 src/iac_code/providers/registry.py:418
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: src/iac_code/commands/auth.py:1045 src/iac_code/providers/registry.py:419
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Anthropic"
 msgstr "Anthropic"
 
-#: src/iac_code/commands/auth.py:1046 src/iac_code/providers/registry.py:422
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
-#: src/iac_code/commands/auth.py:1047 src/iac_code/providers/registry.py:435
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Azure OpenAI"
 msgstr "Azure OpenAI"
 
-#: src/iac_code/commands/auth.py:1048 src/iac_code/providers/registry.py:434
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenRouter"
 msgstr "OpenRouter"
 
-#: src/iac_code/commands/auth.py:1049
+#: src/iac_code/commands/auth.py
 msgid "Local"
 msgstr "Local"
 
-#: src/iac_code/commands/auth.py:1050
+#: src/iac_code/commands/auth.py
 msgid "Compatible"
 msgstr "Compatível"
 
-#: src/iac_code/commands/auth.py:1067
+#: src/iac_code/commands/auth.py
 msgid "Select Cloud Provider"
 msgstr "Selecionar provedor de nuvem"
 
-#: src/iac_code/commands/auth.py:1083
+#: src/iac_code/commands/auth.py
 msgid "Credential"
 msgstr "Credencial"
 
-#: src/iac_code/commands/auth.py:1084 src/iac_code/commands/auth.py:1199
-#: src/iac_code/commands/auth.py:1527 src/iac_code/commands/status.py:36
-#: src/iac_code/ui/renderer.py:455
+#: src/iac_code/commands/auth.py src/iac_code/commands/status.py
+#: src/iac_code/ui/renderer.py
 msgid "Region"
 msgstr "Região"
 
-#: src/iac_code/commands/auth.py:1086
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud"
 msgstr "Configurar Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1188
+#: src/iac_code/commands/auth.py
 msgid "Current configuration"
 msgstr "Configuração atual"
 
-#: src/iac_code/commands/auth.py:1190
+#: src/iac_code/commands/auth.py
 msgid "Mode"
 msgstr "Modo"
 
-#: src/iac_code/commands/auth.py:1196
+#: src/iac_code/commands/auth.py
 msgid "(not set)"
 msgstr "(não definido)"
 
-#: src/iac_code/commands/auth.py:1205
+#: src/iac_code/commands/auth.py
 msgid "AccessKey"
 msgstr "AccessKey"
 
-#: src/iac_code/commands/auth.py:1207 src/iac_code/commands/auth.py:1219
+#: src/iac_code/commands/auth.py
 msgid "STS Token"
 msgstr "Token STS"
 
-#: src/iac_code/commands/auth.py:1209
+#: src/iac_code/commands/auth.py
 msgid "RAM Role"
 msgstr "Função RAM"
 
-#: src/iac_code/commands/auth.py:1211
+#: src/iac_code/commands/auth.py
 msgid "OAuth Login (Browser)"
 msgstr "Login OAuth (navegador)"
 
-#: src/iac_code/commands/auth.py:1217
+#: src/iac_code/commands/auth.py
 msgid "AccessKey ID"
 msgstr "ID da AccessKey"
 
-#: src/iac_code/commands/auth.py:1218
+#: src/iac_code/commands/auth.py
 msgid "AccessKey Secret"
 msgstr "Segredo da AccessKey"
 
-#: src/iac_code/commands/auth.py:1220
+#: src/iac_code/commands/auth.py
 msgid "RAM Role ARN"
 msgstr "ARN da função RAM"
 
-#: src/iac_code/commands/auth.py:1221
+#: src/iac_code/commands/auth.py
 msgid "Session Name"
 msgstr "Nome da sessão"
 
-#: src/iac_code/commands/auth.py:1222
+#: src/iac_code/commands/auth.py
 msgid "OAuth Site Type"
 msgstr "Tipo de site OAuth"
 
-#: src/iac_code/commands/auth.py:1223
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token"
 msgstr "Token de acesso OAuth"
 
-#: src/iac_code/commands/auth.py:1224
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token"
 msgstr "Token de atualização OAuth"
 
-#: src/iac_code/commands/auth.py:1225
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token Expire"
 msgstr "Expiração do token de acesso OAuth"
 
-#: src/iac_code/commands/auth.py:1226
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token Expire"
 msgstr "Expiração do token de atualização OAuth"
 
-#: src/iac_code/commands/auth.py:1227
+#: src/iac_code/commands/auth.py
 msgid "STS Expiration"
 msgstr "Expiração STS"
 
-#: src/iac_code/commands/auth.py:1384
+#: src/iac_code/commands/auth.py
 msgid "China"
 msgstr "China"
 
-#: src/iac_code/commands/auth.py:1385
+#: src/iac_code/commands/auth.py
 msgid "International"
 msgstr "Internacional"
 
-#: src/iac_code/commands/auth.py:1387
+#: src/iac_code/commands/auth.py
 msgid "Choose site type"
 msgstr "Escolha o tipo de site"
 
-#: src/iac_code/commands/auth.py:1402
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Alibaba Cloud OAuth login failed: {error}"
 msgstr "Falha no login OAuth da Alibaba Cloud: {error}"
 
-#: src/iac_code/commands/auth.py:1418
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud OAuth credentials saved"
 msgstr "Configurado: credenciais OAuth da Alibaba Cloud salvas"
 
-#: src/iac_code/commands/auth.py:1430
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud credentials"
 msgstr "Configurar credenciais da Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1443
+#: src/iac_code/commands/auth.py
 msgid "Reconfigure credential"
 msgstr "Reconfigurar credencial"
 
-#: src/iac_code/commands/auth.py:1456
+#: src/iac_code/commands/auth.py
 msgid "Select credential type"
 msgstr "Selecionar tipo de credencial"
 
-#: src/iac_code/commands/auth.py:1512
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud credentials saved to ~/.iac-code"
 msgstr "Configurado: credenciais da Alibaba Cloud salvas em ~/.iac-code"
 
-#: src/iac_code/commands/auth.py:1519
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud region"
 msgstr "Configurar região da Alibaba Cloud"
 
-#: src/iac_code/commands/auth.py:1545
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud region saved to ~/.iac-code"
 msgstr "Configurado: região da Alibaba Cloud salva em ~/.iac-code"
 
-#: src/iac_code/commands/compact.py:12
+#: src/iac_code/commands/compact.py
 msgid "Compact command requires a context."
 msgstr "O comando compact requer um contexto."
 
-#: src/iac_code/commands/compact.py:16
+#: src/iac_code/commands/compact.py
 msgid "No active REPL."
 msgstr "Nenhum REPL ativo."
 
-#: src/iac_code/commands/compact.py:20
+#: src/iac_code/commands/compact.py
 msgid "No active agent loop."
 msgstr "Nenhum agent loop ativo."
 
-#: src/iac_code/commands/compact.py:35
+#: src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent_display} "
@@ -1026,108 +1014,107 @@ msgstr ""
 "Contexto compactado: {original} → {compacted} tokens (redução de "
 "{percent_display}). Uso do contexto: {usage_display}"
 
-#: src/iac_code/commands/debug.py:21
+#: src/iac_code/commands/debug.py
 msgid "Debug command requires a context."
 msgstr "O comando debug requer um contexto."
 
-#: src/iac_code/commands/debug.py:26
+#: src/iac_code/commands/debug.py
 msgid "No active session."
 msgstr "Nenhuma sessão ativa."
 
-#: src/iac_code/commands/effort.py:54 src/iac_code/commands/model.py:95
-#: src/iac_code/commands/model.py:99
+#: src/iac_code/commands/effort.py src/iac_code/commands/model.py
 msgid "No configured providers. Run /auth first."
 msgstr "Nenhum provedor configurado. Execute /auth primeiro."
 
-#: src/iac_code/commands/effort.py:58
+#: src/iac_code/commands/effort.py
 msgid "No model selected. Run /model first."
 msgstr "Nenhum modelo selecionado. Execute /model primeiro."
 
-#: src/iac_code/commands/effort.py:66
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Model {model} does not support effort."
 msgstr "O modelo {model} não suporta nível de esforço (effort)."
 
-#: src/iac_code/commands/effort.py:80
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Invalid effort. Allowed: {labels}"
 msgstr "Esforço inválido. Valores permitidos: {labels}"
 
-#: src/iac_code/commands/effort.py:85
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Current effort: {effort}"
 msgstr "Esforço atual: {effort}"
 
-#: src/iac_code/commands/effort.py:94
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Select effort for {model}"
 msgstr "Selecionar esforço para {model}"
 
-#: src/iac_code/commands/effort.py:103 src/iac_code/commands/effort.py:107
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Kept effort as {effort}"
 msgstr "Esforço mantido como {effort}"
 
-#: src/iac_code/commands/effort.py:116
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Effort switched to: {effort}"
 msgstr "Esforço alterado para: {effort}"
 
-#: src/iac_code/commands/help.py:29
+#: src/iac_code/commands/help.py
 msgid "Commands:"
 msgstr "Comandos:"
 
-#: src/iac_code/commands/help.py:36
+#: src/iac_code/commands/help.py
 msgid "Shortcuts:"
 msgstr "Atalhos:"
 
-#: src/iac_code/commands/help.py:39
+#: src/iac_code/commands/help.py
 msgid "Send message"
 msgstr "Enviar mensagem"
 
-#: src/iac_code/commands/help.py:40
+#: src/iac_code/commands/help.py
 msgid "New line"
 msgstr "Nova linha"
 
-#: src/iac_code/commands/help.py:41
+#: src/iac_code/commands/help.py
 msgid "Show command suggestions"
 msgstr "Mostrar sugestões de comando"
 
-#: src/iac_code/commands/help.py:42
+#: src/iac_code/commands/help.py
 msgid "Exit"
 msgstr "Sair"
 
-#: src/iac_code/commands/memory.py:10
+#: src/iac_code/commands/memory.py
 msgid "Usage: /memory [<name>|search <query>|delete <name>|help]"
 msgstr "Uso: /memory [<nome>|search <consulta>|delete <nome>|help]"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "Saved memories:"
 msgstr "Memórias salvas:"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "No memories saved yet."
 msgstr "Ainda não há memórias salvas."
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "Matching memories:"
 msgstr "Memórias correspondentes:"
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "No matching memories."
 msgstr "Nenhuma memória correspondente."
 
-#: src/iac_code/commands/memory.py:60 src/iac_code/commands/memory.py:75
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' not found."
 msgstr "Memória '{name}' não encontrada."
 
-#: src/iac_code/commands/memory.py:64
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' deleted."
 msgstr "Memória '{name}' excluída."
 
-#: src/iac_code/commands/model.py:57
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid ""
 "Model is managed by '{source}'. To change model, modify it in {source} or"
@@ -1136,183 +1123,181 @@ msgstr ""
 "O modelo é gerenciado por '{source}'. Para alterá-lo, modifique em "
 "{source} ou troque de provedor via /auth."
 
-#: src/iac_code/commands/model.py:88 src/iac_code/commands/model.py:143
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Model switched to: {model}"
 msgstr "Modelo alterado para: {model}"
 
-#: src/iac_code/commands/model.py:92
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Current model: {model}"
 msgstr "Modelo atual: {model}"
 
-#: src/iac_code/commands/model.py:118
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Kept model as {model}"
 msgstr "Modelo mantido como {model}"
 
-#: src/iac_code/commands/rename.py:16 src/iac_code/commands/rename.py:28
+#: src/iac_code/commands/rename.py
 msgid "Rename is only available in interactive mode."
 msgstr "Renomear só está disponível no modo interativo."
 
-#: src/iac_code/commands/rename.py:31
+#: src/iac_code/commands/rename.py
 msgid "Rename cancelled"
 msgstr "Renomeação cancelada"
 
-#: src/iac_code/commands/resume.py:22
+#: src/iac_code/commands/resume.py
 msgid "Resume is only available in interactive mode."
 msgstr "Retomar está disponível apenas no modo interativo."
 
-#: src/iac_code/commands/resume.py:28
+#: src/iac_code/commands/resume.py
 msgid "Resume is unavailable: session index not initialised."
 msgstr "Não é possível retomar: índice de sessões não inicializado."
 
-#: src/iac_code/commands/resume.py:33 src/iac_code/commands/resume.py:36
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Session not found: {arg}"
 msgstr "Sessão não encontrada: {arg}"
 
-#: src/iac_code/commands/resume.py:52 src/iac_code/commands/resume.py:68
+#: src/iac_code/commands/resume.py
 msgid "Resume cancelled"
 msgstr "Retomada cancelada"
 
-#: src/iac_code/commands/resume.py:55
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Unable to resolve session: {arg}"
 msgstr "Não foi possível resolver a sessão: {arg}"
 
-#: src/iac_code/commands/skills.py:14
+#: src/iac_code/commands/skills.py
 msgid "Skills management is only available in interactive mode."
 msgstr "O gerenciamento de habilidades só está disponível no modo interativo."
 
-#: src/iac_code/commands/skills.py:25
+#: src/iac_code/commands/skills.py
 msgid "Skills update cancelled"
 msgstr "Atualização de habilidades cancelada"
 
-#: src/iac_code/commands/skills.py:29
+#: src/iac_code/commands/skills.py
 msgid "Skills updated"
 msgstr "Habilidades atualizadas"
 
-#: src/iac_code/commands/status.py:19
+#: src/iac_code/commands/status.py
 msgid "Status command requires a context."
 msgstr "O comando status requer um contexto."
 
-#: src/iac_code/commands/status.py:22
+#: src/iac_code/commands/status.py
 msgid "Status command requires a REPL context."
 msgstr "O comando status requer um contexto REPL."
 
-#: src/iac_code/commands/status.py:24
+#: src/iac_code/commands/status.py
 msgid "Status is only available in interactive mode."
 msgstr "status está disponível apenas no modo interativo."
 
-#: src/iac_code/commands/status.py:33 src/iac_code/ui/banner.py:136
-#: src/iac_code/ui/banner.py:138
+#: src/iac_code/commands/status.py src/iac_code/ui/banner.py
 msgid "Session"
 msgstr "Sessão"
 
-#: src/iac_code/commands/status.py:34
+#: src/iac_code/commands/status.py
 msgid "Provider"
 msgstr "Provedor"
 
-#: src/iac_code/commands/status.py:34 src/iac_code/commands/status.py:35
-#: src/iac_code/commands/status.py:36
+#: src/iac_code/commands/status.py
 msgid "not configured"
 msgstr "não configurado"
 
-#: src/iac_code/commands/status.py:35
+#: src/iac_code/commands/status.py
 msgid "Model"
 msgstr "Modelo"
 
-#: src/iac_code/commands/status.py:37
+#: src/iac_code/commands/status.py
 msgid "CWD"
 msgstr "Diretório atual"
 
-#: src/iac_code/commands/status.py:41
+#: src/iac_code/commands/status.py
 msgid "API Token Usage (recorded):"
 msgstr "Uso de tokens da API (registrado):"
 
-#: src/iac_code/commands/status.py:44
+#: src/iac_code/commands/status.py
 msgid "Input"
 msgstr "Entrada"
 
-#: src/iac_code/commands/status.py:45
+#: src/iac_code/commands/status.py
 msgid "Output"
 msgstr "Saída"
 
-#: src/iac_code/commands/status.py:46
+#: src/iac_code/commands/status.py
 msgid "Cache read"
 msgstr "Leitura de cache"
 
-#: src/iac_code/commands/status.py:47
+#: src/iac_code/commands/status.py
 msgid "Total"
 msgstr "Total"
 
-#: src/iac_code/commands/status.py:50
+#: src/iac_code/commands/status.py
 msgid "No recorded API usage for this session yet."
 msgstr "Ainda não há uso de API registrado para esta sessão."
 
-#: src/iac_code/commands/status.py:54
+#: src/iac_code/commands/status.py
 msgid "Turns"
 msgstr "Turnos"
 
-#: src/iac_code/commands/status.py:55
+#: src/iac_code/commands/status.py
 msgid "Context"
 msgstr "Contexto"
 
-#: src/iac_code/commands/status.py:57
+#: src/iac_code/commands/status.py
 msgid "Session Status"
 msgstr "Status da sessão"
 
-#: src/iac_code/commands/status.py:73
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{session_id} (resumed)"
 msgstr "{session_id} (retomada)"
 
-#: src/iac_code/commands/status.py:81
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{percent} used ({total} / {window})"
 msgstr "{percent} usado ({total} / {window})"
 
 # Typer/Click built-in strings
-#: src/iac_code/i18n/__init__.py:51
+#: src/iac_code/i18n/__init__.py
 msgid "Options"
 msgstr "Opções"
 
-#: src/iac_code/i18n/__init__.py:52
+#: src/iac_code/i18n/__init__.py
 msgid "Commands"
 msgstr "Comandos"
 
-#: src/iac_code/i18n/__init__.py:53
+#: src/iac_code/i18n/__init__.py
 msgid "Arguments"
 msgstr "Argumentos"
 
-#: src/iac_code/i18n/__init__.py:54
+#: src/iac_code/i18n/__init__.py
 msgid "Show this message and exit."
 msgstr "Mostrar esta mensagem e sair."
 
-#: src/iac_code/i18n/__init__.py:57
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "default: {default}"
 msgstr "padrão: {default}"
 
-#: src/iac_code/i18n/__init__.py:58
+#: src/iac_code/i18n/__init__.py
 msgid "required"
 msgstr "obrigatório"
 
-#: src/iac_code/i18n/__init__.py:59
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "env var: {var}"
 msgstr "variável de ambiente: {var}"
 
-#: src/iac_code/i18n/__init__.py:60
+#: src/iac_code/i18n/__init__.py
 msgid "(dynamic)"
 msgstr "(dinâmico)"
 
-#: src/iac_code/i18n/__init__.py:61
+#: src/iac_code/i18n/__init__.py
 msgid "Aborted!"
 msgstr "Abortado!"
 
-#: src/iac_code/providers/manager.py:78
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Cannot determine provider for model: {model}. Run /auth to configure."
 msgstr ""
@@ -1321,12 +1306,12 @@ msgstr ""
 "configure.Não é possível determinar o provedor para o modelo: {model}. "
 "Execute /auth para configurar."
 
-#: src/iac_code/providers/manager.py:95
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Unknown provider key: '{key}'. Run /auth to configure."
 msgstr "Chave de provedor desconhecida: '{key}'. Execute /auth para configurar."
 
-#: src/iac_code/providers/manager.py:100
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid ""
 "No API key configured for provider '{provider}' (model: {model}). Run "
@@ -1335,7 +1320,7 @@ msgstr ""
 "Nenhuma chave API configurada para o provedor '{provider}' (modelo: "
 "{model}). Execute /auth para configurar."
 
-#: src/iac_code/providers/openai_provider.py:307
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned no data. Please check that your API Base URL is correct "
@@ -1346,7 +1331,7 @@ msgstr ""
 "(atual: {base_url}). Muitos endpoints compatíveis com OpenAI exigem o "
 "sufixo /v1 (por exemplo, {base_url}/v1)."
 
-#: src/iac_code/providers/openai_provider.py:348
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned an invalid response. Please check that your API Base URL is "
@@ -1357,83 +1342,83 @@ msgstr ""
 "correta (atual: {base_url}). Muitos endpoints compatíveis com OpenAI "
 "exigem o sufixo /v1 (por exemplo, {base_url}/v1)."
 
-#: src/iac_code/providers/registry.py:416
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
 msgstr "Alibaba Cloud Bailian"
 
-#: src/iac_code/providers/registry.py:417
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian Token Plan"
 msgstr "Alibaba Cloud Bailian Token Plan"
 
-#: src/iac_code/providers/registry.py:421
+#: src/iac_code/providers/registry.py
 msgid "OpenAPI Compatible"
 msgstr "Compatível com OpenAPI"
 
-#: src/iac_code/providers/registry.py:423
+#: src/iac_code/providers/registry.py
 msgid "Kimi (China)"
 msgstr "Kimi (China)"
 
-#: src/iac_code/providers/registry.py:424
+#: src/iac_code/providers/registry.py
 msgid "Kimi (International)"
 msgstr "Kimi (Internacional)"
 
-#: src/iac_code/providers/registry.py:425
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (China)"
 msgstr "MiniMax (China)"
 
-#: src/iac_code/providers/registry.py:426
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (International)"
 msgstr "MiniMax (Internacional)"
 
-#: src/iac_code/providers/registry.py:428
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI (International)"
 msgstr "ZhiPu AI (Internacional)"
 
-#: src/iac_code/providers/registry.py:430
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (China)"
 msgstr "SiliconFlow (China)"
 
-#: src/iac_code/providers/registry.py:431
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (International)"
 msgstr "SiliconFlow (Internacional)"
 
-#: src/iac_code/providers/registry.py:432
+#: src/iac_code/providers/registry.py
 msgid "Ollama (Local)"
 msgstr "Ollama (Local)"
 
-#: src/iac_code/providers/registry.py:433
+#: src/iac_code/providers/registry.py
 msgid "LM Studio (Local)"
 msgstr "LM Studio (Local)"
 
-#: src/iac_code/providers/registry.py:436
+#: src/iac_code/providers/registry.py
 msgid "ModelScope"
 msgstr "ModelScope"
 
-#: src/iac_code/providers/registry.py:437
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan"
 msgstr "Alibaba Cloud CodingPlan"
 
-#: src/iac_code/providers/registry.py:438
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan (International)"
 msgstr "Alibaba Cloud CodingPlan (Internacional)"
 
-#: src/iac_code/providers/registry.py:439
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan"
 msgstr "ZhiPu AI CodingPlan"
 
-#: src/iac_code/providers/registry.py:440
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan (International)"
 msgstr "ZhiPu AI CodingPlan (Internacional)"
 
-#: src/iac_code/providers/registry.py:441
+#: src/iac_code/providers/registry.py
 msgid "Volcengine CodingPlan"
 msgstr "Volcengine CodingPlan"
 
-#: src/iac_code/providers/registry.py:442
+#: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Compatível com Anthropic"
 
-#: src/iac_code/services/qwenpaw_source.py:205
+#: src/iac_code/services/qwenpaw_source.py
 #, python-brace-format
 msgid ""
 "[QwenPaw mode] Unknown provider '{provider_id}'. iac-code does not "
@@ -1448,90 +1433,90 @@ msgstr ""
 "Solução: mude para um provider suportado no QwenPaw, ou desative o modo "
 "QwenPaw (remova 'llm_source: qwenpaw' do settings.yml)."
 
-#: src/iac_code/services/session_metadata.py:52
+#: src/iac_code/services/session_metadata.py
 #, python-brace-format
 msgid "Session name must match {pattern}"
 msgstr "O nome da sessão deve corresponder a {pattern}"
 
-#: src/iac_code/services/session_storage.py:241
+#: src/iac_code/services/session_storage.py
 #, python-brace-format
 msgid "Session name already exists in this project: {name}"
 msgstr "O nome da sessão já existe neste projeto: {name}"
 
-#: src/iac_code/services/permissions/loader.py:50
+#: src/iac_code/services/permissions/loader.py
 #, python-brace-format
 msgid "Invalid --permission-mode {!r}. Valid values: {}"
 msgstr "--permission-mode inválido {!r}. Valores válidos: {}"
 
-#: src/iac_code/services/permissions/pipeline.py:54
-#: src/iac_code/tools/base.py:199 src/iac_code/tools/bash/bash_tool.py:175
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Allow {}?"
 msgstr "Permitir {}?"
 
-#: src/iac_code/services/providers/aliyun.py:144
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
 msgstr "O site OAuth da Alibaba Cloud está ausente."
 
-#: src/iac_code/services/providers/aliyun.py:150
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth refresh token is missing."
 msgstr "O token de atualização OAuth da Alibaba Cloud está ausente."
 
-#: src/iac_code/services/providers/aliyun.py:158
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth access token is missing."
 msgstr "O token de acesso OAuth da Alibaba Cloud está ausente."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:83
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Run /auth and choose OAuth Login (Browser)."
 msgstr "Execute /auth e escolha Login OAuth (navegador)."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:106
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "Unknown Aliyun OAuth site: {site_type}"
 msgstr "Site OAuth Aliyun desconhecido: {site_type}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:164
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Not found"
 msgstr "Não encontrado"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:170
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "invalid state"
 msgstr "estado inválido"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:171
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Invalid state"
 msgstr "Estado inválido"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:176
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "code not found"
 msgstr "código de autorização não encontrado"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:177
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization code not found"
 msgstr "Código de autorização não encontrado"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:181
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization successful. You can close this window."
 msgstr "Autorização bem-sucedida. Você pode fechar esta janela."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:212
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "No available callback port in range {start}-{end}"
 msgstr "Nenhuma porta de callback disponível no intervalo {start}-{end}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:227
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "OAuth login cancelled."
 msgstr "Login OAuth cancelado."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:278
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Open in your browser:"
 msgstr "Abrir no navegador:"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:299
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Waiting for browser authorization"
 msgstr "Aguardando autorização do navegador"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:300
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "1. The browser may show official-cli; this is the Alibaba Cloud official "
 "CLI OAuth application."
@@ -1539,7 +1524,7 @@ msgstr ""
 "1. O navegador pode mostrar official-cli; este é o aplicativo OAuth "
 "oficial da CLI da Alibaba Cloud."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:302
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "2. If assignment is required, assign the RAM user or RAM role that is "
 "signed in. User groups are not supported."
@@ -1547,7 +1532,7 @@ msgstr ""
 "2. Se a atribuição for necessária, atribua o usuário RAM ou a função RAM "
 "que está conectada. Grupos de usuários não são compatíveis."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:306
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "3. After assignment, close the old authorization page and run OAuth Login"
 " (Browser) again. If it still fails, sign out of Alibaba Cloud and sign "
@@ -1557,7 +1542,7 @@ msgstr ""
 "Login OAuth (navegador) novamente. Se ainda falhar, saia da Alibaba Cloud"
 " e entre novamente."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:310
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "4. STS credentials refresh when possible until Alibaba Cloud expires "
 "them. If refresh fails, run /auth again."
@@ -1565,11 +1550,11 @@ msgstr ""
 "4. As credenciais STS são atualizadas quando possível até expirarem na "
 "Alibaba Cloud. Se a atualização falhar, execute /auth novamente."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:313
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Press Esc to cancel while waiting."
 msgstr "Pressione Esc para cancelar a espera."
 
-#: src/iac_code/services/providers/aliyun_oauth.py:321
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "Timed out waiting for OAuth callback. If Alibaba Cloud asked you to "
 "assign the official-cli application, assign it to the exact RAM user or "
@@ -1584,26 +1569,26 @@ msgstr ""
 "entre novamente se necessário, e execute /auth para escolher Login OAuth "
 "(navegador) novamente."
 
-#: src/iac_code/skills/skill_tool.py:85 src/iac_code/ui/repl.py:842
+#: src/iac_code/skills/skill_tool.py src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Skill '{name}' is disabled. Run /skills to enable it."
 msgstr "A habilidade '{name}' está desativada. Execute /skills para ativá-la."
 
-#: src/iac_code/skills/skill_tool.py:137
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill '{name}' loaded (inline)."
 msgstr "Skill '{name}' carregada (inline)."
 
-#: src/iac_code/skills/skill_tool.py:221
+#: src/iac_code/skills/skill_tool.py
 msgid "Skill"
 msgstr "Skill"
 
-#: src/iac_code/skills/skill_tool.py:245
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill disabled: {name}"
 msgstr "Habilidade desativada: {name}"
 
-#: src/iac_code/skills/bundled/simplify.py:25
+#: src/iac_code/skills/bundled/simplify.py
 msgid ""
 "Review changed code for reuse, quality, and efficiency, then fix issues "
 "found."
@@ -1611,508 +1596,507 @@ msgstr ""
 "Revise o código alterado quanto à reutilização, qualidade e eficiência e,"
 " em seguida, corrija os problemas encontrados."
 
-#: src/iac_code/tools/edit_file.py:116
+#: src/iac_code/tools/edit_file.py
 msgid "Edit"
 msgstr "Editar"
 
-#: src/iac_code/tools/edit_file.py:118
+#: src/iac_code/tools/edit_file.py
 msgid "Create"
 msgstr "Criar"
 
-#: src/iac_code/tools/edit_file.py:119
+#: src/iac_code/tools/edit_file.py
 msgid "Update"
 msgstr "Atualizar"
 
-#: src/iac_code/tools/edit_file.py:126
+#: src/iac_code/tools/edit_file.py
 #, python-brace-format
 msgid "Editing {path}"
 msgstr "Editando {path}"
 
-#: src/iac_code/tools/edit_file.py:127
+#: src/iac_code/tools/edit_file.py
 msgid "Editing file..."
 msgstr "Editando arquivo..."
 
-#: src/iac_code/tools/glob.py:86 src/iac_code/tools/grep.py:237
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Found 0 files"
 msgstr "0 arquivos encontrados"
 
-#: src/iac_code/tools/glob.py:89 src/iac_code/tools/grep.py:240
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Found {count} files"
 msgstr "{count} arquivos encontrados"
 
-#: src/iac_code/tools/glob.py:95 src/iac_code/tools/grep.py:246
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Search"
 msgstr "Buscar"
 
-#: src/iac_code/tools/glob.py:100
+#: src/iac_code/tools/glob.py
 #, python-brace-format
 msgid "Searching {pattern}"
 msgstr "Buscando {pattern}"
 
-#: src/iac_code/tools/glob.py:101
+#: src/iac_code/tools/glob.py
 msgid "Searching files..."
 msgstr "Buscando arquivos..."
 
-#: src/iac_code/tools/grep.py:251
+#: src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Searching for {pattern}"
 msgstr "Buscando por {pattern}"
 
-#: src/iac_code/tools/grep.py:252
+#: src/iac_code/tools/grep.py
 msgid "Searching content..."
 msgstr "Buscando no conteúdo..."
 
-#: src/iac_code/tools/list_files.py:82
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Found {count} items"
 msgstr "{count} itens encontrados"
 
-#: src/iac_code/tools/list_files.py:88
+#: src/iac_code/tools/list_files.py
 msgid "List"
 msgstr "Listar"
 
-#: src/iac_code/tools/list_files.py:92
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Listing {path}"
 msgstr "Listando {path}"
 
-#: src/iac_code/tools/list_files.py:93
+#: src/iac_code/tools/list_files.py
 msgid "Listing files..."
 msgstr "Listando arquivos..."
 
-#: src/iac_code/tools/read_file.py:117
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Read {total} lines"
 msgstr "{total} linhas lidas"
 
-#: src/iac_code/tools/read_file.py:120
+#: src/iac_code/tools/read_file.py
 msgid "Read"
 msgstr "Ler"
 
-#: src/iac_code/tools/read_file.py:127
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Reading {path}"
 msgstr "Lendo {path}"
 
-#: src/iac_code/tools/read_file.py:128
+#: src/iac_code/tools/read_file.py
 msgid "Reading file..."
 msgstr "Lendo arquivo..."
 
-#: src/iac_code/tools/web_fetch.py:94
+#: src/iac_code/tools/web_fetch.py
 msgid "URL cannot be empty."
 msgstr "A URL não pode estar vazia."
 
-#: src/iac_code/tools/web_fetch.py:100
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}"
 msgstr ""
 "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}URL "
 "inválida: esquema ausente (ex.: http:// ou https://). Recebido: {url}"
 
-#: src/iac_code/tools/web_fetch.py:103
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing host/netloc. Got: {url}"
 msgstr "URL inválida: host ausente. Recebido: {url}"
 
-#: src/iac_code/tools/web_fetch.py:129
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "HTTP error {status}: {url}"
 msgstr "Erro HTTP {status}: {url}"
 
-#: src/iac_code/tools/web_fetch.py:131
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Failed to fetch {url}: {error}"
 msgstr "Falha ao obter {url}: {error}"
 
-#: src/iac_code/tools/web_fetch.py:133
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Unexpected error fetching {url}: {error}"
 msgstr "Erro inesperado ao obter {url}: {error}"
 
-#: src/iac_code/tools/web_fetch.py:147
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetched {chars} chars, {lines} lines"
 msgstr "Obtidos {chars} caracteres, {lines} linhas"
 
-#: src/iac_code/tools/web_fetch.py:159
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetch"
 msgstr "Fetch"
 
-#: src/iac_code/tools/web_fetch.py:165
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetching {url}"
 msgstr "Obtendo {url}"
 
-#: src/iac_code/tools/web_fetch.py:166
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetching web page..."
 msgstr "Obtendo página web..."
 
-#: src/iac_code/tools/write_file.py:67
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Successfully wrote {lines} lines to {path}"
 msgstr "{lines} linhas gravadas com sucesso em {path}"
 
-#: src/iac_code/tools/write_file.py:81
+#: src/iac_code/tools/write_file.py
 msgid "Write"
 msgstr "Gravar"
 
-#: src/iac_code/tools/write_file.py:88
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Writing {path}"
 msgstr "Gravando {path}"
 
-#: src/iac_code/tools/write_file.py:89
+#: src/iac_code/tools/write_file.py
 msgid "Writing file..."
 msgstr "Gravando arquivo..."
 
-#: src/iac_code/tools/bash/bash_tool.py:81
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Command timed out after {timeout} seconds: {command}"
 msgstr "O comando expirou após {timeout} segundos: {command}"
 
-#: src/iac_code/tools/bash/bash_tool.py:103
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Error executing command: {}"
 msgstr "Erro ao executar o comando: {}"
 
-#: src/iac_code/tools/bash/bash_tool.py:129
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "{count} more lines"
 msgstr "mais {count} linhas"
 
-#: src/iac_code/tools/bash/bash_tool.py:137
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Bash"
 msgstr "Bash"
 
-#: src/iac_code/tools/bash/bash_tool.py:143
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Running {cmd}"
 msgstr "Executando {cmd}"
 
-#: src/iac_code/tools/bash/bash_tool.py:144
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Running command..."
 msgstr "Executando comando..."
 
-#: src/iac_code/tools/bash/command_parser.py:42
+#: src/iac_code/tools/bash/command_parser.py
 msgid "parse error"
 msgstr "Erro de análise"
 
-#: src/iac_code/tools/bash/command_parser.py:46
+#: src/iac_code/tools/bash/command_parser.py
 msgid "unsupported shell construct"
 msgstr "Construção de shell não suportada"
 
-#: src/iac_code/tools/bash/path_validation.py:111
+#: src/iac_code/tools/bash/path_validation.py
 #, python-brace-format
 msgid "path outside allowed directories: {}"
 msgstr "Caminho fora dos diretórios permitidos: {}"
 
-#: src/iac_code/tools/bash/permissions.py:135
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s): {}"
 msgstr "Regra(s) de negação correspondente(s): {}"
 
-#: src/iac_code/tools/bash/permissions.py:142
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Regra(s) de consulta correspondente(s): {}"
 
-#: src/iac_code/tools/bash/permissions.py:154
-#: src/iac_code/tools/bash/permissions.py:220
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched allow rule(s): {}"
 msgstr "Regra(s) de permissão correspondente(s): {}"
 
-#: src/iac_code/tools/bash/permissions.py:162
+#: src/iac_code/tools/bash/permissions.py
 msgid "complex command requires confirmation"
 msgstr "Comando complexo requer confirmação"
 
-#: src/iac_code/tools/bash/permissions.py:171
+#: src/iac_code/tools/bash/permissions.py
 msgid "sed in-place edit requires confirmation"
 msgstr "A edição sed no local requer confirmação"
 
-#: src/iac_code/tools/bash/permissions.py:194
+#: src/iac_code/tools/bash/permissions.py
 msgid "command failed basic safety checks"
 msgstr "O comando não passou nas verificações básicas de segurança"
 
-#: src/iac_code/tools/bash/permissions.py:210
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s) on full command: {}"
 msgstr "Regra(s) de negação para o comando completo: {}"
 
-#: src/iac_code/tools/bash/permissions.py:227
+#: src/iac_code/tools/bash/permissions.py
 msgid "command too complex to analyze"
 msgstr "Comando complexo demais para analisar"
 
-#: src/iac_code/tools/bash/permissions.py:229
+#: src/iac_code/tools/bash/permissions.py
 msgid "could not parse command"
 msgstr "Não foi possível analisar o comando"
 
-#: src/iac_code/tools/bash/permissions.py:245
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "too many subcommands (>{})"
 msgstr "Muitos subcomandos (>{})"
 
-#: src/iac_code/tools/bash/permissions.py:258
+#: src/iac_code/tools/bash/permissions.py
 msgid "multiple cd commands in compound command"
 msgstr "Múltiplos comandos cd em comando composto"
 
-#: src/iac_code/tools/bash/permissions.py:271
+#: src/iac_code/tools/bash/permissions.py
 msgid "cd combined with git in compound command"
 msgstr "cd combinado com git em comando composto"
 
-#: src/iac_code/tools/bash/safety_checks.py:151
+#: src/iac_code/tools/bash/safety_checks.py
 #, python-brace-format
 msgid "operation touches a sensitive path: {}"
 msgstr "A operação afeta um caminho sensível: {}"
 
-#: src/iac_code/tools/cloud/base_api.py:92
+#: src/iac_code/tools/cloud/base_api.py
 msgid "CloudAPI"
 msgstr "API na nuvem"
 
-#: src/iac_code/tools/cloud/base_api.py:116
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Calling {action}..."
 msgstr "Chamando {action}..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:400
-#: src/iac_code/tools/cloud/base_api.py:123
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#: src/iac_code/tools/cloud/base_api.py
 msgid "Call succeeded"
 msgstr "Chamada bem-sucedida"
 
-#: src/iac_code/tools/cloud/base_api.py:144
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Received response ({count} lines)"
 msgstr "Resposta recebida ({count} linhas)"
 
-#: src/iac_code/tools/cloud/base_stack.py:133
+#: src/iac_code/tools/cloud/base_stack.py
 msgid "CloudStack"
 msgstr "CloudStack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:117
-#: src/iac_code/tools/cloud/base_stack.py:150
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
+#: src/iac_code/tools/cloud/base_stack.py
 #, python-brace-format
 msgid "Running {action}..."
 msgstr "Executando {action}..."
 
-#: src/iac_code/tools/cloud/types.py:8
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_IN_PROGRESS"
 msgstr "Criação em andamento"
 
-#: src/iac_code/tools/cloud/types.py:9
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_FAILED"
 msgstr "Falha na criação"
 
-#: src/iac_code/tools/cloud/types.py:10
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_COMPLETE"
 msgstr "Criação concluída"
 
-#: src/iac_code/tools/cloud/types.py:11
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_IN_PROGRESS"
 msgstr "Atualização em andamento"
 
-#: src/iac_code/tools/cloud/types.py:12
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_FAILED"
 msgstr "Falha na atualização"
 
-#: src/iac_code/tools/cloud/types.py:13
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_COMPLETE"
 msgstr "Atualização concluída"
 
-#: src/iac_code/tools/cloud/types.py:14
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_IN_PROGRESS"
 msgstr "Exclusão em andamento"
 
-#: src/iac_code/tools/cloud/types.py:15
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_FAILED"
 msgstr "Falha na exclusão"
 
-#: src/iac_code/tools/cloud/types.py:16
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_COMPLETE"
 msgstr "Exclusão concluída"
 
-#: src/iac_code/tools/cloud/types.py:17
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "Reversão da criação em andamento"
 
-#: src/iac_code/tools/cloud/types.py:18
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_FAILED"
 msgstr "Falha na reversão da criação"
 
-#: src/iac_code/tools/cloud/types.py:19
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_COMPLETE"
 msgstr "Reversão da criação concluída"
 
-#: src/iac_code/tools/cloud/types.py:20
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_IN_PROGRESS"
 msgstr "Reversão em andamento"
 
-#: src/iac_code/tools/cloud/types.py:21
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_FAILED"
 msgstr "Falha na reversão"
 
-#: src/iac_code/tools/cloud/types.py:22
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_COMPLETE"
 msgstr "Reversão concluída"
 
-#: src/iac_code/tools/cloud/types.py:23
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_IN_PROGRESS"
 msgstr "Verificação em andamento"
 
-#: src/iac_code/tools/cloud/types.py:24
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_FAILED"
 msgstr "Falha na verificação"
 
-#: src/iac_code/tools/cloud/types.py:25
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_COMPLETE"
 msgstr "Verificação concluída"
 
-#: src/iac_code/tools/cloud/types.py:26
+#: src/iac_code/tools/cloud/types.py
 msgid "REVIEW_IN_PROGRESS"
 msgstr "Revisão em andamento"
 
-#: src/iac_code/tools/cloud/types.py:27
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_IN_PROGRESS"
 msgstr "Importação (criação) em andamento"
 
-#: src/iac_code/tools/cloud/types.py:28
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_FAILED"
 msgstr "Falha na importação (criação)"
 
-#: src/iac_code/tools/cloud/types.py:29
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_COMPLETE"
 msgstr "Importação (criação) concluída"
 
-#: src/iac_code/tools/cloud/types.py:30
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "Reversão da importação (criação) em andamento"
 
-#: src/iac_code/tools/cloud/types.py:31
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_FAILED"
 msgstr "Falha na reversão da importação (criação)"
 
-#: src/iac_code/tools/cloud/types.py:32
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_COMPLETE"
 msgstr "Reversão da importação (criação) concluída"
 
-#: src/iac_code/tools/cloud/types.py:33
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_IN_PROGRESS"
 msgstr "Importação (atualização) em andamento"
 
-#: src/iac_code/tools/cloud/types.py:34
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_FAILED"
 msgstr "Falha na importação (atualização)"
 
-#: src/iac_code/tools/cloud/types.py:35
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_COMPLETE"
 msgstr "Importação (atualização) concluída"
 
-#: src/iac_code/tools/cloud/types.py:36
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_IN_PROGRESS"
 msgstr "Reversão da importação (atualização) em andamento"
 
-#: src/iac_code/tools/cloud/types.py:37
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_FAILED"
 msgstr "Falha na reversão da importação (atualização)"
 
-#: src/iac_code/tools/cloud/types.py:38
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_COMPLETE"
 msgstr "Reversão da importação (atualização) concluída"
 
-#: src/iac_code/tools/cloud/types.py:40
+#: src/iac_code/tools/cloud/types.py
 msgid "INIT_COMPLETE"
 msgstr "Inicialização concluída"
 
-#: src/iac_code/tools/cloud/types.py:41
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_IN_PROGRESS"
 msgstr "Importação em andamento"
 
-#: src/iac_code/tools/cloud/types.py:42
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_COMPLETE"
 msgstr "Importação concluída"
 
-#: src/iac_code/tools/cloud/types.py:43
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_FAILED"
 msgstr "Falha na importação"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:172
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 msgid "Aliyun API"
 msgstr "Aliyun API"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:399
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Chamada bem-sucedida (RequestId: {request_id})"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:57
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "DocSearch"
 msgstr "DocSearch"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:70
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Searching docs for {keywords}..."
 msgstr "Buscando documentação para {keywords}..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:71
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Searching docs..."
 msgstr "Buscando documentação..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:76
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "keywords cannot be empty."
 msgstr "As palavras-chave não podem estar vazias."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:96
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "HTTP error {status} when searching docs."
 msgstr "Erro HTTP {status} ao buscar documentação."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:98
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Failed to search docs: {error}"
 msgstr "Falha ao buscar documentação: {error}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:103
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Failed to parse search response as JSON."
 msgstr "Falha ao analisar a resposta da busca como JSON."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:106
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Search API returned failure."
 msgstr "A API de busca retornou falha."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:125
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "No documents found"
 msgstr "Nenhum documento encontrado"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:126
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "No documents found for keywords: {keywords}"
 msgstr "Nenhum documento encontrado para as palavras-chave: {keywords}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:141
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Found {count} documents (total {total})"
 msgstr "{count} documentos encontrados (total {total})"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:143
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Use web_fetch tool to read full document content if needed."
 msgstr ""
 "Use web_fetch tool to read full document content if needed.Se necessário,"
 " use a ferramenta web_fetch para ler o conteúdo completo."
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack.py:143
+#: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:100
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:48
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template YAML syntax error: {}"
 msgstr "Erro de sintaxe YAML no modelo: {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:60
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template YAML syntax error (line {line}, column {col}): {problem}\n"
@@ -2123,12 +2107,12 @@ msgstr ""
 "Contexto:\n"
 "{context}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:66
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template JSON syntax error (line {line}, column {col}): {msg}"
 msgstr "Erro de sintaxe JSON no modelo (linha {line}, coluna {col}): {msg}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:85
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template {fmt} parse result is not an object (dict), please check the "
@@ -2137,7 +2121,7 @@ msgstr ""
 "O resultado da análise {fmt} do modelo não é um objeto (dict), por favor "
 "verifique o formato do modelo"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:104
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"
@@ -2145,16 +2129,16 @@ msgstr ""
 "O modelo não contém ROSTemplateFormatVersion (modelos ROS devem incluir "
 "este campo, ex. '2015-09-01')"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:110
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Template is missing Resources (ROS templates must include Resources)"
 msgstr "O modelo não contém Resources (modelos ROS devem incluir Resources)"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:112
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resources must be an object (dict), current type is {}"
 msgstr "Resources deve ser um objeto (dict), o tipo atual é {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:117
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Resource '{name}' definition must be an object (dict), current type is "
@@ -2163,19 +2147,19 @@ msgstr ""
 "A definição do recurso '{name}' deve ser um objeto (dict), o tipo atual é"
 " {type}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:123
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' is missing the Type field"
 msgstr "O recurso '{name}' não possui o campo Type"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:129
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' has incorrect type '{wrong}', should be '{correct}'"
 msgstr ""
 "O recurso '{name}' possui o tipo incorreto '{wrong}', deveria ser "
 "'{correct}'"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:151
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template structure validation found the following issues, please fix and "
 "retry:"
@@ -2183,240 +2167,233 @@ msgstr ""
 "A validação da estrutura do modelo encontrou os seguintes problemas, por "
 "favor corrija e tente novamente:"
 
-#: src/iac_code/ui/banner.py:42 src/iac_code/ui/banner.py:54
+#: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
 msgstr "Atualização disponível! {} -> {}"
 
-#: src/iac_code/ui/banner.py:43
+#: src/iac_code/ui/banner.py
 msgid "Update command"
 msgstr "Comando de atualização"
 
-#: src/iac_code/ui/banner.py:46 src/iac_code/ui/banner.py:58
+#: src/iac_code/ui/banner.py
 msgid "Release notes"
 msgstr "Notas da versão"
 
-#: src/iac_code/ui/banner.py:55
-#, python-brace-format
-msgid "Run {} to update."
-msgstr "Execute {} para atualizar."
-
-#: src/iac_code/ui/banner.py:110
+#: src/iac_code/ui/banner.py
 msgid "Your AI-powered Infrastructure as Code assistant"
 msgstr "Seu assistente de Infrastructure as Code com IA"
 
-#: src/iac_code/ui/banner.py:144
+#: src/iac_code/ui/banner.py
 msgid "Welcome back"
 msgstr "Bem-vindo de volta"
 
-#: src/iac_code/ui/banner.py:161
+#: src/iac_code/ui/banner.py
 msgid "Debug mode"
 msgstr "Modo debug"
 
-#: src/iac_code/ui/banner.py:162
+#: src/iac_code/ui/banner.py
 msgid "Log file"
 msgstr "Arquivo de log"
 
-#: src/iac_code/ui/renderer.py:388 src/iac_code/ui/renderer.py:668
-#: src/iac_code/ui/renderer.py:1455
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Raciocínio por {seconds:.1f}s"
 
-#: src/iac_code/ui/renderer.py:404 src/iac_code/ui/renderer.py:700
-#: src/iac_code/ui/renderer.py:1476
+#: src/iac_code/ui/renderer.py
 msgid "(ctrl+o to expand)"
 msgstr "(ctrl+o para expandir)"
 
-#: src/iac_code/ui/renderer.py:431
+#: src/iac_code/ui/renderer.py
 msgid "Resource"
 msgstr "Recurso"
 
-#: src/iac_code/ui/renderer.py:432
+#: src/iac_code/ui/renderer.py
 msgid "Type"
 msgstr "Tipo"
 
-#: src/iac_code/ui/renderer.py:433 src/iac_code/ui/renderer.py:456
+#: src/iac_code/ui/renderer.py
 msgid "Status"
 msgstr "Status"
 
-#: src/iac_code/ui/renderer.py:454
+#: src/iac_code/ui/renderer.py
 msgid "Account ID"
 msgstr "ID da conta"
 
-#: src/iac_code/ui/renderer.py:542
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Done ({child_count} tool uses{token_info}{elapsed})"
 msgstr "Concluído ({child_count} usos de ferramenta{token_info}{elapsed})"
 
-#: src/iac_code/ui/renderer.py:572
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "+ {count} more tool uses (ctrl+o to expand)"
 msgstr "+ {count} usos adicionais de ferramenta (ctrl+o para expandir)"
 
-#: src/iac_code/ui/renderer.py:1177
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Context auto-compacted: {original} → {compacted} tokens"
 msgstr "Contexto compactado automaticamente: {original} → {compacted} tokens"
 
-#: src/iac_code/ui/renderer.py:1262
+#: src/iac_code/ui/renderer.py
 msgid "Operation cancelled."
 msgstr "Operação cancelada."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "No API key configured."
 msgstr "Nenhuma API key configurada."
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "Please run /auth to set up your LLM provider and API key."
 msgstr "Execute /auth para configurar seu provedor LLM e API key."
 
-#: src/iac_code/ui/renderer.py:1272
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Erro: {error}"
 
-#: src/iac_code/ui/renderer.py:1342
+#: src/iac_code/ui/renderer.py
 msgid "Allow this action?"
 msgstr "Permitir esta ação?"
 
-#: src/iac_code/ui/renderer.py:1345
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow once"
 msgstr "Sim, permitir uma vez"
 
-#: src/iac_code/ui/renderer.py:1359
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Yes, always allow \"{rule}\" (this session)"
 msgstr "Sim, sempre permitir \"{rule}\" (esta sessão)"
 
-#: src/iac_code/ui/renderer.py:1364
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow always for this tool"
 msgstr "Sim, sempre permitir para esta ferramenta"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "No, reject once"
 msgstr "Não, rejeitar uma vez"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "default"
 msgstr "padrão"
 
-#: src/iac_code/ui/renderer.py:1374
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "No, always deny \"{rule}\" (this session)"
 msgstr "Não, sempre negar \"{rule}\" (esta sessão)"
 
-#: src/iac_code/ui/renderer.py:1379
+#: src/iac_code/ui/renderer.py
 msgid "No, always reject this tool"
 msgstr "Não, sempre rejeitar esta ferramenta"
 
-#: src/iac_code/ui/repl.py:424
+#: src/iac_code/ui/repl.py
 msgid "Press Ctrl+C again to exit."
 msgstr "Pressione Ctrl+C novamente para sair."
 
-#: src/iac_code/ui/repl.py:449
+#: src/iac_code/ui/repl.py
 msgid "Interrupted."
 msgstr "Interrompido."
 
-#: src/iac_code/ui/repl.py:508
+#: src/iac_code/ui/repl.py
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/iac_code/ui/repl.py:510
+#: src/iac_code/ui/repl.py
 msgid "Run the shown update command and exit when it succeeds."
 msgstr ""
 "Executa o comando de atualização mostrado e sai quando ele for concluído "
 "com sucesso."
 
-#: src/iac_code/ui/repl.py:513
+#: src/iac_code/ui/repl.py
 msgid "Skip"
 msgstr "Ignorar"
 
-#: src/iac_code/ui/repl.py:515
+#: src/iac_code/ui/repl.py
 msgid "Continue with the current version for this session."
 msgstr "Continuar com a versão atual nesta sessão."
 
-#: src/iac_code/ui/repl.py:518
+#: src/iac_code/ui/repl.py
 msgid "Skip until next version"
 msgstr "Ignorar até a próxima versão"
 
-#: src/iac_code/ui/repl.py:520
+#: src/iac_code/ui/repl.py
 msgid "Hide this update until a newer version is available."
 msgstr "Ocultar esta atualização até que uma versão mais nova esteja disponível."
 
-#: src/iac_code/ui/repl.py:539 src/iac_code/ui/repl.py:551
+#: src/iac_code/ui/repl.py
 msgid "Update command failed. Continuing with the current version."
 msgstr "O comando de atualização falhou. Continuando com a versão atual."
 
-#: src/iac_code/ui/repl.py:544
+#: src/iac_code/ui/repl.py
 msgid "Update completed. Restart iac-code to continue."
 msgstr "Atualização concluída. Reinicie o iac-code para continuar."
 
-#: src/iac_code/ui/repl.py:582
+#: src/iac_code/ui/repl.py
 msgid "No image in clipboard."
 msgstr "Nenhuma imagem na área de transferência."
 
-#: src/iac_code/ui/repl.py:768
+#: src/iac_code/ui/repl.py
 msgid "Usage: !<shell command>"
 msgstr "Uso: !<comando shell>"
 
-#: src/iac_code/ui/repl.py:775
+#: src/iac_code/ui/repl.py
 msgid "Shell command support is unavailable."
 msgstr "O suporte a comandos shell não está disponível."
 
-#: src/iac_code/ui/repl.py:845
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown skill: ${name}. Type / to list commands and skills."
 msgstr ""
 "Habilidade desconhecida: ${name}. Digite / para listar comandos e "
 "habilidades."
 
-#: src/iac_code/ui/repl.py:847
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown command: /{name}. Type /help for available commands."
 msgstr "Comando desconhecido: /{name}. Digite /help para ver os comandos."
 
-#: src/iac_code/ui/repl.py:852
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "$ only invokes skills. Use /{name} instead."
 msgstr "$ invoca apenas habilidades. Use /{name} em vez disso."
 
-#: src/iac_code/ui/repl.py:874 src/iac_code/ui/repl.py:922
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command error: {error}"
 msgstr "Erro de comando: {error}"
 
-#: src/iac_code/ui/repl.py:881
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command has no handler: {name}"
 msgstr "Comando sem tratador: {name}"
 
-#: src/iac_code/ui/repl.py:1156
+#: src/iac_code/ui/repl.py
 msgid "Goodbye!"
 msgstr "Até logo!"
 
-#: src/iac_code/ui/repl.py:1157
+#: src/iac_code/ui/repl.py
 msgid "Resume this session with:"
 msgstr "Para retomar esta sessão, execute:"
 
-#: src/iac_code/ui/repl.py:1160
+#: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "ID da sessão"
 
-#: src/iac_code/ui/repl.py:1210 src/iac_code/ui/repl.py:1214
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Session not found: {session_id}"
 msgstr "Sessão não encontrada: {session_id}"
 
-#: src/iac_code/ui/repl.py:1263
+#: src/iac_code/ui/repl.py
 msgid "Session name: "
 msgstr "Nome da sessão: "
 
-#: src/iac_code/ui/repl.py:1269
+#: src/iac_code/ui/repl.py
 msgid "Session name cannot be empty."
 msgstr "O nome da sessão não pode estar vazio."
 
-#: src/iac_code/ui/repl.py:1279
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "This session belongs to a different directory.\n"
@@ -2427,23 +2404,23 @@ msgstr ""
 "Para retomar, execute:\n"
 "  {cmd}"
 
-#: src/iac_code/ui/repl.py:1283
+#: src/iac_code/ui/repl.py
 msgid "Multiple sessions match. Resume one by ID:"
 msgstr "Várias sessões correspondem. Retome uma por ID:"
 
-#: src/iac_code/ui/repl.py:1396
+#: src/iac_code/ui/repl.py
 msgid "This conversation is from a different directory."
 msgstr "Esta conversa é de outro diretório."
 
-#: src/iac_code/ui/repl.py:1398
+#: src/iac_code/ui/repl.py
 msgid "To resume, run:"
 msgstr "Para retomar, execute:"
 
-#: src/iac_code/ui/repl.py:1403
+#: src/iac_code/ui/repl.py
 msgid "(Command copied to clipboard)"
 msgstr "(Comando copiado para a área de transferência)"
 
-#: src/iac_code/ui/repl.py:1560
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "Current model {model} does not support image input. Use /model to switch "
@@ -2452,12 +2429,12 @@ msgstr ""
 "O modelo atual {model} não suporta entrada de imagem. Use /model para "
 "alternar para um modelo com capacidade de visão."
 
-#: src/iac_code/ui/repl.py:1569
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Image error: {err}"
 msgstr "Erro de imagem: {err}"
 
-#: src/iac_code/ui/repl.py:1586
+#: src/iac_code/ui/repl.py
 msgid ""
 "Failed to persist image to cache; it will only exist in memory for this "
 "turn."
@@ -2465,193 +2442,193 @@ msgstr ""
 "Falha ao persistir a imagem no cache; ela só existirá na memória durante "
 "este turno."
 
-#: src/iac_code/ui/spinner.py:52
+#: src/iac_code/ui/spinner.py
 msgid "Processing"
 msgstr "Processando"
 
-#: src/iac_code/ui/spinner.py:53
+#: src/iac_code/ui/spinner.py
 msgid "Working"
 msgstr "Trabalhando"
 
-#: src/iac_code/ui/spinner.py:62
+#: src/iac_code/ui/spinner.py
 msgid "Thought"
 msgstr "Raciocínio concluído"
 
-#: src/iac_code/ui/spinner.py:63
+#: src/iac_code/ui/spinner.py
 msgid "Processed"
 msgstr "Processado"
 
-#: src/iac_code/ui/spinner.py:64
+#: src/iac_code/ui/spinner.py
 msgid "Worked"
 msgstr "Concluído"
 
-#: src/iac_code/ui/transcript_view.py:158
+#: src/iac_code/ui/transcript_view.py
 msgid "Prompt:"
 msgstr "Prompt:"
 
-#: src/iac_code/ui/transcript_view.py:186
+#: src/iac_code/ui/transcript_view.py
 msgid "Showing transcript · ctrl+o to toggle"
 msgstr "Exibindo transcrição · ctrl+o para alternar"
 
-#: src/iac_code/ui/components/fuzzy_picker.py:120
+#: src/iac_code/ui/components/fuzzy_picker.py
 msgid "No matches found"
 msgstr "Nenhuma correspondência"
 
-#: src/iac_code/ui/core/prompt_input.py:348
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Image in clipboard · ctrl+v to paste"
 msgstr "Imagem na área de transferência · ctrl+v para colar"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Fill"
 msgstr "Preencher"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: src/iac_code/ui/dialogs/global_search.py:55
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "No matching content"
 msgstr "Nenhum conteúdo correspondente"
 
-#: src/iac_code/ui/dialogs/global_search.py:61
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Search in Files"
 msgstr "Buscar em arquivos"
 
-#: src/iac_code/ui/dialogs/global_search.py:62
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Type to search content..."
 msgstr "Digite para buscar no conteúdo..."
 
-#: src/iac_code/ui/dialogs/global_search.py:63
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Enter search query"
 msgstr "Informe a consulta de busca"
 
-#: src/iac_code/ui/dialogs/history_search.py:55
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Search Conversation History"
 msgstr "Buscar no histórico da conversa"
 
-#: src/iac_code/ui/dialogs/history_search.py:56
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Type to search..."
 msgstr "Digite para buscar..."
 
-#: src/iac_code/ui/dialogs/history_search.py:57
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "No conversation history"
 msgstr "Sem histórico de conversa"
 
-#: src/iac_code/ui/dialogs/history_search.py:98
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Message Preview"
 msgstr "Pré-visualização da mensagem"
 
-#: src/iac_code/ui/dialogs/quick_open.py:58
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Open File"
 msgstr "Abrir arquivo"
 
-#: src/iac_code/ui/dialogs/quick_open.py:59
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Type to search files..."
 msgstr "Digite para buscar arquivos..."
 
-#: src/iac_code/ui/dialogs/quick_open.py:60
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "No matching files"
 msgstr "Nenhum arquivo correspondente"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:116
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Search..."
 msgstr "Buscar..."
 
-#: src/iac_code/ui/dialogs/resume_picker.py:374
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Resume Session"
 msgstr "Retomar sessão"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:384
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "No sessions found"
 msgstr "Nenhuma sessão encontrada"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:444
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show current dir"
 msgstr "mostrar diretório atual"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:446
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all projects"
 msgstr "mostrar todos os projetos"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:449
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all branches"
 msgstr "mostrar todos os branches"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:451
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "only show current branch"
 msgstr "mostrar apenas o branch atual"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:452
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "preview"
 msgstr "pré-visualização"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:453
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Type to search"
 msgstr "Digite para buscar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:454
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "cancel"
 msgstr "cancelar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:569
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} more line{s}"
 msgstr "mais {n} linha{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:583
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} message{s}"
 msgstr "{n} mensagem{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:597
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "resume"
 msgstr "retomar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:601
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "back"
 msgstr "voltar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:606
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "scroll"
 msgstr "rolar"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:625
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "(empty session)"
 msgstr "(sessão vazia)"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:745
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "just now"
 msgstr "agora mesmo"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:748
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} minute{s} ago"
 msgstr "há {n} minuto{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:751
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} hour{s} ago"
 msgstr "há {n} hora{s}"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:753
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} day{s} ago"
 msgstr "há {n} dia{s}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:52
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Search skills..."
 msgstr "Buscar habilidades..."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:159
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Skills"
 msgstr "Habilidades"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:161
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "{current} of {total}"
 msgstr "{current} de {total}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:165
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid ""
 "{count} skills - Space to toggle, Enter to save, Tab to sort, Esc to "
@@ -2660,90 +2637,90 @@ msgstr ""
 "{count} habilidades - Espaço para alternar, Enter para salvar, Tab para "
 "ordenar, Esc para cancelar"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:171
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "Sort: {mode}"
 msgstr "Ordenar: {mode}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:176
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "No skills found"
 msgstr "Nenhuma habilidade encontrada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:245
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Bundled skills cannot be disabled."
 msgstr "Habilidades integradas não podem ser desativadas."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "on"
 msgstr "ativada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "off"
 msgstr "desativada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:265
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "locked"
 msgstr "bloqueada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:268
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "matched description"
 msgstr "corresponde à descrição"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:277
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "source"
 msgstr "origem"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:279
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "size"
 msgstr "tamanho"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:280
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "name"
 msgstr "nome"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:285
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "bundled"
 msgstr "integrada"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:287
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "project"
 msgstr "projeto"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:289
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "user"
 msgstr "usuário"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:296
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count}k tokens"
 msgstr "~{count}k tokens"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:297
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count} tokens"
 msgstr "~{count} tokens"
 
-#: src/iac_code/ui/suggestions/command_provider.py:79
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Search saved memories"
 msgstr "Pesquisar memórias salvas"
 
-#: src/iac_code/ui/suggestions/command_provider.py:80
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Delete a saved memory"
 msgstr "Excluir uma memória salva"
 
-#: src/iac_code/ui/suggestions/command_provider.py:81
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Show memory command help"
 msgstr "Mostrar ajuda do comando memory"
 
-#: src/iac_code/ui/suggestions/command_provider.py:116
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Saved memory"
 msgstr "Memória salva"
 
-#: src/iac_code/utils/platform.py:39
+#: src/iac_code/utils/platform.py
 msgid "iac-code on Windows requires Git for Windows."
 msgstr "iac-code no Windows requer o Git for Windows."
 
-#: src/iac_code/utils/platform.py:41
+#: src/iac_code/utils/platform.py
 msgid ""
 "If installed but not on PATH, set IAC_CODE_GIT_BASH_PATH environment "
 "variable."
@@ -2751,15 +2728,15 @@ msgstr ""
 "Se estiver instalado mas não estiver no PATH, defina a variável de "
 "ambiente IAC_CODE_GIT_BASH_PATH."
 
-#: src/iac_code/utils/platform.py:44
+#: src/iac_code/utils/platform.py
 msgid "To install:"
 msgstr "Para instalar:"
 
-#: src/iac_code/utils/platform.py:47
+#: src/iac_code/utils/platform.py
 msgid "  Option 1 - winget (requires access to github.com):"
 msgstr "  Opção 1 - winget (requer acesso a github.com):"
 
-#: src/iac_code/utils/platform.py:52
+#: src/iac_code/utils/platform.py
 msgid ""
 "  Option 2 - if you cannot reach github.com, run this to install via "
 "npmmirror:"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iac-code 0.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 13:32+0800\n"
+"POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"
 "Last-Translator: \n"
 "Language: zh\n"
@@ -17,188 +17,185 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: src/iac_code/config.py:164
+#: src/iac_code/config.py
 #, python-brace-format
 msgid "Invalid IAC_CODE_PROVIDER value: {!r}. Valid values (case-insensitive): {}"
 msgstr "无效的 IAC_CODE_PROVIDER 值：{!r}。有效值（不区分大小写）：{}"
 
-#: src/iac_code/a2a/transports/base.py:175
+#: src/iac_code/a2a/transports/base.py
 msgid ""
 "Unix domain socket transport is not supported on Windows. Use --transport"
 " http or --transport stdio instead."
 msgstr "Windows 不支持 Unix 域套接字传输。请使用 --transport http 或 --transport stdio。"
 
-#: src/iac_code/acp/server.py:413 src/iac_code/acp/server.py:429
-#: src/iac_code/acp/server.py:456
+#: src/iac_code/acp/server.py
 msgid "Session not found"
 msgstr "未找到会话"
 
-#: src/iac_code/acp/server.py:416
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session name is ambiguous. Candidates: {candidates}"
 msgstr "会话名称不唯一。候选项：{candidates}"
 
-#: src/iac_code/acp/server.py:434 src/iac_code/acp/server.py:708
+#: src/iac_code/acp/server.py
 #, python-brace-format
 msgid "Session belongs to another project. Run: {hint}"
 msgstr "会话属于另一个项目。请运行：{hint}"
 
-#: src/iac_code/acp/slash_registry.py:46
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Command '/{cmd_name}' is not supported over ACP. Supported commands: "
 "{supported}"
 msgstr "命令 '/{cmd_name}' 不支持通过 ACP 使用。支持的命令：{supported}"
 
-#: src/iac_code/acp/slash_registry.py:62
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Command '/{cmd_name}' handler not implemented."
 msgstr "命令 '/{cmd_name}' 的处理器尚未实现。"
 
-#: src/iac_code/acp/slash_registry.py:74
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Compaction failed: {error}"
 msgstr "压缩失败：{error}"
 
-#: src/iac_code/acp/slash_registry.py:77 src/iac_code/commands/compact.py:24
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Nothing to compact: conversation is empty."
 msgstr "无内容可压缩：对话为空。"
 
-#: src/iac_code/acp/slash_registry.py:80 src/iac_code/commands/compact.py:27
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Conversation too short to compact: all messages are within the recent "
 "{turns}-turn preservation window."
 msgstr "对话过短，无需压缩：所有消息都在最近 {turns} 轮保留窗口内。"
 
-#: src/iac_code/acp/slash_registry.py:84 src/iac_code/commands/compact.py:30
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/compact.py
 msgid "Compaction failed. See logs for details."
 msgstr "压缩失败，详情请查看日志。"
 
-#: src/iac_code/acp/slash_registry.py:89
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent} reduction)."
 " Context usage: {usage}"
 msgstr "上下文已压缩：{original} → {compacted} tokens（减少 {percent}）。上下文用量：{usage}"
 
-#: src/iac_code/acp/slash_registry.py:103
+#: src/iac_code/acp/slash_registry.py
 #, python-brace-format
 msgid "Clear failed: {error}"
 msgstr "清除失败：{error}"
 
-#: src/iac_code/acp/slash_registry.py:104
+#: src/iac_code/acp/slash_registry.py
 msgid "Conversation history cleared."
 msgstr "对话历史已清除。"
 
-#: src/iac_code/acp/slash_registry.py:120 src/iac_code/commands/debug.py:34
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging is on. Log file: {path}"
 msgstr "调试日志已启用。日志文件：{path}"
 
-#: src/iac_code/acp/slash_registry.py:121 src/iac_code/commands/debug.py:35
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging is off."
 msgstr "调试日志已关闭。"
 
-#: src/iac_code/acp/slash_registry.py:125 src/iac_code/commands/debug.py:39
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 #, python-brace-format
 msgid "Debug logging enabled. Log file: {path}"
 msgstr "调试日志已启用。日志文件：{path}"
 
-#: src/iac_code/acp/slash_registry.py:129 src/iac_code/commands/debug.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Debug logging disabled."
 msgstr "调试日志已关闭。"
 
-#: src/iac_code/acp/slash_registry.py:131 src/iac_code/commands/debug.py:45
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/debug.py
 msgid "Usage: /debug [on|off]"
 msgstr "用法：/debug [on|off]"
 
-#: src/iac_code/acp/slash_registry.py:136 src/iac_code/commands/memory.py:84
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/memory.py
 msgid "Memory manager is unavailable."
 msgstr "记忆管理器不可用。"
 
-#: src/iac_code/acp/slash_registry.py:146 src/iac_code/commands/rename.py:21
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 msgid "Usage: /rename <name>"
 msgstr "用法：/rename <名称>"
 
-#: src/iac_code/acp/slash_registry.py:152
+#: src/iac_code/acp/slash_registry.py
 msgid "Rename is only available after a session is created."
 msgstr "创建会话后才能重命名。"
 
-#: src/iac_code/acp/slash_registry.py:163 src/iac_code/commands/rename.py:42
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Session is already named {name}"
 msgstr "会话已命名为 {name}"
 
-#: src/iac_code/acp/slash_registry.py:164 src/iac_code/commands/rename.py:43
+#: src/iac_code/acp/slash_registry.py src/iac_code/commands/rename.py
 #, python-brace-format
 msgid "Renamed session to {name}"
 msgstr "已将会话重命名为 {name}"
 
-#: src/iac_code/agent/agent_loop.py:413 src/iac_code/agent/agent_loop.py:428
-#: src/iac_code/ui/repl.py:813 src/iac_code/ui/repl.py:827
+#: src/iac_code/agent/agent_loop.py src/iac_code/ui/repl.py
 msgid "Permission denied."
 msgstr "权限被拒绝。"
 
-#: src/iac_code/agent/agent_tool.py:266
+#: src/iac_code/agent/agent_tool.py
 #, python-brace-format
 msgid "Done ({tool_count} tool uses · {token_display} tokens)"
 msgstr "完成（{tool_count} 次工具调用 · {token_display} tokens）"
 
-#: src/iac_code/agent/agent_tool.py:276
+#: src/iac_code/agent/agent_tool.py
 msgid "Explore"
 msgstr "探索"
 
-#: src/iac_code/agent/agent_tool.py:277
+#: src/iac_code/agent/agent_tool.py
 msgid "Plan"
 msgstr "规划"
 
-#: src/iac_code/agent/agent_tool.py:278 src/iac_code/agent/agent_tool.py:279
-#: src/iac_code/agent/agent_tool.py:280
+#: src/iac_code/agent/agent_tool.py
 msgid "Agent"
 msgstr "智能体"
 
-#: src/iac_code/cli/headless.py:50
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool started: {}"
 msgstr "工具已开始：{}"
 
-#: src/iac_code/cli/headless.py:53
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool failed: {}"
 msgstr "工具失败：{}"
 
-#: src/iac_code/cli/headless.py:55
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Tool finished: {}"
 msgstr "工具已完成：{}"
 
-#: src/iac_code/cli/headless.py:59
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool failed: {}"
 msgstr "子工具失败：{}"
 
-#: src/iac_code/cli/headless.py:61
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool finished: {}"
 msgstr "子工具已完成：{}"
 
-#: src/iac_code/cli/headless.py:63
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Child tool started: {}"
 msgstr "子工具已开始：{}"
 
-#: src/iac_code/cli/headless.py:65
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack {}: {} ({:.1f}%)"
 msgstr "资源栈 {}：{} ({:.1f}%)"
 
-#: src/iac_code/cli/headless.py:71
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid "Stack group {}: {} ({}%)"
 msgstr "资源栈组 {}：{} ({}%)"
 
-#: src/iac_code/cli/headless.py:110
+#: src/iac_code/cli/headless.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -217,779 +214,770 @@ msgstr ""
 "  文档：https://aliyun.github.io/iac-code/zh-"
 "Hans/docs/configuration/authentication\n"
 
-#: src/iac_code/cli/install_git_bash.py:40
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git Bash is already installed at {}"
 msgstr "Git Bash 已存在于 {}"
 
-#: src/iac_code/cli/install_git_bash.py:43
+#: src/iac_code/cli/install_git_bash.py
 msgid "Installing Git for Windows via npmmirror..."
 msgstr "正在通过 npmmirror 下载并安装 Git for Windows..."
 
-#: src/iac_code/cli/install_git_bash.py:59
+#: src/iac_code/cli/install_git_bash.py
 msgid "powershell.exe was not found on PATH; cannot run installer."
 msgstr "PATH 中未找到 powershell.exe，无法运行安装程序。"
 
-#: src/iac_code/cli/install_git_bash.py:66
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Installation failed (PowerShell exited with code {})"
 msgstr "安装失败（PowerShell 退出码 {}）"
 
-#: src/iac_code/cli/install_git_bash.py:77
+#: src/iac_code/cli/install_git_bash.py
 msgid ""
 "Installer exited but bash.exe was not found in common locations; UAC may "
 "have been cancelled or the installer used a non-standard path."
 msgstr "安装程序已退出，但常见路径下未找到 bash.exe；可能 UAC 被取消或安装程序使用了非标准路径。"
 
-#: src/iac_code/cli/install_git_bash.py:84
+#: src/iac_code/cli/install_git_bash.py
 #, python-brace-format
 msgid "Git for Windows installed at {}"
 msgstr "Git for Windows 已安装于 {}"
 
-#: src/iac_code/cli/main.py:33 src/iac_code/commands/help.py:26
+#: src/iac_code/cli/main.py src/iac_code/commands/help.py
 msgid "AI-powered infrastructure orchestration tool"
 msgstr "AI 驱动的基础设施编排工具"
 
-#: src/iac_code/cli/main.py:41
+#: src/iac_code/cli/main.py
 msgid "Use iac-code as an A2A client."
 msgstr "将 iac-code 作为 A2A 客户端使用。"
 
-#: src/iac_code/cli/main.py:54
+#: src/iac_code/cli/main.py
 msgid "Install Git for Windows via the npmmirror mirror (Windows only)."
 msgstr "通过 npmmirror 镜像安装 Git for Windows（仅 Windows）。"
 
-#: src/iac_code/cli/main.py:61
+#: src/iac_code/cli/main.py
+msgid "Update iac-code to the latest version."
+msgstr "将 iac-code 更新到最新版本。"
+
+#: src/iac_code/cli/main.py
 msgid "YAML config file containing A2A client options"
 msgstr "包含 A2A 客户端选项的 YAML 配置文件"
 
-#: src/iac_code/cli/main.py:68 src/iac_code/cli/main.py:1501
-#: src/iac_code/cli/main.py:1862 src/iac_code/cli/main.py:1901
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A client dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
 msgstr "缺少 A2A 客户端依赖。请使用以下命令安装：pip install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:82
+#: src/iac_code/cli/main.py
 msgid "LLM model to use"
 msgstr "使用的 LLM 模型"
 
-#: src/iac_code/cli/main.py:83
+#: src/iac_code/cli/main.py
 msgid "Non-interactive mode: run a single prompt and exit"
 msgstr "非交互模式：运行单个提示并退出"
 
-#: src/iac_code/cli/main.py:84
+#: src/iac_code/cli/main.py
 msgid "Output format: text, json, stream-json"
 msgstr "输出格式：text、json、stream-json"
 
-#: src/iac_code/cli/main.py:85
+#: src/iac_code/cli/main.py
 msgid "Maximum agent turns in headless mode"
 msgstr "无头模式下最大智能体轮次"
 
-#: src/iac_code/cli/main.py:86 src/iac_code/cli/main.py:366
-#: src/iac_code/cli/main.py:591
+#: src/iac_code/cli/main.py
 msgid "Enable debug logging"
 msgstr "启用调试日志"
 
-#: src/iac_code/cli/main.py:87
+#: src/iac_code/cli/main.py
 msgid "Show headless progress on stderr"
 msgstr "在 stderr 显示无头模式进度"
 
-#: src/iac_code/cli/main.py:88
+#: src/iac_code/cli/main.py
 msgid "Show version and exit"
 msgstr "显示版本号并退出"
 
-#: src/iac_code/cli/main.py:89
+#: src/iac_code/cli/main.py
 msgid "Resume a session by ID or name"
 msgstr "通过 ID 或名称恢复会话"
 
-#: src/iac_code/cli/main.py:90
+#: src/iac_code/cli/main.py
 msgid "Resume the most recent session"
 msgstr "恢复最近一次会话"
 
-#: src/iac_code/cli/main.py:97 src/iac_code/i18n/__init__.py:55
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid "Install completion for the current shell."
 msgstr "为当前 shell 安装自动补全。"
 
-#: src/iac_code/cli/main.py:105 src/iac_code/i18n/__init__.py:56
+#: src/iac_code/cli/main.py src/iac_code/i18n/__init__.py
 msgid ""
 "Show completion for the current shell, to copy it or customize the "
 "installation."
 msgstr "显示当前 shell 的自动补全脚本，可复制或自定义安装。"
 
-#: src/iac_code/cli/main.py:110
+#: src/iac_code/cli/main.py
 msgid ""
 "Comma-separated tool permission patterns to allow, e.g. 'bash(git "
 "*),write_file'"
 msgstr "允许的工具权限模式（逗号分隔），例如 'bash(git *),write_file'"
 
-#: src/iac_code/cli/main.py:115
+#: src/iac_code/cli/main.py
 msgid "Comma-separated tool permission patterns to deny"
 msgstr "拒绝的工具权限模式（逗号分隔）"
 
-#: src/iac_code/cli/main.py:120
+#: src/iac_code/cli/main.py
 msgid "Permission mode: default, accept_edits, bypass_permissions, dont_ask"
 msgstr "权限模式：default, accept_edits, bypass_permissions, dont_ask"
 
-#: src/iac_code/cli/main.py:151
+#: src/iac_code/cli/main.py
 msgid "Error: --resume and --continue cannot be used together."
 msgstr "错误：--resume 和 --continue 不能同时使用。"
 
-#: src/iac_code/cli/main.py:163
+#: src/iac_code/cli/main.py
 #, python-brace-format
 msgid "Invalid --output-format '{}'. Valid values: {}"
 msgstr "无效的 --output-format '{}'。有效值：{}"
 
-#: src/iac_code/cli/main.py:361
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an ACP server."
 msgstr "将 iac-code 作为 ACP 服务器运行。"
 
-#: src/iac_code/cli/main.py:363
+#: src/iac_code/cli/main.py
 msgid "Transport type: stdio or http"
 msgstr "传输类型：stdio 或 http"
 
-#: src/iac_code/cli/main.py:364
+#: src/iac_code/cli/main.py
 msgid "HTTP server port"
 msgstr "HTTP 服务器端口"
 
-#: src/iac_code/cli/main.py:365 src/iac_code/cli/main.py:581
+#: src/iac_code/cli/main.py
 msgid "HTTP server host"
 msgstr "HTTP 服务器主机"
 
-#: src/iac_code/cli/main.py:577
+#: src/iac_code/cli/main.py
 msgid "Run iac-code as an A2A 1.0 server."
 msgstr "将 iac-code 作为 A2A 1.0 服务器运行。"
 
-#: src/iac_code/cli/main.py:580
+#: src/iac_code/cli/main.py
 msgid "YAML config file for A2A server options"
 msgstr "用于 A2A 服务器选项的 YAML 配置文件"
 
-#: src/iac_code/cli/main.py:584
+#: src/iac_code/cli/main.py
 msgid ""
 "HTTP server port. 41242 is the iac-code default inspired by Gemini CLI, "
 "not a registered A2A port."
 msgstr "HTTP 服务器端口。41242 是受 Gemini CLI 启发的 iac-code 默认值，并非已注册的 A2A 端口。"
 
-#: src/iac_code/cli/main.py:589
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A transport: http, stdio, unix, websocket, grpc, grpc-jsonrpc, or "
 "redis-streams"
 msgstr "A2A 传输方式：http、stdio、unix、websocket、grpc、grpc-jsonrpc 或 redis-streams"
 
-#: src/iac_code/cli/main.py:595
+#: src/iac_code/cli/main.py
 msgid ""
 "Expose A2A thinking signal types; repeat for multiple. Values: raw-"
 "thinking, tool-trace."
 msgstr "暴露 A2A thinking 信号类型；可重复指定多个。取值：raw-thinking、tool-trace。"
 
-#: src/iac_code/cli/main.py:646
+#: src/iac_code/cli/main.py
 msgid ""
 "A2A server dependencies are missing. Install with: pip install 'iac-"
 "code[a2a]'"
 msgstr "缺少 A2A 服务器依赖。请使用以下命令安装：pip install 'iac-code[a2a]'"
 
-#: src/iac_code/cli/main.py:778
+#: src/iac_code/cli/main.py
 msgid "Send a prompt to an A2A JSON-RPC endpoint."
 msgstr "向 A2A JSON-RPC 端点发送提示。"
 
-#: src/iac_code/cli/main.py:781 src/iac_code/cli/main.py:951
-#: src/iac_code/cli/main.py:1004 src/iac_code/cli/main.py:1064
-#: src/iac_code/cli/main.py:1114 src/iac_code/cli/main.py:1163
-#: src/iac_code/cli/main.py:1242 src/iac_code/cli/main.py:1299
-#: src/iac_code/cli/main.py:1355 src/iac_code/cli/main.py:1412
+#: src/iac_code/cli/main.py
 msgid "A2A JSON-RPC endpoint URL"
 msgstr "A2A JSON-RPC 端点 URL"
 
-#: src/iac_code/cli/main.py:782 src/iac_code/cli/main.py:1457
+#: src/iac_code/cli/main.py
 msgid "Route spec: name=url;skills=skill1,skill2;tags=tag1,tag2"
 msgstr "路由规范：name=url;skills=skill1,skill2;tags=tag1,tag2"
 
-#: src/iac_code/cli/main.py:783
+#: src/iac_code/cli/main.py
 msgid "Named A2A route to call"
 msgstr "要调用的命名 A2A 路由"
 
-#: src/iac_code/cli/main.py:784
+#: src/iac_code/cli/main.py
 msgid "Prompt to send"
 msgstr "要发送的提示"
 
-#: src/iac_code/cli/main.py:785
+#: src/iac_code/cli/main.py
 msgid "Working directory metadata to send with the request"
 msgstr "随请求一起发送的工作目录元数据"
 
-#: src/iac_code/cli/main.py:786
+#: src/iac_code/cli/main.py
 msgid "A2A context ID to continue"
 msgstr "要继续的 A2A 上下文 ID"
 
-#: src/iac_code/cli/main.py:787 src/iac_code/cli/main.py:882
-#: src/iac_code/cli/main.py:954 src/iac_code/cli/main.py:1011
-#: src/iac_code/cli/main.py:1066 src/iac_code/cli/main.py:1116
-#: src/iac_code/cli/main.py:1170 src/iac_code/cli/main.py:1245
-#: src/iac_code/cli/main.py:1303 src/iac_code/cli/main.py:1358
-#: src/iac_code/cli/main.py:1413
+#: src/iac_code/cli/main.py
 msgid "Bearer token for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的 Bearer 令牌"
 
-#: src/iac_code/cli/main.py:788 src/iac_code/cli/main.py:883
-#: src/iac_code/cli/main.py:955 src/iac_code/cli/main.py:1012
-#: src/iac_code/cli/main.py:1067 src/iac_code/cli/main.py:1117
-#: src/iac_code/cli/main.py:1171 src/iac_code/cli/main.py:1246
-#: src/iac_code/cli/main.py:1304 src/iac_code/cli/main.py:1359
-#: src/iac_code/cli/main.py:1414
+#: src/iac_code/cli/main.py
 msgid "Basic auth username for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的基本认证用户名"
 
-#: src/iac_code/cli/main.py:789 src/iac_code/cli/main.py:884
-#: src/iac_code/cli/main.py:956 src/iac_code/cli/main.py:1013
-#: src/iac_code/cli/main.py:1068 src/iac_code/cli/main.py:1118
-#: src/iac_code/cli/main.py:1172 src/iac_code/cli/main.py:1247
-#: src/iac_code/cli/main.py:1305 src/iac_code/cli/main.py:1360
-#: src/iac_code/cli/main.py:1415
+#: src/iac_code/cli/main.py
 msgid "Basic auth password for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的基本认证密码"
 
-#: src/iac_code/cli/main.py:790 src/iac_code/cli/main.py:885
-#: src/iac_code/cli/main.py:957 src/iac_code/cli/main.py:1014
-#: src/iac_code/cli/main.py:1069 src/iac_code/cli/main.py:1119
-#: src/iac_code/cli/main.py:1173 src/iac_code/cli/main.py:1248
-#: src/iac_code/cli/main.py:1306 src/iac_code/cli/main.py:1361
-#: src/iac_code/cli/main.py:1416
+#: src/iac_code/cli/main.py
 msgid "API key for A2A HTTP requests"
 msgstr "用于 A2A HTTP 请求的 API 密钥"
 
-#: src/iac_code/cli/main.py:791 src/iac_code/cli/main.py:886
-#: src/iac_code/cli/main.py:958 src/iac_code/cli/main.py:1015
-#: src/iac_code/cli/main.py:1070 src/iac_code/cli/main.py:1120
-#: src/iac_code/cli/main.py:1174 src/iac_code/cli/main.py:1249
-#: src/iac_code/cli/main.py:1307 src/iac_code/cli/main.py:1362
-#: src/iac_code/cli/main.py:1417
+#: src/iac_code/cli/main.py
 msgid "HTTP header name for A2A API key"
 msgstr "A2A API 密钥使用的 HTTP 请求头名称"
 
-#: src/iac_code/cli/main.py:796 src/iac_code/cli/main.py:891
+#: src/iac_code/cli/main.py
 msgid "Secret used to verify the A2A Agent Card"
 msgstr "用于验证 A2A Agent Card 的密钥"
 
-#: src/iac_code/cli/main.py:801 src/iac_code/cli/main.py:896
+#: src/iac_code/cli/main.py
 msgid "Remote JWKS URL used to verify the A2A Agent Card"
 msgstr "用于验证 A2A Agent Card 的远程 JWKS URL"
 
-#: src/iac_code/cli/main.py:807 src/iac_code/cli/main.py:902
+#: src/iac_code/cli/main.py
 msgid "Require a valid A2A Agent Card signature"
 msgstr "要求 A2A Agent Card 提供有效签名"
 
-#: src/iac_code/cli/main.py:809
+#: src/iac_code/cli/main.py
 msgid "A2A call timeout in seconds"
 msgstr "A2A 调用超时时间（秒）"
 
-#: src/iac_code/cli/main.py:810
+#: src/iac_code/cli/main.py
 msgid "Use A2A streaming message delivery"
 msgstr "使用 A2A 流式消息传递"
 
-#: src/iac_code/cli/main.py:878
+#: src/iac_code/cli/main.py
 msgid "Discover an A2A Agent Card."
 msgstr "发现 A2A Agent Card。"
 
-#: src/iac_code/cli/main.py:881
+#: src/iac_code/cli/main.py
 msgid "A2A agent base URL"
 msgstr "A2A 代理基础 URL"
 
-#: src/iac_code/cli/main.py:948
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task."
 msgstr "获取 A2A 任务。"
 
-#: src/iac_code/cli/main.py:952 src/iac_code/cli/main.py:1065
-#: src/iac_code/cli/main.py:1115 src/iac_code/cli/main.py:1164
-#: src/iac_code/cli/main.py:1243 src/iac_code/cli/main.py:1300
-#: src/iac_code/cli/main.py:1356
+#: src/iac_code/cli/main.py
 msgid "A2A task ID"
 msgstr "A2A 任务 ID"
 
-#: src/iac_code/cli/main.py:953
+#: src/iac_code/cli/main.py
 msgid "Maximum task history items to return"
 msgstr "最多返回的任务历史条目数"
 
-#: src/iac_code/cli/main.py:1001
+#: src/iac_code/cli/main.py
 msgid "List A2A tasks."
 msgstr "列出 A2A 任务。"
 
-#: src/iac_code/cli/main.py:1005
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A context ID"
 msgstr "按 A2A 上下文 ID 过滤"
 
-#: src/iac_code/cli/main.py:1006
+#: src/iac_code/cli/main.py
 msgid "Filter by A2A task state"
 msgstr "按 A2A 任务状态过滤"
 
-#: src/iac_code/cli/main.py:1007
+#: src/iac_code/cli/main.py
 msgid "Maximum tasks to return"
 msgstr "最多返回的任务数"
 
-#: src/iac_code/cli/main.py:1008 src/iac_code/cli/main.py:1302
+#: src/iac_code/cli/main.py
 msgid "Pagination token"
 msgstr "分页令牌"
 
-#: src/iac_code/cli/main.py:1009
+#: src/iac_code/cli/main.py
 msgid "Include task artifacts"
 msgstr "包含任务工件"
 
-#: src/iac_code/cli/main.py:1010
+#: src/iac_code/cli/main.py
 msgid "Output format: table or json"
 msgstr "输出格式：table 或 json"
 
-#: src/iac_code/cli/main.py:1061
+#: src/iac_code/cli/main.py
 msgid "Cancel an A2A task."
 msgstr "取消 A2A 任务。"
 
-#: src/iac_code/cli/main.py:1111
+#: src/iac_code/cli/main.py
 msgid "Subscribe to an A2A task event stream."
 msgstr "订阅 A2A 任务事件流。"
 
-#: src/iac_code/cli/main.py:1160
+#: src/iac_code/cli/main.py
 msgid "Create an A2A task push notification config."
 msgstr "创建 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1165 src/iac_code/cli/main.py:1244
-#: src/iac_code/cli/main.py:1357
+#: src/iac_code/cli/main.py
 msgid "Push config ID"
 msgstr "推送配置 ID"
 
-#: src/iac_code/cli/main.py:1166
+#: src/iac_code/cli/main.py
 msgid "Push callback URL"
 msgstr "推送回调 URL"
 
-#: src/iac_code/cli/main.py:1167
+#: src/iac_code/cli/main.py
 msgid "Notification verification token"
 msgstr "通知验证令牌"
 
-#: src/iac_code/cli/main.py:1168
+#: src/iac_code/cli/main.py
 msgid "Callback authentication scheme"
 msgstr "回调认证方案"
 
-#: src/iac_code/cli/main.py:1169
+#: src/iac_code/cli/main.py
 msgid "Callback authentication credentials"
 msgstr "回调认证凭据"
 
-#: src/iac_code/cli/main.py:1239
+#: src/iac_code/cli/main.py
 msgid "Get an A2A task push notification config."
 msgstr "获取 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1296
+#: src/iac_code/cli/main.py
 msgid "List A2A task push notification configs."
 msgstr "列出 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1301
+#: src/iac_code/cli/main.py
 msgid "Maximum configs to return"
 msgstr "最多返回的配置数"
 
-#: src/iac_code/cli/main.py:1352
+#: src/iac_code/cli/main.py
 msgid "Delete an A2A task push notification config."
 msgstr "删除 A2A 任务推送通知配置。"
 
-#: src/iac_code/cli/main.py:1409
+#: src/iac_code/cli/main.py
 msgid "Get an authenticated extended A2A Agent Card."
 msgstr "获取经过身份验证的扩展 A2A Agent Card。"
 
-#: src/iac_code/cli/main.py:1452
+#: src/iac_code/cli/main.py
 msgid "Preview A2A route resolution."
 msgstr "预览 A2A 路由解析。"
 
-#: src/iac_code/cli/main.py:1459
+#: src/iac_code/cli/main.py
 msgid "Route name to resolve"
 msgstr "要解析的路由名称"
 
-#: src/iac_code/cli/main.py:1460
+#: src/iac_code/cli/main.py
 msgid "Skill ID to resolve"
 msgstr "要解析的技能 ID"
 
-#: src/iac_code/cli/main.py:1461
+#: src/iac_code/cli/main.py
 msgid "Prompt text used for tag/name route matching"
 msgstr "用于标签/名称路由匹配的提示文本"
 
-#: src/iac_code/cli/main.py:1466
+#: src/iac_code/cli/main.py
 msgid "Directory for persisted A2A routes"
 msgstr "持久化 A2A 路由的目录"
 
-#: src/iac_code/cli/main.py:1468
+#: src/iac_code/cli/main.py
 msgid "Save the provided routes as a route snapshot"
 msgstr "将提供的路由保存为路由快照"
 
-#: src/iac_code/commands/__init__.py:26
+#: src/iac_code/cli/update.py
+msgid "Check for updates without installing."
+msgstr "仅检查更新，不安装。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "iac-code is already up to date (v{})."
+msgstr "iac-code 已是最新版本（v{}）。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update available: v{} -> v{}"
+msgstr "有可用更新：v{} -> v{}"
+
+#: src/iac_code/cli/update.py src/iac_code/ui/banner.py
+#, python-brace-format
+msgid "Run {} to update."
+msgstr "运行 {} 进行更新。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Updating iac-code from v{} to v{}..."
+msgstr "正在将 iac-code 从 v{} 更新到 v{}..."
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed: {}"
+msgstr "更新命令失败：{}"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Update command failed with exit code {}."
+msgstr "更新命令失败，退出码为 {}。"
+
+#: src/iac_code/cli/update.py
+#, python-brace-format
+msgid "Successfully updated to v{}!"
+msgstr "已成功更新到 v{}！"
+
+#: src/iac_code/commands/__init__.py
 msgid "Show available commands"
 msgstr "显示可用命令"
 
-#: src/iac_code/commands/__init__.py:35
+#: src/iac_code/commands/__init__.py
 msgid "Clear conversation history"
 msgstr "清除对话历史"
 
-#: src/iac_code/commands/__init__.py:43
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch model"
 msgstr "显示或切换模型"
 
-#: src/iac_code/commands/__init__.py:52
+#: src/iac_code/commands/__init__.py
 msgid "Show or switch thinking effort"
 msgstr "显示或切换思考强度"
 
-#: src/iac_code/commands/__init__.py:61
+#: src/iac_code/commands/__init__.py
 msgid "Compact conversation context"
 msgstr "压缩对话上下文"
 
-#: src/iac_code/commands/__init__.py:63
+#: src/iac_code/commands/__init__.py
 msgid "Compacting conversation"
 msgstr "正在压缩对话"
 
-#: src/iac_code/commands/__init__.py:70
+#: src/iac_code/commands/__init__.py
 msgid "Exit the application"
 msgstr "退出应用程序"
 
-#: src/iac_code/commands/__init__.py:79
+#: src/iac_code/commands/__init__.py
 msgid "Authenticate with LLM provider"
 msgstr "配置 LLM 提供商认证"
 
-#: src/iac_code/commands/__init__.py:88
+#: src/iac_code/commands/__init__.py
 msgid "Toggle debug logging"
 msgstr "切换调试日志开关"
 
-#: src/iac_code/commands/__init__.py:97
+#: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"
 msgstr "查看和管理持久记忆"
 
-#: src/iac_code/commands/__init__.py:99
+#: src/iac_code/commands/__init__.py
 msgid "[<name>|search <query>|delete <name>|help]"
 msgstr "[<名称>|search <查询>|delete <名称>|help]"
 
-#: src/iac_code/commands/__init__.py:106
+#: src/iac_code/commands/__init__.py
 msgid "Resume a previous session"
 msgstr "恢复之前的会话"
 
-#: src/iac_code/commands/__init__.py:108
+#: src/iac_code/commands/__init__.py
 msgid "[conversation id or search term]"
 msgstr "[会话 ID 或搜索词]"
 
-#: src/iac_code/commands/__init__.py:115
+#: src/iac_code/commands/__init__.py
 msgid "Rename the current session"
 msgstr "重命名当前会话"
 
-#: src/iac_code/commands/__init__.py:124
+#: src/iac_code/commands/__init__.py
 msgid "Manage skills"
 msgstr "管理技能"
 
-#: src/iac_code/commands/__init__.py:132
+#: src/iac_code/commands/__init__.py
 msgid "Show current session status"
 msgstr "显示当前会话状态"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:1117
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Navigate"
 msgstr "导航"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:538
-#: src/iac_code/commands/auth.py:570 src/iac_code/commands/auth.py:577
-#: src/iac_code/commands/auth.py:612 src/iac_code/commands/auth.py:619
-#: src/iac_code/commands/auth.py:640 src/iac_code/commands/auth.py:1117
-#: src/iac_code/commands/auth.py:1551 src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/commands/auth.py src/iac_code/ui/core/prompt_input.py
 msgid "Confirm"
 msgstr "确认"
 
-#: src/iac_code/commands/auth.py:390 src/iac_code/commands/auth.py:536
-#: src/iac_code/commands/auth.py:538 src/iac_code/commands/auth.py:570
-#: src/iac_code/commands/auth.py:577 src/iac_code/commands/auth.py:612
-#: src/iac_code/commands/auth.py:619 src/iac_code/commands/auth.py:640
-#: src/iac_code/commands/auth.py:1117 src/iac_code/commands/auth.py:1443
-#: src/iac_code/commands/auth.py:1551
+#: src/iac_code/commands/auth.py
 msgid "Back"
 msgstr "返回"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Keep"
 msgstr "保留"
 
-#: src/iac_code/commands/auth.py:536
+#: src/iac_code/commands/auth.py
 msgid "Re-enter"
 msgstr "重新输入"
 
-#: src/iac_code/commands/auth.py:749 src/iac_code/commands/auth.py:863
-#: src/iac_code/commands/auth.py:921 src/iac_code/commands/auth.py:929
-#: src/iac_code/commands/auth.py:956
+#: src/iac_code/commands/auth.py
 msgid " (current)"
 msgstr " (当前)"
 
-#: src/iac_code/commands/auth.py:752
+#: src/iac_code/commands/auth.py
 msgid "Custom model..."
 msgstr "自定义模型..."
 
-#: src/iac_code/commands/auth.py:755
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select model for {provider}"
 msgstr "为 {provider} 选择模型"
 
-#: src/iac_code/commands/auth.py:757
+#: src/iac_code/commands/auth.py
 msgid "Select model"
 msgstr "选择模型"
 
-#: src/iac_code/commands/auth.py:765
+#: src/iac_code/commands/auth.py
 msgid "Enter custom model name: "
 msgstr "输入自定义模型名称："
 
-#: src/iac_code/commands/auth.py:791
+#: src/iac_code/commands/auth.py
 msgid "Error: console not available"
 msgstr "错误：控制台不可用"
 
-#: src/iac_code/commands/auth.py:820
+#: src/iac_code/commands/auth.py
 msgid "Configure LLM Provider"
 msgstr "配置 LLM 提供商"
 
-#: src/iac_code/commands/auth.py:821
+#: src/iac_code/commands/auth.py
 msgid "Configure IaC Cloud Service"
 msgstr "配置 IaC 云服务"
 
-#: src/iac_code/commands/auth.py:823
+#: src/iac_code/commands/auth.py
 msgid "Select configuration type"
 msgstr "选择配置类型"
 
-#: src/iac_code/commands/auth.py:825 src/iac_code/commands/auth.py:981
-#: src/iac_code/commands/auth.py:997 src/iac_code/commands/auth.py:1076
-#: src/iac_code/commands/auth.py:1490 src/iac_code/commands/auth.py:1531
+#: src/iac_code/commands/auth.py
 msgid "Auth cancelled"
 msgstr "认证已取消"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:961
-#: src/iac_code/commands/auth.py:1051
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Select provider — {group}"
 msgstr "选择提供商 — {group}"
 
-#: src/iac_code/commands/auth.py:867 src/iac_code/commands/auth.py:919
-#: src/iac_code/commands/auth.py:1036
+#: src/iac_code/commands/auth.py
 msgid "Third-party"
 msgstr "第三方"
 
-#: src/iac_code/commands/auth.py:877
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider}"
 msgstr "{status}：{provider}"
 
-#: src/iac_code/commands/auth.py:878 src/iac_code/commands/auth.py:1029
+#: src/iac_code/commands/auth.py
 msgid "Configured"
 msgstr "已配置"
 
-#: src/iac_code/commands/auth.py:933
+#: src/iac_code/commands/auth.py
 msgid "Select provider"
 msgstr "选择提供商"
 
-#: src/iac_code/commands/auth.py:974
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Configure {provider}"
 msgstr "配置 {provider}"
 
-#: src/iac_code/commands/auth.py:990
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Enter API key for {provider}"
 msgstr "为 {provider} 输入 API 密钥"
 
-#: src/iac_code/commands/auth.py:1028
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "{status}: {provider} / {model}"
 msgstr "{status}：{provider} / {model}"
 
-#: src/iac_code/commands/auth.py:1037 src/iac_code/commands/auth.py:1058
+#: src/iac_code/commands/auth.py
 msgid "Alibaba Cloud"
 msgstr "阿里云"
 
-#: src/iac_code/commands/auth.py:1038 src/iac_code/providers/registry.py:427
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "ZhiPu AI"
 msgstr "智谱 AI"
 
-#: src/iac_code/commands/auth.py:1039
+#: src/iac_code/commands/auth.py
 msgid "Kimi"
 msgstr "Kimi"
 
-#: src/iac_code/commands/auth.py:1040
+#: src/iac_code/commands/auth.py
 msgid "MiniMax"
 msgstr "MiniMax"
 
-#: src/iac_code/commands/auth.py:1041 src/iac_code/providers/registry.py:429
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Volcengine"
 msgstr "火山引擎"
 
-#: src/iac_code/commands/auth.py:1042
+#: src/iac_code/commands/auth.py
 msgid "SiliconFlow"
 msgstr "硅基流动"
 
-#: src/iac_code/commands/auth.py:1043 src/iac_code/providers/registry.py:420
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: src/iac_code/commands/auth.py:1044 src/iac_code/providers/registry.py:418
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: src/iac_code/commands/auth.py:1045 src/iac_code/providers/registry.py:419
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Anthropic"
 msgstr "Anthropic"
 
-#: src/iac_code/commands/auth.py:1046 src/iac_code/providers/registry.py:422
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Google Gemini"
 msgstr "Google Gemini"
 
-#: src/iac_code/commands/auth.py:1047 src/iac_code/providers/registry.py:435
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "Azure OpenAI"
 msgstr "Azure OpenAI"
 
-#: src/iac_code/commands/auth.py:1048 src/iac_code/providers/registry.py:434
+#: src/iac_code/commands/auth.py src/iac_code/providers/registry.py
 msgid "OpenRouter"
 msgstr "OpenRouter"
 
-#: src/iac_code/commands/auth.py:1049
+#: src/iac_code/commands/auth.py
 msgid "Local"
 msgstr "本地模型"
 
-#: src/iac_code/commands/auth.py:1050
+#: src/iac_code/commands/auth.py
 msgid "Compatible"
 msgstr "兼容模式"
 
-#: src/iac_code/commands/auth.py:1067
+#: src/iac_code/commands/auth.py
 msgid "Select Cloud Provider"
 msgstr "选择云服务商"
 
-#: src/iac_code/commands/auth.py:1083
+#: src/iac_code/commands/auth.py
 msgid "Credential"
 msgstr "凭证"
 
-#: src/iac_code/commands/auth.py:1084 src/iac_code/commands/auth.py:1199
-#: src/iac_code/commands/auth.py:1527 src/iac_code/commands/status.py:36
-#: src/iac_code/ui/renderer.py:455
+#: src/iac_code/commands/auth.py src/iac_code/commands/status.py
+#: src/iac_code/ui/renderer.py
 msgid "Region"
 msgstr "地域"
 
-#: src/iac_code/commands/auth.py:1086
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud"
 msgstr "配置阿里云"
 
-#: src/iac_code/commands/auth.py:1188
+#: src/iac_code/commands/auth.py
 msgid "Current configuration"
 msgstr "当前配置"
 
-#: src/iac_code/commands/auth.py:1190
+#: src/iac_code/commands/auth.py
 msgid "Mode"
 msgstr "模式"
 
-#: src/iac_code/commands/auth.py:1196
+#: src/iac_code/commands/auth.py
 msgid "(not set)"
 msgstr "（未设置）"
 
-#: src/iac_code/commands/auth.py:1205
+#: src/iac_code/commands/auth.py
 msgid "AccessKey"
 msgstr "AccessKey"
 
-#: src/iac_code/commands/auth.py:1207 src/iac_code/commands/auth.py:1219
+#: src/iac_code/commands/auth.py
 msgid "STS Token"
 msgstr "STS 令牌"
 
-#: src/iac_code/commands/auth.py:1209
+#: src/iac_code/commands/auth.py
 msgid "RAM Role"
 msgstr "RAM 角色"
 
-#: src/iac_code/commands/auth.py:1211
+#: src/iac_code/commands/auth.py
 msgid "OAuth Login (Browser)"
 msgstr "OAuth 登录（浏览器）"
 
-#: src/iac_code/commands/auth.py:1217
+#: src/iac_code/commands/auth.py
 msgid "AccessKey ID"
 msgstr "AccessKey ID"
 
-#: src/iac_code/commands/auth.py:1218
+#: src/iac_code/commands/auth.py
 msgid "AccessKey Secret"
 msgstr "AccessKey 密钥"
 
-#: src/iac_code/commands/auth.py:1220
+#: src/iac_code/commands/auth.py
 msgid "RAM Role ARN"
 msgstr "RAM 角色 ARN"
 
-#: src/iac_code/commands/auth.py:1221
+#: src/iac_code/commands/auth.py
 msgid "Session Name"
 msgstr "会话名称"
 
-#: src/iac_code/commands/auth.py:1222
+#: src/iac_code/commands/auth.py
 msgid "OAuth Site Type"
 msgstr "OAuth 站点类型"
 
-#: src/iac_code/commands/auth.py:1223
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token"
 msgstr "OAuth 访问令牌"
 
-#: src/iac_code/commands/auth.py:1224
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token"
 msgstr "OAuth 刷新令牌"
 
-#: src/iac_code/commands/auth.py:1225
+#: src/iac_code/commands/auth.py
 msgid "OAuth Access Token Expire"
 msgstr "OAuth 访问令牌过期时间"
 
-#: src/iac_code/commands/auth.py:1226
+#: src/iac_code/commands/auth.py
 msgid "OAuth Refresh Token Expire"
 msgstr "OAuth 刷新令牌过期时间"
 
-#: src/iac_code/commands/auth.py:1227
+#: src/iac_code/commands/auth.py
 msgid "STS Expiration"
 msgstr "STS 过期时间"
 
-#: src/iac_code/commands/auth.py:1384
+#: src/iac_code/commands/auth.py
 msgid "China"
 msgstr "中国"
 
-#: src/iac_code/commands/auth.py:1385
+#: src/iac_code/commands/auth.py
 msgid "International"
 msgstr "国际"
 
-#: src/iac_code/commands/auth.py:1387
+#: src/iac_code/commands/auth.py
 msgid "Choose site type"
 msgstr "选择站点类型"
 
-#: src/iac_code/commands/auth.py:1402
+#: src/iac_code/commands/auth.py
 #, python-brace-format
 msgid "Alibaba Cloud OAuth login failed: {error}"
 msgstr "阿里云 OAuth 登录失败：{error}"
 
-#: src/iac_code/commands/auth.py:1418
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud OAuth credentials saved"
 msgstr "已配置：阿里云 OAuth 凭证已保存"
 
-#: src/iac_code/commands/auth.py:1430
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud credentials"
 msgstr "配置阿里云凭证"
 
-#: src/iac_code/commands/auth.py:1443
+#: src/iac_code/commands/auth.py
 msgid "Reconfigure credential"
 msgstr "重新配置凭证"
 
-#: src/iac_code/commands/auth.py:1456
+#: src/iac_code/commands/auth.py
 msgid "Select credential type"
 msgstr "选择凭证类型"
 
-#: src/iac_code/commands/auth.py:1512
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud credentials saved to ~/.iac-code"
 msgstr "已配置：阿里云凭证已保存到 ~/.iac-code"
 
-#: src/iac_code/commands/auth.py:1519
+#: src/iac_code/commands/auth.py
 msgid "Configure Alibaba Cloud region"
 msgstr "配置阿里云地域"
 
-#: src/iac_code/commands/auth.py:1545
+#: src/iac_code/commands/auth.py
 msgid "Configured: Alibaba Cloud region saved to ~/.iac-code"
 msgstr "已配置：阿里云地域已保存到 ~/.iac-code"
 
-#: src/iac_code/commands/compact.py:12
+#: src/iac_code/commands/compact.py
 msgid "Compact command requires a context."
 msgstr "压缩命令需要上下文。"
 
-#: src/iac_code/commands/compact.py:16
+#: src/iac_code/commands/compact.py
 msgid "No active REPL."
 msgstr "没有活动的 REPL。"
 
-#: src/iac_code/commands/compact.py:20
+#: src/iac_code/commands/compact.py
 msgid "No active agent loop."
 msgstr "没有活动的智能体循环。"
 
-#: src/iac_code/commands/compact.py:35
+#: src/iac_code/commands/compact.py
 #, python-brace-format
 msgid ""
 "Context compacted: {original} → {compacted} tokens ({percent_display} "
@@ -998,308 +986,305 @@ msgstr ""
 "上下文已压缩：{original} → {compacted} tokens（减少 "
 "{percent_display}）。上下文用量：{usage_display}"
 
-#: src/iac_code/commands/debug.py:21
+#: src/iac_code/commands/debug.py
 msgid "Debug command requires a context."
 msgstr "调试命令需要上下文。"
 
-#: src/iac_code/commands/debug.py:26
+#: src/iac_code/commands/debug.py
 msgid "No active session."
 msgstr "没有活动的会话。"
 
-#: src/iac_code/commands/effort.py:54 src/iac_code/commands/model.py:95
-#: src/iac_code/commands/model.py:99
+#: src/iac_code/commands/effort.py src/iac_code/commands/model.py
 msgid "No configured providers. Run /auth first."
 msgstr "没有已配置的提供商。请先运行 /auth。"
 
-#: src/iac_code/commands/effort.py:58
+#: src/iac_code/commands/effort.py
 msgid "No model selected. Run /model first."
 msgstr "没有选择模型。请先运行 /model。"
 
-#: src/iac_code/commands/effort.py:66
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Model {model} does not support effort."
 msgstr "模型 {model} 不支持调整思考强度。"
 
-#: src/iac_code/commands/effort.py:80
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Invalid effort. Allowed: {labels}"
 msgstr "非法的思考强度。允许的值：{labels}"
 
-#: src/iac_code/commands/effort.py:85
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Current effort: {effort}"
 msgstr "当前思考强度：{effort}"
 
-#: src/iac_code/commands/effort.py:94
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Select effort for {model}"
 msgstr "为 {model} 选择思考强度"
 
-#: src/iac_code/commands/effort.py:103 src/iac_code/commands/effort.py:107
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Kept effort as {effort}"
 msgstr "已保持思考强度为 {effort}"
 
-#: src/iac_code/commands/effort.py:116
+#: src/iac_code/commands/effort.py
 #, python-brace-format
 msgid "Effort switched to: {effort}"
 msgstr "思考强度已切换为：{effort}"
 
-#: src/iac_code/commands/help.py:29
+#: src/iac_code/commands/help.py
 msgid "Commands:"
 msgstr "命令："
 
-#: src/iac_code/commands/help.py:36
+#: src/iac_code/commands/help.py
 msgid "Shortcuts:"
 msgstr "快捷键："
 
-#: src/iac_code/commands/help.py:39
+#: src/iac_code/commands/help.py
 msgid "Send message"
 msgstr "发送消息"
 
-#: src/iac_code/commands/help.py:40
+#: src/iac_code/commands/help.py
 msgid "New line"
 msgstr "换行"
 
-#: src/iac_code/commands/help.py:41
+#: src/iac_code/commands/help.py
 msgid "Show command suggestions"
 msgstr "显示命令建议"
 
-#: src/iac_code/commands/help.py:42
+#: src/iac_code/commands/help.py
 msgid "Exit"
 msgstr "退出"
 
-#: src/iac_code/commands/memory.py:10
+#: src/iac_code/commands/memory.py
 msgid "Usage: /memory [<name>|search <query>|delete <name>|help]"
 msgstr "用法：/memory [<名称>|search <查询>|delete <名称>|help]"
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "Saved memories:"
 msgstr "已保存的记忆："
 
-#: src/iac_code/commands/memory.py:40
+#: src/iac_code/commands/memory.py
 msgid "No memories saved yet."
 msgstr "尚未保存任何记忆。"
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "Matching memories:"
 msgstr "匹配的记忆："
 
-#: src/iac_code/commands/memory.py:51
+#: src/iac_code/commands/memory.py
 msgid "No matching memories."
 msgstr "没有匹配的记忆。"
 
-#: src/iac_code/commands/memory.py:60 src/iac_code/commands/memory.py:75
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' not found."
 msgstr "未找到记忆 '{name}'。"
 
-#: src/iac_code/commands/memory.py:64
+#: src/iac_code/commands/memory.py
 #, python-brace-format
 msgid "Memory '{name}' deleted."
 msgstr "记忆 '{name}' 已删除。"
 
-#: src/iac_code/commands/model.py:57
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid ""
 "Model is managed by '{source}'. To change model, modify it in {source} or"
 " switch provider via /auth."
 msgstr "模型由 '{source}' 管理。如需修改模型，请在 {source} 中调整，或通过 /auth 切换其他 Provider。"
 
-#: src/iac_code/commands/model.py:88 src/iac_code/commands/model.py:143
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Model switched to: {model}"
 msgstr "模型已切换为：{model}"
 
-#: src/iac_code/commands/model.py:92
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Current model: {model}"
 msgstr "当前模型：{model}"
 
-#: src/iac_code/commands/model.py:118
+#: src/iac_code/commands/model.py
 #, python-brace-format
 msgid "Kept model as {model}"
 msgstr "保持模型为 {model}"
 
-#: src/iac_code/commands/rename.py:16 src/iac_code/commands/rename.py:28
+#: src/iac_code/commands/rename.py
 msgid "Rename is only available in interactive mode."
 msgstr "重命名仅在交互模式下可用。"
 
-#: src/iac_code/commands/rename.py:31
+#: src/iac_code/commands/rename.py
 msgid "Rename cancelled"
 msgstr "已取消重命名"
 
-#: src/iac_code/commands/resume.py:22
+#: src/iac_code/commands/resume.py
 msgid "Resume is only available in interactive mode."
 msgstr "/resume 仅在交互模式下可用。"
 
-#: src/iac_code/commands/resume.py:28
+#: src/iac_code/commands/resume.py
 msgid "Resume is unavailable: session index not initialised."
 msgstr "无法恢复：会话索引未初始化。"
 
-#: src/iac_code/commands/resume.py:33 src/iac_code/commands/resume.py:36
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Session not found: {arg}"
 msgstr "未找到会话：{arg}"
 
-#: src/iac_code/commands/resume.py:52 src/iac_code/commands/resume.py:68
+#: src/iac_code/commands/resume.py
 msgid "Resume cancelled"
 msgstr "已取消恢复"
 
-#: src/iac_code/commands/resume.py:55
+#: src/iac_code/commands/resume.py
 #, python-brace-format
 msgid "Unable to resolve session: {arg}"
 msgstr "无法解析会话：{arg}"
 
-#: src/iac_code/commands/skills.py:14
+#: src/iac_code/commands/skills.py
 msgid "Skills management is only available in interactive mode."
 msgstr "技能管理仅在交互模式下可用。"
 
-#: src/iac_code/commands/skills.py:25
+#: src/iac_code/commands/skills.py
 msgid "Skills update cancelled"
 msgstr "已取消技能更新"
 
-#: src/iac_code/commands/skills.py:29
+#: src/iac_code/commands/skills.py
 msgid "Skills updated"
 msgstr "技能已更新"
 
-#: src/iac_code/commands/status.py:19
+#: src/iac_code/commands/status.py
 msgid "Status command requires a context."
 msgstr "status 命令需要上下文。"
 
-#: src/iac_code/commands/status.py:22
+#: src/iac_code/commands/status.py
 msgid "Status command requires a REPL context."
 msgstr "status 命令需要 REPL 上下文。"
 
-#: src/iac_code/commands/status.py:24
+#: src/iac_code/commands/status.py
 msgid "Status is only available in interactive mode."
 msgstr "status 仅在交互模式下可用。"
 
-#: src/iac_code/commands/status.py:33 src/iac_code/ui/banner.py:136
-#: src/iac_code/ui/banner.py:138
+#: src/iac_code/commands/status.py src/iac_code/ui/banner.py
 msgid "Session"
 msgstr "会话"
 
-#: src/iac_code/commands/status.py:34
+#: src/iac_code/commands/status.py
 msgid "Provider"
 msgstr "提供商"
 
-#: src/iac_code/commands/status.py:34 src/iac_code/commands/status.py:35
-#: src/iac_code/commands/status.py:36
+#: src/iac_code/commands/status.py
 msgid "not configured"
 msgstr "未配置"
 
-#: src/iac_code/commands/status.py:35
+#: src/iac_code/commands/status.py
 msgid "Model"
 msgstr "模型"
 
-#: src/iac_code/commands/status.py:37
+#: src/iac_code/commands/status.py
 msgid "CWD"
 msgstr "当前目录"
 
-#: src/iac_code/commands/status.py:41
+#: src/iac_code/commands/status.py
 msgid "API Token Usage (recorded):"
 msgstr "API Token 用量（已记录）："
 
-#: src/iac_code/commands/status.py:44
+#: src/iac_code/commands/status.py
 msgid "Input"
 msgstr "输入"
 
-#: src/iac_code/commands/status.py:45
+#: src/iac_code/commands/status.py
 msgid "Output"
 msgstr "输出"
 
-#: src/iac_code/commands/status.py:46
+#: src/iac_code/commands/status.py
 msgid "Cache read"
 msgstr "缓存读取"
 
-#: src/iac_code/commands/status.py:47
+#: src/iac_code/commands/status.py
 msgid "Total"
 msgstr "总计"
 
-#: src/iac_code/commands/status.py:50
+#: src/iac_code/commands/status.py
 msgid "No recorded API usage for this session yet."
 msgstr "此会话尚无已记录的 API 用量。"
 
-#: src/iac_code/commands/status.py:54
+#: src/iac_code/commands/status.py
 msgid "Turns"
 msgstr "轮次"
 
-#: src/iac_code/commands/status.py:55
+#: src/iac_code/commands/status.py
 msgid "Context"
 msgstr "上下文"
 
-#: src/iac_code/commands/status.py:57
+#: src/iac_code/commands/status.py
 msgid "Session Status"
 msgstr "会话状态"
 
-#: src/iac_code/commands/status.py:73
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{session_id} (resumed)"
 msgstr "{session_id}（已恢复）"
 
-#: src/iac_code/commands/status.py:81
+#: src/iac_code/commands/status.py
 #, python-brace-format
 msgid "{percent} used ({total} / {window})"
 msgstr "已使用 {percent}（{total} / {window}）"
 
 # Typer/Click built-in strings
-#: src/iac_code/i18n/__init__.py:51
+#: src/iac_code/i18n/__init__.py
 msgid "Options"
 msgstr "选项"
 
-#: src/iac_code/i18n/__init__.py:52
+#: src/iac_code/i18n/__init__.py
 msgid "Commands"
 msgstr "命令"
 
-#: src/iac_code/i18n/__init__.py:53
+#: src/iac_code/i18n/__init__.py
 msgid "Arguments"
 msgstr "参数"
 
-#: src/iac_code/i18n/__init__.py:54
+#: src/iac_code/i18n/__init__.py
 msgid "Show this message and exit."
 msgstr "显示此帮助信息并退出。"
 
-#: src/iac_code/i18n/__init__.py:57
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "default: {default}"
 msgstr "默认值: {default}"
 
-#: src/iac_code/i18n/__init__.py:58
+#: src/iac_code/i18n/__init__.py
 msgid "required"
 msgstr "必填"
 
-#: src/iac_code/i18n/__init__.py:59
+#: src/iac_code/i18n/__init__.py
 #, python-brace-format
 msgid "env var: {var}"
 msgstr "环境变量: {var}"
 
-#: src/iac_code/i18n/__init__.py:60
+#: src/iac_code/i18n/__init__.py
 msgid "(dynamic)"
 msgstr "(动态)"
 
-#: src/iac_code/i18n/__init__.py:61
+#: src/iac_code/i18n/__init__.py
 msgid "Aborted!"
 msgstr "已中止！"
 
-#: src/iac_code/providers/manager.py:78
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Cannot determine provider for model: {model}. Run /auth to configure."
 msgstr "无法确定模型 {model} 的提供商。请运行 /auth 进行配置。"
 
-#: src/iac_code/providers/manager.py:95
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid "Unknown provider key: '{key}'. Run /auth to configure."
 msgstr "未知的 Provider 标识：'{key}'。请运行 /auth 进行配置。"
 
-#: src/iac_code/providers/manager.py:100
+#: src/iac_code/providers/manager.py
 #, python-brace-format
 msgid ""
 "No API key configured for provider '{provider}' (model: {model}). Run "
 "/auth to configure."
 msgstr "提供商 '{provider}' 未配置 API 密钥（模型: {model}）。请运行 /auth 进行配置。"
 
-#: src/iac_code/providers/openai_provider.py:307
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned no data. Please check that your API Base URL is correct "
@@ -1309,7 +1294,7 @@ msgstr ""
 "API 未返回数据。请检查您的 API Base URL 是否正确（当前：{base_url}）。许多 OpenAI 兼容端点需要 /v1 "
 "后缀（如 {base_url}/v1）。"
 
-#: src/iac_code/providers/openai_provider.py:348
+#: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
 "API returned an invalid response. Please check that your API Base URL is "
@@ -1319,83 +1304,83 @@ msgstr ""
 "API 返回了无效响应。请检查您的 API Base URL 是否正确（当前：{base_url}）。许多 OpenAI 兼容端点需要 /v1 "
 "后缀（如 {base_url}/v1）。"
 
-#: src/iac_code/providers/registry.py:416
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
 msgstr "阿里云百炼"
 
-#: src/iac_code/providers/registry.py:417
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian Token Plan"
 msgstr "阿里云百炼 Token Plan"
 
-#: src/iac_code/providers/registry.py:421
+#: src/iac_code/providers/registry.py
 msgid "OpenAPI Compatible"
 msgstr "OpenAPI 兼容"
 
-#: src/iac_code/providers/registry.py:423
+#: src/iac_code/providers/registry.py
 msgid "Kimi (China)"
 msgstr "Kimi（中国版）"
 
-#: src/iac_code/providers/registry.py:424
+#: src/iac_code/providers/registry.py
 msgid "Kimi (International)"
 msgstr "Kimi（国际版）"
 
-#: src/iac_code/providers/registry.py:425
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (China)"
 msgstr "MiniMax（中国版）"
 
-#: src/iac_code/providers/registry.py:426
+#: src/iac_code/providers/registry.py
 msgid "MiniMax (International)"
 msgstr "MiniMax（国际版）"
 
-#: src/iac_code/providers/registry.py:428
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI (International)"
 msgstr "智谱 AI（国际版）"
 
-#: src/iac_code/providers/registry.py:430
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (China)"
 msgstr "硅基流动（中国版）"
 
-#: src/iac_code/providers/registry.py:431
+#: src/iac_code/providers/registry.py
 msgid "SiliconFlow (International)"
 msgstr "硅基流动（国际版）"
 
-#: src/iac_code/providers/registry.py:432
+#: src/iac_code/providers/registry.py
 msgid "Ollama (Local)"
 msgstr "Ollama（本地）"
 
-#: src/iac_code/providers/registry.py:433
+#: src/iac_code/providers/registry.py
 msgid "LM Studio (Local)"
 msgstr "LM Studio（本地）"
 
-#: src/iac_code/providers/registry.py:436
+#: src/iac_code/providers/registry.py
 msgid "ModelScope"
 msgstr "魔搭"
 
-#: src/iac_code/providers/registry.py:437
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan"
 msgstr "阿里云编程计划"
 
-#: src/iac_code/providers/registry.py:438
+#: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud CodingPlan (International)"
 msgstr "阿里云编程计划（国际版）"
 
-#: src/iac_code/providers/registry.py:439
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan"
 msgstr "智谱 AI 编程计划"
 
-#: src/iac_code/providers/registry.py:440
+#: src/iac_code/providers/registry.py
 msgid "ZhiPu AI CodingPlan (International)"
 msgstr "智谱 AI 编程计划（国际版）"
 
-#: src/iac_code/providers/registry.py:441
+#: src/iac_code/providers/registry.py
 msgid "Volcengine CodingPlan"
 msgstr "火山引擎编程计划"
 
-#: src/iac_code/providers/registry.py:442
+#: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Anthropic 兼容"
 
-#: src/iac_code/services/qwenpaw_source.py:205
+#: src/iac_code/services/qwenpaw_source.py
 #, python-brace-format
 msgid ""
 "[QwenPaw mode] Unknown provider '{provider_id}'. iac-code does not "
@@ -1409,119 +1394,119 @@ msgstr ""
 "解决方法：在 QwenPaw 中切换到已支持的 provider，或关闭 QwenPaw 模式（从 settings.yml 移除 "
 "'llm_source: qwenpaw'）。"
 
-#: src/iac_code/services/session_metadata.py:52
+#: src/iac_code/services/session_metadata.py
 #, python-brace-format
 msgid "Session name must match {pattern}"
 msgstr "会话名称必须匹配 {pattern}"
 
-#: src/iac_code/services/session_storage.py:241
+#: src/iac_code/services/session_storage.py
 #, python-brace-format
 msgid "Session name already exists in this project: {name}"
 msgstr "此项目中已存在会话名称：{name}"
 
-#: src/iac_code/services/permissions/loader.py:50
+#: src/iac_code/services/permissions/loader.py
 #, python-brace-format
 msgid "Invalid --permission-mode {!r}. Valid values: {}"
 msgstr "无效的 --permission-mode {!r}。有效值：{}"
 
-#: src/iac_code/services/permissions/pipeline.py:54
-#: src/iac_code/tools/base.py:199 src/iac_code/tools/bash/bash_tool.py:175
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Allow {}?"
 msgstr "允许 {}？"
 
-#: src/iac_code/services/providers/aliyun.py:144
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
 msgstr "阿里云 OAuth 站点缺失。"
 
-#: src/iac_code/services/providers/aliyun.py:150
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth refresh token is missing."
 msgstr "阿里云 OAuth 刷新令牌缺失。"
 
-#: src/iac_code/services/providers/aliyun.py:158
+#: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth access token is missing."
 msgstr "阿里云 OAuth 访问令牌缺失。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:83
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Run /auth and choose OAuth Login (Browser)."
 msgstr "请运行 /auth 并选择 OAuth 登录（浏览器）。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:106
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "Unknown Aliyun OAuth site: {site_type}"
 msgstr "未知的阿里云 OAuth 站点：{site_type}"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:164
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Not found"
 msgstr "未找到"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:170
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "invalid state"
 msgstr "无效状态"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:171
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Invalid state"
 msgstr "无效状态"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:176
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "code not found"
 msgstr "未找到授权码"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:177
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization code not found"
 msgstr "未找到授权码"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:181
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Authorization successful. You can close this window."
 msgstr "授权成功。你可以关闭此窗口。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:212
+#: src/iac_code/services/providers/aliyun_oauth.py
 #, python-brace-format
 msgid "No available callback port in range {start}-{end}"
 msgstr "范围 {start}-{end} 内没有可用的回调端口"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:227
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "OAuth login cancelled."
 msgstr "OAuth 登录已取消。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:278
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Open in your browser:"
 msgstr "在浏览器中打开："
 
-#: src/iac_code/services/providers/aliyun_oauth.py:299
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Waiting for browser authorization"
 msgstr "等待浏览器授权"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:300
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "1. The browser may show official-cli; this is the Alibaba Cloud official "
 "CLI OAuth application."
 msgstr "1. 浏览器可能显示 official-cli，这是 Alibaba Cloud 官方 CLI OAuth 应用。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:302
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "2. If assignment is required, assign the RAM user or RAM role that is "
 "signed in. User groups are not supported."
 msgstr "2. 如需分配应用，请分配给当前登录的 RAM 用户或 RAM 角色；不支持用户组。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:306
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "3. After assignment, close the old authorization page and run OAuth Login"
 " (Browser) again. If it still fails, sign out of Alibaba Cloud and sign "
 "in again."
 msgstr "3. 分配后关闭旧授权页，并再次运行 OAuth 登录（浏览器）。若仍失败，请退出 Alibaba Cloud 后重新登录。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:310
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "4. STS credentials refresh when possible until Alibaba Cloud expires "
 "them. If refresh fails, run /auth again."
 msgstr "4. STS 凭证会在可能时自动刷新；如果刷新失败，请重新运行 /auth。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:313
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid "Press Esc to cancel while waiting."
 msgstr "按 Esc 可取消等待。"
 
-#: src/iac_code/services/providers/aliyun_oauth.py:321
+#: src/iac_code/services/providers/aliyun_oauth.py
 msgid ""
 "Timed out waiting for OAuth callback. If Alibaba Cloud asked you to "
 "assign the official-cli application, assign it to the exact RAM user or "
@@ -1533,529 +1518,528 @@ msgstr ""
 " RAM 角色。不支持用户组。然后关闭旧的授权页面，必要时退出 Alibaba Cloud 并重新登录，再运行 /auth 重新选择 OAuth "
 "登录（浏览器）。"
 
-#: src/iac_code/skills/skill_tool.py:85 src/iac_code/ui/repl.py:842
+#: src/iac_code/skills/skill_tool.py src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Skill '{name}' is disabled. Run /skills to enable it."
 msgstr "技能“{name}”已禁用。运行 /skills 以启用它。"
 
-#: src/iac_code/skills/skill_tool.py:137
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill '{name}' loaded (inline)."
 msgstr "技能 '{name}' 已加载（内联）。"
 
-#: src/iac_code/skills/skill_tool.py:221
+#: src/iac_code/skills/skill_tool.py
 msgid "Skill"
 msgstr "技能"
 
-#: src/iac_code/skills/skill_tool.py:245
+#: src/iac_code/skills/skill_tool.py
 #, python-brace-format
 msgid "Skill disabled: {name}"
 msgstr "技能已禁用：{name}"
 
-#: src/iac_code/skills/bundled/simplify.py:25
+#: src/iac_code/skills/bundled/simplify.py
 msgid ""
 "Review changed code for reuse, quality, and efficiency, then fix issues "
 "found."
 msgstr "审查变更的代码的可复用性、质量和效率，然后修复发现的问题。"
 
-#: src/iac_code/tools/edit_file.py:116
+#: src/iac_code/tools/edit_file.py
 msgid "Edit"
 msgstr "编辑"
 
-#: src/iac_code/tools/edit_file.py:118
+#: src/iac_code/tools/edit_file.py
 msgid "Create"
 msgstr "创建"
 
-#: src/iac_code/tools/edit_file.py:119
+#: src/iac_code/tools/edit_file.py
 msgid "Update"
 msgstr "更新"
 
-#: src/iac_code/tools/edit_file.py:126
+#: src/iac_code/tools/edit_file.py
 #, python-brace-format
 msgid "Editing {path}"
 msgstr "正在编辑 {path}"
 
-#: src/iac_code/tools/edit_file.py:127
+#: src/iac_code/tools/edit_file.py
 msgid "Editing file..."
 msgstr "正在编辑文件..."
 
-#: src/iac_code/tools/glob.py:86 src/iac_code/tools/grep.py:237
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Found 0 files"
 msgstr "找到 0 个文件"
 
-#: src/iac_code/tools/glob.py:89 src/iac_code/tools/grep.py:240
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Found {count} files"
 msgstr "找到 {count} 个文件"
 
-#: src/iac_code/tools/glob.py:95 src/iac_code/tools/grep.py:246
+#: src/iac_code/tools/glob.py src/iac_code/tools/grep.py
 msgid "Search"
 msgstr "搜索"
 
-#: src/iac_code/tools/glob.py:100
+#: src/iac_code/tools/glob.py
 #, python-brace-format
 msgid "Searching {pattern}"
 msgstr "正在搜索 {pattern}"
 
-#: src/iac_code/tools/glob.py:101
+#: src/iac_code/tools/glob.py
 msgid "Searching files..."
 msgstr "正在搜索文件..."
 
-#: src/iac_code/tools/grep.py:251
+#: src/iac_code/tools/grep.py
 #, python-brace-format
 msgid "Searching for {pattern}"
 msgstr "正在搜索 {pattern}"
 
-#: src/iac_code/tools/grep.py:252
+#: src/iac_code/tools/grep.py
 msgid "Searching content..."
 msgstr "正在搜索内容..."
 
-#: src/iac_code/tools/list_files.py:82
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Found {count} items"
 msgstr "找到 {count} 个项目"
 
-#: src/iac_code/tools/list_files.py:88
+#: src/iac_code/tools/list_files.py
 msgid "List"
 msgstr "列表"
 
-#: src/iac_code/tools/list_files.py:92
+#: src/iac_code/tools/list_files.py
 #, python-brace-format
 msgid "Listing {path}"
 msgstr "正在列出 {path}"
 
-#: src/iac_code/tools/list_files.py:93
+#: src/iac_code/tools/list_files.py
 msgid "Listing files..."
 msgstr "正在列出文件..."
 
-#: src/iac_code/tools/read_file.py:117
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Read {total} lines"
 msgstr "读取了 {total} 行"
 
-#: src/iac_code/tools/read_file.py:120
+#: src/iac_code/tools/read_file.py
 msgid "Read"
 msgstr "读取"
 
-#: src/iac_code/tools/read_file.py:127
+#: src/iac_code/tools/read_file.py
 #, python-brace-format
 msgid "Reading {path}"
 msgstr "正在读取 {path}"
 
-#: src/iac_code/tools/read_file.py:128
+#: src/iac_code/tools/read_file.py
 msgid "Reading file..."
 msgstr "正在读取文件..."
 
-#: src/iac_code/tools/web_fetch.py:94
+#: src/iac_code/tools/web_fetch.py
 msgid "URL cannot be empty."
 msgstr "URL 不能为空。"
 
-#: src/iac_code/tools/web_fetch.py:100
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing scheme (e.g. http:// or https://). Got: {url}"
 msgstr "无效 URL：缺少协议（如 http:// 或 https://）。当前：{url}"
 
-#: src/iac_code/tools/web_fetch.py:103
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Invalid URL: missing host/netloc. Got: {url}"
 msgstr "无效 URL：缺少主机地址。当前：{url}"
 
-#: src/iac_code/tools/web_fetch.py:129
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "HTTP error {status}: {url}"
 msgstr "HTTP 错误 {status}：{url}"
 
-#: src/iac_code/tools/web_fetch.py:131
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Failed to fetch {url}: {error}"
 msgstr "获取 {url} 失败：{error}"
 
-#: src/iac_code/tools/web_fetch.py:133
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Unexpected error fetching {url}: {error}"
 msgstr "获取 {url} 时发生意外错误：{error}"
 
-#: src/iac_code/tools/web_fetch.py:147
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetched {chars} chars, {lines} lines"
 msgstr "获取了 {chars} 个字符，{lines} 行"
 
-#: src/iac_code/tools/web_fetch.py:159
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetch"
 msgstr "获取"
 
-#: src/iac_code/tools/web_fetch.py:165
+#: src/iac_code/tools/web_fetch.py
 #, python-brace-format
 msgid "Fetching {url}"
 msgstr "正在获取 {url}"
 
-#: src/iac_code/tools/web_fetch.py:166
+#: src/iac_code/tools/web_fetch.py
 msgid "Fetching web page..."
 msgstr "正在获取网页..."
 
-#: src/iac_code/tools/write_file.py:67
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Successfully wrote {lines} lines to {path}"
 msgstr "成功写入 {lines} 行到 {path}"
 
-#: src/iac_code/tools/write_file.py:81
+#: src/iac_code/tools/write_file.py
 msgid "Write"
 msgstr "写入"
 
-#: src/iac_code/tools/write_file.py:88
+#: src/iac_code/tools/write_file.py
 #, python-brace-format
 msgid "Writing {path}"
 msgstr "正在写入 {path}"
 
-#: src/iac_code/tools/write_file.py:89
+#: src/iac_code/tools/write_file.py
 msgid "Writing file..."
 msgstr "正在写入文件..."
 
-#: src/iac_code/tools/bash/bash_tool.py:81
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Command timed out after {timeout} seconds: {command}"
 msgstr "命令在 {timeout} 秒后超时：{command}"
 
-#: src/iac_code/tools/bash/bash_tool.py:103
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Error executing command: {}"
 msgstr "执行命令时出错：{}"
 
-#: src/iac_code/tools/bash/bash_tool.py:129
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "{count} more lines"
 msgstr "还有 {count} 行"
 
-#: src/iac_code/tools/bash/bash_tool.py:137
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Bash"
 msgstr "Bash"
 
-#: src/iac_code/tools/bash/bash_tool.py:143
+#: src/iac_code/tools/bash/bash_tool.py
 #, python-brace-format
 msgid "Running {cmd}"
 msgstr "正在运行 {cmd}"
 
-#: src/iac_code/tools/bash/bash_tool.py:144
+#: src/iac_code/tools/bash/bash_tool.py
 msgid "Running command..."
 msgstr "正在运行命令..."
 
-#: src/iac_code/tools/bash/command_parser.py:42
+#: src/iac_code/tools/bash/command_parser.py
 msgid "parse error"
 msgstr "解析错误"
 
-#: src/iac_code/tools/bash/command_parser.py:46
+#: src/iac_code/tools/bash/command_parser.py
 msgid "unsupported shell construct"
 msgstr "不支持的 Shell 语法结构"
 
-#: src/iac_code/tools/bash/path_validation.py:111
+#: src/iac_code/tools/bash/path_validation.py
 #, python-brace-format
 msgid "path outside allowed directories: {}"
 msgstr "路径不在允许的目录范围内：{}"
 
-#: src/iac_code/tools/bash/permissions.py:135
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s): {}"
 msgstr "匹配到拒绝规则：{}"
 
-#: src/iac_code/tools/bash/permissions.py:142
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "匹配到询问规则：{}"
 
-#: src/iac_code/tools/bash/permissions.py:154
-#: src/iac_code/tools/bash/permissions.py:220
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched allow rule(s): {}"
 msgstr "匹配到允许规则：{}"
 
-#: src/iac_code/tools/bash/permissions.py:162
+#: src/iac_code/tools/bash/permissions.py
 msgid "complex command requires confirmation"
 msgstr "复杂命令需要确认"
 
-#: src/iac_code/tools/bash/permissions.py:171
+#: src/iac_code/tools/bash/permissions.py
 msgid "sed in-place edit requires confirmation"
 msgstr "sed 原地编辑需要确认"
 
-#: src/iac_code/tools/bash/permissions.py:194
+#: src/iac_code/tools/bash/permissions.py
 msgid "command failed basic safety checks"
 msgstr "命令未通过基本安全检查"
 
-#: src/iac_code/tools/bash/permissions.py:210
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "matched deny rule(s) on full command: {}"
 msgstr "完整命令匹配到拒绝规则：{}"
 
-#: src/iac_code/tools/bash/permissions.py:227
+#: src/iac_code/tools/bash/permissions.py
 msgid "command too complex to analyze"
 msgstr "命令过于复杂，无法分析"
 
-#: src/iac_code/tools/bash/permissions.py:229
+#: src/iac_code/tools/bash/permissions.py
 msgid "could not parse command"
 msgstr "无法解析命令"
 
-#: src/iac_code/tools/bash/permissions.py:245
+#: src/iac_code/tools/bash/permissions.py
 #, python-brace-format
 msgid "too many subcommands (>{})"
 msgstr "子命令过多（>{}）"
 
-#: src/iac_code/tools/bash/permissions.py:258
+#: src/iac_code/tools/bash/permissions.py
 msgid "multiple cd commands in compound command"
 msgstr "复合命令中包含多个 cd 命令"
 
-#: src/iac_code/tools/bash/permissions.py:271
+#: src/iac_code/tools/bash/permissions.py
 msgid "cd combined with git in compound command"
 msgstr "复合命令中 cd 与 git 组合使用"
 
-#: src/iac_code/tools/bash/safety_checks.py:151
+#: src/iac_code/tools/bash/safety_checks.py
 #, python-brace-format
 msgid "operation touches a sensitive path: {}"
 msgstr "操作涉及敏感路径：{}"
 
-#: src/iac_code/tools/cloud/base_api.py:92
+#: src/iac_code/tools/cloud/base_api.py
 msgid "CloudAPI"
 msgstr "云API"
 
-#: src/iac_code/tools/cloud/base_api.py:116
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Calling {action}..."
 msgstr "正在调用 {action}..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:400
-#: src/iac_code/tools/cloud/base_api.py:123
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#: src/iac_code/tools/cloud/base_api.py
 msgid "Call succeeded"
 msgstr "调用成功"
 
-#: src/iac_code/tools/cloud/base_api.py:144
+#: src/iac_code/tools/cloud/base_api.py
 #, python-brace-format
 msgid "Received response ({count} lines)"
 msgstr "收到响应（{count} 行）"
 
-#: src/iac_code/tools/cloud/base_stack.py:133
+#: src/iac_code/tools/cloud/base_stack.py
 msgid "CloudStack"
 msgstr "云资源栈"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:117
-#: src/iac_code/tools/cloud/base_stack.py:150
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
+#: src/iac_code/tools/cloud/base_stack.py
 #, python-brace-format
 msgid "Running {action}..."
 msgstr "正在运行 {action}..."
 
-#: src/iac_code/tools/cloud/types.py:8
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_IN_PROGRESS"
 msgstr "创建中"
 
-#: src/iac_code/tools/cloud/types.py:9
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_FAILED"
 msgstr "创建失败"
 
-#: src/iac_code/tools/cloud/types.py:10
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_COMPLETE"
 msgstr "创建完成"
 
-#: src/iac_code/tools/cloud/types.py:11
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_IN_PROGRESS"
 msgstr "更新中"
 
-#: src/iac_code/tools/cloud/types.py:12
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_FAILED"
 msgstr "更新失败"
 
-#: src/iac_code/tools/cloud/types.py:13
+#: src/iac_code/tools/cloud/types.py
 msgid "UPDATE_COMPLETE"
 msgstr "更新完成"
 
-#: src/iac_code/tools/cloud/types.py:14
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_IN_PROGRESS"
 msgstr "删除中"
 
-#: src/iac_code/tools/cloud/types.py:15
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_FAILED"
 msgstr "删除失败"
 
-#: src/iac_code/tools/cloud/types.py:16
+#: src/iac_code/tools/cloud/types.py
 msgid "DELETE_COMPLETE"
 msgstr "删除完成"
 
-#: src/iac_code/tools/cloud/types.py:17
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "创建回滚中"
 
-#: src/iac_code/tools/cloud/types.py:18
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_FAILED"
 msgstr "创建回滚失败"
 
-#: src/iac_code/tools/cloud/types.py:19
+#: src/iac_code/tools/cloud/types.py
 msgid "CREATE_ROLLBACK_COMPLETE"
 msgstr "创建回滚完成"
 
-#: src/iac_code/tools/cloud/types.py:20
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_IN_PROGRESS"
 msgstr "回滚中"
 
-#: src/iac_code/tools/cloud/types.py:21
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_FAILED"
 msgstr "回滚失败"
 
-#: src/iac_code/tools/cloud/types.py:22
+#: src/iac_code/tools/cloud/types.py
 msgid "ROLLBACK_COMPLETE"
 msgstr "回滚完成"
 
-#: src/iac_code/tools/cloud/types.py:23
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_IN_PROGRESS"
 msgstr "检查中"
 
-#: src/iac_code/tools/cloud/types.py:24
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_FAILED"
 msgstr "检查失败"
 
-#: src/iac_code/tools/cloud/types.py:25
+#: src/iac_code/tools/cloud/types.py
 msgid "CHECK_COMPLETE"
 msgstr "检查完成"
 
-#: src/iac_code/tools/cloud/types.py:26
+#: src/iac_code/tools/cloud/types.py
 msgid "REVIEW_IN_PROGRESS"
 msgstr "审查中"
 
-#: src/iac_code/tools/cloud/types.py:27
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_IN_PROGRESS"
 msgstr "导入创建中"
 
-#: src/iac_code/tools/cloud/types.py:28
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_FAILED"
 msgstr "导入创建失败"
 
-#: src/iac_code/tools/cloud/types.py:29
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_COMPLETE"
 msgstr "导入创建完成"
 
-#: src/iac_code/tools/cloud/types.py:30
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_IN_PROGRESS"
 msgstr "导入创建回滚中"
 
-#: src/iac_code/tools/cloud/types.py:31
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_FAILED"
 msgstr "导入创建回滚失败"
 
-#: src/iac_code/tools/cloud/types.py:32
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_CREATE_ROLLBACK_COMPLETE"
 msgstr "导入创建回滚完成"
 
-#: src/iac_code/tools/cloud/types.py:33
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_IN_PROGRESS"
 msgstr "导入更新中"
 
-#: src/iac_code/tools/cloud/types.py:34
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_FAILED"
 msgstr "导入更新失败"
 
-#: src/iac_code/tools/cloud/types.py:35
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_COMPLETE"
 msgstr "导入更新完成"
 
-#: src/iac_code/tools/cloud/types.py:36
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_IN_PROGRESS"
 msgstr "导入更新回滚中"
 
-#: src/iac_code/tools/cloud/types.py:37
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_FAILED"
 msgstr "导入更新回滚失败"
 
-#: src/iac_code/tools/cloud/types.py:38
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_UPDATE_ROLLBACK_COMPLETE"
 msgstr "导入更新回滚完成"
 
-#: src/iac_code/tools/cloud/types.py:40
+#: src/iac_code/tools/cloud/types.py
 msgid "INIT_COMPLETE"
 msgstr "初始化完成"
 
-#: src/iac_code/tools/cloud/types.py:41
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_IN_PROGRESS"
 msgstr "导入中"
 
-#: src/iac_code/tools/cloud/types.py:42
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_COMPLETE"
 msgstr "导入完成"
 
-#: src/iac_code/tools/cloud/types.py:43
+#: src/iac_code/tools/cloud/types.py
 msgid "IMPORT_FAILED"
 msgstr "导入失败"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:172
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 msgid "Aliyun API"
 msgstr "阿里云 API"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py:399
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "调用成功（RequestId: {request_id}）"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:57
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "DocSearch"
 msgstr "文档搜索"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:70
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Searching docs for {keywords}..."
 msgstr "正在搜索 {keywords} 的文档..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:71
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Searching docs..."
 msgstr "正在搜索文档..."
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:76
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "keywords cannot be empty."
 msgstr "关键词不能为空。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:96
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "HTTP error {status} when searching docs."
 msgstr "搜索文档时发生 HTTP 错误 {status}。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:98
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Failed to search docs: {error}"
 msgstr "搜索文档失败：{error}"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:103
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Failed to parse search response as JSON."
 msgstr "无法将搜索响应解析为 JSON。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:106
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Search API returned failure."
 msgstr "搜索 API 返回失败。"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:125
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "No documents found"
 msgstr "未找到文档"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:126
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "No documents found for keywords: {keywords}"
 msgstr "未找到关键词为 {keywords} 的文档"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:141
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 #, python-brace-format
 msgid "Found {count} documents (total {total})"
 msgstr "找到 {count} 篇文档（共 {total} 篇）"
 
-#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py:143
+#: src/iac_code/tools/cloud/aliyun/aliyun_doc_search.py
 msgid "Use web_fetch tool to read full document content if needed."
 msgstr "如需要，请使用 web_fetch 工具读取完整文档内容。"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack.py:143
+#: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS 资源栈"
 
-#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py:100
+#: src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
 msgid "CloudStackInstances"
 msgstr "云资源栈实例"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:48
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template YAML syntax error: {}"
 msgstr "模板 YAML 语法错误：{}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:60
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template YAML syntax error (line {line}, column {col}): {problem}\n"
@@ -2066,286 +2050,279 @@ msgstr ""
 "上下文：\n"
 "{context}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:66
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Template JSON syntax error (line {line}, column {col}): {msg}"
 msgstr "模板 JSON 语法错误（第 {line} 行，第 {col} 列）：{msg}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:85
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Template {fmt} parse result is not an object (dict), please check the "
 "template format"
 msgstr "模板 {fmt} 解析结果不是对象（dict），请检查模板格式"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:104
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"
 msgstr "模板缺少 ROSTemplateFormatVersion 字段（ROS 模板必须包含此字段，如 '2015-09-01'）"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:110
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Template is missing Resources (ROS templates must include Resources)"
 msgstr "模板缺少 Resources 字段（ROS 模板必须包含 Resources）"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:112
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resources must be an object (dict), current type is {}"
 msgstr "Resources 必须是对象（dict），当前类型为 {}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:117
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid ""
 "Resource '{name}' definition must be an object (dict), current type is "
 "{type}"
 msgstr "资源 '{name}' 定义必须是对象（dict），当前类型为 {type}"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:123
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' is missing the Type field"
 msgstr "资源 '{name}' 缺少 Type 字段"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:129
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
 msgid "Resource '{name}' has incorrect type '{wrong}', should be '{correct}'"
 msgstr "资源 '{name}' 的类型 '{wrong}' 不正确，应改为 '{correct}'"
 
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py:151
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template structure validation found the following issues, please fix and "
 "retry:"
 msgstr "模板结构校验发现以下问题，请修复后重试："
 
-#: src/iac_code/ui/banner.py:42 src/iac_code/ui/banner.py:54
+#: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
 msgstr "有可用更新！{} -> {}"
 
-#: src/iac_code/ui/banner.py:43
+#: src/iac_code/ui/banner.py
 msgid "Update command"
 msgstr "更新命令"
 
-#: src/iac_code/ui/banner.py:46 src/iac_code/ui/banner.py:58
+#: src/iac_code/ui/banner.py
 msgid "Release notes"
 msgstr "发行说明"
 
-#: src/iac_code/ui/banner.py:55
-#, python-brace-format
-msgid "Run {} to update."
-msgstr "运行 {} 进行更新。"
-
-#: src/iac_code/ui/banner.py:110
+#: src/iac_code/ui/banner.py
 msgid "Your AI-powered Infrastructure as Code assistant"
 msgstr "您的 AI 驱动的基础设施即代码助手"
 
-#: src/iac_code/ui/banner.py:144
+#: src/iac_code/ui/banner.py
 msgid "Welcome back"
 msgstr "欢迎回来"
 
-#: src/iac_code/ui/banner.py:161
+#: src/iac_code/ui/banner.py
 msgid "Debug mode"
 msgstr "调试模式"
 
-#: src/iac_code/ui/banner.py:162
+#: src/iac_code/ui/banner.py
 msgid "Log file"
 msgstr "日志文件"
 
-#: src/iac_code/ui/renderer.py:388 src/iac_code/ui/renderer.py:668
-#: src/iac_code/ui/renderer.py:1455
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "思考完成（耗时 {seconds:.1f}s）"
 
-#: src/iac_code/ui/renderer.py:404 src/iac_code/ui/renderer.py:700
-#: src/iac_code/ui/renderer.py:1476
+#: src/iac_code/ui/renderer.py
 msgid "(ctrl+o to expand)"
 msgstr "(ctrl+o 展开)"
 
-#: src/iac_code/ui/renderer.py:431
+#: src/iac_code/ui/renderer.py
 msgid "Resource"
 msgstr "资源"
 
-#: src/iac_code/ui/renderer.py:432
+#: src/iac_code/ui/renderer.py
 msgid "Type"
 msgstr "类型"
 
-#: src/iac_code/ui/renderer.py:433 src/iac_code/ui/renderer.py:456
+#: src/iac_code/ui/renderer.py
 msgid "Status"
 msgstr "状态"
 
-#: src/iac_code/ui/renderer.py:454
+#: src/iac_code/ui/renderer.py
 msgid "Account ID"
 msgstr "账号 ID"
 
-#: src/iac_code/ui/renderer.py:542
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Done ({child_count} tool uses{token_info}{elapsed})"
 msgstr "完成（{child_count} 次工具调用{token_info}{elapsed}）"
 
-#: src/iac_code/ui/renderer.py:572
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "+ {count} more tool uses (ctrl+o to expand)"
 msgstr "+ {count} 个工具调用 (ctrl+o 展开)"
 
-#: src/iac_code/ui/renderer.py:1177
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Context auto-compacted: {original} → {compacted} tokens"
 msgstr "上下文自动压缩：{original} → {compacted} tokens"
 
-#: src/iac_code/ui/renderer.py:1262
+#: src/iac_code/ui/renderer.py
 msgid "Operation cancelled."
 msgstr "操作已取消。"
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "No API key configured."
 msgstr "尚未配置 API 密钥。"
 
-#: src/iac_code/ui/renderer.py:1267
+#: src/iac_code/ui/renderer.py
 msgid "Please run /auth to set up your LLM provider and API key."
 msgstr "请运行 /auth 设置您的 LLM 提供商和 API 密钥。"
 
-#: src/iac_code/ui/renderer.py:1272
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "错误：{error}"
 
-#: src/iac_code/ui/renderer.py:1342
+#: src/iac_code/ui/renderer.py
 msgid "Allow this action?"
 msgstr "是否允许执行此操作？"
 
-#: src/iac_code/ui/renderer.py:1345
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow once"
 msgstr "是，仅本次允许"
 
-#: src/iac_code/ui/renderer.py:1359
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Yes, always allow \"{rule}\" (this session)"
 msgstr "是，始终允许 \"{rule}\"（本次会话）"
 
-#: src/iac_code/ui/renderer.py:1364
+#: src/iac_code/ui/renderer.py
 msgid "Yes, allow always for this tool"
 msgstr "是，始终允许此工具"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "No, reject once"
 msgstr "否，仅本次拒绝"
 
-#: src/iac_code/ui/renderer.py:1367
+#: src/iac_code/ui/renderer.py
 msgid "default"
 msgstr "默认"
 
-#: src/iac_code/ui/renderer.py:1374
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "No, always deny \"{rule}\" (this session)"
 msgstr "否，始终拒绝 \"{rule}\"（本次会话）"
 
-#: src/iac_code/ui/renderer.py:1379
+#: src/iac_code/ui/renderer.py
 msgid "No, always reject this tool"
 msgstr "否，始终拒绝此工具"
 
-#: src/iac_code/ui/repl.py:424
+#: src/iac_code/ui/repl.py
 msgid "Press Ctrl+C again to exit."
 msgstr "再次按 Ctrl+C 退出。"
 
-#: src/iac_code/ui/repl.py:449
+#: src/iac_code/ui/repl.py
 msgid "Interrupted."
 msgstr "已中断。"
 
-#: src/iac_code/ui/repl.py:508
+#: src/iac_code/ui/repl.py
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/iac_code/ui/repl.py:510
+#: src/iac_code/ui/repl.py
 msgid "Run the shown update command and exit when it succeeds."
 msgstr "运行显示的更新命令，成功后退出。"
 
-#: src/iac_code/ui/repl.py:513
+#: src/iac_code/ui/repl.py
 msgid "Skip"
 msgstr "跳过"
 
-#: src/iac_code/ui/repl.py:515
+#: src/iac_code/ui/repl.py
 msgid "Continue with the current version for this session."
 msgstr "本次会话继续使用当前版本。"
 
-#: src/iac_code/ui/repl.py:518
+#: src/iac_code/ui/repl.py
 msgid "Skip until next version"
 msgstr "跳过直到下一个版本"
 
-#: src/iac_code/ui/repl.py:520
+#: src/iac_code/ui/repl.py
 msgid "Hide this update until a newer version is available."
 msgstr "隐藏此更新，直到有更新的版本可用。"
 
-#: src/iac_code/ui/repl.py:539 src/iac_code/ui/repl.py:551
+#: src/iac_code/ui/repl.py
 msgid "Update command failed. Continuing with the current version."
 msgstr "更新命令失败。将继续使用当前版本。"
 
-#: src/iac_code/ui/repl.py:544
+#: src/iac_code/ui/repl.py
 msgid "Update completed. Restart iac-code to continue."
 msgstr "更新已完成。请重启 iac-code 以继续。"
 
-#: src/iac_code/ui/repl.py:582
+#: src/iac_code/ui/repl.py
 msgid "No image in clipboard."
 msgstr "剪贴板中没有图像。"
 
-#: src/iac_code/ui/repl.py:768
+#: src/iac_code/ui/repl.py
 msgid "Usage: !<shell command>"
 msgstr "用法：!<shell command>"
 
-#: src/iac_code/ui/repl.py:775
+#: src/iac_code/ui/repl.py
 msgid "Shell command support is unavailable."
 msgstr "Shell 命令支持不可用。"
 
-#: src/iac_code/ui/repl.py:845
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown skill: ${name}. Type / to list commands and skills."
 msgstr "未知技能：${name}。输入 / 可列出命令和技能。"
 
-#: src/iac_code/ui/repl.py:847
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Unknown command: /{name}. Type /help for available commands."
 msgstr "未知命令：/{name}。输入 /help 查看可用命令。"
 
-#: src/iac_code/ui/repl.py:852
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "$ only invokes skills. Use /{name} instead."
 msgstr "$ 只能调用技能。请改用 /{name}。"
 
-#: src/iac_code/ui/repl.py:874 src/iac_code/ui/repl.py:922
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command error: {error}"
 msgstr "命令错误：{error}"
 
-#: src/iac_code/ui/repl.py:881
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Command has no handler: {name}"
 msgstr "命令没有处理器：{name}"
 
-#: src/iac_code/ui/repl.py:1156
+#: src/iac_code/ui/repl.py
 msgid "Goodbye!"
 msgstr "再见！"
 
-#: src/iac_code/ui/repl.py:1157
+#: src/iac_code/ui/repl.py
 msgid "Resume this session with:"
 msgstr "恢复此会话请运行："
 
-#: src/iac_code/ui/repl.py:1160
+#: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "会话 ID"
 
-#: src/iac_code/ui/repl.py:1210 src/iac_code/ui/repl.py:1214
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Session not found: {session_id}"
 msgstr "会话不存在：{session_id}"
 
-#: src/iac_code/ui/repl.py:1263
+#: src/iac_code/ui/repl.py
 msgid "Session name: "
 msgstr "会话名称："
 
-#: src/iac_code/ui/repl.py:1269
+#: src/iac_code/ui/repl.py
 msgid "Session name cannot be empty."
 msgstr "会话名称不能为空。"
 
-#: src/iac_code/ui/repl.py:1279
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "This session belongs to a different directory.\n"
@@ -2356,331 +2333,331 @@ msgstr ""
 "请运行以下命令恢复：\n"
 "  {cmd}"
 
-#: src/iac_code/ui/repl.py:1283
+#: src/iac_code/ui/repl.py
 msgid "Multiple sessions match. Resume one by ID:"
 msgstr "匹配到多个会话。请通过 ID 恢复其中一个："
 
-#: src/iac_code/ui/repl.py:1396
+#: src/iac_code/ui/repl.py
 msgid "This conversation is from a different directory."
 msgstr "该会话来自另一个目录。"
 
-#: src/iac_code/ui/repl.py:1398
+#: src/iac_code/ui/repl.py
 msgid "To resume, run:"
 msgstr "请运行以下命令恢复："
 
-#: src/iac_code/ui/repl.py:1403
+#: src/iac_code/ui/repl.py
 msgid "(Command copied to clipboard)"
 msgstr "（命令已复制到剪贴板）"
 
-#: src/iac_code/ui/repl.py:1560
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid ""
 "Current model {model} does not support image input. Use /model to switch "
 "to a vision-capable model."
 msgstr "当前模型 {model} 不支持图像输入。请使用 /model 切换到支持视觉的模型。"
 
-#: src/iac_code/ui/repl.py:1569
+#: src/iac_code/ui/repl.py
 #, python-brace-format
 msgid "Image error: {err}"
 msgstr "图像错误：{err}"
 
-#: src/iac_code/ui/repl.py:1586
+#: src/iac_code/ui/repl.py
 msgid ""
 "Failed to persist image to cache; it will only exist in memory for this "
 "turn."
 msgstr "无法将图像持久化到缓存；本轮对话期间它仅存在于内存中。"
 
-#: src/iac_code/ui/spinner.py:52
+#: src/iac_code/ui/spinner.py
 msgid "Processing"
 msgstr "处理中"
 
-#: src/iac_code/ui/spinner.py:53
+#: src/iac_code/ui/spinner.py
 msgid "Working"
 msgstr "工作中"
 
-#: src/iac_code/ui/spinner.py:62
+#: src/iac_code/ui/spinner.py
 msgid "Thought"
 msgstr "已思考"
 
-#: src/iac_code/ui/spinner.py:63
+#: src/iac_code/ui/spinner.py
 msgid "Processed"
 msgstr "已处理"
 
-#: src/iac_code/ui/spinner.py:64
+#: src/iac_code/ui/spinner.py
 msgid "Worked"
 msgstr "已完成"
 
-#: src/iac_code/ui/transcript_view.py:158
+#: src/iac_code/ui/transcript_view.py
 msgid "Prompt:"
 msgstr "提示词："
 
-#: src/iac_code/ui/transcript_view.py:186
+#: src/iac_code/ui/transcript_view.py
 msgid "Showing transcript · ctrl+o to toggle"
 msgstr "显示完整记录 · 按 ctrl+o 切换"
 
-#: src/iac_code/ui/components/fuzzy_picker.py:120
+#: src/iac_code/ui/components/fuzzy_picker.py
 msgid "No matches found"
 msgstr "未找到匹配项"
 
-#: src/iac_code/ui/core/prompt_input.py:348
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Image in clipboard · ctrl+v to paste"
 msgstr "剪贴板中有图像 · 按 ctrl+v 粘贴"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Fill"
 msgstr "填充"
 
-#: src/iac_code/ui/core/prompt_input.py:557
+#: src/iac_code/ui/core/prompt_input.py
 msgid "Dismiss"
 msgstr "关闭"
 
-#: src/iac_code/ui/dialogs/global_search.py:55
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "No matching content"
 msgstr "没有匹配的内容"
 
-#: src/iac_code/ui/dialogs/global_search.py:61
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Search in Files"
 msgstr "在文件中搜索"
 
-#: src/iac_code/ui/dialogs/global_search.py:62
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Type to search content..."
 msgstr "输入以搜索内容..."
 
-#: src/iac_code/ui/dialogs/global_search.py:63
+#: src/iac_code/ui/dialogs/global_search.py
 msgid "Enter search query"
 msgstr "输入搜索查询"
 
-#: src/iac_code/ui/dialogs/history_search.py:55
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Search Conversation History"
 msgstr "搜索对话历史"
 
-#: src/iac_code/ui/dialogs/history_search.py:56
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Type to search..."
 msgstr "输入以搜索..."
 
-#: src/iac_code/ui/dialogs/history_search.py:57
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "No conversation history"
 msgstr "没有对话历史"
 
-#: src/iac_code/ui/dialogs/history_search.py:98
+#: src/iac_code/ui/dialogs/history_search.py
 msgid "Message Preview"
 msgstr "消息预览"
 
-#: src/iac_code/ui/dialogs/quick_open.py:58
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Open File"
 msgstr "打开文件"
 
-#: src/iac_code/ui/dialogs/quick_open.py:59
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "Type to search files..."
 msgstr "输入以搜索文件..."
 
-#: src/iac_code/ui/dialogs/quick_open.py:60
+#: src/iac_code/ui/dialogs/quick_open.py
 msgid "No matching files"
 msgstr "没有匹配的文件"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:116
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Search..."
 msgstr "搜索…"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:374
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Resume Session"
 msgstr "恢复会话"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:384
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "No sessions found"
 msgstr "未找到会话"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:444
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show current dir"
 msgstr "显示当前目录"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:446
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all projects"
 msgstr "显示所有项目"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:449
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "show all branches"
 msgstr "显示所有分支"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:451
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "only show current branch"
 msgstr "仅显示当前分支"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:452
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "preview"
 msgstr "预览"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:453
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "Type to search"
 msgstr "输入以搜索"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:454
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "cancel"
 msgstr "取消"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:569
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} more line{s}"
 msgstr "还有 {n} 行"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:583
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} message{s}"
 msgstr "{n} 条消息"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:597
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "resume"
 msgstr "恢复"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:601
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "back"
 msgstr "返回"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:606
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "scroll"
 msgstr "滚动"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:625
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "(empty session)"
 msgstr "（空会话）"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:745
+#: src/iac_code/ui/dialogs/resume_picker.py
 msgid "just now"
 msgstr "刚刚"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:748
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} minute{s} ago"
 msgstr "{n} 分钟前"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:751
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} hour{s} ago"
 msgstr "{n} 小时前"
 
-#: src/iac_code/ui/dialogs/resume_picker.py:753
+#: src/iac_code/ui/dialogs/resume_picker.py
 #, python-brace-format
 msgid "{n} day{s} ago"
 msgstr "{n} 天前"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:52
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Search skills..."
 msgstr "搜索技能..."
 
-#: src/iac_code/ui/dialogs/skills_picker.py:159
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Skills"
 msgstr "技能"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:161
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "{current} of {total}"
 msgstr "{current} / {total}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:165
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid ""
 "{count} skills - Space to toggle, Enter to save, Tab to sort, Esc to "
 "cancel"
 msgstr "{count} 个技能 - 空格切换，Enter 保存，Tab 排序，Esc 取消"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:171
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "Sort: {mode}"
 msgstr "排序：{mode}"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:176
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "No skills found"
 msgstr "未找到技能"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:245
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "Bundled skills cannot be disabled."
 msgstr "内置技能不能被禁用。"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "on"
 msgstr "启用"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:259
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "off"
 msgstr "禁用"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:265
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "locked"
 msgstr "已锁定"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:268
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "matched description"
 msgstr "匹配描述"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:277
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "source"
 msgstr "来源"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:279
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "size"
 msgstr "大小"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:280
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "name"
 msgstr "名称"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:285
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "bundled"
 msgstr "内置"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:287
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "project"
 msgstr "项目"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:289
+#: src/iac_code/ui/dialogs/skills_picker.py
 msgid "user"
 msgstr "用户"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:296
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count}k tokens"
 msgstr "约 {count}k 个 token"
 
-#: src/iac_code/ui/dialogs/skills_picker.py:297
+#: src/iac_code/ui/dialogs/skills_picker.py
 #, python-brace-format
 msgid "~{count} tokens"
 msgstr "约 {count} 个 token"
 
-#: src/iac_code/ui/suggestions/command_provider.py:79
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Search saved memories"
 msgstr "搜索已保存的记忆"
 
-#: src/iac_code/ui/suggestions/command_provider.py:80
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Delete a saved memory"
 msgstr "删除已保存的记忆"
 
-#: src/iac_code/ui/suggestions/command_provider.py:81
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Show memory command help"
 msgstr "显示 memory 命令帮助"
 
-#: src/iac_code/ui/suggestions/command_provider.py:116
+#: src/iac_code/ui/suggestions/command_provider.py
 msgid "Saved memory"
 msgstr "已保存的记忆"
 
-#: src/iac_code/utils/platform.py:39
+#: src/iac_code/utils/platform.py
 msgid "iac-code on Windows requires Git for Windows."
 msgstr "iac-code 在 Windows 上需要安装 Git for Windows。"
 
-#: src/iac_code/utils/platform.py:41
+#: src/iac_code/utils/platform.py
 msgid ""
 "If installed but not on PATH, set IAC_CODE_GIT_BASH_PATH environment "
 "variable."
 msgstr "如果已安装但不在 PATH 中，请设置 IAC_CODE_GIT_BASH_PATH 环境变量。"
 
-#: src/iac_code/utils/platform.py:44
+#: src/iac_code/utils/platform.py
 msgid "To install:"
 msgstr "安装方法："
 
-#: src/iac_code/utils/platform.py:47
+#: src/iac_code/utils/platform.py
 msgid "  Option 1 - winget (requires access to github.com):"
 msgstr "  方式 1 - winget（需要能访问 github.com）："
 
-#: src/iac_code/utils/platform.py:52
+#: src/iac_code/utils/platform.py
 msgid ""
 "  Option 2 - if you cannot reach github.com, run this to install via "
 "npmmirror:"

--- a/src/iac_code/services/update_checker.py
+++ b/src/iac_code/services/update_checker.py
@@ -127,6 +127,7 @@ def check_for_updates_once(
     now: float | None = None,
     python_executable: str | None = None,
     python_version: str | None = None,
+    force: bool = False,
 ) -> UpdateState:
     from iac_code import __release_date__, __version__
 
@@ -135,10 +136,14 @@ def check_for_updates_once(
     checked_at = time.time() if now is None else now
     build_release_date = __release_date__ if release_date is None else release_date
 
-    if not build_release_date.strip():
+    if not force and not build_release_date.strip():
         return state
     last_successful_check_at = state.last_successful_check_at
-    if last_successful_check_at is not None and checked_at - last_successful_check_at < CHECK_THROTTLE_SECONDS:
+    if (
+        not force
+        and last_successful_check_at is not None
+        and checked_at - last_successful_check_at < CHECK_THROTTLE_SECONDS
+    ):
         return state
 
     installed_version = current_version or __version__

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from iac_code.services.update_checker import OFFICIAL_PYPI_SOURCE, PendingUpdate, UpdateState
+
+runner = CliRunner()
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _pending_update() -> PendingUpdate:
+    return PendingUpdate(
+        version="0.6.0",
+        current_version="0.5.0",
+        source=OFFICIAL_PYPI_SOURCE,
+        checked_at=1000.0,
+        update_command=("/python", "-m", "pip", "install", "--upgrade", "iac-code"),
+        release_notes_url="https://github.com/aliyun/iac-code/releases/tag/v0.6.0",
+    )
+
+
+def test_update_check_reports_available_update_without_installing():
+    from iac_code.cli.main import app
+
+    pending = _pending_update()
+    with (
+        patch("iac_code.cli.update.check_for_updates_once", return_value=UpdateState(pending=pending)) as check,
+        patch("iac_code.cli.update.run_update_command") as run_update,
+    ):
+        result = runner.invoke(app, ["update", "--check"])
+
+    assert result.exit_code == 0
+    assert "Update available: v0.5.0 -> v0.6.0" in result.output
+    assert "Run /python -m pip install --upgrade iac-code to update." in result.output
+    check.assert_called_once()
+    assert check.call_args.kwargs["force"] is True
+    run_update.assert_not_called()
+
+
+def test_update_check_help_is_translated_in_chinese_locale():
+    env = os.environ.copy()
+    env["LANGUAGE"] = "zh"
+    env["LC_ALL"] = "zh_CN.UTF-8"
+    env["LANG"] = "zh_CN.UTF-8"
+    env["NO_COLOR"] = "1"
+    env["TERM"] = "dumb"
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from typer.testing import CliRunner\n"
+                "from iac_code.cli.main import app\n"
+                "result = CliRunner().invoke(app, ['update', '-h'])\n"
+                "print(result.output)\n"
+                "raise SystemExit(result.exit_code)\n"
+            ),
+        ],
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "仅检查更新，不安装。" in result.stdout
+    assert "Check for updates without installing." not in result.stdout
+
+
+def test_update_runs_detected_update_command_and_prints_summary():
+    from iac_code.cli.main import app
+
+    pending = _pending_update()
+    completed = subprocess.CompletedProcess(args=pending.update_command, returncode=0)
+    with (
+        patch("iac_code.cli.update.check_for_updates_once", return_value=UpdateState(pending=pending)),
+        patch("iac_code.cli.update.run_update_command", return_value=completed) as run_update,
+    ):
+        result = runner.invoke(app, ["update"])
+
+    assert result.exit_code == 0
+    assert "Updating iac-code from v0.5.0 to v0.6.0..." in result.output
+    assert "Successfully updated to v0.6.0!" in result.output
+    run_update.assert_called_once_with(pending)
+
+
+def test_update_reports_current_version_when_no_update_is_available():
+    from iac_code.cli.main import app
+
+    with patch("iac_code.cli.update.check_for_updates_once", return_value=UpdateState(pending=None)):
+        result = runner.invoke(app, ["update", "--check"])
+
+    assert result.exit_code == 0
+    assert "iac-code is already up to date" in result.output
+
+
+def test_update_exits_nonzero_when_update_command_fails():
+    from iac_code.cli.main import app
+
+    pending = _pending_update()
+    completed = subprocess.CompletedProcess(args=pending.update_command, returncode=7)
+    with (
+        patch("iac_code.cli.update.check_for_updates_once", return_value=UpdateState(pending=pending)),
+        patch("iac_code.cli.update.run_update_command", return_value=completed),
+    ):
+        result = runner.invoke(app, ["update"])
+
+    assert result.exit_code == 7
+    assert "Update command failed with exit code 7." in result.output

--- a/tests/services/test_update_checker.py
+++ b/tests/services/test_update_checker.py
@@ -508,6 +508,40 @@ def test_successful_check_within_two_hours_is_throttled(monkeypatch, tmp_path):
     assert http_client.urls == []
 
 
+def test_force_check_ignores_throttle_for_manual_update(monkeypatch, tmp_path):
+    path = tmp_path / "update-state.yml"
+    path.write_text(yaml.safe_dump({"last_successful_check_at": 1000.0}), encoding="utf-8")
+    http_client = FakeHTTPClient(
+        _json_response("https://pypi.org/pypi/iac-code/json", {"releases": {"0.4.0": [{}], "0.3.0": [{}]}}),
+        _json_response(
+            "https://api.github.com/repos/aliyun/iac-code/releases/latest",
+            {"html_url": "https://github.com/aliyun/iac-code/releases/tag/v0.4.0"},
+        ),
+    )
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("pip subprocess must not run")
+
+    monkeypatch.setattr(update_checker.subprocess, "run", fail_run)
+
+    state = check_for_updates_once(
+        path=path,
+        current_version="0.3.0",
+        http_client=http_client,
+        now=8199.0,
+        python_executable="/python",
+        force=True,
+    )
+
+    assert state.pending is not None
+    assert state.pending.version == "0.4.0"
+    assert state.last_successful_check_at == 8199.0
+    assert http_client.urls == [
+        "https://pypi.org/pypi/iac-code/json",
+        "https://api.github.com/repos/aliyun/iac-code/releases/latest",
+    ]
+
+
 def test_failed_check_does_not_update_last_successful_check_at(monkeypatch, tmp_path):
     path = tmp_path / "update-state.yml"
     http_client = FakeHTTPClient(
@@ -658,6 +692,40 @@ def test_local_development_build_skips_detection(monkeypatch, tmp_path):
     assert state == UpdateState()
     assert load_update_state(path) == UpdateState()
     assert http_client.urls == []
+
+
+def test_force_check_runs_for_manual_update_from_local_development_build(monkeypatch, tmp_path):
+    path = tmp_path / "update-state.yml"
+    http_client = FakeHTTPClient(
+        _json_response("https://pypi.org/pypi/iac-code/json", {"releases": {"0.4.0": [{}], "0.3.0": [{}]}}),
+        _json_response(
+            "https://api.github.com/repos/aliyun/iac-code/releases/latest",
+            {"html_url": "https://github.com/aliyun/iac-code/releases/tag/v0.4.0"},
+        ),
+    )
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("pip subprocess must not run")
+
+    monkeypatch.setattr(update_checker.subprocess, "run", fail_run)
+
+    state = check_for_updates_once(
+        path=path,
+        current_version="0.3.0",
+        http_client=http_client,
+        now=1000.0,
+        python_executable="/python",
+        release_date="",
+        force=True,
+    )
+
+    assert state.pending is not None
+    assert state.pending.version == "0.4.0"
+    assert state.last_successful_check_at == 1000.0
+    assert http_client.urls == [
+        "https://pypi.org/pypi/iac-code/json",
+        "https://api.github.com/repos/aliyun/iac-code/releases/latest",
+    ]
 
 
 def test_newer_existing_pending_is_preserved_when_detector_races(monkeypatch, tmp_path):

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -103,6 +103,29 @@ def test_pot_file_exists():
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="messages.pot not generated on Windows")
+def test_translation_source_references_do_not_include_line_numbers():
+    """Avoid noisy PO churn from line-number-only source changes."""
+    catalog_files = [POT_FILE, *LOCALES_DIR.glob("*/LC_MESSAGES/messages.po")]
+    references_with_line_numbers = []
+
+    for catalog_file in catalog_files:
+        for line_number, line in enumerate(catalog_file.read_text(encoding="utf-8").splitlines(), start=1):
+            has_line_number = any(reference.rsplit(":", 1)[-1].isdigit() for reference in line.split()[1:])
+            if line.startswith("#:") and has_line_number:
+                references_with_line_numbers.append(f"{catalog_file.relative_to(PROJECT_ROOT)}:{line_number}: {line}")
+
+    displayed_references = references_with_line_numbers[:20]
+    if len(references_with_line_numbers) > len(displayed_references):
+        displayed_references.append(f"... and {len(references_with_line_numbers) - len(displayed_references)} more")
+
+    assert not references_with_line_numbers, (
+        "Translation catalogs should use file-only source references. "
+        "Run: uv run pybabel extract -F babel.cfg --add-location=file -o src/iac_code/i18n/messages.pot .\n"
+        + "\n".join(displayed_references)
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="messages.pot not generated on Windows")
 def test_pot_is_up_to_date():
     """Verify .pot file is in sync with source code _() calls."""
     with tempfile.NamedTemporaryFile(suffix=".pot", delete=False) as tmp:
@@ -110,7 +133,7 @@ def test_pot_is_up_to_date():
 
     try:
         subprocess.run(
-            ["uv", "run", "pybabel", "extract", "-F", "babel.cfg", "-o", tmp_path, "."],
+            ["uv", "run", "pybabel", "extract", "-F", "babel.cfg", "--add-location=file", "-o", tmp_path, "."],
             cwd=str(PROJECT_ROOT),
             check=True,
             capture_output=True,
@@ -137,7 +160,8 @@ def test_pot_is_up_to_date():
         if errors:
             pytest.fail(
                 "messages.pot is out of date. Run: "
-                "uv run pybabel extract -F babel.cfg -o src/iac_code/i18n/messages.pot .\n" + "\n".join(errors)
+                "uv run pybabel extract -F babel.cfg --add-location=file "
+                "-o src/iac_code/i18n/messages.pot .\n" + "\n".join(errors)
             )
     finally:
         Path(tmp_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Add `iac-code update` with `--check` support and shared update command execution.
- Allow manual update checks to bypass startup throttling and local development release-date gating.
- Keep update command translations and i18n catalog generation stable, including translated `--check` help text.

## Test Plan
- `uv run pytest tests/cli/test_update_command.py tests/services/test_update_checker.py tests/test_i18n.py -q`
- `make lint`

Fixes #74