### PR TITLE
Fix duplicate startup update notice

### DIFF
--- a/src/iac_code/ui/repl.py
+++ b/src/iac_code/ui/repl.py
@@ -52,7 +52,7 @@ from iac_code.state.app_state import AppState
 from iac_code.tasks.notification_queue import NotificationQueue
 from iac_code.tasks.task_state import TaskManager
 from iac_code.tools.base import ToolRegistry
-from iac_code.ui.banner import render_update_notice, render_update_prompt_header, render_welcome_banner
+from iac_code.ui.banner import render_update_prompt_header, render_welcome_banner
 from iac_code.ui.components.select import Select, SelectLayout, TextOption
 from iac_code.ui.core.input_history import InputHistory
 from iac_code.ui.core.prompt_input import PromptInput, PromptInputResult
@@ -339,10 +339,8 @@ class InlineREPL:
         # Capture session start time for duration calculation
         self._started_monotonic = time.monotonic()
 
-        startup_update = self._handle_startup_update()
+        self._handle_startup_update()
         state = self.store.get_state()
-        if startup_update is not None:
-            self.console.print(render_update_notice(startup_update))
         self.console.print(
             render_welcome_banner(state.model, state.cwd, session_id=self._session_id, session_name=self._session_name)
         )

--- a/tests/ui/test_repl_integration.py
+++ b/tests/ui/test_repl_integration.py
@@ -979,3 +979,35 @@ def test_run_reads_pending_update_then_renders_banner_then_starts_background(moc
         "render_welcome_banner",
         "start_background_update_check",
     ]
+
+
+@patch("iac_code.ui.repl.ProviderManager")
+@patch("iac_code.ui.repl.SessionStorage")
+@patch("iac_code.ui.repl.MemoryManager")
+def test_run_does_not_render_second_update_notice_after_startup_prompt(mock_mm, mock_ss, mock_pm):
+    import asyncio
+    from io import StringIO
+    from unittest.mock import AsyncMock
+
+    from rich.console import Console
+    from rich.text import Text
+
+    from iac_code.ui.repl import ExitREPLError, InlineREPL
+
+    update = make_pending_update()
+    repl = InlineREPL(model="test-model")
+    output = StringIO()
+    repl.console = Console(file=output, force_terminal=False, width=120)
+    repl._prompt_input.get_input = AsyncMock(side_effect=ExitREPLError())
+
+    with (
+        patch("iac_code.ui.repl.get_pending_update", return_value=update),
+        patch("iac_code.ui.repl.render_welcome_banner", return_value=Text("welcome")),
+        patch("iac_code.ui.repl.Select") as select,
+        patch("iac_code.ui.repl.start_background_housekeeping"),
+        patch("iac_code.ui.repl.start_background_update_check"),
+    ):
+        select.return_value.run.return_value = "skip"
+        asyncio.run(repl.run())
+
+    assert output.getvalue().count("Update available!") == 1


### PR DESCRIPTION
## Summary
- Avoid rendering the skipped-update notice immediately after the interactive startup update prompt.
- Add a regression test that verifies the startup update message appears only once.

Fixes #75

## Test Plan
- make test
- make lint