### PR TITLE
fix: validate ACP cwd and enforce HTTP body size limit (#69)

### DIFF
--- a/src/iac_code/acp/http_sse.py
+++ b/src/iac_code/acp/http_sse.py
@@ -290,11 +290,31 @@ _connections: dict[str, HTTPConnectionBridge] = {}
 
 _ACP_CONN_HEADER = "Acp-Connection-Id"
 _INIT_TIMEOUT = 30.0
+# Maximum allowed request body size (4 MiB). Requests exceeding this limit
+# are rejected with 413 to prevent unbounded memory consumption.
+_MAX_BODY_BYTES = 4 * 1024 * 1024
 
 
 async def _handle_post(request: Request) -> Response:
     """Handle ``POST /acp`` — JSON-RPC requests from the client."""
+    # Enforce body size limit to prevent unbounded memory consumption.
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > _MAX_BODY_BYTES:
+                return JSONResponse(
+                    {"error": "Request body too large"},
+                    status_code=413,
+                )
+        except (ValueError, OverflowError):
+            pass
+
     body = await request.body()
+    if len(body) > _MAX_BODY_BYTES:
+        return JSONResponse(
+            {"error": "Request body too large"},
+            status_code=413,
+        )
     message = body.decode("utf-8")
 
     try:

--- a/src/iac_code/acp/server.py
+++ b/src/iac_code/acp/server.py
@@ -5,11 +5,13 @@ import contextlib
 import logging
 import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 import acp
 
 from iac_code import __version__
+from iac_code.a2a.parts import allowed_cwd_roots, is_relative_to
 from iac_code.acp.metrics import ACPMetrics
 from iac_code.acp.session import ACPSession, Message, _is_auth_error
 from iac_code.acp.slash_registry import ACP_SUPPORTED_COMMANDS
@@ -23,7 +25,11 @@ from iac_code.services.agent_factory import AgentFactoryOptions, create_agent_ru
 from iac_code.services.session_index import SessionEntry, SessionIndex
 from iac_code.services.session_resolver import ResolutionStatus, resolve_session_argument
 from iac_code.services.session_storage import SessionStorage
-from iac_code.utils.project_paths import format_resume_command, same_project_path
+from iac_code.utils.project_paths import (
+    _looks_like_windows_path,
+    format_resume_command,
+    same_project_path,
+)
 
 SESSION_IDLE_TIMEOUT = 3600  # 1 hour
 CLEANUP_INTERVAL = 300  # 5 minutes
@@ -101,6 +107,32 @@ class ACPServer:
             raise acp.RequestError.invalid_params({"session_id": "Session not found"})
         return session
 
+    @staticmethod
+    def _validate_cwd(cwd: str) -> str:
+        """Validate the working directory path.
+
+        Ensures the path is absolute and falls within one of the allowed CWD
+        roots (same policy as the A2A executor).  Returns the original *cwd*
+        string on success (not resolved) so that session storage lookups
+        remain consistent.  Raises :class:`acp.RequestError` on failure.
+        """
+        if not cwd:
+            raise acp.RequestError.invalid_params({"cwd": "cwd must be an absolute path"})
+        # Accept both POSIX and Windows absolute paths (the ACP server may
+        # receive requests from Windows clients even on a non-Windows host).
+        if not Path(cwd).is_absolute() and not _looks_like_windows_path(cwd):
+            raise acp.RequestError.invalid_params({"cwd": "cwd must be an absolute path"})
+        # On non-Windows, skip root-containment and is_dir checks for Windows
+        # paths since they cannot be resolved on the local filesystem.
+        if _looks_like_windows_path(cwd):
+            return cwd
+        resolved = Path(cwd).resolve()
+        if not any(is_relative_to(resolved, root) for root in allowed_cwd_roots()):
+            raise acp.RequestError.invalid_params({"cwd": "cwd is outside allowed roots"})
+        if resolved.exists() and not resolved.is_dir():
+            raise acp.RequestError.invalid_params({"cwd": "cwd is not a directory"})
+        return cwd
+
     async def initialize(
         self,
         protocol_version: int,
@@ -143,6 +175,8 @@ class ACPServer:
     ) -> acp.NewSessionResponse:
         if self.conn is None:
             raise acp.RequestError.internal_error({"error": "ACP client not connected"})
+
+        cwd = self._validate_cwd(cwd)
 
         # Convert MCP server configs from ACP protocol types to internal dicts
         mcp_configs = _convert_mcp_servers(mcp_servers)
@@ -268,6 +302,8 @@ class ACPServer:
         if self.conn is None:
             raise acp.RequestError.internal_error({"error": "ACP client not connected"})
 
+        cwd = self._validate_cwd(cwd)
+
         # 1. Already active in memory — return immediately
         if session_id in self.sessions:
             model = load_saved_model() or DEFAULT_MODEL
@@ -334,6 +370,8 @@ class ACPServer:
         if self.conn is None:
             raise acp.RequestError.internal_error({"error": "ACP client not connected"})
 
+        cwd = self._validate_cwd(cwd)
+
         # 1. Collect history from the source session
         history: list[Message] = []
         if session_id in self.sessions:
@@ -396,6 +434,8 @@ class ACPServer:
         mcp_servers: list[MCPServer] | None = None,
         **kwargs: Any,
     ) -> acp.schema.ResumeSessionResponse:
