### PR TITLE
fix: resolve A2A persistence write race and Unix transport file deletion (#91)

### DIFF
--- a/src/iac_code/a2a/persistence.py
+++ b/src/iac_code/a2a/persistence.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import cast
 
 from iac_code.a2a.types import validate_protocol_id
+from iac_code.utils.file_security import atomic_write_text
 
 _INTERRUPTED_RESTORE_STATES = {"submitted", "working", "auth-required"}
 
@@ -175,9 +176,7 @@ class A2APersistenceStore:
 
     @staticmethod
     def _write_json(path: Path, data: dict[str, object]) -> None:
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(data, ensure_ascii=False, sort_keys=True), encoding="utf-8")
-        tmp.replace(path)
+        atomic_write_text(path, json.dumps(data, ensure_ascii=False, sort_keys=True))
 
     @staticmethod
     def _read_json(path: Path) -> dict[str, object] | None:

--- a/src/iac_code/a2a/transports/unix.py
+++ b/src/iac_code/a2a/transports/unix.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
+import stat
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -10,10 +12,19 @@ from iac_code.a2a.transports.dispatcher import A2ARuntimeComponents
 from iac_code.a2a.transports.stdio import StdioA2AClient, StdioA2AServer
 
 
+def _is_socket(path: Path) -> bool:
+    try:
+        return stat.S_ISSOCK(os.lstat(path).st_mode)
+    except OSError:
+        return False
+
+
 def validate_socket_path(socket_path: str) -> Path:
     path = Path(socket_path)
     if not path.parent.exists():
         raise ValueError(f"Unix socket parent does not exist: {path.parent}")
+    if path.exists() and not _is_socket(path):
+        raise ValueError(f"Path exists and is not a Unix socket: {path}")
     return path
 
 
@@ -22,11 +33,15 @@ class UnixA2AServer:
         self._components = components
         self._socket_path = validate_socket_path(socket_path)
         self._server: asyncio.AbstractServer | None = None
+        self._owns_socket = False
 
     async def serve(self) -> None:
         if self._socket_path.exists():
+            if not _is_socket(self._socket_path):
+                raise ValueError(f"Path exists and is not a Unix socket: {self._socket_path}")
             self._socket_path.unlink()
         self._server = await asyncio.start_unix_server(self._handle_client, path=str(self._socket_path))
+        self._owns_socket = True
         async with self._server:
             await self._server.serve_forever()
 
@@ -43,8 +58,9 @@ class UnixA2AServer:
         if self._server is not None:
             self._server.close()
             await self._server.wait_closed()
-        with contextlib.suppress(FileNotFoundError):
-            self._socket_path.unlink()
+        if self._owns_socket:
+            with contextlib.suppress(FileNotFoundError):
+                self._socket_path.unlink()
         await self._components.aclose()
 
 


### PR DESCRIPTION
## Summary

- **Persistence**: Replace fixed `.json.tmp` temp path in `_write_json` with `atomic_write_text` (uses `tempfile.mkstemp` for unique temp names + `fsync` + atomic `os.replace`), eliminating data corruption under concurrent saves.
- **Unix transport**: Add `stat.S_ISSOCK` validation before `unlink()` — reject non-socket paths in `validate_socket_path()` and `serve()`. Only clean up sockets created by the current server instance via `_owns_socket` flag.

Closes #91

## Test plan

- [x] All 317 existing a2a tests pass
- [x] Lint and format checks pass
- [ ] Manual: verify concurrent task saves don't corrupt JSON
- [ ] Manual: verify server startup refuses to delete regular files at socket path

🤖 Generated with [Claude Code](https://claude.com/claude-code)