### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __release_date__ = ""

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.5.0\n"
+"Project-Id-Version: iac-code 0.6.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.5.0\n"
+"Project-Id-Version: iac-code 0.6.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.5.0\n"
+"Project-Id-Version: iac-code 0.6.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.5.0\n"
+"Project-Id-Version: iac-code 0.6.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.5.0\n"
+"Project-Id-Version: iac-code 0.6.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.5.0\n"
+"Project-Id-Version: iac-code 0.6.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -37,7 +37,7 @@ def test_selling_skill_references_are_expanded_for_installed_artifacts(monkeypat
 
 def test_selling_skill_references_are_expanded_for_sdist_release_tree(monkeypatch, tmp_path):
     setup_module = _load_setup_module(monkeypatch)
-    release_tree = tmp_path / "iac_code-0.5.0"
+    release_tree = tmp_path / "iac_code-0.6.0"
 
     setup_module._copy_selling_skill_references_to_sdist_release_tree(str(release_tree))
 
@@ -71,7 +71,7 @@ def test_legacy_setup_declares_package_metadata(monkeypatch):
     kwargs = setup_module._TEST_SETUP_KWARGS
 
     assert kwargs["name"] == "iac_code"
-    assert kwargs["version"] == "0.5.0"
+    assert kwargs["version"] == "0.6.0"
     assert kwargs["package_dir"] == {"": "src"}
     assert "iac_code.pipeline.selling.tools" in kwargs["packages"]
     assert "iac_code.pipeline.selling.hooks" in kwargs["packages"]


### PR DESCRIPTION
## Summary

- Bump `iac_code.__version__` from `0.5.0` to `0.6.0`.
- Run `make translate` and update locale `Project-Id-Version` headers.
- Update legacy setup packaging tests to expect the new release version.

## Release note draft

### Pipeline Mode

This release introduces **Pipeline mode**, a new step-by-step execution mode for longer Alibaba Cloud infrastructure workflows. The first built-in pipeline is `selling`, which can guide a request through intent clarification, architecture planning, ROS template generation, cost estimation, candidate selection, and deployment confirmation.

### How to use Pipeline Mode

Pipeline mode currently runs in the interactive REPL and cannot be combined with `--prompt`.

On macOS or Linux:

```bash
IAC_CODE_MODE=pipeline iac-code
```

On PowerShell:

```powershell
$env:IAC_CODE_MODE = "pipeline"
iac-code
```

The default pipeline is `selling`. To select it explicitly:

```bash
IAC_CODE_MODE=pipeline IAC_CODE_PIPELINE_NAME=selling iac-code
```

Example requests:

```text
Select an existing VPC and create a VSwitch
```

```text
Design a low-cost Alibaba Cloud web application deployment and generate a template
```

The `selling` pipeline walks through these stages: understand the requirement, propose candidate architectures, generate and evaluate ROS templates, estimate costs, ask the user to choose a plan, and then continue to deployment after confirmation.

Pipeline progress is saved with the session. If the process exits or is interrupted, return to the session with `--resume` to inspect previous progress and continue from a recoverable point.

Current limitations:

- Pipeline mode requires the interactive REPL.
- `--prompt` / non-interactive mode does not run Pipeline steps.
- ACP does not currently support Pipeline mode.
- The current release includes only the built-in `selling` pipeline.
- Pipeline mode currently supports text input; pasted images are ignored while a pipeline is active.
- Mid-pipeline shell escapes, skill triggers, and most slash commands are restricted unless allowed by the pipeline definition.

## Validation

- `PATH="$HOME/.local/bin:$PATH" make translate`
- `PATH="$HOME/.local/bin:$PATH" uv run pytest tests/services/test_update_checker.py tests/test_i18n.py tests/test_setup_packaging.py -q` (`71 passed`)
- `git diff --check`
- pre-commit hooks during commit: `lint` and `format` passed

## Notes

The local non-interactive shell did not include `$HOME/.local/bin` or `/opt/homebrew/bin` in `PATH`, so commands that use `uv` or `gh` were run with those paths prepended.