### PR TITLE
Queue streaming input at tool boundaries

### DIFF
--- a/src/iac_code/agent/agent_loop.py
+++ b/src/iac_code/agent/agent_loop.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import time
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -23,6 +23,7 @@ from iac_code.types.stream_events import (
     CompactionEvent,
     MessageEndEvent,
     PermissionRequestEvent,
+    QueuedInputSubmittedEvent,
     StackInstancesProgressEvent,
     StackProgressEvent,
     StreamEvent,
@@ -186,7 +187,11 @@ class AgentLoop:
                 final_text += event.text
         return final_text
 
-    async def run_streaming(self, user_input: str | list[ContentBlock]) -> AsyncGenerator[StreamEvent, None]:
+    async def run_streaming(
+        self,
+        user_input: str | list[ContentBlock],
+        queued_input_provider: Callable[[], list[str]] | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]:
         """Streaming execution yielding fine-grained StreamEvents.
 
         Flow:
@@ -256,7 +261,10 @@ class AgentLoop:
                         git_branch=self._current_git_branch,
                     )
                 try:
-                    async for event in self._run_streaming_inner(user_input):
+                    async for event in self._run_streaming_inner(
+                        user_input,
+                        queued_input_provider=queued_input_provider,
+                    ):
                         if isinstance(event, TextDeltaEvent) and not first_token_received:
                             first_token_received = True
                             ttft_ns = int((time.monotonic() - interaction_started) * 1_000_000_000)
@@ -280,7 +288,11 @@ class AgentLoop:
                         serialize_output_messages("".join(final_text_chunks), final_stop_reason),
                     )
 
-    async def _run_streaming_inner(self, user_input: str | list[ContentBlock]) -> AsyncGenerator[StreamEvent, None]:
+    async def _run_streaming_inner(
+        self,
+        user_input: str | list[ContentBlock],
+        queued_input_provider: Callable[[], list[str]] | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]:
         """Inner streaming loop (called from run_streaming inside the ENTRY span)."""
         from iac_code.services.telemetry import start_span
         from iac_code.services.telemetry.names import GenAiAttr, GenAiOperationName, GenAiSpanKind, Spans
@@ -460,8 +472,13 @@ class AgentLoop:
 
                             denied_content: list[ContentBlock] = list(denied_blocks)
                             self._session_storage.append(
-                                self._cwd, self._session_id, Message(role="user", content=denied_content)
+                                self._cwd,
+                                self._session_id,
+                                Message(role="user", content=denied_content),
+                                git_branch=self._current_git_branch,
                             )
+                        async for event in self._submit_queued_inputs_after_tool_call(queued_input_provider):
+                            yield event
                     continue
 
                 requests = allowed_requests
@@ -558,8 +575,34 @@ class AgentLoop:
                             self.context_manager.add_raw_message(msg)
                     if result.context_modifier is not None:
                         self._apply_context_modifier(result.context_modifier)
+
+                async for event in self._submit_queued_inputs_after_tool_call(queued_input_provider):
+                    yield event
         else:
             yield MessageEndEvent(stop_reason="max_turns", usage=Usage())
+
+    async def _submit_queued_inputs_after_tool_call(
+        self,
+        queued_input_provider: Callable[[], list[str]] | None,
+    ) -> AsyncGenerator[QueuedInputSubmittedEvent, None]:
+        if queued_input_provider is None:
+            return
+
+        queued_inputs = queued_input_provider()
+        for raw_input in queued_inputs:
+            text = raw_input.strip()
+            if not text:
+                continue
+            await self._apply_auto_triggers(text)
+            message = self.context_manager.add_user_message(text)
+            if self._session_storage:
+                self._session_storage.append(
+                    self._cwd,
+                    self._session_id,
+                    message,
+                    git_branch=self._current_git_branch,
+                )
+            yield QueuedInputSubmittedEvent(text=text)
 
     async def _apply_auto_triggers(self, user_input: str | list[ContentBlock]) -> None:
         if not self._auto_trigger_skills:

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -2396,6 +2396,14 @@ msgid "Log file"
 msgstr "Protokolldatei"
 
 #: src/iac_code/ui/renderer.py
+msgid "Messages to be submitted after next tool call"
+msgstr "Nachrichten, die nach dem nächsten Werkzeugaufruf gesendet werden"
+
+#: src/iac_code/ui/renderer.py
+msgid "press esc to interrupt and send immediately"
+msgstr "Esc drücken, um zu unterbrechen und sofort zu senden"
+
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Nachgedacht für {seconds:.1f}s"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -2399,6 +2399,14 @@ msgid "Log file"
 msgstr "Archivo de registro"
 
 #: src/iac_code/ui/renderer.py
+msgid "Messages to be submitted after next tool call"
+msgstr "Mensajes que se enviarán después de la próxima llamada a herramienta"
+
+#: src/iac_code/ui/renderer.py
+msgid "press esc to interrupt and send immediately"
+msgstr "pulsa esc para interrumpir y enviar inmediatamente"
+
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Razonamiento durante {seconds:.1f} s"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -2405,6 +2405,14 @@ msgid "Log file"
 msgstr "Fichier journal"
 
 #: src/iac_code/ui/renderer.py
+msgid "Messages to be submitted after next tool call"
+msgstr "Messages à envoyer après le prochain appel d'outil"
+
+#: src/iac_code/ui/renderer.py
+msgid "press esc to interrupt and send immediately"
+msgstr "appuyez sur esc pour interrompre et envoyer immédiatement"
+
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Réflexion pendant {seconds:.1f}s"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -2333,6 +2333,14 @@ msgid "Log file"
 msgstr "ログファイル"
 
 #: src/iac_code/ui/renderer.py
+msgid "Messages to be submitted after next tool call"
+msgstr "次のツール呼び出し後に送信されるメッセージ"
+
+#: src/iac_code/ui/renderer.py
+msgid "press esc to interrupt and send immediately"
+msgstr "esc で中断してすぐに送信"
+
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "{seconds:.1f} 秒考えました"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -2382,6 +2382,14 @@ msgid "Log file"
 msgstr "Arquivo de log"
 
 #: src/iac_code/ui/renderer.py
+msgid "Messages to be submitted after next tool call"
+msgstr "Mensagens a enviar após a próxima chamada de ferramenta"
+
+#: src/iac_code/ui/renderer.py
+msgid "press esc to interrupt and send immediately"
+msgstr "pressione esc para interromper e enviar imediatamente"
+
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "Raciocínio por {seconds:.1f}s"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -2307,6 +2307,14 @@ msgid "Log file"
 msgstr "日志文件"
 
 #: src/iac_code/ui/renderer.py
+msgid "Messages to be submitted after next tool call"
+msgstr "下次工具调用后要提交的消息"
+
+#: src/iac_code/ui/renderer.py
+msgid "press esc to interrupt and send immediately"
+msgstr "按 esc 中断并立即发送"
+
+#: src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Thought for {seconds:.1f}s"
 msgstr "思考完成（耗时 {seconds:.1f}s）"

--- a/src/iac_code/types/stream_events.py
+++ b/src/iac_code/types/stream_events.py
@@ -154,6 +154,14 @@ class TaskNotificationEvent:
 
 
 @dataclass
+class QueuedInputSubmittedEvent:
+    """A user prompt queued during streaming was submitted mid-turn."""
+
+    text: str
+    type: Literal["queued_input_submitted"] = "queued_input_submitted"
+
+
+@dataclass
 class SubAgentToolEvent:
     """A sub-agent's internal tool activity — forwarded to parent Renderer."""
 
@@ -222,6 +230,7 @@ StreamEvent = Union[
     PermissionRequestEvent,
     CompactionEvent,
     TaskNotificationEvent,
+    QueuedInputSubmittedEvent,
     SubAgentToolEvent,
     StackProgressEvent,
     StackInstancesProgressEvent,

--- a/src/iac_code/ui/core/prompt_input.py
+++ b/src/iac_code/ui/core/prompt_input.py
@@ -598,7 +598,7 @@ class PromptInput:
     # Public async entry-point
     # ------------------------------------------------------------------
 
-    async def get_input(self, prompt: str = "❯ ") -> Optional[str]:
+    async def get_input(self, prompt: str = "❯ ", *, initial_text: str = "") -> Optional[str]:
         """Prompt the user for input and return it.
 
         Runs the blocking input loop directly in the main thread because
@@ -609,21 +609,21 @@ class PromptInput:
         Returns the entered string, or None if the user pressed Ctrl+C or
         Ctrl+D.
         """
-        return self._input_loop(prompt)
+        return self._input_loop(prompt, initial_text=initial_text)
 
-    def _input_loop(self, prompt: str) -> Optional[str]:
+    def _input_loop(self, prompt: str, *, initial_text: str = "") -> Optional[str]:
         """Blocking input loop with inline rendering."""
         from iac_code.ui.core.raw_input import RawInputCapture
 
         # Reset state
-        self._buffer = []
-        self._cursor = 0
+        self._buffer = list(initial_text)
+        self._cursor = len(self._buffer)
         self._pasted_contents = {}
         self._next_paste_id = 1
         self._submitted = False
         self._cancelled = False
         self._esc_pressed = False
-        self._text_changed = False
+        self._text_changed = bool(initial_text)
         self._pending_action = None
         self._clipboard_has_image = False
         self._prompt = prompt
@@ -632,8 +632,10 @@ class PromptInput:
         self._prev_cursor_physical_row = 0
 
         # Initial render (just prompt)
-        sys.stdout.write(f"{_COLOR_BOLD}{_COLOR_CYAN}{prompt}{_COLOR_RESET}")
-        sys.stdout.flush()
+        if self._text_changed:
+            self._update_suggestions_sync()
+            self._text_changed = False
+        self._render()
 
         while not self._submitted and not self._cancelled:
             with RawInputCapture() as cap:

--- a/src/iac_code/ui/renderer.py
+++ b/src/iac_code/ui/renderer.py
@@ -10,6 +10,7 @@ is re-rendered on toggle.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import os
 import sys
@@ -42,6 +43,7 @@ from iac_code.types.stream_events import (
     MessageEndEvent,
     MessageStartEvent,
     PermissionRequestEvent,
+    QueuedInputSubmittedEvent,
     StackInstancesProgressEvent,
     StackProgressEvent,
     StreamEvent,
@@ -57,6 +59,7 @@ from iac_code.types.stream_events import (
     Usage,
 )
 from iac_code.ui.components.select import OptionType, Select, SelectLayout, TextOption
+from iac_code.ui.core.key_event import KeyEvent
 from iac_code.ui.spinner import ShimmerSpinner
 from iac_code.utils.json_utils import extract_partial_string_fields
 
@@ -190,6 +193,91 @@ class RenderedTurn:
     text: str = ""  # For user turns, the raw input text
 
 
+@dataclass
+class StreamingOutputResult:
+    """Result from one streamed assistant turn."""
+
+    elapsed: float
+    queued_inputs: list[str] = field(default_factory=list)
+    draft_input: str = ""
+    interrupted: bool = False
+
+
+class StreamingInputBuffer:
+    """Minimal line buffer used while an assistant response is streaming."""
+
+    def __init__(self) -> None:
+        self._chars: list[str] = []
+        self._queued_inputs: list[str] = []
+        self.interrupted = False
+
+    @property
+    def text(self) -> str:
+        return "".join(self._chars)
+
+    @property
+    def queued_inputs(self) -> list[str]:
+        return list(self._queued_inputs)
+
+    def drain_queued_inputs(self, predicate: Callable[[str], bool] | None = None) -> list[str]:
+        """Remove and return queued inputs matching *predicate*.
+
+        Non-matching inputs stay queued so slash/local commands can be handled by
+        the REPL after the active assistant turn exits.
+        """
+        if predicate is None:
+            drained = list(self._queued_inputs)
+            self._queued_inputs.clear()
+            return drained
+
+        drained: list[str] = []
+        remaining: list[str] = []
+        for value in self._queued_inputs:
+            if predicate(value):
+                drained.append(value)
+            else:
+                remaining.append(value)
+        self._queued_inputs = remaining
+        return drained
+
+    def handle_key(self, event: KeyEvent) -> str | None:
+        """Apply a key event.
+
+        Returns ``"queued"``, ``"interrupt"``, ``"changed"``, or ``None``.
+        """
+        if event.key == "escape":
+            self._queue_current()
+            self.interrupted = True
+            return "interrupt"
+
+        if event.key == "enter":
+            return "queued" if self._queue_current() else None
+
+        if event.key == "backspace":
+            if self._chars:
+                self._chars.pop()
+                return "changed"
+            return None
+
+        if event.ctrl:
+            return None
+
+        char = event.char
+        if char and char.isprintable():
+            self._chars.append(char)
+            return "changed"
+        return None
+
+    def _queue_current(self) -> bool:
+        text = self.text
+        if not text.strip():
+            self._chars.clear()
+            return False
+        self._queued_inputs.append(text)
+        self._chars.clear()
+        return True
+
+
 class Renderer:
     """Bridge between stream events and terminal output."""
 
@@ -215,6 +303,7 @@ class Renderer:
         # shared LRU cache at AppState.always_allow_rules. None in pure-unit
         # contexts where no session state is wired up.
         self._app_state_store = app_state_store
+        self._streaming_input: StreamingInputBuffer | None = None
 
     # ── Footer (shown inside Live during streaming) ─────────────────
 
@@ -222,11 +311,30 @@ class Renderer:
         """Build the persistent footer: separator + disabled input + status."""
         status_text = self._status_callback() if self._status_callback else ""
         status = Text(status_text, style="dim", justify="right")
-        return Group(
-            Rule(style="dim"),
-            Text("❯ ", style="dim"),
-            status,
-        )
+        parts: list[Any] = [Rule(style="dim")]
+
+        if self._streaming_input is not None and self._streaming_input.queued_inputs:
+            header = Text()
+            header.append(_("Messages to be submitted after next tool call"))
+            header.append(" (", style="dim")
+            header.append(_("press esc to interrupt and send immediately"), style="dim")
+            header.append(")", style="dim")
+            parts.append(header)
+            for queued_input in self._streaming_input.queued_inputs:
+                line = Text()
+                line.append("↳ ", style="dim")
+                line.append(queued_input, style="dim")
+                parts.append(line)
+
+        prompt = Text()
+        if self._streaming_input is not None:
+            prompt.append("❯ ", style="bold cyan")
+            if self._streaming_input.text:
+                prompt.append(self._streaming_input.text)
+        else:
+            prompt.append("❯ ", style="dim")
+        parts.extend([prompt, status])
+        return Group(*parts)
 
     def _with_footer(self, content) -> Group:
         """Wrap content with the persistent footer below it."""
@@ -727,7 +835,8 @@ class Renderer:
         self,
         events: AsyncGenerator[StreamEvent, None],
         permission_handler: Callable[[PermissionRequestEvent], Awaitable[bool]],
-    ) -> float:
+        streaming_input: StreamingInputBuffer | None = None,
+    ) -> StreamingOutputResult:
         """Consume the event stream and render everything."""
         self._last_streaming_errors = []
         self.console.print()  # blank line between user input and agent response
@@ -741,6 +850,10 @@ class Renderer:
         thinking_start_time: float | None = None
         segments: list[_Segment] = []
         turn_start_time: float = time.monotonic()
+        input_buffer = streaming_input or StreamingInputBuffer()
+        previous_streaming_input = self._streaming_input
+        self._streaming_input = input_buffer
+        streaming_task = asyncio.current_task()
 
         # Save terminal settings before any background task modifies them
         # so we can unconditionally restore on exit.
@@ -765,6 +878,26 @@ class Renderer:
                     segments, spinner, text_buffer, task_spinner, thinking_buffer=thinking_buffer
                 )
                 live.update(self._with_footer(content))
