### PR TITLE
fix: resolve concurrency safety issues in task store, app state, and agent tool (#71)

### DIFF
--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -51,12 +51,13 @@ class A2ATaskStore(TaskStore):
     async def save(self, task: Task, context: ServerCallContext | None = None) -> None:
         owner = self._owner(context)
         task_id = validate_protocol_id(task.id)
-        owner_tasks = self._sdk_tasks.setdefault(owner, {})
-        previous = owner_tasks.get(task_id)
-        if previous is not None:
-            self._remove_sdk_task_from_index(owner, task_id, previous.context_id)
-        owner_tasks[task_id] = _copy_task(task)
-        self._sdk_tasks_by_context.setdefault(owner, {}).setdefault(task.context_id, set()).add(task_id)
+        async with self._mutation_lock:
+            owner_tasks = self._sdk_tasks.setdefault(owner, {})
+            previous = owner_tasks.get(task_id)
+            if previous is not None:
+                self._remove_sdk_task_from_index(owner, task_id, previous.context_id)
+            owner_tasks[task_id] = _copy_task(task)
+            self._sdk_tasks_by_context.setdefault(owner, {}).setdefault(task.context_id, set()).add(task_id)
 
     async def delete(self, task_id: str, context: ServerCallContext | None = None) -> None:
         owner = self._owner(context)

--- a/src/iac_code/agent/agent_tool.py
+++ b/src/iac_code/agent/agent_tool.py
@@ -196,9 +196,7 @@ class AgentTool(Tool):
                 agent_type=agent_type,
             )
             background_task = asyncio.create_task(self._run_background(task_id, prompt, agent_type, context))
-            attach_task = getattr(self._task_manager, "attach_task", None)
-            if callable(attach_task):
-                attach_task(task_id, background_task)
+            self._task_manager.attach_task(task_id, background_task)
             background_task.add_done_callback(self._consume_background_task_exception)
             if event_queue is not None:
                 await event_queue.put(None)

--- a/src/iac_code/state/app_state.py
+++ b/src/iac_code/state/app_state.py
@@ -110,7 +110,7 @@ class AppStateStore:
 
     def _notify(self) -> None:
         """Notify all listeners"""
-        for listener in self._listeners:
+        for listener in list(self._listeners):
             listener(self._state)
 
 


### PR DESCRIPTION
## Summary

- **A2ATaskStore.save()**: Added `_mutation_lock` acquisition to prevent race conditions with `delete()` and `cleanup_once()` which already hold the lock when modifying the same shared state (`_sdk_tasks`, `_sdk_tasks_by_context`).
- **AppStateStore._notify()**: Changed iteration to use a snapshot copy (`list(self._listeners)`) to prevent undefined behavior when a listener callback calls `subscribe()` or `unsubscribe()` during notification dispatch.
- **AgentTool**: Replaced conditional `getattr(self._task_manager, "attach_task", None)` pattern with a direct `self._task_manager.attach_task()` call to guarantee that background tasks are always tracked by the task manager, enabling proper cancellation via `stop()`.

## Test plan

- [x] All 61 existing tests in `tests/a2a/test_task_store.py`, `tests/state/test_app_state.py`, and `tests/agent/test_agent_tool.py` continue to pass
- [x] Full test suite passes (2143 tests, only pre-existing unrelated `test_pot_file_exists` failure)
- [x] Pre-commit hooks (ruff + ty) pass

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)