### PR TITLE
feat: support per-task user_id override in A2A server

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import uuid
@@ -27,7 +28,7 @@ from iac_code.a2a.types import (
 )
 from iac_code.services.agent_factory import AgentFactoryOptions, create_agent_runtime
 from iac_code.services.session_storage import SessionStorage
-from iac_code.services.telemetry import use_session_id
+from iac_code.services.telemetry import use_session_id, use_user_id
 
 logger = logging.getLogger(__name__)
 _CONTEXT_LOCK_ACQUIRE_TIMEOUT_SECONDS = 1
@@ -87,6 +88,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                 getattr(context, "message", None), "metadata", None
             )
             cwd = self._resolve_cwd(metadata)
+            user_id = self._resolve_user_id(metadata)
             prompt = self._prompt_from_context(context, cwd=cwd)
         except Exception as exc:
             if _is_retryable_executor_error(exc):
@@ -222,7 +224,8 @@ class IacCodeA2AExecutor(AgentExecutor):
                     context_id=context_id,
                     state=TaskState.TASK_STATE_WORKING,
                 )
-                with use_session_id(ctx.session_id):
+                user_id_ctx = use_user_id(user_id) if user_id else contextlib.nullcontext()
+                with use_session_id(ctx.session_id), user_id_ctx:
                     async for event in runtime.agent_loop.run_streaming(prompt):
                         text_chunk = await publish_stream_event(
                             event_queue,
@@ -347,6 +350,19 @@ class IacCodeA2AExecutor(AgentExecutor):
         else:
             resolved_cwd.mkdir(parents=True, exist_ok=True)
         return str(resolved_cwd)
+
+    def _resolve_user_id(self, metadata: Any | None) -> str | None:
+        if metadata is not None and hasattr(metadata, "DESCRIPTOR"):
+            metadata = MessageToDict(metadata, preserving_proto_field_name=False)
+        if not isinstance(metadata, Mapping):
+            return None
+        raw_iac_meta = metadata.get("iac_code")
+        if not isinstance(raw_iac_meta, Mapping):
+            return None
+        raw_user_id = raw_iac_meta.get("user_id")
+        if isinstance(raw_user_id, str) and raw_user_id.strip():
+            return raw_user_id.strip()
+        return None
 
     def _prompt_from_context(self, context: RequestContext, *, cwd: str) -> str:
         message = getattr(context, "message", None)

--- a/src/iac_code/services/telemetry/__init__.py
+++ b/src/iac_code/services/telemetry/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from iac_code.services.telemetry.client import TelemetryClient
-from iac_code.services.telemetry.identity import use_session_id
+from iac_code.services.telemetry.identity import use_session_id, use_user_id
 
 __all__ = [
     "log_event",
@@ -19,6 +19,7 @@ __all__ = [
     "get_session_id",
     "get_user_id",
     "use_session_id",
+    "use_user_id",
 ]
 
 _client: TelemetryClient | None = None

--- a/src/iac_code/services/telemetry/identity.py
+++ b/src/iac_code/services/telemetry/identity.py
@@ -31,6 +31,13 @@ _session_id_override: contextvars.ContextVar[str | None] = contextvars.ContextVa
     "iac_code_telemetry_session_id_override", default=None
 )
 
+# Per-async-context override for user id. Set via use_user_id; when present,
+# Identity.get_user_id returns this instead of the process-level value.
+# Enables a2a servers to report per-task user ids in telemetry.
+_user_id_override: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "iac_code_telemetry_user_id_override", default=None
+)
+
 
 @contextmanager
 def use_session_id(session_id: str) -> Iterator[None]:
@@ -43,6 +50,18 @@ def use_session_id(session_id: str) -> Iterator[None]:
         yield
     finally:
         _session_id_override.reset(token)