+
+        def _request_interrupt() -> None:
+            if streaming_task is not None and not streaming_task.done():
+                streaming_task.cancel()
+
+        def _new_key_task() -> asyncio.Task:
+            if live is None:
+                raise RuntimeError("Cannot listen for streaming input before Live starts")
+            return asyncio.create_task(
+                self._key_listener(
+                    live,
+                    segments,
+                    spinner,
+                    lambda: text_buffer,
+                    _rebuild_after_transcript,
+                    streaming_input=input_buffer,
+                    on_input_changed=_update_live,
+                    on_interrupt=_request_interrupt,
+                )
+            )
 
         def _ensure_live():
             nonlocal live
@@ -860,15 +993,7 @@ class Renderer:
                 # would swallow Ctrl+O until the next MessageStart or
                 # ToolUseStart rebuilt it.
                 if live is not None and (key_task is None or key_task.done()):
-                    key_task = asyncio.create_task(
-                        self._key_listener(
-                            live,
-                            segments,
-                            spinner,
-                            lambda: text_buffer,
-                            _rebuild_after_transcript,
-                        )
-                    )
+                    key_task = _new_key_task()
 
                 # ── Message start ───────────────────────────────
                 if isinstance(event, MessageStartEvent):
@@ -889,15 +1014,7 @@ class Renderer:
                             )
                         )
                     if key_task is None or key_task.done():
