### PR TITLE
fix: resolve transport-layer message loss (#72)

### DIFF
--- a/src/iac_code/a2a/transports/redis_streams.py
+++ b/src/iac_code/a2a/transports/redis_streams.py
@@ -97,13 +97,18 @@ class RedisStreamsA2AClient:
 
     async def _read_responses(self, correlation_id: str) -> AsyncIterator[RedisStreamsMessage]:
         deadline = asyncio.get_running_loop().time() + self._timeout_seconds
+        # Start from "0-0" instead of "$" to avoid a race where the server
+        # responds before the first xread call.  After each batch we advance
+        # the cursor to the last entry ID we saw, which is the standard
+        # Redis Streams consumer pattern.
+        last_id = "0-0"
         consecutive_errors = 0
         max_consecutive_errors = 3
         while asyncio.get_running_loop().time() < deadline:
             try:
                 remaining = deadline - asyncio.get_running_loop().time()
                 rows = await asyncio.wait_for(
-                    self._redis.xread({self._response_stream: "$"}, count=1, block=100),
+                    self._redis.xread({self._response_stream: last_id}, count=10, block=100),
                     timeout=max(0.001, min(0.2, remaining)),
                 )
                 consecutive_errors = 0
@@ -121,6 +126,8 @@ class RedisStreamsA2AClient:
                 continue
             for _stream, entries in rows:
                 for entry_id, fields in entries:
+                    # Advance cursor past this entry so we don't re-read it.
+                    last_id = entry_id if isinstance(entry_id, str) else entry_id.decode("utf-8")
                     message = parse_redis_entry(entry_id, fields)
                     if message.correlation_id == correlation_id:
                         yield message

--- a/src/iac_code/acp/http_sse.py
+++ b/src/iac_code/acp/http_sse.py
@@ -247,9 +247,39 @@ class HTTPConnectionBridge:
                     self._initialized.set()
                 else:
                     try:
-                        self._sse_queue.put_nowait(message)
-                    except asyncio.QueueFull:
-                        logger.warning("SSE queue full for connection %s, discarding message", self.connection_id[:8])
+                        # Apply backpressure: block until space is available
+                        # (up to a timeout) rather than silently discarding.
+                        await asyncio.wait_for(self._sse_queue.put(message), timeout=30.0)
+                    except asyncio.TimeoutError:
+                        # Client is not consuming events within a reasonable
+                        # window — send an error notification and tear down.
+                        logger.error(
+                            "SSE queue full for connection %s: client not consuming events, closing",
+                            self.connection_id[:8],
+                        )
+                        error_event = json.dumps(
+                            {
+                                "jsonrpc": "2.0",
+                                "method": "notifications/cancelled",
+                                "params": {
+                                    "reason": "SSE queue full: client is not consuming events",
+                                },
+                            }
+                        )
+                        # Make room by discarding the oldest pending event so
+                        # the error notification reaches the client.
+                        try:
+                            self._sse_queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            pass
+                        try:
+                            self._sse_queue.put_nowait(error_event)
+                        except asyncio.QueueFull:
+                            pass
+                        # Break out of the read loop — the finally block will
+                        # send the sentinel and trigger connection teardown.
+                        fatal_error = True
+                        break
         except asyncio.CancelledError:
             raise
         except Exception:


### PR DESCRIPTION
## Summary

- **Redis Streams client race condition**: Replaced `"$"` (only-new-messages) offset in `xread` with a tracked cursor starting from `"0-0"`, advancing after each batch. This eliminates the race where fast server responses sent before the first `xread` call were permanently lost.
- **HTTP SSE silent message discard**: Replaced `put_nowait` (which silently discarded messages when the queue was full) with a backpressure-based approach using `asyncio.wait_for` with a 30-second timeout. If the client fails to consume within the timeout, a JSON-RPC error notification (`notifications/cancelled`) is sent to inform the client before tearing down the connection.

## Test plan

- [x] All existing Redis Streams transport tests pass (cursor change is backward-compatible with the FakeRedis mock)
- [x] All existing HTTP SSE transport tests pass (queue never fills in normal operation)
- [x] Full test suite passes (2143 tests, only pre-existing unrelated i18n test failure)
- [x] `ruff check` and `ty check` both pass cleanly

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)