+
+
+@contextmanager
+def use_user_id(user_id: str) -> Iterator[None]:
+    """Override the telemetry user id for the current async context."""
+    if not user_id:
+        raise ValueError("user_id must be a non-empty string")
+    token = _user_id_override.set(user_id)
+    try:
+        yield
+    finally:
+        _user_id_override.reset(token)
 
 
 class Identity:
@@ -59,7 +78,14 @@ class Identity:
         self._was_first_run = False
 
     def get_user_id(self) -> str:
-        """Return the persistent user.id; generate + persist on first miss."""
+        """Return the persistent user.id; generate + persist on first miss.
+
+        Honors an active ``use_user_id`` override so a2a servers can report
+        per-task user ids in telemetry without mutating process state.
+        """
+        override = _user_id_override.get()
+        if override is not None:
+            return override
         if self._user_id is not None:
             return self._user_id
         settings = _load_yaml(self._settings_path)

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -759,3 +759,110 @@ async def test_executor_swallows_flush_errors(monkeypatch: pytest.MonkeyPatch, t
         FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}),
         FakeEventQueue(),
     )
+
+
+class TestResolveUserId:
+    def _make_executor(self) -> IacCodeA2AExecutor:
+        store = A2ATaskStore(metrics=NoOpA2AMetrics())
+        return IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus")
+
+    def test_extracts_user_id_from_iac_code_metadata(self) -> None:
+        executor = self._make_executor()
+        result = executor._resolve_user_id({"iac_code": {"user_id": "custom-user-123"}})
+        assert result == "custom-user-123"
+
+    def test_returns_none_when_no_metadata(self) -> None:
+        executor = self._make_executor()
+        assert executor._resolve_user_id(None) is None
+
+    def test_returns_none_when_empty_metadata(self) -> None:
+        executor = self._make_executor()
+        assert executor._resolve_user_id({}) is None
+
+    def test_returns_none_when_no_iac_code_key(self) -> None:
+        executor = self._make_executor()
+        assert executor._resolve_user_id({"other": "value"}) is None
+
+    def test_returns_none_when_no_user_id_key(self) -> None:
+        executor = self._make_executor()
+        assert executor._resolve_user_id({"iac_code": {"cwd": "/tmp"}}) is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        executor = self._make_executor()
+        assert executor._resolve_user_id({"iac_code": {"user_id": ""}}) is None
+
+    def test_returns_none_for_whitespace_only(self) -> None:
+        executor = self._make_executor()
+        assert executor._resolve_user_id({"iac_code": {"user_id": "   "}}) is None
+
+    def test_strips_whitespace(self) -> None:
+        executor = self._make_executor()
+        result = executor._resolve_user_id({"iac_code": {"user_id": "  user-abc  "}})
+        assert result == "user-abc"
+
+    def test_passes_through_non_prefixed_value(self) -> None:
+        executor = self._make_executor()
+        result = executor._resolve_user_id({"iac_code": {"user_id": "raw-value"}})
+        assert result == "raw-value"
+
+    def test_returns_none_for_non_string_value(self) -> None:
+        executor = self._make_executor()
+        assert executor._resolve_user_id({"iac_code": {"user_id": 12345}}) is None
+
+
+@pytest.mark.asyncio
+async def test_executor_applies_user_id_to_telemetry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from iac_code.services.telemetry.identity import _user_id_override
+
+    captured_user_ids: list[str | None] = []
+
+    original_run_streaming = FakeAgentLoop.run_streaming
+
+    async def capturing_run_streaming(self, prompt):
+        captured_user_ids.append(_user_id_override.get())
+        async for event in original_run_streaming(self, prompt):
+            yield event
+
+    monkeypatch.setattr(FakeAgentLoop, "run_streaming", capturing_run_streaming)
+
+    loop = FakeAgentLoop([TextDeltaEvent(text="ok")])
+    runtime = FakeRuntime(agent_loop=loop, session_id="sess-uid")
+    monkeypatch.setattr("iac_code.a2a.executor.create_agent_runtime", lambda options: runtime)
+
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    executor = IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus")
+    queue = FakeEventQueue()
+    context = FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path), "user_id": "client-user-xyz"}})
+
+    await executor.execute(context, queue)
+
+    assert captured_user_ids == ["client-user-xyz"]
+
+
+@pytest.mark.asyncio
+async def test_executor_no_user_id_override_when_not_specified(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from iac_code.services.telemetry.identity import _user_id_override
+
+    captured_user_ids: list[str | None] = []
+
+    original_run_streaming = FakeAgentLoop.run_streaming
+
+    async def capturing_run_streaming(self, prompt):
+        captured_user_ids.append(_user_id_override.get())
+        async for event in original_run_streaming(self, prompt):
+            yield event
+
+    monkeypatch.setattr(FakeAgentLoop, "run_streaming", capturing_run_streaming)
+
+    loop = FakeAgentLoop([TextDeltaEvent(text="ok")])
+    runtime = FakeRuntime(agent_loop=loop, session_id="sess-no-uid")
+    monkeypatch.setattr("iac_code.a2a.executor.create_agent_runtime", lambda options: runtime)
+
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    executor = IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus")
+    queue = FakeEventQueue()
+    context = FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}})
+
+    await executor.execute(context, queue)
+
+    assert captured_user_ids == [None]