-                        key_task = asyncio.create_task(
-                            self._key_listener(
-                                live,
-                                segments,
-                                spinner,
-                                lambda: text_buffer,
-                                _rebuild_after_transcript,
-                            )
-                        )
+                        key_task = _new_key_task()
 
                 # ── Thinking delta ─────────────────────────────
                 elif isinstance(event, ThinkingDeltaEvent):
@@ -960,15 +1077,7 @@ class Renderer:
                                 )
                             )
                             if key_task is None or key_task.done():
-                                key_task = asyncio.create_task(
-                                    self._key_listener(
-                                        live,
-                                        segments,
-                                        spinner,
-                                        lambda: text_buffer,
-                                        _rebuild_after_transcript,
-                                    )
-                                )
+                                key_task = _new_key_task()
 
                     _update_live()
 
@@ -1018,15 +1127,7 @@ class Renderer:
                         )
                     )
                     if key_task is None or key_task.done():
-                        key_task = asyncio.create_task(
-                            self._key_listener(
-                                live,
-                                segments,
-                                spinner,
-                                lambda: text_buffer,
-                                _rebuild_after_transcript,
-                            )
-                        )
+                        key_task = _new_key_task()
 
                 # ── Tool input delta ────────────────────────────
                 elif isinstance(event, ToolInputDeltaEvent):