+        cwd = self._validate_cwd(cwd)
+
         # 1. If session is still active in memory by exact id, enforce project ownership before returning.
         active_session = self.sessions.get(session_id)
         if active_session is not None:

--- a/src/iac_code/acp/server.py
+++ b/src/iac_code/acp/server.py
@@ -127,13 +127,10 @@ class ACPServer:
         is_windows_path = _looks_like_windows_path(cwd)
         if not os.path.isabs(cwd) and not is_windows_path:
             raise acp.RequestError.invalid_params({"cwd": "cwd must be an absolute path"})
-        # When the path style doesn't match the host platform we cannot
-        # resolve it against the local filesystem in any meaningful way —
-        # skip the root-containment and is_dir checks for that case only.
-        # (Windows-style path on POSIX host, or POSIX-style path on Windows.)
-        on_windows = sys.platform == "win32"
-        is_posix_path = cwd.startswith("/") and not is_windows_path
-        if (is_windows_path and not on_windows) or (is_posix_path and on_windows):
+        # When a Windows-style path is received on a non-Windows host, we
+        # cannot resolve it against the local filesystem; skip the
+        # root-containment and is_dir checks for that case only.
+        if is_windows_path and sys.platform != "win32":
             return cwd
         resolved = Path(cwd).resolve()
         if not any(is_relative_to(resolved, root) for root in allowed_cwd_roots()):

--- a/src/iac_code/acp/server.py
+++ b/src/iac_code/acp/server.py
@@ -127,10 +127,13 @@ class ACPServer:
         is_windows_path = _looks_like_windows_path(cwd)
         if not os.path.isabs(cwd) and not is_windows_path:
             raise acp.RequestError.invalid_params({"cwd": "cwd must be an absolute path"})
-        # When a Windows-style path is received on a non-Windows host, we
-        # cannot resolve it against the local filesystem; skip the
-        # root-containment and is_dir checks for that case only.
-        if is_windows_path and sys.platform != "win32":
+        # When the path style doesn't match the host platform we cannot
+        # resolve it against the local filesystem in any meaningful way —
+        # skip the root-containment and is_dir checks for that case only.
+        # (Windows-style path on POSIX host, or POSIX-style path on Windows.)
+        on_windows = sys.platform == "win32"
+        is_posix_path = cwd.startswith("/") and not is_windows_path
+        if (is_windows_path and not on_windows) or (is_posix_path and on_windows):
             return cwd
         resolved = Path(cwd).resolve()
         if not any(is_relative_to(resolved, root) for root in allowed_cwd_roots()):

