### PR TITLE
Fix auto-memory recall prefetch lifecycle

### DIFF
--- a/src/iac_code/agent/agent_loop.py
+++ b/src/iac_code/agent/agent_loop.py
@@ -279,6 +279,33 @@ class AgentLoop:
         self._pending_memory_prefetches.clear()
         self._recorded_memory_prefetch_ids.clear()
 
+    def _discard_memory_prefetch_for_turn(self, prefetch: Any | None) -> None:
+        if prefetch is None:
+            return
+        if not any(pending is prefetch for pending in self._pending_memory_prefetches):
+            return
+        self._pending_memory_prefetches = [
+            pending for pending in self._pending_memory_prefetches if pending is not prefetch
+        ]
+        done = getattr(prefetch, "done", None)
+        if callable(done) and done():
+            try:
+                result = prefetch.result()
+            except asyncio.CancelledError:
+                self._forget_memory_prefetch(prefetch)
+                return
+            except Exception as exc:
+                logger.debug("Memory recall prefetch usage unavailable: {}", exc)
+                self._forget_memory_prefetch(prefetch)
+                return
+            self._record_memory_recall_result_usage_once(prefetch, result)
+            self._forget_memory_prefetch(prefetch)
+            return
+        cancel = getattr(prefetch, "cancel", None)
+        if callable(cancel):
+            cancel()
+        self._forget_memory_prefetch(prefetch)
+
     def _sync_recall_suppression_from_context(self) -> None:
         if self._memory_recall_service is None:
             return
@@ -403,7 +430,6 @@ class AgentLoop:
         if self._memory_recall_active_turns > 0:
             return
         self._pending_memory_prefetches = [item for item in self._pending_memory_prefetches if item is not prefetch]
-        self._inject_recalled_memory_result(result)
         self._forget_memory_prefetch(prefetch)
 
     def _record_memory_recall_result_usage_once(self, prefetch: Any, result: Any) -> None:
@@ -618,14 +644,14 @@ class AgentLoop:
                         yield event
                 except asyncio.CancelledError:
                     turn_cancelled = True
-                    self._memory_recall_generation += 1
-                    self._cancel_pending_memory_prefetches()
+                    self._discard_memory_prefetch_for_turn(memory_prefetch)
                     log_event(Events.SESSION_CANCELLED, {"stage": "in_query"})
                     raise
             finally:
-                self._memory_recall_active_turns = max(0, self._memory_recall_active_turns - 1)
                 if not turn_cancelled:
-                    await self._consume_ready_memory_prefetches()
+                    # Recall prefetches are turn-scoped: ready results are consumed only at in-turn poll points.
+                    self._discard_memory_prefetch_for_turn(memory_prefetch)
+                self._memory_recall_active_turns = max(0, self._memory_recall_active_turns - 1)
                 self.context_manager.set_system_prompt(self.system_prompt)
                 elapsed = time.monotonic() - interaction_started
                 add_metric(Metrics.ACTIVE_TIME_TOTAL, int(elapsed), {})