@@ -1213,6 +1314,26 @@ class Renderer:
                         notice.append(f" (error: {event.error})", style="red")
                     self.console.print(notice)
 
+                # ── Queued user input submitted mid-turn ─────────────
+                elif isinstance(event, QueuedInputSubmittedEvent):
+                    await self._stop_refresh(refresh_task)
+                    refresh_task = None
+                    await self._stop_refresh(key_task)
+                    key_task = None
+                    if live:
+                        self._quiet_stop_live(live)
+                        live = None
+                    spinner = None
+                    if segments or text_buffer:
+                        self._print_segments_to_scrollback(segments, text_buffer)
+                        segments.clear()
+                        text_buffer = ""
+                        tool_records.clear()
+                    self._text_flushed = False
+                    self.print_user_message(event.text)
+                    self.record_user_turn(event.text)
+                    self.console.print()
+
                 # ── Error ──────────────────────────────────────
                 elif isinstance(event, ErrorEvent):
                     self._last_streaming_errors.append(event.error)
@@ -1259,6 +1380,7 @@ class Renderer:
                     # DON'T break — there may be more events after tool execution
 
         except (asyncio.CancelledError, KeyboardInterrupt):
+            input_buffer.interrupted = True
             self.console.print(Text(_("Operation cancelled."), style="yellow"))
         except Exception as e:
             error_msg = str(e)
@@ -1305,8 +1427,14 @@ class Renderer:
                 self.console.print()  # blank line before completion
                 verb = random_completion_verb()
                 self.console.print(Text(f"✻ {verb} {_format_elapsed(elapsed)}", style="dim italic"))
+            self._streaming_input = previous_streaming_input
 
-        return elapsed
+        return StreamingOutputResult(
+            elapsed=elapsed,
+            queued_inputs=input_buffer.queued_inputs,
+            draft_input=input_buffer.text,
+            interrupted=input_buffer.interrupted,
+        )
 
     # ── Permission prompting ────────────────────────────────────────
 
@@ -1584,6 +1712,60 @@ class Renderer:
         except asyncio.CancelledError:
             pass
 
+    @staticmethod
+    async def _read_streaming_key_event(first_byte: int, queue: asyncio.Queue[int]) -> KeyEvent | None:
+        """Convert bytes from the streaming key listener into a small KeyEvent subset."""
+        if first_byte == 0x1B:
+            with contextlib.suppress(asyncio.TimeoutError):
+                second = await asyncio.wait_for(queue.get(), timeout=0.05)
+                if second == ord("["):
+                    # Ignore CSI sequences (arrows, bracketed-paste markers, focus events).
+                    for _ in range(16):
+                        with contextlib.suppress(asyncio.TimeoutError):
+                            b = await asyncio.wait_for(queue.get(), timeout=0.01)
+                            if 0x40 <= b <= 0x7E:
+                                break
+                            continue
+                        break
+                    return None
+                if 32 <= second <= 126:
+                    char = chr(second)
+                    return KeyEvent(key=char, char=char, alt=True)
+                return None
+            return KeyEvent(key="escape", char="\x1b")
+
+        if first_byte in (10, 13):
+            return KeyEvent(key="enter", char=chr(first_byte))
+        if first_byte == 9:
+            return KeyEvent(key="tab", char="\t")
+        if first_byte in (8, 127):
+            return KeyEvent(key="backspace", char=chr(first_byte))
+        if 1 <= first_byte <= 26:
+            letter = chr(ord("a") + first_byte - 1)
+            return KeyEvent(key=letter, char=chr(first_byte), ctrl=True)
+        if 32 <= first_byte <= 126:
+            char = chr(first_byte)
+            return KeyEvent(key=char, char=char, shift=char.isupper())
+        if first_byte >= 0x80:
+            if first_byte < 0xC0:
+                return None
+            if first_byte < 0xE0:
+                remaining = 1
+            elif first_byte < 0xF0:
+                remaining = 2
+            else:
+                remaining = 3
+            data = bytes([first_byte])
+            for _ in range(remaining):
+                try:
+                    data += bytes([await asyncio.wait_for(queue.get(), timeout=0.05)])
+                except asyncio.TimeoutError:
+                    return None
+            with contextlib.suppress(UnicodeDecodeError):
+                char = data.decode("utf-8")
+                return KeyEvent(key=char, char=char)
+        return None
+
     async def _key_listener(
         self,
         live: Live,
@@ -1591,8 +1773,12 @@ class Renderer:
         spinner: ShimmerSpinner | None,
         get_text: Callable[[], str],
         on_transcript_done: Callable[[], Awaitable[None]] | None = None,
+        *,
+        streaming_input: StreamingInputBuffer | None = None,
+        on_input_changed: Callable[[], None] | None = None,
+        on_interrupt: Callable[[], None] | None = None,
     ) -> None:
-        """Background task: listen for Ctrl+O to toggle verbose mode.
+        """Background task: listen for streaming keys.
 
         Uses loop.add_reader for proper asyncio integration on Unix (clears
         IEXTEN to prevent macOS from intercepting Ctrl+O as VDISCARD).
@@ -1644,10 +1830,24 @@ class Renderer:
             show_transcript_after = False
             while True:
                 ch = await queue.get()
-                if ch == 0x0F:  # Ctrl+O — break out and open transcript view
+                event = await self._read_streaming_key_event(ch, queue)
+                if event is None:
+                    continue
+                if event.ctrl and event.key == "o":  # Ctrl+O — break out and open transcript view
                     show_transcript_after = True
                     break