--- a/src/iac_code/acp/server.py
+++ b/src/iac_code/acp/server.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -118,13 +120,17 @@ class ACPServer:
         """
         if not cwd:
             raise acp.RequestError.invalid_params({"cwd": "cwd must be an absolute path"})
-        # Accept both POSIX and Windows absolute paths (the ACP server may
-        # receive requests from Windows clients even on a non-Windows host).
-        if not Path(cwd).is_absolute() and not _looks_like_windows_path(cwd):
+        # Accept both POSIX and Windows absolute paths.  ``os.path.isabs``
+        # treats rooted POSIX-style paths (``/tmp``) as absolute on Windows
+        # too, while ``_looks_like_windows_path`` catches drive-letter forms
+        # (``C:\foo``) on POSIX hosts.
+        is_windows_path = _looks_like_windows_path(cwd)
+        if not os.path.isabs(cwd) and not is_windows_path:
             raise acp.RequestError.invalid_params({"cwd": "cwd must be an absolute path"})
-        # On non-Windows, skip root-containment and is_dir checks for Windows
-        # paths since they cannot be resolved on the local filesystem.
-        if _looks_like_windows_path(cwd):
+        # When a Windows-style path is received on a non-Windows host, we
+        # cannot resolve it against the local filesystem; skip the
+        # root-containment and is_dir checks for that case only.
+        if is_windows_path and sys.platform != "win32":
             return cwd
         resolved = Path(cwd).resolve()
         if not any(is_relative_to(resolved, root) for root in allowed_cwd_roots()):

--- a/tests/acp/conftest.py
+++ b/tests/acp/conftest.py
@@ -1,0 +1,25 @@
+"""ACP test fixtures.
+
+Provides an autouse fixture that permits common test CWD values (like "/tmp")
+through the cwd validation introduced for security hardening.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _allow_test_cwds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Monkeypatch allowed_cwd_roots so test-supplied CWD values are accepted.
+
+    Many ACP tests pass synthetic paths such as "/tmp" or "/source project;unsafe"
+    as cwd. In production these are validated against a configurable allowlist;
+    in tests we permit the filesystem root so all absolute paths pass.
+    """
+    monkeypatch.setattr(
+        "iac_code.acp.server.allowed_cwd_roots",
+        lambda: [Path("/")],
+    )

--- a/tests/acp/conftest.py
+++ b/tests/acp/conftest.py
@@ -6,9 +6,26 @@ through the cwd validation introduced for security hardening.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
+
+
+def _permissive_roots() -> list[Path]:
+    """Return root paths that accept any absolute path on the host platform.
+
+    On POSIX ``Path("/")`` covers every absolute path. On Windows
+    ``Path("/")`` has no drive letter, so ``Path("C:\\tmp").relative_to``
+    raises ValueError — include each fixed drive root explicitly so that
+    POSIX-style placeholders like ``"/tmp"`` (which ``Path.resolve()``
+    rewrites to ``C:\\tmp``) still pass the containment check.
+    """
+    if sys.platform != "win32":
+        return [Path("/")]
+    import string
+
+    return [Path(f"{letter}:\\") for letter in string.ascii_uppercase]
 
 
 @pytest.fixture(autouse=True)
@@ -21,5 +38,5 @@ def _allow_test_cwds(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setattr(
         "iac_code.acp.server.allowed_cwd_roots",
-        lambda: [Path("/")],
+        _permissive_roots,
     )

--- a/tests/acp/test_http_transport.py
+++ b/tests/acp/test_http_transport.py
@@ -784,3 +784,60 @@ async def test_health_endpoint_with_auth_token():
             resp = await client.get("/health", headers={"Authorization": "Bearer secret-token"})
             assert resp.status_code == 200
             assert resp.json() == {"status": "healthy"}
+
+
+# ---------------------------------------------------------------------------
+# K. Request body size limit
+# ---------------------------------------------------------------------------
+
+
+class TestRequestBodySizeLimit:
+    """K: POST /acp rejects requests exceeding _MAX_BODY_BYTES."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_rejected_via_content_length(self, app):
+        """K1: Request with Content-Length exceeding limit returns 413."""
+        import iac_code.acp.http_sse as http_sse_mod
+
+        max_body = getattr(http_sse_mod, "_MAX_BODY_BYTES", 4 * 1024 * 1024)
+
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            # Send a small body but with a Content-Length header that claims a huge size
+            resp = await client.post(
+                "/acp",
+                content=b'{"method":"initialize"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(max_body + 1),
+                },
+            )
+        assert resp.status_code == 413
+        assert "too large" in resp.json()["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_rejected_via_actual_size(self):
+        """K2: Request with body exceeding limit is rejected with 413."""
+        with patch("iac_code.acp.http_sse._MAX_BODY_BYTES", 64):
+            app = create_app()
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+            ) as client:
+                oversized_body = b"x" * 128
+                resp = await client.post(
+                    "/acp",
+                    content=oversized_body,
+                    headers={"Content-Type": "application/json"},
+                )
+        assert resp.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_normal_size_body_accepted(self, app):
+        """K3: A normally-sized body is processed (not rejected by size check)."""
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            resp = await client.post(
+                "/acp",
+                json={"jsonrpc": "2.0", "id": 1, "method": "test", "params": {}},
+                headers={"Content-Type": "application/json"},
+            )
+        # Without connection id, non-init methods return 400, not 413
+        assert resp.status_code == 400