--- a/tests/test_services/test_telemetry/test_identity.py
+++ b/tests/test_services/test_telemetry/test_identity.py
@@ -139,6 +139,63 @@ def test_context_override_prefix_idempotent(settings_path):
         assert identity.get_session_id() == already_prefixed
 
 
+def test_user_id_override_takes_precedence(settings_path):
+    from iac_code.services.telemetry.identity import use_user_id
+
+    identity = Identity(settings_path)
+    original = identity.get_user_id()
+    with use_user_id("custom-user-abc"):
+        assert identity.get_user_id() == "custom-user-abc"
+    assert identity.get_user_id() == original
+
+
+def test_user_id_override_no_prefix_added(settings_path):
+    from iac_code.services.telemetry.identity import use_user_id
+
+    identity = Identity(settings_path)
+    with use_user_id("raw-value-123"):
+        assert identity.get_user_id() == "raw-value-123"
+
+
+def test_user_id_override_rejects_empty_string(settings_path):
+    from iac_code.services.telemetry.identity import use_user_id
+
+    with pytest.raises(ValueError, match="user_id must be a non-empty string"):
+        with use_user_id(""):
+            pass
+
+
+def test_user_id_override_isolated_between_async_tasks(settings_path):
+    import asyncio
+
+    from iac_code.services.telemetry.identity import use_user_id
+
+    identity = Identity(settings_path)
+
+    async def under_override(uid: str, started: asyncio.Event, release: asyncio.Event) -> str:
+        with use_user_id(uid):
+            started.set()
+            await release.wait()
+            return identity.get_user_id()
+
+    async def main() -> tuple[str, str, str]:
+        started_a = asyncio.Event()
+        started_b = asyncio.Event()
+        release = asyncio.Event()
+        task_a = asyncio.create_task(under_override("user-a", started_a, release))
+        task_b = asyncio.create_task(under_override("user-b", started_b, release))
+        await started_a.wait()
+        await started_b.wait()
+        outside = identity.get_user_id()
+        release.set()
+        return outside, await task_a, await task_b
+
+    outside, a, b = asyncio.run(main())
+    assert outside.startswith(USER_ID_PREFIX)
+    assert a == "user-a"
+    assert b == "user-b"
+
+
 def test_context_override_isolated_between_async_tasks(settings_path):
     import asyncio
 


### PR DESCRIPTION
Allow A2A clients to specify a user_id via message metadata (metadata.iac_code.user_id) that applies only to the current task. The override flows into all telemetry signals (events, spans) for that task. When not provided, falls back to the existing process-level userID from settings.yml.