-                if ch == 0x1B:  # Escape — interrupt
+                if streaming_input is None:
+                    if event.key == "escape":
+                        break
+                    continue
+                outcome = streaming_input.handle_key(event)
+                if outcome is None:
+                    continue
+                if on_input_changed is not None:
+                    on_input_changed()
+                if outcome == "interrupt":
+                    if on_interrupt is not None:
+                        on_interrupt()
                     break
         except asyncio.CancelledError:
             return

--- a/src/iac_code/ui/repl.py
+++ b/src/iac_code/ui/repl.py
@@ -21,7 +21,7 @@ import sys
 import time
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 from loguru import logger
 from rich.console import Console
@@ -57,7 +57,7 @@ from iac_code.ui.components.select import Select, SelectLayout, TextOption
 from iac_code.ui.core.input_history import InputHistory
 from iac_code.ui.core.prompt_input import PromptInput, PromptInputResult
 from iac_code.ui.keybindings.manager import KeyBinding, KeybindingManager
-from iac_code.ui.renderer import Renderer
+from iac_code.ui.renderer import Renderer, StreamingInputBuffer
 from iac_code.ui.suggestions.aggregator import SuggestionAggregator
 from iac_code.ui.suggestions.command_provider import CommandProvider
 from iac_code.ui.suggestions.directory_provider import DirectoryProvider
@@ -393,6 +393,8 @@ class InlineREPL:
 
         first_turn = True
         last_ctrl_c_time: float = 0.0
+        queued_inputs: list[str] = []
+        draft_input = ""
 
         try:
             while True:
@@ -411,12 +413,16 @@ class InlineREPL:
                     first_turn = False
 
                     # Use initial_prompt for the first turn if provided
-                    if initial_prompt is not None:
+                    if queued_inputs:
+                        user_input = queued_inputs.pop(0)
+                        self.renderer.print_user_message(user_input)
+                    elif initial_prompt is not None:
                         user_input = initial_prompt
                         initial_prompt = None
                         self.console.print(f"[bold cyan]❯[/bold cyan] {user_input}")
                     else:
-                        user_input = await self._prompt_input.get_input()
+                        user_input = await self._prompt_input.get_input(initial_text=draft_input)
+                        draft_input = ""
                     if user_input is None:  # Ctrl+C with empty input
                         now = time.monotonic()
                         if now - last_ctrl_c_time < 1.5:
@@ -436,7 +442,10 @@ class InlineREPL:
 
                     if self.command_registry.is_command(user_input):
                         self._record_command_history(user_input)
-                        await self._handle_command(user_input)
+                        queued_inputs.extend(await self._handle_command(user_input))
+                        new_draft = self._consume_streaming_draft_input()
+                        if new_draft:
+                            draft_input = new_draft
                         self._clear_cancel_state()
                         continue
                     self._history.append(user_input)
@@ -444,7 +453,10 @@ class InlineREPL:
                     chat_input: PromptInputResult | str
                     result = self._prompt_input.make_result()
                     chat_input = result if result.pasted_contents else user_input
-                    await self._handle_chat(chat_input)
+                    queued_inputs.extend(await self._handle_chat(chat_input))
+                    new_draft = self._consume_streaming_draft_input()
+                    if new_draft:
+                        draft_input = new_draft
                     self._clear_cancel_state()
                 except (KeyboardInterrupt, asyncio.CancelledError):
                     self._clear_cancel_state()
@@ -829,7 +841,7 @@ class InlineREPL:
             self.renderer.print_system_message(_("Permission denied."), style="red")
         return allowed
 
-    async def _handle_command(self, user_input: str) -> None:
+    async def _handle_command(self, user_input: str) -> list[str]:
         """Dispatch a slash command and print the result."""
         is_skill_trigger = user_input.startswith("$")
         name, args = self.command_registry.parse(user_input)
@@ -842,17 +854,17 @@ class InlineREPL:
         if cmd is None:
             if is_skill_trigger and normalize_skill_name(name) in getattr(self, "_disabled_skill_commands", {}):
                 _emit_error(_("Skill '{name}' is disabled. Run /skills to enable it.").format(name=name))
-                return
+                return []
             if is_skill_trigger:
                 _emit_error(_("Unknown skill: ${name}. Type / to list commands and skills.").format(name=name))
             else:
                 _emit_error(_("Unknown command: /{name}. Type /help for available commands.").format(name=name))
-            return
+            return []
 
         # The "$" trigger invokes skills only; reject built-in commands with a clear hint.
         if is_skill_trigger and not isinstance(cmd, PromptCommand):
             _emit_error(_("$ only invokes skills. Use /{name} instead.").format(name=name))
-            return
+            return []
 
         if isinstance(cmd, PromptCommand):
             # Skill command: process via unified path
@@ -862,7 +874,7 @@ class InlineREPL:
             try:
                 result = await process_prompt_command(cmd, args_str)
                 if result.is_fork:
-                    await self._handle_chat(result.prompt_content)
+                    return await self._handle_chat(result.prompt_content)
                 else:
                     # Inline mode: inject messages and continue agent loop
                     for msg in result.new_messages:
@@ -870,12 +882,13 @@ class InlineREPL:
                     if result.context_modifier:
                         self._agent_loop._apply_context_modifier(result.context_modifier)
                     # Stream the agent's response to the injected skill prompt
-                    await self._handle_chat_continue()
+                    return await self._handle_chat_continue()
             except Exception as exc:
                 self.renderer.print_system_message(
                     _("Command error: {error}").format(error=exc),
                     style="red",
                 )
+            return []
         elif isinstance(cmd, LocalCommand):
             context = CommandContext(console=self.console, store=self.store, repl=self)
             if cmd.handler is None:
@@ -883,7 +896,7 @@ class InlineREPL:
                     _("Command has no handler: {name}").format(name=cmd.name),
                     style="red",
                 )
-                return
+                return []
             from iac_code.config import get_active_provider_key
 
             prev_model = self.store.get_state().model