--- a/src/iac_code/commands/__init__.py
+++ b/src/iac_code/commands/__init__.py
@@ -95,7 +95,7 @@ def create_default_registry() -> CommandRegistry:
     registry.register(
         LocalCommand(
             name="memory",
-            description=_("Edit IAC-CODE memory files"),
+            description=_("Edit memory files"),
             handler=memory_command,
             history_mode="session",
         )

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -820,8 +820,8 @@ msgid "Toggle debug logging"
 msgstr "Debug-Protokollierung umschalten"
 
 #: src/iac_code/commands/__init__.py
-msgid "Edit IAC-CODE memory files"
-msgstr "IAC-CODE-Speicherdateien bearbeiten"
+msgid "Edit memory files"
+msgstr "Speicherdateien bearbeiten"
 
 #: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -820,8 +820,8 @@ msgid "Toggle debug logging"
 msgstr "Activar o desactivar el registro de depuración"
 
 #: src/iac_code/commands/__init__.py
-msgid "Edit IAC-CODE memory files"
-msgstr "Editar archivos de memoria de IAC-CODE"
+msgid "Edit memory files"
+msgstr "Editar archivos de memoria"
 
 #: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -819,8 +819,8 @@ msgid "Toggle debug logging"
 msgstr "Activer ou désactiver la journalisation debug"
 
 #: src/iac_code/commands/__init__.py
-msgid "Edit IAC-CODE memory files"
-msgstr "Modifier les fichiers memoire IAC-CODE"
+msgid "Edit memory files"
+msgstr "Modifier les fichiers memoire"
 
 #: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -786,8 +786,8 @@ msgid "Toggle debug logging"
 msgstr "デバッグログのオン／オフを切り替えます"
 
 #: src/iac_code/commands/__init__.py
-msgid "Edit IAC-CODE memory files"
-msgstr "IAC-CODEメモリファイルを編集"
+msgid "Edit memory files"
+msgstr "メモリファイルを編集"
 
 #: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -814,8 +814,8 @@ msgid "Toggle debug logging"
 msgstr "Alternar debug"
 
 #: src/iac_code/commands/__init__.py
-msgid "Edit IAC-CODE memory files"
-msgstr "Editar arquivos de memoria do IAC-CODE"
+msgid "Edit memory files"
+msgstr "Editar arquivos de memoria"
 
 #: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -778,8 +778,8 @@ msgid "Toggle debug logging"
 msgstr "切换调试日志开关"
 
 #: src/iac_code/commands/__init__.py
-msgid "Edit IAC-CODE memory files"
-msgstr "编辑 IAC-CODE 记忆文件"
+msgid "Edit memory files"
+msgstr "编辑记忆文件"
 
 #: src/iac_code/commands/__init__.py
 msgid "View and manage persistent memories"

--- a/src/iac_code/memory/recall.py
+++ b/src/iac_code/memory/recall.py
@@ -154,7 +154,7 @@ class MemoryRecallService:
         provider_manager: Any,
         *,
         max_files: int = 5,
-        timeout_seconds: float = 3.0,
+        timeout_seconds: float = 10.0,
         max_bytes_per_file: int = 12_000,
         max_lines_per_file: int = 240,
         is_enabled: Callable[[], bool] | None = None,
@@ -175,7 +175,7 @@ class MemoryRecallService:
         if not query:
             self._record("skipped", time.monotonic(), selected_files=[])
             return None
-        task = asyncio.create_task(self._recall(query, timeout_seconds=None))
+        task = asyncio.create_task(self._recall(query, timeout_seconds=self._timeout_seconds))
         return MemoryRecallPrefetch(task, on_cancel=lambda: self._record_cancelled())
 
     async def recall(self, user_input: str) -> MemoryRecallResult:

--- a/tests/agent/test_agent_loop_new.py
+++ b/tests/agent/test_agent_loop_new.py
@@ -408,7 +408,7 @@ class TestAgentLoopStreaming:
         assert totals.recorded_events == 2
         assert store.load("/tmp/status-project", "recall-usage-session").total_tokens == 20
 
-    async def test_slow_memory_prefetch_does_not_block_provider_call_and_appends_late(
+    async def test_slow_memory_prefetch_does_not_block_provider_call_and_is_cancelled_after_turn(
         self, mock_provider, mock_registry
     ):
         recall_can_finish = asyncio.Event()
@@ -457,18 +457,208 @@ class TestAgentLoopStreaming:
 
         assert any(isinstance(event, MessageEndEvent) for event in events)
         assert all("# Recalled Memory" not in str(message.content) for message in captured_messages[0])
-        assert recall_service.cancelled is False
+        assert recall_service.cancelled is True
 
         recall_can_finish.set()
         for _ in range(5):
             await asyncio.sleep(0)
-            if recall_service.surfaced:
-                break
 
-        assert any("# Recalled Memory\nlate" in str(message.content) for message in loop.context_manager.get_messages())
-        assert recall_service.surfaced == ["late.md"]
+        assert not any(
+            "# Recalled Memory\nlate" in str(message.content) for message in loop.context_manager.get_messages()
+        )
+        assert recall_service.surfaced == []
 
-    async def test_late_memory_recall_is_persisted_for_matching_next_turn(self, mock_provider, mock_registry):
+    async def test_finished_turn_cancels_only_its_own_memory_prefetch(self, mock_provider, mock_registry):
+        slow_stream_started = asyncio.Event()
+        slow_stream_can_finish = asyncio.Event()
+
+        class FakeRecallService:
+            def __init__(self):
+                self.cancelled: list[str] = []
+
+            def start_prefetch(self, user_input):
+                from iac_code.memory.recall import MemoryRecallPrefetch, MemoryRecallResult
+
+                async def recall():
+                    await asyncio.Event().wait()
+                    return MemoryRecallResult(content="# Recalled Memory\nunused", selected_files=["unused.md"])
+
+                return MemoryRecallPrefetch(
+                    asyncio.create_task(recall()),
+                    on_cancel=lambda: self.cancelled.append(user_input),
+                )
+
+            def get_stats_snapshot(self):
+                return {"last_status": "cancelled"}
+
+        call_count = 0
+
+        async def fake_stream(messages, system, tools=None, max_tokens=8192):
+            nonlocal call_count
+            call_count += 1
+            yield MessageStartEvent(message_id=f"m{call_count}")
+            if call_count == 1:
+                slow_stream_started.set()
+                await slow_stream_can_finish.wait()
+            yield TextDeltaEvent(text="ok")
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+
+        mock_provider.stream = fake_stream
+        recall_service = FakeRecallService()
+        loop = AgentLoop(
+            provider_manager=mock_provider,
+            system_prompt="base system",
+            tool_registry=mock_registry,
+            memory_recall_service=recall_service,
+        )
+
+        slow_task = asyncio.create_task(loop.run("slow turn"))
+        await slow_stream_started.wait()
+        await loop.run("fast turn")
+
+        assert recall_service.cancelled == ["fast turn"]
+
+        slow_stream_can_finish.set()
+        await slow_task
+
+        assert recall_service.cancelled == ["fast turn", "slow turn"]
+
+    async def test_discarded_completed_memory_prefetch_records_usage_without_injection(
+        self, mock_provider, mock_registry, tmp_path
+    ):
+        from iac_code.memory.recall import MemoryRecallResult
+        from iac_code.services.session_usage import SessionUsageStore
+
+        class FakeMemoryPrefetch:
+            def __init__(self):
+                self.finished = False
+                self.cancelled = False
+
+            def done(self):
+                return self.finished
+
+            def result(self):
+                return MemoryRecallResult(
+                    content="# Recalled Memory\nlate",
+                    selected_files=["late.md"],
+                    usage=Usage(input_tokens=4, output_tokens=1, cache_read_input_tokens=2),
+                )
+
+            def cancel(self):
+                self.cancelled = True
+
+        class FakeRecallService:
+            def __init__(self):
+                self.prefetch = FakeMemoryPrefetch()
+                self.surfaced: list[str] = []
+
+            def start_prefetch(self, user_input):
+                return self.prefetch
+
+            def get_stats_snapshot(self):
+                return {"last_status": "success"}
+
+            def mark_files_surfaced(self, filenames):
+                self.surfaced.extend(filenames)
+
+        recall_service = FakeRecallService()
+
+        async def fake_stream(messages, system, tools=None, max_tokens=8192):
+            yield MessageStartEvent(message_id="m1")
+            recall_service.prefetch.finished = True
+            yield TextDeltaEvent(text="ok")
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage(input_tokens=10, output_tokens=5))
+
+        mock_provider.stream = fake_stream
+        store = SessionUsageStore(projects_dir=tmp_path)
+        loop = AgentLoop(
+            provider_manager=mock_provider,
+            system_prompt="base system",
+            tool_registry=mock_registry,
+            session_id="discarded-recall-usage",
+            cwd="/tmp/status-project",
+            session_usage_store=store,
+            memory_recall_service=recall_service,
+        )
+
+        await loop.run("fast answer")
+
+        totals = loop.get_session_usage()
+        assert totals.input_tokens == 14
+        assert totals.output_tokens == 6
+        assert totals.cache_read_input_tokens == 2
+        assert totals.recorded_events == 2
+        assert recall_service.prefetch.cancelled is False
+        assert recall_service.surfaced == []
+        assert not any(
+            "# Recalled Memory\nlate" in str(message.content) for message in loop.context_manager.get_messages()
+        )
+
+    async def test_ready_memory_prefetch_injects_at_next_provider_round(self, mock_provider, mock_registry):
+        recall_can_finish = asyncio.Event()
+        captured_messages = []
+
+        class FakeRecallService:
+            def __init__(self):
+                self.surfaced: set[str] = set()
+
+            def start_prefetch(self, user_input):
+                from iac_code.memory.recall import MemoryRecallPrefetch, MemoryRecallResult
+
+                async def recall():
+                    await recall_can_finish.wait()
+                    return MemoryRecallResult(
+                        content="# Recalled Memory\nUse YAML for ROS templates",
+                        selected_files=["ros-yaml.md"],
+                    )
+
+                return MemoryRecallPrefetch(asyncio.create_task(recall()))
+
+            def get_stats_snapshot(self):
+                return {"last_status": "success"}
+
+            def mark_files_surfaced(self, filenames):
+                self.surfaced.update(filenames)
+
+        call_count = 0
+
+        async def fake_stream(messages, system, tools=None, max_tokens=8192):
+            nonlocal call_count
+            call_count += 1
+            captured_messages.append(messages)
+            if call_count == 1:
+                yield MessageStartEvent(message_id="m1")
+                yield ToolUseStartEvent(tool_use_id="toolu_1", name="read_file")
+                yield ToolUseEndEvent(tool_use_id="toolu_1", name="read_file", input={"path": "a.txt"})
+                yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+                return
+
+            yield MessageStartEvent(message_id="m2")
+            yield TextDeltaEvent(text="ok")
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+
+        async def execute_batch(requests, context):
+            recall_can_finish.set()
+            return [ToolResult(content="file content", is_error=False)]
+
+        mock_provider.stream = fake_stream
+        mock_registry.get.return_value = None
+        recall_service = FakeRecallService()
+        loop = AgentLoop(
+            provider_manager=mock_provider,
+            system_prompt="base system",
+            tool_registry=mock_registry,
+            memory_recall_service=recall_service,
+        )
+        loop._tool_executor.execute_batch = execute_batch
+
+        await loop.run("what format should I use?")
+
+        assert "# Recalled Memory" not in str(captured_messages[0])
+        assert "Use YAML for ROS templates" in str(captured_messages[1])
+        assert recall_service.surfaced == {"ros-yaml.md"}
+
+    async def test_late_memory_recall_is_not_persisted_for_matching_next_turn(self, mock_provider, mock_registry):
         captured_messages = []
 
         async def fake_stream(messages, system, tools=None, max_tokens=8192):
@@ -518,13 +708,17 @@ class TestAgentLoopStreaming:
         await loop.run("what format should I use?")
         await loop.run("what format should I use?")
 
-        assert recall_service.queries == ["what format should I use?"]
+        assert recall_service.queries == [
+            "what format should I use?",
+            "what format should I use?",
+            "what format should I use?",
+        ]
         assert "# Recalled Memory" not in str(captured_messages[0])
-        assert "Use YAML for ROS templates" in str(captured_messages[1])
-        assert "Use YAML for ROS templates" in str(captured_messages[2])
-        assert recall_service.surfaced == {"ros-yaml.md"}
+        assert "Use YAML for ROS templates" not in str(captured_messages[1])
+        assert "Use YAML for ROS templates" not in str(captured_messages[2])
+        assert recall_service.surfaced == set()
 
-    async def test_late_memory_recall_is_persisted_after_different_next_turn(self, mock_provider, mock_registry):
+    async def test_late_memory_recall_is_not_persisted_after_different_next_turn(self, mock_provider, mock_registry):
         captured_messages = []
 
         async def fake_stream(messages, system, tools=None, max_tokens=8192):
@@ -574,11 +768,14 @@ class TestAgentLoopStreaming:
         await loop.run("different question")
         await loop.run("what format should I use?")
 
-        assert recall_service.queries == ["what format should I use?"]
-        assert "Use YAML for ROS templates" in str(captured_messages[1])
-        assert "Use YAML for ROS templates" in str(captured_messages[2])
+        assert recall_service.queries == ["what format should I use?", "what format should I use?"]
+        assert "Use YAML for ROS templates" not in str(captured_messages[1])
+        assert "Use YAML for ROS templates" not in str(captured_messages[2])
+        assert recall_service.surfaced == set()
 
-    async def test_previous_turn_recall_completing_during_next_turn_is_persisted(self, mock_provider, mock_registry):
+    async def test_previous_turn_recall_completing_during_next_turn_is_not_persisted(
+        self, mock_provider, mock_registry
+    ):
         first_recall_can_finish = asyncio.Event()
         second_stream_started = asyncio.Event()
         second_stream_can_finish = asyncio.Event()
@@ -646,9 +843,9 @@ class TestAgentLoopStreaming:
         await second_run
         await loop.run("third")
 
-        assert recall_service.surfaced == {"ros-yaml.md"}
+        assert recall_service.surfaced == set()
         assert "Use YAML for ROS templates" not in str(captured_messages[1])
-        assert "Use YAML for ROS templates" in str(captured_messages[2])
+        assert "Use YAML for ROS templates" not in str(captured_messages[2])
 
     async def test_cancelled_turn_discards_pending_memory_prefetch(self, mock_provider, mock_registry):
         recall_can_finish = asyncio.Event()

--- a/tests/commands/test_memory.py
+++ b/tests/commands/test_memory.py
@@ -149,7 +149,7 @@ def test_default_registry_exposes_new_memory_and_hides_memory_folder():
     memory_folder = registry.get("memory-folder")
 
     assert memory is not None
-    assert memory.description == "Edit IAC-CODE memory files"
+    assert memory.description == "Edit memory files"
     assert memory.hidden is False
     assert memory.arg_hint is None
     assert memory_folder is not None

--- a/tests/memory/test_recall.py
+++ b/tests/memory/test_recall.py
@@ -337,10 +337,9 @@ async def test_prefetch_applies_configured_timeout(memory_manager):
     prefetch = service.start_prefetch("deadline")
     assert prefetch is not None
 
-    await asyncio.sleep(0.01)
+    result = await prefetch.wait()
 
     assert prefetch.done() is True
-    result = prefetch.result()
     assert result.status == "timeout"
     stats = service.get_stats_snapshot()
     assert stats["total_side_queries"] == 1

--- a/tests/memory/test_recall.py
+++ b/tests/memory/test_recall.py
@@ -74,6 +74,25 @@ def memory_manager(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_recall_default_timeout_is_ten_seconds(memory_manager, monkeypatch):
+    from iac_code.memory import recall as recall_mod
+
+    captured: dict[str, float] = {}
+
+    async def capture_wait_for(awaitable, timeout):
+        captured["timeout"] = timeout
+        return await awaitable
+
+    monkeypatch.setattr(recall_mod.asyncio, "wait_for", capture_wait_for)
+    provider = FakeRecallProvider(json.dumps({"files": []}))
+    service = recall_mod.MemoryRecallService(memory_manager=memory_manager, provider_manager=provider)
+
+    await service.recall("deadline")
+
+    assert captured["timeout"] == 10.0
+
+
+@pytest.mark.asyncio
 async def test_recall_selects_valid_topic_files_and_reads_content(memory_manager):
     from iac_code.memory.recall import MemoryRecallService
 
@@ -306,7 +325,7 @@ async def test_inflight_prefetch_is_reported_as_pending(memory_manager):
 
 
 @pytest.mark.asyncio
-async def test_prefetch_uses_turn_lifetime_instead_of_sync_timeout(memory_manager):
+async def test_prefetch_applies_configured_timeout(memory_manager):
     from iac_code.memory.recall import MemoryRecallService
 
     service = MemoryRecallService(
@@ -320,13 +339,16 @@ async def test_prefetch_uses_turn_lifetime_instead_of_sync_timeout(memory_manage
 
     await asyncio.sleep(0.01)
 
-    assert prefetch.done() is False
-    assert service.get_stats_snapshot()["last_status"] != "timeout"
-
-    prefetch.cancel()
-    await asyncio.sleep(0)
-
-    assert service.get_stats_snapshot()["last_status"] == "cancelled"
+    assert prefetch.done() is True
+    result = prefetch.result()
+    assert result.status == "timeout"
+    stats = service.get_stats_snapshot()
+    assert stats["total_side_queries"] == 1
+    assert stats["in_flight_side_queries"] == 0
+    assert stats["failed_side_queries"] == 1
+    assert stats["cancelled_side_queries"] == 0
+    assert stats["last_status"] == "timeout"
+    assert stats["last_side_query_status"] == "timeout"
 
 
 @pytest.mark.asyncio

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -29,6 +29,7 @@ MEMORY_COMMAND_MSGIDS = {
     "Memory '{name}' not found.",
     "Memory '{name}' deleted.",
     "Memory manager is unavailable.",
+    "Edit memory files",
     "View and manage persistent memories",
     "[<name>|search <query>|delete <name>|help]",
     "Search saved memories",


### PR DESCRIPTION
## Summary

This PR tightens the auto-memory recall prefetch lifecycle so slow or late recall results do not affect later turns, while still preserving useful recall metrics and token accounting.

User-visible behavior changes:

- Auto-memory recall side calls now use a bounded timeout during both direct recall and per-turn prefetch.
- The default recall timeout is increased to 10 seconds to reduce real-provider timeout failures.
- Recall results are only injected when they are ready within the current turn's provider flow.
- Slow recall prefetches are discarded or cancelled at turn cleanup instead of being injected into a later user turn.
- Completed but unused recall prefetches still report side-call usage, so `/status` accounting remains accurate.
- `/memory` is described generically as “Edit memory files” instead of mentioning the old IAC-CODE-specific wording.

## Details

The updated agent loop now treats each memory prefetch as turn-scoped. If a recall finishes in time for an in-turn provider round, it can still be appended to context. If it finishes after the last in-turn poll, it is discarded for injection purposes and only its usage metadata is recorded. Pending prefetches are cancelled when their owning turn exits.

This follows the intended zero-wait recall behavior: auto-memory can improve the current turn when it is ready soon enough, but it should not delay the next user input or mutate future-turn context with late results.

## Testing

- `make lint`
  - `ruff check`: passed
  - `ty check`: passed
- `make test`
  - `4616 passed, 244 warnings`

Notes:

- Before the final successful test run, local generated `.mo` files were recompiled because they are not tracked and their timestamps were older than the updated `.po` files after rebase.