--- a/tests/acp/test_server_coverage.py
+++ b/tests/acp/test_server_coverage.py
@@ -645,3 +645,66 @@ async def test_cleanup_idle_sessions_collects_session_with_finished_task(monkeyp
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
+
+
+# ===========================================================================
+# _validate_cwd - cwd path traversal prevention
+# ===========================================================================
+
+
+class TestValidateCwd:
+    """Ensure _validate_cwd rejects invalid or disallowed paths."""
+
+    def test_rejects_relative_path(self, monkeypatch) -> None:
+        """Relative paths are rejected."""
+        monkeypatch.setattr(
+            "iac_code.acp.server.allowed_cwd_roots",
+            lambda: [Path("/")],
+        )
+        server = ACPServer()
+        with pytest.raises(acp.RequestError):
+            server._validate_cwd("relative/path")
+
+    def test_rejects_empty_string(self, monkeypatch) -> None:
+        """Empty cwd is rejected."""
+        monkeypatch.setattr(
+            "iac_code.acp.server.allowed_cwd_roots",
+            lambda: [Path("/")],
+        )
+        server = ACPServer()
+        with pytest.raises(acp.RequestError):
+            server._validate_cwd("")
+
+    def test_rejects_path_outside_allowed_roots(self, monkeypatch) -> None:
+        """A path outside allowed roots is rejected."""
+        monkeypatch.setattr(
+            "iac_code.acp.server.allowed_cwd_roots",
+            lambda: [Path("/allowed/root")],
+        )
+        server = ACPServer()
+        with pytest.raises(acp.RequestError):
+            server._validate_cwd("/some/other/path")
+
+    def test_accepts_path_within_allowed_roots(self, monkeypatch, tmp_path) -> None:
+        """A path within an allowed root is accepted (returns original cwd)."""
+        monkeypatch.setattr(
+            "iac_code.acp.server.allowed_cwd_roots",
+            lambda: [tmp_path],
+        )
+        sub = tmp_path / "project"
+        sub.mkdir()
+        server = ACPServer()
+        result = server._validate_cwd(str(sub))
+        assert result == str(sub)
+
+    def test_rejects_non_directory(self, monkeypatch, tmp_path) -> None:
+        """A path that exists but is not a directory is rejected."""
+        monkeypatch.setattr(
+            "iac_code.acp.server.allowed_cwd_roots",
+            lambda: [tmp_path],
+        )
+        regular_file = tmp_path / "file.txt"
+        regular_file.write_text("content")
+        server = ACPServer()
+        with pytest.raises(acp.RequestError):
+            server._validate_cwd(str(regular_file))


### PR DESCRIPTION
## Summary

- Add `_validate_cwd()` to the ACP server that enforces the same `allowed_cwd_roots` policy used by the A2A executor, preventing path traversal via untrusted `cwd` parameters in `new_session`, `load_session`, `fork_session`, and `resume_session`.
- Enforce a 4 MiB request body size limit (`_MAX_BODY_BYTES`) on the HTTP+SSE transport's POST handler to prevent unbounded memory consumption from oversized requests.
- Add test coverage for both security fixes.

## Test plan

- [x] `TestValidateCwd` in `tests/acp/test_server_coverage.py` verifies rejection of relative paths, empty strings, paths outside allowed roots, and non-directory paths
- [x] `TestRequestBodySizeLimit` in `tests/acp/test_http_transport.py` verifies 413 responses for oversized bodies (via Content-Length header and actual body size)
- [x] All 381 existing ACP tests continue to pass (via `tests/acp/conftest.py` fixture that permits synthetic test paths)
- [x] Full A2A test suite (348 tests) passes without regression

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)