@@ -924,12 +937,39 @@ class InlineREPL:
                     _("Command error: {error}").format(error=exc),
                     style="red",
                 )
+        return []
 
     def _message_count(self) -> int:
         try:
             return len(self._agent_loop.context_manager.get_messages())
         except Exception:
             return 0
+
+    @staticmethod
+    def _normalize_streaming_output_result(result: object) -> tuple[float, list[str], str]:
+        """Return ``(elapsed, queued_inputs, draft_input)`` from the renderer result.
+
+        Older tests and light-weight fakes may still return the pre-queueing
+        float elapsed value. Keep accepting that shape at this boundary.
+        """
+        elapsed = cast(Any, getattr(result, "elapsed", result))
+        queued_inputs = cast(Any, getattr(result, "queued_inputs", []))
+        draft_input = cast(Any, getattr(result, "draft_input", ""))
+        return float(elapsed), list(queued_inputs), str(draft_input)
+
+    def _consume_streaming_draft_input(self) -> str:
+        draft = getattr(self, "_streaming_draft_input", "")
+        self._streaming_draft_input = ""
+        return draft
+
+    def _should_submit_mid_turn(self, value: str) -> bool:
+        stripped = value.strip()
+        if not stripped or stripped.startswith("!"):
+            return False
+        try:
+            return not self.command_registry.is_command(stripped)
+        except Exception:
+            return True
 
     def _record_command_log(self, user_input: str, result: str, *, is_error: bool) -> None:
         if hasattr(self, "_command_log"):
@@ -990,7 +1030,7 @@ class InlineREPL:
     # Chat handling
     # ------------------------------------------------------------------
 
-    async def _handle_chat_continue(self) -> None:
+    async def _handle_chat_continue(self) -> list[str]:
         """Continue the agent loop after injecting messages (e.g., skill prompt).
 
         Unlike _handle_chat, this doesn't add a new user message — the messages
@@ -998,21 +1038,29 @@ class InlineREPL:
         """
         self.store.set_state(is_busy=True)
         try:
-            events = self._agent_loop.run_streaming("")
-            elapsed = await self.renderer.run_streaming_output(
+            streaming_input = StreamingInputBuffer()
+            events = self._agent_loop.run_streaming(
+                "",
+                queued_input_provider=lambda: streaming_input.drain_queued_inputs(self._should_submit_mid_turn),
+            )
+            result = await self.renderer.run_streaming_output(
                 events,
                 permission_handler=self.renderer.prompt_permission,
+                streaming_input=streaming_input,
             )
+            elapsed, queued_inputs, draft_input = self._normalize_streaming_output_result(result)
+            self._streaming_draft_input = draft_input
             if elapsed >= 1.0:
                 self._agent_loop.stamp_last_turn_elapsed(elapsed)
             if self.renderer._last_streaming_errors:
                 msg_count = len(self._agent_loop.context_manager.get_messages())
                 for err in self.renderer._last_streaming_errors:
                     self._streaming_error_log.append((err, msg_count))
+            return queued_inputs
         finally:
             self.store.set_state(is_busy=False)
 
-    async def _handle_chat(self, user_input: PromptInputResult | str) -> None:
+    async def _handle_chat(self, user_input: PromptInputResult | str) -> list[str]:
         """Send the user message to the agent loop and stream output."""
         from iac_code.agent.message import ContentBlock, ImageBlock
         from iac_code.utils.image.processor import process_user_input
@@ -1034,17 +1082,25 @@ class InlineREPL:
         self.store.set_state(is_busy=True)
         self.renderer.record_user_turn(record_text)
         try:
-            events = self._agent_loop.run_streaming(payload)
-            elapsed = await self.renderer.run_streaming_output(
+            streaming_input = StreamingInputBuffer()
+            events = self._agent_loop.run_streaming(
+                payload,
+                queued_input_provider=lambda: streaming_input.drain_queued_inputs(self._should_submit_mid_turn),
+            )
+            result = await self.renderer.run_streaming_output(
                 events,
                 permission_handler=self.renderer.prompt_permission,
+                streaming_input=streaming_input,
             )
+            elapsed, queued_inputs, draft_input = self._normalize_streaming_output_result(result)
+            self._streaming_draft_input = draft_input
             if elapsed >= 1.0:
                 self._agent_loop.stamp_last_turn_elapsed(elapsed)
             if self.renderer._last_streaming_errors:
                 msg_count = len(self._agent_loop.context_manager.get_messages())
                 for err in self.renderer._last_streaming_errors:
                     self._streaming_error_log.append((err, msg_count))
+            return queued_inputs
         finally:
             self.store.set_state(is_busy=False)
 

--- a/tests/agent/test_agent_loop_new.py
+++ b/tests/agent/test_agent_loop_new.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -10,6 +10,7 @@ from iac_code.types.stream_events import (
     CompactionEvent,
     MessageEndEvent,
     MessageStartEvent,
+    QueuedInputSubmittedEvent,
     TextDeltaEvent,
     ToolResultEvent,
     ToolUseEndEvent,
@@ -259,6 +260,70 @@ class TestAgentLoopStreaming:
         assert totals.output_tokens == 8
         assert totals.recorded_events == 2
         assert store.load("/tmp/status-project", "multi-call-session").total_tokens == 25
+
+    async def test_queued_input_is_submitted_after_tool_results_before_next_model_call(
+        self, mock_provider, mock_registry
+    ):
+        call_messages = []
+        call_count = 0
+
+        async def fake_stream(messages, system, tools=None, max_tokens=8192):
+            nonlocal call_count
+            call_count += 1
+            call_messages.append(messages)
+            if call_count == 1:
+                yield MessageStartEvent(message_id="m1")
+                yield ToolUseStartEvent(tool_use_id="toolu_1", name="read_file")
+                yield ToolUseEndEvent(tool_use_id="toolu_1", name="read_file", input={"path": "a.txt"})
+                yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+                return
+
+            yield MessageStartEvent(message_id="m2")
+            yield TextDeltaEvent(text="handled queued input")
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+
+        drained = False
+
+        def queued_input_provider():
+            nonlocal drained
+            if drained:
+                return []
+            drained = True
+            return ["你好"]
+
+        mock_provider.stream = fake_stream
+        loop = AgentLoop(provider_manager=mock_provider, system_prompt="test", tool_registry=mock_registry)
+        loop._result_storage = MagicMock()
+        loop._result_storage.process.return_value = SimpleNamespace(content="file contents")
+        loop._tool_executor.execute_batch = AsyncMock(return_value=[ToolResult(content="raw result", is_error=False)])
+
+        events = [e async for e in loop.run_streaming("Hi", queued_input_provider=queued_input_provider)]
+
+        assert call_count == 2
+        assert any(isinstance(e, QueuedInputSubmittedEvent) and e.text == "你好" for e in events)
+        second_call = call_messages[1]
+        assert [message.role for message in second_call] == ["user", "assistant", "user", "user"]
+        assert second_call[0].content == "Hi"
+        assert second_call[2].content[0].type == "tool_result"
+        assert second_call[3].content == "你好"
+
+    async def test_queued_input_provider_is_not_drained_without_tool_call(self, mock_provider, mock_registry):
+        queued_input_provider = Mock(return_value=["should wait"])
+
+        async def fake_stream(messages, system, tools=None, max_tokens=8192):
+            yield MessageStartEvent(message_id="m1")
+            yield TextDeltaEvent(text="done")
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+
+        mock_provider.stream = fake_stream
+        loop = AgentLoop(provider_manager=mock_provider, system_prompt="test", tool_registry=mock_registry)
+
+        events = [e async for e in loop.run_streaming("Hi", queued_input_provider=queued_input_provider)]
+
+        assert not any(isinstance(e, QueuedInputSubmittedEvent) for e in events)
+        queued_input_provider.assert_not_called()
+        user_texts = [message.get_text() for message in loop.context_manager.get_messages() if message.role == "user"]
+        assert user_texts == ["Hi"]
 
     async def test_does_not_record_zero_message_end_usage(self, mock_provider, mock_registry, tmp_path):
         async def fake_stream(messages, system, tools=None, max_tokens=8192):

--- a/tests/types/test_stream_events.py
+++ b/tests/types/test_stream_events.py
@@ -4,6 +4,7 @@ from iac_code.types.stream_events import (
     MessageEndEvent,
     MessageStartEvent,
     PermissionRequestEvent,
+    QueuedInputSubmittedEvent,
     StreamEvent,
     TaskNotificationEvent,
     TextDeltaEvent,
@@ -76,6 +77,11 @@ class TestStreamEventTypes:
         )
         assert event.type == "task_notification"
 
+    def test_queued_input_submitted(self):
+        event = QueuedInputSubmittedEvent(text="new instruction")
+        assert event.type == "queued_input_submitted"
+        assert event.text == "new instruction"
+
     def test_stream_event_union_covers_all(self):
         events: list[StreamEvent] = [
             MessageStartEvent(message_id="m1"),
@@ -91,5 +97,6 @@ class TestStreamEventTypes:
             PermissionRequestEvent(tool_name="bash", tool_input={}, tool_use_id="t1"),
             CompactionEvent(),
             TaskNotificationEvent(task_id="t1", description="x", status="completed"),
+            QueuedInputSubmittedEvent(text="queued"),
         ]
-        assert len(events) == 13
+        assert len(events) == 14

--- a/tests/ui/core/test_prompt_input.py
+++ b/tests/ui/core/test_prompt_input.py
@@ -602,6 +602,33 @@ class TestPromptInputLoop:
         inp = make_input()
         assert inp._input_loop("❯ ") == ""
 
+    def test_input_loop_uses_initial_text(self, monkeypatch):
+        import iac_code.ui.core.prompt_input as prompt_mod
+
+        events = iter([_key("enter")])
+
+        class FakeCapture:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read_key(self):
+                return next(events)
+
+        out = StringIO()
+        monkeypatch.setattr(prompt_mod, "sys", SimpleNamespace(stdout=out))
+        monkeypatch.setattr(
+            prompt_mod.shutil,
+            "get_terminal_size",
+            lambda *args, **kwargs: os.terminal_size((40, 24)),
+        )
+        monkeypatch.setattr("iac_code.ui.core.raw_input.RawInputCapture", FakeCapture)
+
+        inp = make_input()
+        assert inp._input_loop("❯ ", initial_text="draft") == "draft"
+
     def test_input_loop_runs_pending_action_outside_raw_mode(self, monkeypatch):
         import iac_code.ui.core.prompt_input as prompt_mod
 

--- a/tests/ui/test_renderer_helpers.py
+++ b/tests/ui/test_renderer_helpers.py
@@ -9,9 +9,11 @@ from rich.console import Console
 from iac_code.tools.base import Tool, ToolContext, ToolRegistry, ToolResult
 from iac_code.tools.read_file import ReadFileTool
 from iac_code.types.stream_events import StackInstancesProgressEvent, StackProgressEvent
+from iac_code.ui.core.key_event import KeyEvent
 from iac_code.ui.renderer import (
     RenderedTurn,
     Renderer,
+    StreamingInputBuffer,
     _CropTop,
     _DashMarkdown,
     _Segment,
@@ -122,6 +124,45 @@ class TestRendererHelpers:
             RenderedTurn(role="user", text="hello", timestamp=renderer.message_history[0].timestamp)
         ]
 
+    def test_build_footer_shows_full_queued_message_section(self):
+        renderer = make_renderer()
+        buffer = StreamingInputBuffer()
+        for char in "你好":
+            buffer.handle_key(KeyEvent(key=char, char=char))
+        buffer.handle_key(KeyEvent(key="enter", char="\n"))
+        renderer._streaming_input = buffer
+
+        renderer.console.print(renderer._build_footer())
+        output = renderer.console.file.getvalue()
+
+        assert "Messages to be submitted after next tool call" in output
+        assert "press esc to interrupt" in output
+        assert "send" in output
+        assert "immediately" in output
+        assert "↳ 你好" in output
+        assert "↵ 1" not in output
+
+    def test_build_footer_uses_i18n_for_queued_message_section(self, monkeypatch):
+        import iac_code.ui.renderer as renderer_mod
+
+        translations = {
+            "Messages to be submitted after next tool call": "下次工具调用后要提交的消息",
+            "press esc to interrupt and send immediately": "按 esc 中断并立即发送",
+        }
+        monkeypatch.setattr(renderer_mod, "_", lambda message: translations.get(message, message))
+        renderer = make_renderer()
+        buffer = StreamingInputBuffer()
+        for char in "你好":
+            buffer.handle_key(KeyEvent(key=char, char=char))
+        buffer.handle_key(KeyEvent(key="enter", char="\n"))
+        renderer._streaming_input = buffer
+
+        renderer.console.print(renderer._build_footer())
+        output = renderer.console.file.getvalue()
+
+        assert "下次工具调用后要提交的消息" in output
+        assert "按 esc 中断并立即发送" in output
+
     def test_any_segment_has_verbose_content(self):
         renderer = make_renderer()
         segments = [
@@ -227,6 +268,54 @@ class TestRendererHelpers:
         output = renderer.console.file.getvalue()
         assert "Allow this action?" in output
         assert "detail" in output
+
+
+class TestStreamingInputBuffer:
+    def test_enter_queues_current_buffer_and_clears_prompt(self):
+        buffer = StreamingInputBuffer()
+
+        for char in "next turn":
+            buffer.handle_key(KeyEvent(key=char, char=char))
+        outcome = buffer.handle_key(KeyEvent(key="enter", char="\n"))
+
+        assert outcome == "queued"
+        assert buffer.queued_inputs == ["next turn"]
+        assert buffer.text == ""
+
+    def test_escape_interrupts_and_queues_unsubmitted_buffer(self):
+        buffer = StreamingInputBuffer()
+
+        for char in "redirect":
+            buffer.handle_key(KeyEvent(key=char, char=char))
+        outcome = buffer.handle_key(KeyEvent(key="escape", char="\x1b"))
+
+        assert outcome == "interrupt"
+        assert buffer.interrupted is True
+        assert buffer.queued_inputs == ["redirect"]
+
+    def test_escape_interrupts_without_duplicating_existing_queue(self):
+        buffer = StreamingInputBuffer()
+
+        for char in "queued":
+            buffer.handle_key(KeyEvent(key=char, char=char))
+        buffer.handle_key(KeyEvent(key="enter", char="\n"))
+        outcome = buffer.handle_key(KeyEvent(key="escape", char="\x1b"))
+
+        assert outcome == "interrupt"
+        assert buffer.interrupted is True
+        assert buffer.queued_inputs == ["queued"]
+
+    def test_drain_queued_inputs_keeps_non_matching_items(self):
+        buffer = StreamingInputBuffer()
+        for text in ("prompt", "/help", "second"):
+            for char in text:
+                buffer.handle_key(KeyEvent(key=char, char=char))
+            buffer.handle_key(KeyEvent(key="enter", char="\n"))
+
+        drained = buffer.drain_queued_inputs(lambda value: not value.startswith("/"))
+
+        assert drained == ["prompt", "second"]
+        assert buffer.queued_inputs == ["/help"]
 
 
 class TestStreamingHeaderPreview:

--- a/tests/ui/test_repl_integration.py
+++ b/tests/ui/test_repl_integration.py
@@ -219,6 +219,52 @@ async def test_run_once_routes_normal_chat_unchanged():
 
 
 @pytest.mark.asyncio
+async def test_handle_chat_returns_queued_inputs_from_streaming_renderer():
+    from iac_code.ui.renderer import StreamingOutputResult
+    from iac_code.ui.repl import InlineREPL
+
+    async def events():
+        if False:
+            yield None
+
+    repl = InlineREPL.__new__(InlineREPL)
+    repl.store = SimpleNamespace(set_state=Mock())
+    repl.renderer = SimpleNamespace(
+        record_user_turn=Mock(),
+        run_streaming_output=AsyncMock(return_value=StreamingOutputResult(elapsed=0.2, queued_inputs=["next turn"])),
+        prompt_permission=AsyncMock(),
+        _last_streaming_errors=[],
+    )
+    repl._agent_loop = SimpleNamespace(
+        run_streaming=Mock(return_value=events()),
+        stamp_last_turn_elapsed=Mock(),
+        context_manager=SimpleNamespace(get_messages=Mock(return_value=[])),
+    )
+    repl._streaming_error_log = []
+
+    queued_inputs = await repl._handle_chat("first turn")
+
+    assert queued_inputs == ["next turn"]
+    args, kwargs = repl._agent_loop.run_streaming.call_args
+    assert args == ("first turn",)
+    assert callable(kwargs["queued_input_provider"])
+    _, renderer_kwargs = repl.renderer.run_streaming_output.call_args
+    assert renderer_kwargs["streaming_input"] is not None
+    repl.renderer.record_user_turn.assert_called_once_with("first turn")
+
+
+def test_normalize_streaming_output_result_includes_draft_input():
+    from iac_code.ui.renderer import StreamingOutputResult
+    from iac_code.ui.repl import InlineREPL
+
+    result = InlineREPL._normalize_streaming_output_result(
+        StreamingOutputResult(elapsed=0.2, queued_inputs=["next"], draft_input="half typed")
+    )
+
+    assert result == (0.2, ["next"], "half typed")
+
+
+@pytest.mark.asyncio
 async def test_handle_command_reports_disabled_skill():
     from iac_code.ui.repl import InlineREPL
 


### PR DESCRIPTION
## Summary
- capture input typed while the agent is streaming and render it as queued messages in the terminal footer
- submit queued prompt messages after the next completed tool call, before the next model turn
- preserve slash/local commands for normal REPL handling and add translations/tests for the queued-message footer

Fixes #73

## Test Plan
- [x] make translate
- [x] make lint
- [x] make test
