### PR TITLE
[codex] Fix ROS selling pipeline and A2A compatibility issues

### DIFF
--- a/scripts/a2a/debugger.py
+++ b/scripts/a2a/debugger.py
@@ -1547,6 +1547,7 @@ def render_index_html(config: DebuggerConfig) -> str:
         touchedKeys: new Set(),
         textGroups: {},
         normalMessageGroups: {},
+        normalMetadataGroups: {},
         lastStepKey: "",
         lastCandidateKey: "",
         lastCandidateStepKey: ""
@@ -2155,24 +2156,32 @@ def render_index_html(config: DebuggerConfig) -> str:
         .join("");
     }
 
-    function a2aStatusMessage(payload) {
+    function a2aStatusUpdate(payload) {
       if (!payload || typeof payload !== "object") {
         return null;
       }
       if (Array.isArray(payload)) {
         for (const item of payload) {
-          const message = a2aStatusMessage(item);
-          if (message) {
-            return message;
+          const update = a2aStatusUpdate(item);
+          if (update) {
+            return update;
           }
         }
         return null;
       }
       if (payload.result) {
-        return a2aStatusMessage(payload.result);
+        return a2aStatusUpdate(payload.result);
       }
       const statusUpdate = payload.statusUpdate || payload.status_update;
       if (!statusUpdate || typeof statusUpdate !== "object") {
+        return null;
+      }
+      return statusUpdate;
+    }
+
+    function a2aStatusMessage(payload) {
+      const statusUpdate = a2aStatusUpdate(payload);
+      if (!statusUpdate) {
         return null;
       }
       const status = statusUpdate.status && typeof statusUpdate.status === "object" ? statusUpdate.status : {};
@@ -2249,6 +2258,125 @@ def render_index_html(config: DebuggerConfig) -> str:
         message.messageId || "",
         message.role || "ROLE_AGENT"
       ].join("|");
+    }
+
+    function normalIacCodeMetadataFromRawItem(item) {
+      const statusUpdate = a2aStatusUpdate(rawItemValue(item));
+      if (!statusUpdate) {
+        return null;
+      }
+      const metadata = statusUpdate.metadata && typeof statusUpdate.metadata === "object" ? statusUpdate.metadata : {};
+      const iacCode = metadata.iac_code || metadata.iacCode || metadata["iac-code"];
+      if (!iacCode || typeof iacCode !== "object") {
+        return null;
+      }
+      const status = statusUpdate.status && typeof statusUpdate.status === "object" ? statusUpdate.status : {};
+      return {
+        metadata: iacCode,
+        taskId: statusUpdate.taskId || statusUpdate.task_id || "",
+        contextId: statusUpdate.contextId || statusUpdate.context_id || "",
+        state: status.state || ""
+      };
+    }
+
+    function normalCompactValueText(value, maxLength = 500) {
+      if (value === null || value === undefined || value === "") {
+        return "";
+      }
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        return compactText(value, maxLength);
+      }
+      if (typeof value === "object") {
+        const preferred =
+          value.content || value.text || value.summary || value.safeSummary || value.message || value.error;
+        return preferred ? compactText(preferred, maxLength) : compactText(asPrettyJson(value), maxLength);
+      }
+      return compactText(String(value), maxLength);
+    }
+
+    function normalToolText(tool) {
+      if (!tool || typeof tool !== "object") {
+        return "";
+      }
+      const statusMap = {
+        started: "started",
+        input_delta: "input streaming",
+        input_complete: "input complete",
+        completed: "completed",
+        failed: "failed"
+      };
+      const status = statusMap[tool.status] || tool.status || "";
+      const payload = tool.result || tool.input || tool.inputSummary || tool.artifact || tool.partialJson || "";
+      return [status, normalCompactValueText(payload)].filter(Boolean).join(": ");
+    }
+
+    function normalMetadataEventsFromRawItem(item) {
+      const context = normalIacCodeMetadataFromRawItem(item);
+      if (!context) {
+        return [];
+      }
+      const metadata = context.metadata;
+      const events = [];
+      if (metadata.thinking && typeof metadata.thinking === "object") {
+        const text = normalCompactValueText(metadata.thinking.text || metadata.thinking);
+        if (text) {
+          events.push({
+            type: "normal_thinking_group",
+            kind: "thinking",
+            label: "thinking",
+            text,
+            className: "timeline-thinking",
+            groupKey: `${context.contextId}|${context.taskId}|thinking`,
+            context,
+            raw: rawItemValue(item)
+          });
+        }
+      }
+      if (metadata.tool && typeof metadata.tool === "object") {
+        const tool = metadata.tool;
+        const toolUseId = tool.toolUseId || tool.tool_use_id || "";
+        const status = tool.status || "tool";
+        const name = tool.name || tool.toolName || "tool";
+        const text = normalToolText(tool);
+        events.push({
+          type: "normal_tool_event",
+          kind: "tool",
+          label: `tool: ${name}`,
+          text,
+          meta: [toolUseId, status].filter(Boolean).join(" · "),
+          className: "timeline-tool",
+          groupKey: `${context.contextId}|${context.taskId}|tool|${toolUseId}|${status}`,
+          context,
+          raw: rawItemValue(item)
+        });
+      }
+      if (metadata.permission && typeof metadata.permission === "object") {
+        const permission = metadata.permission;
+        const permissionId = permission.toolUseId || permission.permissionId || "";
+        events.push({
+          type: "normal_permission_event",
+          kind: "permission",
+          label: `permission: ${permission.toolName || permission.tool_name || "tool"}`,
+          text: permission.safeSummary || normalCompactValueText(permission),
+          className: "timeline-permission",
+          groupKey: `${context.contextId}|${context.taskId}|permission|${permissionId}`,
+          context,
+          raw: rawItemValue(item)
+        });
+      }
+      if (metadata.mcpWarning && typeof metadata.mcpWarning === "object") {
+        events.push({
+          type: "normal_warning_event",
+          kind: "warning",
+          label: "mcp warning",
+          text: normalCompactValueText(metadata.mcpWarning.message || metadata.mcpWarning),
+          className: "timeline-event",
+          groupKey: `${context.contextId}|${context.taskId}|mcpWarning`,
+          context,
+          raw: rawItemValue(item)
+        });
+      }
+      return events;
     }
 
     function flushTextDeltaGroup(target, group) {
@@ -2982,6 +3110,56 @@ def render_index_html(config: DebuggerConfig) -> str:
       state.executionTree.touchedKeys.add(node.key);
     }
 
+    function appendNormalMetadataEvent(row) {
+      const events = normalMetadataEventsFromRawItem(row);
+      if (events.length === 0) {
+        return;
+      }
+      events.forEach((event) => {
+        const node = ensureNormalChatNode(event.context);
+        const thinkingKey = `normal:${node.key}:thinking`;
+        if (event.type !== "normal_thinking_group") {
+          delete state.executionTree.normalMetadataGroups[thinkingKey];
+        }
+        let item = null;
+        if (event.type === "normal_thinking_group") {
+          item = state.executionTree.normalMetadataGroups[thinkingKey];
+        } else if (event.kind === "tool" && String(event.groupKey).includes("|input_delta")) {
+          item = state.executionTree.normalMetadataGroups[`normal:${node.key}:${event.groupKey}`];
+        }
+        if (!item) {
+          item = {
+            key: `normal:${node.key}:${event.groupKey}:${node.timeline.length}`,
+            type: event.type,
+            label: event.label,
+            text: "",
+            meta: event.meta || "",
+            className: event.className,
+            count: 0,
+            raw: {
+              eventType: event.type,
+              targetKey: node.key,
+              text: "",
+              events: []
+            }
+          };
+          if (event.type === "normal_thinking_group") {
+            state.executionTree.normalMetadataGroups[thinkingKey] = item;
+          } else if (event.kind === "tool" && String(event.groupKey).includes("|input_delta")) {
+            state.executionTree.normalMetadataGroups[`normal:${node.key}:${event.groupKey}`] = item;
+          }
+          node.timeline.push(item);
+        }
+        item.count += 1;
+        item.text += event.type === "normal_thinking_group" ? event.text : item.text ? `\\n${event.text}` : event.text;
+        item.meta = event.type === "normal_thinking_group" ? `thinking_delta x${item.count}` : event.meta || item.meta;
+        item.raw.count = item.count;
+        item.raw.text = item.text;
+        item.raw.events.push(event.raw);
+        state.executionTree.touchedKeys.add(node.key);
+      });
+    }
+
     function appendExecutionTreeEvent(envelope) {
       if (!envelope || typeof envelope !== "object") {
         return;
@@ -3126,6 +3304,7 @@ def render_index_html(config: DebuggerConfig) -> str:
       const envelope = extractPipelineEnvelope(payload);
       if (!envelope || typeof envelope !== "object") {
         appendNormalMessageEvent(rawRow || payload);
+        appendNormalMetadataEvent(rawRow || payload);
         renderPipeline();
         return;
       }
@@ -4572,6 +4751,55 @@ def render_index_html(config: DebuggerConfig) -> str:
       return tree;
     }
 
+    function executionTreeHasNormalMetadataTimeline(tree) {
+      if (!tree || !tree.nodes || typeof tree.nodes !== "object") {
+        return false;
+      }
+      return Object.values(tree.nodes).some((node) => {
+        const timeline = node && Array.isArray(node.timeline) ? node.timeline : [];
+        return timeline.some((item) => {
+          const type = String((item && item.type) || "");
+          return (
+            type === "normal_thinking_group" ||
+            type === "normal_tool_event" ||
+            type === "normal_permission_event" ||
+            type === "normal_warning_event"
+          );
+        });
+      });
+    }
+
+    function removeNormalChatNodes() {
+      const normalKeys = Object.values(state.executionTree.nodes)
+        .filter((node) => node && node.kind === "normal-chat")
+        .map((node) => node.key);
+      const normalKeySet = new Set(normalKeys);
+      normalKeys.forEach((key) => {
+        const node = state.executionTree.nodes[key];
+        if (node && node.parentKey && state.executionTree.nodes[node.parentKey]) {
+          const parent = state.executionTree.nodes[node.parentKey];
+          parent.children = parent.children.filter((childKey) => childKey !== key);
+        }
+        delete state.executionTree.nodes[key];
+      });
+      state.executionTree.rootIds = state.executionTree.rootIds.filter((key) => !normalKeySet.has(key));
+      state.executionTree.normalMessageGroups = {};
+      state.executionTree.normalMetadataGroups = {};
+    }
+
+    function rebuildNormalChatTimelineFromRawEvents(rows) {
+      if (!Array.isArray(rows)) {
+        return;
+      }
+      removeNormalChatNodes();
+      rows.forEach((row) => {
+        if (!pipelineEnvelopeFromRawItem(row)) {
+          appendNormalMessageEvent(row);
+          appendNormalMetadataEvent(row);
+        }
+      });
+    }
+
     function rebuildExecutionTreeFromRawEvents(rows) {
       if (!Array.isArray(rows)) {
         return;
@@ -4583,6 +4811,7 @@ def render_index_html(config: DebuggerConfig) -> str:
           appendExecutionTreeEvent(envelope);
         } else {
           appendNormalMessageEvent(row);
+          appendNormalMetadataEvent(row);
         }
       });
     }
@@ -4614,6 +4843,8 @@ def render_index_html(config: DebuggerConfig) -> str:
       state.executionTree = restoreExecutionTree(data.executionTree);
       if (state.executionTree.rootIds.length === 0) {
         rebuildExecutionTreeFromRawEvents(state.raw.sse);
+      } else if (!executionTreeHasNormalMetadataTimeline(state.executionTree)) {
+        rebuildNormalChatTimelineFromRawEvents(state.raw.sse);
       }
       state.expandedTreeKeys = restoreSet(uiState.expandedTreeKeys);
       state.expandedTimelineKeys = restoreSet(uiState.expandedTimelineKeys);

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools.command.sdist import sdist
 INIT_PATH = Path("src/iac_code/__init__.py")
 LOCALES_DIR = Path("src/iac_code/i18n/locales")
 PROJECT_ROOT = Path(__file__).resolve().parent
-IAC_ALIYUN_REFERENCES_DIR = PROJECT_ROOT / "src/iac_code/skills/bundled/iac_aliyun/references"
+SELLING_REFERENCES_DIR = PROJECT_ROOT / "src/iac_code/pipeline/selling/references"
 SELLING_IAC_ALIYUN_SKILLS = (
     "iac-aliyun-template-generating",
     "iac-aliyun-cost",
@@ -207,10 +207,54 @@ def _replace_release_date():
     INIT_PATH.write_text(content, encoding="utf-8")
 
 
+def _git_symlink_placeholder_target(path: Path) -> Path | None:
+    """Return the target for a Windows core.symlinks=false placeholder file."""
+    if path.is_symlink() or not path.is_file():
+        return None
+    try:
+        if path.stat().st_size > 4096:
+            return None
+        raw_target = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not raw_target or "\n" in raw_target or "\r" in raw_target:
+        return None
+    target = Path(raw_target)
+    if not target.is_absolute():
+        target = path.parent / target
+    try:
+        return target.resolve(strict=True)
+    except OSError:
+        return None
+
+
+def _copy_reference_entry(source: Path, target: Path) -> None:
+    placeholder_target = _git_symlink_placeholder_target(source)
+    if placeholder_target is not None:
+        source = placeholder_target
+    elif source.is_symlink():
+        source = source.resolve(strict=True)
+
+    if source.is_dir():
+        target.mkdir(parents=True, exist_ok=True)
+        for child in source.iterdir():
+            _copy_reference_entry(child, target / child.name)
+        return
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+def _copy_reference_tree(source: Path, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    for child in source.iterdir():
+        _copy_reference_entry(child, target / child.name)
+
+
 def _copy_selling_skill_references_to_package_root(package_root) -> None:
     """Expand selling-skill reference symlinks into real dirs under an iac_code package root."""
-    if not IAC_ALIYUN_REFERENCES_DIR.is_dir():
-        raise RuntimeError("references directory not found: %s" % IAC_ALIYUN_REFERENCES_DIR)
+    if not SELLING_REFERENCES_DIR.is_dir():
+        raise RuntimeError("references directory not found: %s" % SELLING_REFERENCES_DIR)
 
     package_root = Path(package_root)
     for skill_name in SELLING_IAC_ALIYUN_SKILLS:
@@ -220,7 +264,7 @@ def _copy_selling_skill_references_to_package_root(package_root) -> None:
         elif target.exists():
             shutil.rmtree(target)
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(IAC_ALIYUN_REFERENCES_DIR, target)
+        _copy_reference_tree(SELLING_REFERENCES_DIR, target)
 
 
 def _copy_selling_skill_references(build_lib: str) -> None:

--- a/src/iac_code/a2a/artifacts.py
+++ b/src/iac_code/a2a/artifacts.py
@@ -6,6 +6,7 @@ import ntpath
 import os
 import re
 import uuid
+from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,7 @@ from iac_code.services.session_layout import (
     require_supported_session_layout,
 )
 from iac_code.utils.public_errors import sanitize_public_text
+from iac_code.utils.public_paths import relativize_public_file_uri
 from iac_code.utils.state_io import atomic_write_bytes
 
 PUBLIC_ARTIFACT_URI_PREFIX = "iac-code-artifact://"
@@ -112,64 +114,101 @@ def _windows_safe_filename(filename: str) -> str:
     return sanitized
 
 
-def sanitize_public_artifact_data(value: Any) -> Any:
+def sanitize_public_artifact_data(
+    value: Any,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> Any:
     if isinstance(value, list):
-        return [sanitize_public_artifact_data(item) for item in value]
+        return [sanitize_public_artifact_data(item, public_path_roots=public_path_roots) for item in value]
     if isinstance(value, tuple):
-        return [sanitize_public_artifact_data(item) for item in value]
+        return [sanitize_public_artifact_data(item, public_path_roots=public_path_roots) for item in value]
     if isinstance(value, str):
-        return _sanitize_artifact_scalar_string(value)
+        return _sanitize_artifact_scalar_string(value, public_path_roots=public_path_roots)
     if not isinstance(value, dict):
         return value
 
     sanitized: dict[Any, Any] = {}
     for key, raw_value in value.items():
         key_name = str(key)
+        output_key, key_is_public_path = _sanitize_public_mapping_key(key, public_path_roots=public_path_roots)
         if key_name.lower() in _ARTIFACT_PAYLOAD_KEYS:
             continue
-        if _is_sensitive_output_key(key_name):
-            sanitized[key] = "[REDACTED]"
+        if not key_is_public_path and _is_sensitive_output_key(key_name):
+            sanitized[output_key] = "[REDACTED]"
             continue
         if _is_artifact_uri_key(key_name):
             if isinstance(raw_value, str):
-                sanitized_value = _sanitize_artifact_string(key_name, raw_value)
+                sanitized_value = _sanitize_artifact_string(key_name, raw_value, public_path_roots=public_path_roots)
                 if sanitized_value is not None:
-                    sanitized[key] = sanitized_value
+                    sanitized[output_key] = sanitized_value
             continue
         if isinstance(raw_value, str):
-            sanitized_value = _sanitize_artifact_string(key_name, raw_value)
+            sanitized_value = _sanitize_artifact_string(key_name, raw_value, public_path_roots=public_path_roots)
             if sanitized_value is None:
                 continue
-            sanitized[key] = sanitized_value
+            sanitized[output_key] = sanitized_value
             continue
-        sanitized[key] = sanitize_public_artifact_data(raw_value)
+        sanitized[output_key] = sanitize_public_artifact_data(raw_value, public_path_roots=public_path_roots)
     return sanitized
 
 
-def sanitize_public_tool_output_data(value: Any) -> Any:
+def sanitize_public_tool_output_data(
+    value: Any,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> Any:
     if isinstance(value, str):
-        return sanitize_public_artifact_text(value, fallback_summary="")
+        return sanitize_public_artifact_text(value, fallback_summary="", public_path_roots=public_path_roots)
     if isinstance(value, list):
-        return [sanitize_public_tool_output_data(item) for item in value]
+        return [sanitize_public_tool_output_data(item, public_path_roots=public_path_roots) for item in value]
     if isinstance(value, tuple):
-        return [sanitize_public_tool_output_data(item) for item in value]
+        return [sanitize_public_tool_output_data(item, public_path_roots=public_path_roots) for item in value]
     if not isinstance(value, dict):
         return value
     if _looks_like_artifact_payload_dict(value):
-        return sanitize_public_artifact_data(value)
+        return sanitize_public_artifact_data(value, public_path_roots=public_path_roots)
 
     sanitized: dict[Any, Any] = {}
     for key, raw_value in value.items():
-        if str(key).lower() in _ARTIFACT_CONTAINER_KEYS:
-            sanitized[key] = sanitize_public_artifact_data(raw_value)
-        elif _is_sensitive_output_key(key):
-            sanitized[key] = "[REDACTED]"
+        key_name = str(key)
+        output_key, key_is_public_path = _sanitize_public_mapping_key(key, public_path_roots=public_path_roots)
+        if key_name.lower() in _ARTIFACT_CONTAINER_KEYS:
+            sanitized[output_key] = sanitize_public_artifact_data(raw_value, public_path_roots=public_path_roots)
+        elif not key_is_public_path and _is_sensitive_output_key(key_name):
+            sanitized[output_key] = "[REDACTED]"
         else:
-            sanitized[key] = sanitize_public_tool_output_data(raw_value)
+            sanitized[output_key] = sanitize_public_tool_output_data(raw_value, public_path_roots=public_path_roots)
     return sanitized
 
 
-def _sanitize_artifact_string(key: str, value: str) -> str | None:
+def _sanitize_public_mapping_key(
+    key: Any,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> tuple[Any, bool]:
+    if not isinstance(key, str):
+        return key, False
+    sanitized_key = _sanitize_artifact_scalar_string(key, public_path_roots=public_path_roots)
+    return sanitized_key, sanitized_key != key and _is_path_like_mapping_key(key)
+
+
+def _is_path_like_mapping_key(key: str) -> bool:
+    stripped = key.strip()
+    if not stripped or re.search(r"\s", stripped):
+        return False
+    if stripped.lower().startswith("file://"):
+        parsed = urlsplit(stripped)
+        return parsed.scheme.lower() == "file" and bool(parsed.path or parsed.netloc)
+    return bool(stripped.startswith("/") or stripped.startswith("\\\\") or ntpath.splitdrive(stripped)[0])
+
+
+def _sanitize_artifact_string(
+    key: str,
+    value: str,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> str | None:
     if _is_artifact_uri_key(key):
         return value if is_valid_public_artifact_uri(value) else None
     if key.lower() in {"filename", "name"}:
@@ -179,34 +218,51 @@ def _sanitize_artifact_string(key: str, value: str) -> str | None:
             except UnsafeArtifactNameError:
                 pass
     if value.lower().startswith("file://"):
-        return "[PATH]"
-    return _sanitize_artifact_scalar_string(value)
+        return relativize_public_file_uri(value, public_path_roots) or "[PATH]"
+    return _sanitize_artifact_scalar_string(value, public_path_roots=public_path_roots)
 
 
-def _sanitize_artifact_scalar_string(value: str) -> str:
+def _sanitize_artifact_scalar_string(
+    value: str,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> str:
     if value.lower().startswith("file://"):
-        return "[PATH]"
+        return relativize_public_file_uri(value, public_path_roots) or "[PATH]"
     decoded = unquote(value)
     if decoded != value:
         if decoded.lower().startswith("file://"):
-            return "[PATH]"
-        decoded_sanitized = sanitize_public_artifact_text(decoded, fallback_summary="")
+            return relativize_public_file_uri(decoded, public_path_roots) or "[PATH]"
+        decoded_sanitized = sanitize_public_artifact_text(
+            decoded,
+            fallback_summary="",
+            public_path_roots=public_path_roots,
+        )
         if decoded_sanitized != decoded:
             return decoded_sanitized
-    return sanitize_public_artifact_text(value, fallback_summary="")
+    return sanitize_public_artifact_text(value, fallback_summary="", public_path_roots=public_path_roots)
 
 
-def sanitize_public_artifact_text(value: str, *, fallback_summary: str | None = None) -> str:
+def sanitize_public_artifact_text(
+    value: str,
+    *,
+    fallback_summary: str | None = None,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> str:
     if fallback_summary is None:
         fallback_summary = _("Unknown error")
     protected, placeholders = _replace_public_artifact_uri_tokens(value)
-    protected = _replace_file_uri_tokens(protected)
-    sanitized = sanitize_public_text(protected, fallback_summary=fallback_summary)
+    protected = _replace_file_uri_tokens(protected, public_path_roots=public_path_roots)
+    sanitized = sanitize_public_text(
+        protected,
+        fallback_summary=fallback_summary,
+        public_path_roots=public_path_roots,
+    )
     decoded_raw = unquote(protected)
     decoded, decoded_placeholders = _replace_public_artifact_uri_tokens(decoded_raw, prefix="__IAC_CODE_DECODED_URI_")
-    decoded = _replace_file_uri_tokens(decoded)
+    decoded = _replace_file_uri_tokens(decoded, public_path_roots=public_path_roots)
     if decoded_raw != protected:
-        decoded_sanitized = sanitize_public_text(decoded, fallback_summary="")
+        decoded_sanitized = sanitize_public_text(decoded, fallback_summary="", public_path_roots=public_path_roots)
         if decoded != decoded_raw or decoded_sanitized != decoded:
             sanitized = decoded_sanitized
             placeholders.update(decoded_placeholders)
@@ -215,13 +271,20 @@ def sanitize_public_artifact_text(value: str, *, fallback_summary: str | None = 
     return sanitized
 
 
-def _replace_file_uri_tokens(value: str) -> str:
+def _replace_file_uri_tokens(
+    value: str,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> str:
     def replace_file_uri(match: re.Match[str]) -> str:
         uri = match.group(0)
         trailing = ""
         while uri and uri[-1] in ".,:!?":
             trailing = uri[-1] + trailing
             uri = uri[:-1]
+        public_path = relativize_public_file_uri(uri, public_path_roots)
+        if public_path is not None:
+            return f"{public_path}{trailing}"
         return f"[PATH]{trailing}"
 
     return _FILE_URI_TEXT_PATTERN.sub(replace_file_uri, value)

--- a/src/iac_code/a2a/events.py
+++ b/src/iac_code/a2a/events.py
@@ -176,10 +176,15 @@ def _extract_artifact_metadata(result: Any, artifact_store: Any | None) -> dict[
     return None
 
 
-def _tool_result_metadata(result: Any, *, is_error: bool = False) -> Any:
-    sanitized = sanitize_public_tool_output_data(result)
+def _tool_result_metadata(
+    result: Any,
+    *,
+    is_error: bool = False,
+    public_path_roots: list[dict[str, str]] | None = None,
+) -> Any:
+    sanitized = sanitize_public_tool_output_data(result, public_path_roots=public_path_roots)
     if is_error and isinstance(sanitized, str):
-        return sanitize_public_artifact_text(sanitized)
+        return sanitize_public_artifact_text(sanitized, public_path_roots=public_path_roots)
     return _truncate(sanitized)
 
 
@@ -351,7 +356,11 @@ async def publish_stream_event(
             "status": "failed" if event.is_error else "completed",
             "toolUseId": event.tool_use_id,
             "name": event.tool_name,
-            "result": _tool_result_metadata(event.result, is_error=event.is_error),
+            "result": _tool_result_metadata(
+                event.result,
+                is_error=event.is_error,
+                public_path_roots=event.public_path_roots,
+            ),
         }
         if artifact_metadata is not None:
             tool_metadata["artifact"] = artifact_metadata

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -85,6 +85,7 @@ from iac_code.services.session_storage import SessionStorage
 from iac_code.types.stream_events import TextDeltaEvent
 from iac_code.utils.file_security import atomic_write_text, ensure_private_dir, ensure_private_file
 from iac_code.utils.public_errors import public_exception_summary, sanitize_public_text
+from iac_code.utils.public_paths import build_public_path_roots
 
 logger = logging.getLogger(__name__)
 _CONTEXT_LOCK_ACQUIRE_TIMEOUT_SECONDS = 1
@@ -836,12 +837,19 @@ class IacCodeA2AExecutor(AgentExecutor):
         context_id = context.context_id or "ctx-" + uuid.uuid4().hex[:12]
         task = None
         initial_task_published = False
+        public_path_roots: list[dict[str, str]] | None = None
 
         async def publish_initial_task_if_missing() -> None:
             nonlocal initial_task_published
             if initial_task_published or isinstance(getattr(context, "current_task", None), Task):
                 return
-            await self._publish_initial_task(event_queue, task_id=task_id, context_id=context_id, context=context)
+            await self._publish_initial_task(
+                event_queue,
+                task_id=task_id,
+                context_id=context_id,
+                context=context,
+                public_path_roots=public_path_roots,
+            )
             initial_task_published = True
 
         try:
@@ -849,6 +857,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                 getattr(context, "message", None), "metadata", None
             )
             cwd = self._resolve_cwd(metadata)
+            public_path_roots = build_public_path_roots(cwd=cwd)
             user_id = self._resolve_user_id(metadata)
             metadata_model = self._resolve_model(metadata)
             metadata_api_key = self._resolve_api_key(metadata)
@@ -1680,6 +1689,7 @@ class IacCodeA2AExecutor(AgentExecutor):
         context_id: str,
         context: RequestContext,
         session_id: str | None = None,
+        public_path_roots: list[dict[str, str]] | None = None,
     ) -> None:
         task = Task(
             id=task_id,
@@ -1690,7 +1700,12 @@ class IacCodeA2AExecutor(AgentExecutor):
             ParseDict(iac_code_session_metadata(session_id), task.metadata)
         message = getattr(context, "message", None)
         if isinstance(message, Message):
-            task.history.append(self._metadata_echo_redactor.redact_message_echo(message))
+            task.history.append(
+                self._metadata_echo_redactor.redact_message_echo(
+                    message,
+                    public_path_roots=public_path_roots,
+                )
+            )
         await event_queue.enqueue_event(task)
 
     def _refresh_runtime_cloud_tools(self, runtime: Any) -> None:

--- a/src/iac_code/a2a/metadata_redaction.py
+++ b/src/iac_code/a2a/metadata_redaction.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from a2a.types import Message
 from google.protobuf.json_format import MessageToDict, ParseDict
+
+from iac_code.a2a.artifacts import sanitize_public_artifact_text
 
 
 class A2AMetadataEchoRedactor:
@@ -31,27 +33,48 @@ class A2AMetadataEchoRedactor:
         "access_key_secret",
     }
 
-    def redact_message_echo(self, message: Message) -> Message:
+    def redact_message_echo(
+        self,
+        message: Message,
+        *,
+        public_path_roots: Iterable[Mapping[str, str]] | None = None,
+    ) -> Message:
+        message_dict = MessageToDict(message, preserving_proto_field_name=False)
+        metadata = message_dict.get("metadata")
+        if isinstance(metadata, Mapping):
+            message_dict["metadata"] = self.redact(metadata, public_path_roots=public_path_roots)
+        parts = message_dict.get("parts")
+        if isinstance(parts, list):
+            for part in parts:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    part["text"] = sanitize_public_artifact_text(
+                        part["text"],
+                        fallback_summary="",
+                        public_path_roots=public_path_roots,
+                    )
         redacted_message = Message()
-        redacted_message.CopyFrom(message)
-        if not message.metadata.fields:
-            return redacted_message
-
-        metadata = MessageToDict(message.metadata, preserving_proto_field_name=False)
-        redacted_message.metadata.Clear()
-        ParseDict(self.redact(metadata), redacted_message.metadata)
+        ParseDict(message_dict, redacted_message)
         return redacted_message
 
-    def redact(self, value: Any) -> Any:
+    def redact(
+        self,
+        value: Any,
+        *,
+        public_path_roots: Iterable[Mapping[str, str]] | None = None,
+    ) -> Any:
         if isinstance(value, Mapping):
             return {
-                key: self.REDACTED_VALUE if self._is_sensitive_key(key) else self.redact(item)
+                key: self.REDACTED_VALUE
+                if self._is_sensitive_key(key)
+                else self.redact(item, public_path_roots=public_path_roots)
                 for key, item in value.items()
             }
         if isinstance(value, list):
-            return [self.redact(item) for item in value]
+            return [self.redact(item, public_path_roots=public_path_roots) for item in value]
         if isinstance(value, tuple):
-            return [self.redact(item) for item in value]
+            return [self.redact(item, public_path_roots=public_path_roots) for item in value]
+        if isinstance(value, str):
+            return sanitize_public_artifact_text(value, fallback_summary="", public_path_roots=public_path_roots)
         return value
 
     def _is_sensitive_key(self, key: Any) -> bool:

--- a/src/iac_code/a2a/pipeline_events.py
+++ b/src/iac_code/a2a/pipeline_events.py
@@ -1287,7 +1287,11 @@ def _tool_result_data(event: ToolResultEvent) -> dict[str, Any]:
         "toolName": event.tool_name,
         "toolUseId": event.tool_use_id,
         "isError": event.is_error,
-        "result": _tool_result_metadata(event.result, is_error=event.is_error),
+        "result": _tool_result_metadata(
+            event.result,
+            is_error=event.is_error,
+            public_path_roots=event.public_path_roots,
+        ),
     }
 
 

--- a/src/iac_code/a2a/pipeline_events.py
+++ b/src/iac_code/a2a/pipeline_events.py
@@ -749,6 +749,8 @@ class PipelineEventTranslator:
             "toolUseId": event.tool_use_id,
             "provider": operation["provider"],
             "action": action,
+            "deployAction": operation.get("deployAction"),
+            "previousStackId": operation.get("previousStackId"),
             "regionId": operation["regionId"],
             "stackId": stack_id,
             "stackName": _first_string_from_sources((result, params), ("StackName", "stackName", "stack_name", "name")),
@@ -1103,9 +1105,25 @@ def _dict_or_empty(value: Any) -> dict[str, Any]:
 def _stack_operation_from_tool_input(tool_name: str, tool_input: dict[str, Any]) -> dict[str, Any] | None:
     normalized_tool_name = tool_name.lower()
     params = _dict_or_empty(tool_input.get("params") or tool_input.get("parameters"))
+    extra: dict[str, Any] = {}
     if normalized_tool_name == "ros_stack":
         provider = "ros"
         action = _first_string_value(tool_input, ("action", "Action"))
+    elif normalized_tool_name == "ros_deploy":
+        provider = "ros"
+        deploy_action = _first_string_value(tool_input, ("action", "Action"))
+        action = {
+            "create": "CreateStack",
+            "continue_create": "ContinueCreateStack",
+            "delete_and_create": "CreateStack",
+        }.get(deploy_action or "")
+        params = {
+            "StackId": _first_string_value(tool_input, ("stack_id", "stackId", "StackId")),
+            "StackName": _first_string_value(tool_input, ("stack_name", "stackName", "StackName")),
+        }
+        if deploy_action == "delete_and_create":
+            extra["deployAction"] = deploy_action
+            extra["previousStackId"] = params["StackId"]
     elif normalized_tool_name == "aliyun_api":
         product = _first_string_value(tool_input, ("product", "Product", "service", "Service"))
         if product is None or product.lower() != "ros":
@@ -1122,6 +1140,7 @@ def _stack_operation_from_tool_input(tool_name: str, tool_input: dict[str, Any])
         "action": action,
         "params": params,
         "regionId": _first_string_from_sources((tool_input, params), ("region_id", "regionId", "RegionId")),
+        **extra,
     }
 
 

--- a/src/iac_code/acp/convert.py
+++ b/src/iac_code/acp/convert.py
@@ -74,6 +74,7 @@ _TOOL_KIND_MAP: dict[str, ToolKind] = {
     "bash": "execute",
     "task_stop": "execute",
     "ros_stack": "execute",
+    "ros_deploy": "execute",
     "ros_stack_instances": "execute",
     # Fetch operations
     "web_fetch": "fetch",

--- a/src/iac_code/acp/convert.py
+++ b/src/iac_code/acp/convert.py
@@ -259,8 +259,14 @@ class ACPEventConverter:
                         ],
                     )
                 ]
-            case ToolResultEvent(tool_use_id=tool_use_id, tool_name=tool_name, result=result, is_error=is_error):
-                visible_result = _public_tool_result_text(result)
+            case ToolResultEvent(
+                tool_use_id=tool_use_id,
+                tool_name=tool_name,
+                result=result,
+                is_error=is_error,
+                public_path_roots=public_path_roots,
+            ):
+                visible_result = _public_tool_result_text(result, public_path_roots=public_path_roots)
                 content: list[
                     acp.schema.ContentToolCallContent
                     | acp.schema.FileEditToolCallContent
@@ -386,8 +392,8 @@ def _input_delta_summary_text(accumulated_input: str) -> str:
     return _("Input received ({count} chars)").format(count=len(accumulated_input))
 
 
-def _public_tool_result_text(value: Any) -> str:
-    sanitized = sanitize_public_tool_output_data(value)
+def _public_tool_result_text(value: Any, *, public_path_roots: list[dict[str, str]] | None = None) -> str:
+    sanitized = sanitize_public_tool_output_data(value, public_path_roots=public_path_roots)
     if isinstance(sanitized, str):
         return sanitized
     return json.dumps(sanitized, ensure_ascii=False, default=str)

--- a/src/iac_code/acp/session.py
+++ b/src/iac_code/acp/session.py
@@ -663,6 +663,12 @@ class ACPSession:
         ):
             suggestions = event.permission_result.suggestions
 
+        def _suggestion_rules() -> str:
+            return ",".join(s.rule_content for s in suggestions)
+
+        def _suggestion_display() -> str:
+            return ",".join(s.display_label() for s in suggestions)
+
         # Build dynamic option list aligned with local REPL behavior.
         options: list[acp.schema.PermissionOption] = [
             acp.schema.PermissionOption(
@@ -673,10 +679,11 @@ class ACPSession:
         ]
 
         if suggestions:
-            rules_display = ",".join(s.rule_content for s in suggestions)
+            rules_value = _suggestion_rules()
+            rules_display = _suggestion_display()
             options.append(
                 acp.schema.PermissionOption(
-                    option_id=_PREFIX_ALLOW_RULE + rules_display,
+                    option_id=_PREFIX_ALLOW_RULE + rules_value,
                     name=_('Always allow "{rule}" (this session)').format(rule=rules_display),
                     kind="allow_always",
                 )
@@ -699,10 +706,11 @@ class ACPSession:
         )
 
         if suggestions:
-            rules_display = ",".join(s.rule_content for s in suggestions)
+            rules_value = _suggestion_rules()
+            rules_display = _suggestion_display()
             options.append(
                 acp.schema.PermissionOption(
-                    option_id=_PREFIX_DENY_RULE + rules_display,
+                    option_id=_PREFIX_DENY_RULE + rules_value,
                     name=_('Always deny "{rule}" (this session)').format(rule=rules_display),
                     kind="reject_always",
                 )
@@ -741,9 +749,7 @@ class ACPSession:
                 input=tool_input_redacted,
             )
         if suggestions:
-            content_text += "\n" + _("Suggested rule: {rule}").format(
-                rule=",".join(s.rule_content for s in suggestions)
-            )
+            content_text += "\n" + _("Suggested rule: {rule}").format(rule=_suggestion_display())
 
         response = await self._conn.request_permission(
             options,

--- a/src/iac_code/agent/agent_loop.py
+++ b/src/iac_code/agent/agent_loop.py
@@ -91,16 +91,31 @@ def _extend_unique(target: list[str], values: list[str]) -> None:
             seen.add(value)
 
 
-def _with_trusted_read_directories(permission_context: Any, directories: list[str]) -> Any:
-    if not directories:
+def _with_tool_read_directories(
+    permission_context: Any,
+    *,
+    trusted_directories: list[str],
+    relative_directories: list[str],
+) -> Any:
+    if not trusted_directories and not relative_directories:
         return permission_context
 
     trusted_read_directories = list(getattr(permission_context, "trusted_read_directories", []))
-    original_count = len(trusted_read_directories)
-    _extend_unique(trusted_read_directories, directories)
-    if len(trusted_read_directories) == original_count:
+    relative_read_directories = list(getattr(permission_context, "relative_read_directories", []))
+    original_trusted_count = len(trusted_read_directories)
+    original_relative_count = len(relative_read_directories)
+    _extend_unique(trusted_read_directories, trusted_directories)
+    _extend_unique(relative_read_directories, relative_directories)
+    if (
+        len(trusted_read_directories) == original_trusted_count
+        and len(relative_read_directories) == original_relative_count
+    ):
         return permission_context
-    return replace(permission_context, trusted_read_directories=trusted_read_directories)
+    return replace(
+        permission_context,
+        trusted_read_directories=trusted_read_directories,
+        relative_read_directories=relative_read_directories,
+    )
 
 
 def _emit_no_prompt_permission_audit(
@@ -1022,12 +1037,18 @@ class AgentLoop:
                     if perm_ctx is not None:
                         from iac_code.services.permissions.pipeline import check_tool_permission
 
-                        effective_perm_ctx = _with_trusted_read_directories(
-                            perm_ctx, self._tool_context_trusted_read_directories
+                        effective_perm_ctx = _with_tool_read_directories(
+                            perm_ctx,
+                            trusted_directories=self._tool_context_trusted_read_directories,
+                            relative_directories=self._tool_context_relative_read_directories,
                         )
                         _extend_unique(context.additional_directories, list(effective_perm_ctx.additional_directories))
                         _extend_unique(
                             context.trusted_read_directories, list(effective_perm_ctx.trusted_read_directories)
+                        )
+                        _extend_unique(
+                            context.relative_read_directories,
+                            list(effective_perm_ctx.relative_read_directories),
                         )
                         permission = await check_tool_permission(tool, request.input, effective_perm_ctx)
                     else:

--- a/src/iac_code/agent/agent_loop.py
+++ b/src/iac_code/agent/agent_loop.py
@@ -47,6 +47,7 @@ from iac_code.types.stream_events import (
     ToolUseStartEvent,
     Usage,
 )
+from iac_code.utils.public_paths import build_public_path_roots
 
 
 @dataclass
@@ -1115,12 +1116,20 @@ class AgentLoop:
                     else:
                         denied_results.append((request, ToolResult.error(_("Permission denied."))))
 
+                public_path_roots = build_public_path_roots(
+                    cwd=context.cwd,
+                    additional_directories=context.additional_directories,
+                    trusted_read_directories=context.trusted_read_directories,
+                    relative_read_directories=context.relative_read_directories,
+                )
+
                 for request, result in denied_results:
                     yield ToolResultEvent(
                         tool_use_id=request.id,
                         tool_name=request.name,
                         result=result.content,
                         is_error=True,
+                        public_path_roots=public_path_roots,
                     )
 
                 if not allowed_requests:
@@ -1226,6 +1235,7 @@ class AgentLoop:
                         result=processed.content,
                         is_error=result.is_error,
                         metadata=result.metadata,
+                        public_path_roots=public_path_roots,
                     )
 
                     tool_result_blocks.append(

--- a/src/iac_code/agent/system_prompt.py
+++ b/src/iac_code/agent/system_prompt.py
@@ -111,7 +111,7 @@ class SystemPromptBuilder:
 
 def _build_identity_section() -> str:
     return (
-        "You are an expert AI coding assistant specialized in Infrastructure as Code. "
+        "You are IaC Code (iac-code), an AI-powered Infrastructure as Code assistant. "
         "You help users with software engineering tasks including writing, debugging, "
         "and refactoring code. You are precise, careful, and focused on delivering "
         "correct solutions.\n\n"
@@ -161,9 +161,20 @@ def _build_environment_section(cwd: str) -> str:
     return "\n".join(lines)
 
 
-def _build_current_time_section(current_time: str | None = None) -> str:
+def _build_runtime_context_section(
+    current_time: str | None = None,
+    provider_display: str = "",
+    model: str = "",
+) -> str:
     now = current_time or datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    return "# Current Time\n" + f"- Current time: {now}"
+    lines = ["# Runtime Context", f"- Current time: {now}"]
+    provider_display = provider_display.strip()
+    model = model.strip()
+    if provider_display and model:
+        lines.append(f"- Provider & Model: {provider_display} / {model}")
+    elif model:
+        lines.append(f"- Provider & Model: {model}")
+    return "\n".join(lines)
 
 
 def _build_tools_section() -> str:
@@ -299,6 +310,7 @@ SECTION_BUILDERS: dict[str, Callable[..., str]] = {
     "system": _build_system_section,
     "env": _build_environment_section,
     "cloud_config": _build_cloud_config_section,
+    "runtime_context": _build_runtime_context_section,
     "tools": _build_tools_section,
     "doing_tasks": _build_doing_tasks_section,
     "actions": _build_actions_section,
@@ -313,13 +325,21 @@ SECTION_PRIORITIES: dict[str, int] = {
     "tools": 85,
     "doing_tasks": 80,
     "actions": 75,
+    "runtime_context": 72,
     "output_style": 50,
 }
 
-DEFAULT_PIPELINE_SECTIONS: list[str] = ["identity", "system", "env", "cloud_config", "tools"]
+DEFAULT_PIPELINE_SECTIONS: list[str] = ["identity", "system", "env", "cloud_config", "tools", "runtime_context"]
 
 
-def build_base_sections(section_names: list[str], cwd: str, memory_content: str = "") -> str:
+def build_base_sections(
+    section_names: list[str],
+    cwd: str,
+    memory_content: str = "",
+    current_time: str | None = None,
+    provider_display: str = "",
+    model: str = "",
+) -> str:
     """Build system prompt from a subset of section names, ordered by priority.
 
     Args:
@@ -328,6 +348,9 @@ def build_base_sections(section_names: list[str], cwd: str, memory_content: str 
         memory_content: if non-empty, inserted as a "# Memory\\n<content>" section
             at priority 60 (matching build_system_prompt's placement so both
             implementations produce identical ordering relative to other sections).
+        current_time: optional stable timestamp for the runtime context section
+        provider_display: provider display name for the runtime context section
+        model: model name for the runtime context section
     """
     parts: list[tuple[int, str]] = []
     if section_names:
@@ -336,7 +359,9 @@ def build_base_sections(section_names: list[str], cwd: str, memory_content: str 
             if builder is None:
                 continue
             priority = SECTION_PRIORITIES.get(name, 0)
-            if "cwd" in inspect.signature(builder).parameters:
+            if name == "runtime_context":
+                content = _build_runtime_context_section(current_time, provider_display, model)
+            elif "cwd" in inspect.signature(builder).parameters:
                 content = builder(cwd)
             else:
                 content = builder()
@@ -360,6 +385,8 @@ def build_system_prompt(
     skill_listing: str = "",
     memory_context: object | None = None,
     current_time: str | None = None,
+    provider_display: str = "",
+    model: str = "",
 ) -> str:
     """Build complete system prompt from all sections."""
     cwd = cwd or os.getcwd()
@@ -373,8 +400,8 @@ def build_system_prompt(
     builder.add_cached_section("doing_tasks", _build_doing_tasks_section, priority=80, is_static=True)
     builder.add_cached_section("actions", _build_actions_section, priority=75, is_static=True)
     builder.add_uncached_section(
-        "current_time",
-        lambda: _build_current_time_section(current_time),
+        "runtime_context",
+        lambda: _build_runtime_context_section(current_time, provider_display, model),
         priority=72,
         is_static=False,
     )

--- a/src/iac_code/cli/output_formats.py
+++ b/src/iac_code/cli/output_formats.py
@@ -38,22 +38,27 @@ class OutputFormat(str, Enum):
 
 
 def _public_tool_result(event: ToolResultEvent) -> Any:
-    return sanitize_public_tool_output_data(event.result)
+    return sanitize_public_tool_output_data(event.result, public_path_roots=event.public_path_roots)
 
 
 def _public_tool_metadata(event: ToolResultEvent, metadata: Any) -> Any:
-    return sanitize_public_tool_output_data(_sanitize_public_value(metadata) if event.is_error else metadata)
+    return sanitize_public_tool_output_data(
+        _sanitize_public_value(metadata, public_path_roots=event.public_path_roots) if event.is_error else metadata,
+        public_path_roots=event.public_path_roots,
+    )
 
 
-def _sanitize_public_value(value: Any) -> Any:
+def _sanitize_public_value(value: Any, *, public_path_roots: list[dict[str, str]] | None = None) -> Any:
     if isinstance(value, str):
-        return sanitize_public_text(value)
+        return sanitize_public_text(value, public_path_roots=public_path_roots)
     if isinstance(value, list):
-        return [_sanitize_public_value(item) for item in value]
+        return [_sanitize_public_value(item, public_path_roots=public_path_roots) for item in value]
     if isinstance(value, tuple):
-        return [_sanitize_public_value(item) for item in value]
+        return [_sanitize_public_value(item, public_path_roots=public_path_roots) for item in value]
     if isinstance(value, dict):
-        return {str(key): _sanitize_public_value(item) for key, item in value.items()}
+        return {
+            str(key): _sanitize_public_value(item, public_path_roots=public_path_roots) for key, item in value.items()
+        }
     return value
 
 
@@ -99,6 +104,7 @@ def _stream_json_event_data(event: StreamEvent) -> dict[str, Any]:
     if isinstance(event, ErrorEvent):
         data["error"] = sanitize_public_text(event.error)
     elif isinstance(event, ToolResultEvent):
+        data.pop("public_path_roots", None)
         if data.get("metadata") is None:
             data.pop("metadata", None)
         elif "metadata" in data:

--- a/src/iac_code/commands/memory.py
+++ b/src/iac_code/commands/memory.py
@@ -231,6 +231,18 @@ def _refresh_repl_memory_context(repl: object | None) -> None:
     cwd = getattr(repl, "_original_cwd", os.getcwd())
     skill_listing = getattr(repl, "_skill_listing", "")
     current_time = getattr(repl, "_runtime_current_time", None)
+    provider_display = ""
+    if hasattr(provider_manager, "get_provider_display"):
+        try:
+            provider_display = provider_manager.get_provider_display()
+        except Exception:
+            provider_display = ""
+    model = ""
+    if hasattr(provider_manager, "get_model_name"):
+        try:
+            model = provider_manager.get_model_name()
+        except Exception:
+            model = ""
     agent_loop.set_provider(
         provider_manager,
         system_prompt=build_system_prompt(
@@ -238,5 +250,7 @@ def _refresh_repl_memory_context(repl: object | None) -> None:
             memory_context=memory_context,
             skill_listing=skill_listing,
             current_time=current_time if isinstance(current_time, str) else None,
+            provider_display=provider_display,
+            model=model,
         ),
     )

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -2922,6 +2922,26 @@ msgstr "Architekturdiagramm anzeigen"
 msgid "Show candidate details"
 msgstr "Kandidatendetails anzeigen"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Validate Template"
+msgstr "ROS-Vorlage validieren"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Template Parameters"
+msgstr "ROS-Vorlagenparameter"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Preview Stack"
+msgstr "ROS-Stack-Vorschau"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Estimate Cost"
+msgstr "ROS-Kostenschätzung"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -4465,6 +4485,21 @@ msgstr "ROS Stack"
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid "Calling ROS template tool for {template_url}..."
+msgstr "Rufe das ROS-Vorlagenwerkzeug für {template_url} auf..."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated {tool_name} tool "
+"instead of aliyun_api. Do not call the raw ROS template API directly."
+msgstr ""
+"ROS-Pipeline-Aufrufe für {action} müssen das dedizierte Tool {tool_name} "
+"statt aliyun_api verwenden. Rufe die rohe ROS-Vorlagen-API nicht direkt "
+"auf."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""
 "ROS template calls must use TemplateURL instead of TemplateBody. Save the"
@@ -4472,6 +4507,18 @@ msgid ""
 " path or OSS/HTTP URL."
 msgstr ""
 "ROS-Vorlagenaufrufe müssen TemplateURL statt TemplateBody verwenden. "
+"Speichern Sie die Vorlage in einer Datei und übergeben Sie "
+"params.TemplateURL, zum Beispiel einen lokalen Dateipfad oder eine OSS"
+"/HTTP-URL."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must pass params.TemplateURL. Save the "
+"template to a file and pass params.TemplateURL, for example a local file "
+"path or OSS/HTTP URL."
+msgstr ""
+"ROS-Pipeline-Aufrufe für {action} müssen params.TemplateURL übergeben. "
 "Speichern Sie die Vorlage in einer Datei und übergeben Sie "
 "params.TemplateURL, zum Beispiel einen lokalen Dateipfad oder eine OSS"
 "/HTTP-URL."

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4554,6 +4554,35 @@ msgstr ""
 "überprüfen Sie das Vorlagenformat"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', but CidrBlock references parameter '{cidr_param}' with a "
+"Default. Remove Parameters.{cidr_param}.Default and let deployment "
+"parameters choose a non-overlapping CIDR after VpcId is selected."
+msgstr ""
+"Die Ressource '{name}' erstellt einen VSwitch im Parameter für eine "
+"vorhandene VPC '{vpc_param}', aber CidrBlock verweist auf den Parameter "
+"'{cidr_param}' mit einem Default. Entfernen Sie "
+"Parameters.{cidr_param}.Default und lassen Sie die "
+"Bereitstellungsparameter nach Auswahl von VpcId einen nicht überlappenden"
+" CIDR-Bereich wählen."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', so CidrBlock must not be a static value. Remove the fixed "
+"CidrBlock and let deployment parameters choose a non-overlapping CIDR "
+"after VpcId is selected."
+msgstr ""
+"Die Ressource '{name}' erstellt einen VSwitch im Parameter für eine "
+"vorhandene VPC '{vpc_param}', daher darf CidrBlock kein statischer Wert "
+"sein. Entfernen Sie den festen CidrBlock und lassen Sie die "
+"Bereitstellungsparameter nach Auswahl von VpcId einen nicht überlappenden"
+" CIDR-Bereich wählen."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -2942,6 +2942,11 @@ msgstr "ROS-Stack-Vorschau"
 msgid "ROS Estimate Cost"
 msgstr "ROS-Kostenschätzung"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "ROS Deploy"
+msgstr "ROS-Bereitstellung"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -3420,6 +3425,64 @@ msgstr "Der Template-Dateipfad darf das Arbeitsverzeichnis nicht verlassen"
 msgid "[Image input]"
 msgstr "[Bildeingabe]"
 
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{error_code}; recommended action: {action}"
+msgstr "{error_code}; empfohlene Aktion: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Create ROS stack: {target}"
+msgstr "ROS-Stack erstellen: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Continue ROS stack creation: {target}"
+msgstr "Erstellung des ROS-Stacks fortsetzen: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Delete failed ROS stack and create replacement: {target}"
+msgstr "Fehlgeschlagenen ROS-Stack löschen und Ersatz erstellen: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid ""
+"ROS stack {stack_id} was not created by the current selling deployment "
+"step."
+msgstr ""
+"Der ROS-Stack {stack_id} wurde nicht vom aktuellen Bereitstellungsschritt"
+" der Selling-Pipeline erstellt."
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "matched {behavior} rule: {rule}"
+msgstr "Übereinstimmende {behavior}-Regel: {rule}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "Allow {}?"
+msgstr "{} erlauben?"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Missing required field: {}"
+msgstr "Erforderliches Feld fehlt: {}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Template file is not readable: {template_url}: {error}"
+msgstr "Vorlagendatei kann nicht gelesen werden: {template_url}: {error}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Invalid action '{}'. Supported actions: {}"
+msgstr "Ungültige Aktion '{}'. Unterstützte Aktionen: {}"
+
 #: src/iac_code/pipeline/selling/tools/show_candidate_detail_tool.py
 msgid ""
 "Display candidate details (summary and cost breakdown) in the comparison "
@@ -3781,13 +3844,6 @@ msgstr "Ungültiges --permission-mode {!r}. Gültige Werte: {}"
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Übereinstimmende Abfrageregel(n): {}"
-
-#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
-#: src/iac_code/tools/bash/bash_tool.py
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
-msgid "Allow {}?"
-msgstr "{} erlauben?"
 
 #: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
@@ -4413,11 +4469,6 @@ msgstr "Aliyun API"
 
 #: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
-msgid "matched {behavior} rule: {rule}"
-msgstr "Übereinstimmende {behavior}-Regel: {rule}"
-
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Aufruf erfolgreich (RequestId: {request_id})"
 
@@ -4499,6 +4550,16 @@ msgstr ""
 "ROS-Pipeline-Aufrufe für {action} müssen das dedizierte Tool {tool_name} "
 "statt aliyun_api verwenden. Rufe die rohe ROS-Vorlagen-API nicht direkt "
 "auf."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated ros_deploy tool "
+"instead of aliyun_api. Do not call the raw ROS deployment API directly."
+msgstr ""
+"ROS-Pipeline-Aufrufe für {action} müssen das dedizierte Tool ros_deploy "
+"anstelle von aliyun_api verwenden. Rufen Sie die rohe ROS-"
+"Bereitstellungs-API nicht direkt auf."
 
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -2923,6 +2923,26 @@ msgstr "Mostrar diagrama de arquitectura"
 msgid "Show candidate details"
 msgstr "Mostrar detalles del candidato"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Validate Template"
+msgstr "Validar plantilla ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Template Parameters"
+msgstr "Parámetros de plantilla ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Preview Stack"
+msgstr "Vista previa de pila ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Estimate Cost"
+msgstr "Estimación de costo ROS"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -4453,6 +4473,21 @@ msgstr "ROS Stack"
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid "Calling ROS template tool for {template_url}..."
+msgstr "Llamando a la herramienta de plantilla ROS para {template_url}..."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated {tool_name} tool "
+"instead of aliyun_api. Do not call the raw ROS template API directly."
+msgstr ""
+"Las llamadas ROS en pipeline para {action} deben usar la herramienta "
+"dedicada {tool_name} en lugar de aliyun_api. No llames directamente a la "
+"API bruta de plantilla ROS."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""
 "ROS template calls must use TemplateURL instead of TemplateBody. Save the"
@@ -4461,6 +4496,18 @@ msgid ""
 msgstr ""
 "Las llamadas a plantillas ROS deben usar TemplateURL en lugar de "
 "TemplateBody. Guarda la plantilla en un archivo y pasa "
+"params.TemplateURL, por ejemplo una ruta de archivo local o una URL "
+"OSS/HTTP."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must pass params.TemplateURL. Save the "
+"template to a file and pass params.TemplateURL, for example a local file "
+"path or OSS/HTTP URL."
+msgstr ""
+"Las llamadas de pipeline de ROS para {action} deben pasar "
+"params.TemplateURL. Guarda la plantilla en un archivo y pasa "
 "params.TemplateURL, por ejemplo una ruta de archivo local o una URL "
 "OSS/HTTP."
 

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -2943,6 +2943,11 @@ msgstr "Vista previa de pila ROS"
 msgid "ROS Estimate Cost"
 msgstr "Estimación de costo ROS"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "ROS Deploy"
+msgstr "Despliegue de ROS"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -3412,6 +3417,64 @@ msgstr "La ruta del archivo de plantilla no puede salir del directorio de trabaj
 msgid "[Image input]"
 msgstr "[Entrada de imagen]"
 
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{error_code}; recommended action: {action}"
+msgstr "{error_code}; acción recomendada: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Create ROS stack: {target}"
+msgstr "Crear pila ROS: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Continue ROS stack creation: {target}"
+msgstr "Continuar la creación de la pila ROS: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Delete failed ROS stack and create replacement: {target}"
+msgstr "Eliminar la pila ROS fallida y crear una de reemplazo: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid ""
+"ROS stack {stack_id} was not created by the current selling deployment "
+"step."
+msgstr ""
+"La pila ROS {stack_id} no fue creada por el paso de despliegue de venta "
+"actual."
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "matched {behavior} rule: {rule}"
+msgstr "Regla {behavior} coincidente: {rule}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "Allow {}?"
+msgstr "¿Permitir {}?"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Missing required field: {}"
+msgstr "Falta el campo obligatorio: {}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Template file is not readable: {template_url}: {error}"
+msgstr "No se puede leer el archivo de plantilla: {template_url}: {error}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Invalid action '{}'. Supported actions: {}"
+msgstr "Acción '{}' no válida. Acciones admitidas: {}"
+
 #: src/iac_code/pipeline/selling/tools/show_candidate_detail_tool.py
 msgid ""
 "Display candidate details (summary and cost breakdown) in the comparison "
@@ -3772,13 +3835,6 @@ msgstr "Modo --permission-mode no válido: {!r}. Valores válidos: {}"
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Regla(s) de consulta coincidente(s): {}"
-
-#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
-#: src/iac_code/tools/bash/bash_tool.py
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
-msgid "Allow {}?"
-msgstr "¿Permitir {}?"
 
 #: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
@@ -4401,11 +4457,6 @@ msgstr "Aliyun API"
 
 #: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
-msgid "matched {behavior} rule: {rule}"
-msgstr "Regla {behavior} coincidente: {rule}"
-
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Llamada correcta (RequestId: {request_id})"
 
@@ -4487,6 +4538,16 @@ msgstr ""
 "Las llamadas ROS en pipeline para {action} deben usar la herramienta "
 "dedicada {tool_name} en lugar de aliyun_api. No llames directamente a la "
 "API bruta de plantilla ROS."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated ros_deploy tool "
+"instead of aliyun_api. Do not call the raw ROS deployment API directly."
+msgstr ""
+"Las llamadas ROS en pipeline para {action} deben usar la herramienta "
+"dedicada ros_deploy en lugar de aliyun_api. No llames directamente a la "
+"API de despliegue ROS sin procesar."
 
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4545,6 +4545,33 @@ msgstr ""
 "por favor verifique el formato de la plantilla"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', but CidrBlock references parameter '{cidr_param}' with a "
+"Default. Remove Parameters.{cidr_param}.Default and let deployment "
+"parameters choose a non-overlapping CIDR after VpcId is selected."
+msgstr ""
+"El recurso '{name}' crea un VSwitch en el parámetro de VPC existente "
+"'{vpc_param}', pero CidrBlock hace referencia al parámetro '{cidr_param}'"
+" con un Default. Quite Parameters.{cidr_param}.Default y deje que los "
+"parámetros de despliegue elijan un CIDR que no se superponga después de "
+"seleccionar VpcId."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', so CidrBlock must not be a static value. Remove the fixed "
+"CidrBlock and let deployment parameters choose a non-overlapping CIDR "
+"after VpcId is selected."
+msgstr ""
+"El recurso '{name}' crea un VSwitch en el parámetro de VPC existente "
+"'{vpc_param}', por lo que CidrBlock no debe ser un valor estático. Quite "
+"el CidrBlock fijo y deje que los parámetros de despliegue elijan un CIDR "
+"que no se superponga después de seleccionar VpcId."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4557,6 +4557,33 @@ msgstr ""
 "veuillez vérifier le format du modèle"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', but CidrBlock references parameter '{cidr_param}' with a "
+"Default. Remove Parameters.{cidr_param}.Default and let deployment "
+"parameters choose a non-overlapping CIDR after VpcId is selected."
+msgstr ""
+"La ressource '{name}' crée un VSwitch dans le paramètre de VPC existant "
+"'{vpc_param}', mais CidrBlock référence le paramètre '{cidr_param}' avec "
+"une valeur Default. Supprimez Parameters.{cidr_param}.Default et laissez "
+"les paramètres de déploiement choisir un CIDR sans chevauchement après la"
+" sélection de VpcId."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', so CidrBlock must not be a static value. Remove the fixed "
+"CidrBlock and let deployment parameters choose a non-overlapping CIDR "
+"after VpcId is selected."
+msgstr ""
+"La ressource '{name}' crée un VSwitch dans le paramètre de VPC existant "
+"'{vpc_param}', donc CidrBlock ne doit pas être une valeur statique. "
+"Supprimez le CidrBlock fixe et laissez les paramètres de déploiement "
+"choisir un CIDR sans chevauchement après la sélection de VpcId."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -2930,6 +2930,26 @@ msgstr "Afficher le diagramme d’architecture"
 msgid "Show candidate details"
 msgstr "Afficher les détails du candidat"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Validate Template"
+msgstr "Validation du modèle ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Template Parameters"
+msgstr "Paramètres du modèle ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Preview Stack"
+msgstr "Aperçu de la pile ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Estimate Cost"
+msgstr "Estimation du coût ROS"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -4465,6 +4485,21 @@ msgstr "ROS Stack"
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid "Calling ROS template tool for {template_url}..."
+msgstr "Appel de l'outil de modèle ROS pour {template_url}..."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated {tool_name} tool "
+"instead of aliyun_api. Do not call the raw ROS template API directly."
+msgstr ""
+"Les appels ROS en pipeline pour {action} doivent utiliser l'outil dédié "
+"{tool_name} au lieu de aliyun_api. N'appelez pas directement l'API brute "
+"de modèle ROS."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""
 "ROS template calls must use TemplateURL instead of TemplateBody. Save the"
@@ -4473,6 +4508,18 @@ msgid ""
 msgstr ""
 "Les appels de modèle ROS doivent utiliser TemplateURL au lieu de "
 "TemplateBody. Enregistrez le modèle dans un fichier et transmettez "
+"params.TemplateURL, par exemple un chemin de fichier local ou une URL "
+"OSS/HTTP."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must pass params.TemplateURL. Save the "
+"template to a file and pass params.TemplateURL, for example a local file "
+"path or OSS/HTTP URL."
+msgstr ""
+"Les appels de pipeline ROS pour {action} doivent transmettre "
+"params.TemplateURL. Enregistrez le modèle dans un fichier et transmettez "
 "params.TemplateURL, par exemple un chemin de fichier local ou une URL "
 "OSS/HTTP."
 

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -2950,6 +2950,11 @@ msgstr "Aperçu de la pile ROS"
 msgid "ROS Estimate Cost"
 msgstr "Estimation du coût ROS"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "ROS Deploy"
+msgstr "Déploiement ROS"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -3417,6 +3422,66 @@ msgstr "Le chemin du fichier de modèle ne peut pas sortir du répertoire de tra
 msgid "[Image input]"
 msgstr "[Entrée d'image]"
 
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{error_code}; recommended action: {action}"
+msgstr "{error_code} ; action recommandée : {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Create ROS stack: {target}"
+msgstr "Créer la pile ROS : {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Continue ROS stack creation: {target}"
+msgstr "Continuer la création de la pile ROS : {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Delete failed ROS stack and create replacement: {target}"
+msgstr ""
+"Supprimer la pile ROS en échec et créer une pile de remplacement : "
+"{target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid ""
+"ROS stack {stack_id} was not created by the current selling deployment "
+"step."
+msgstr ""
+"La pile ROS {stack_id} n’a pas été créée par l’étape de déploiement de "
+"vente actuelle."
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "matched {behavior} rule: {rule}"
+msgstr "Règle {behavior} correspondante : {rule}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "Allow {}?"
+msgstr "Autoriser {} ?"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Missing required field: {}"
+msgstr "Champ obligatoire manquant : {}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Template file is not readable: {template_url}: {error}"
+msgstr "Impossible de lire le fichier de modèle : {template_url} : {error}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Invalid action '{}'. Supported actions: {}"
+msgstr "Action '{}' non valide. Actions prises en charge : {}"
+
 #: src/iac_code/pipeline/selling/tools/show_candidate_detail_tool.py
 msgid ""
 "Display candidate details (summary and cost breakdown) in the comparison "
@@ -3782,13 +3847,6 @@ msgstr "--permission-mode invalide : {!r}. Valeurs valides : {}"
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Règle(s) de demande correspondante(s) : {}"
-
-#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
-#: src/iac_code/tools/bash/bash_tool.py
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
-msgid "Allow {}?"
-msgstr "Autoriser {} ?"
 
 #: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
@@ -4414,11 +4472,6 @@ msgstr "Aliyun API"
 
 #: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
-msgid "matched {behavior} rule: {rule}"
-msgstr "Règle {behavior} correspondante : {rule}"
-
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Appel réussi (RequestId : {request_id})"
 
@@ -4499,6 +4552,16 @@ msgstr ""
 "Les appels ROS en pipeline pour {action} doivent utiliser l'outil dédié "
 "{tool_name} au lieu de aliyun_api. N'appelez pas directement l'API brute "
 "de modèle ROS."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated ros_deploy tool "
+"instead of aliyun_api. Do not call the raw ROS deployment API directly."
+msgstr ""
+"Les appels ROS en pipeline pour {action} doivent utiliser l'outil dédié "
+"ros_deploy au lieu d'aliyun_api. N'appelez pas directement l'API de "
+"déploiement ROS brute."
 
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -2813,6 +2813,26 @@ msgstr "アーキテクチャ図を表示"
 msgid "Show candidate details"
 msgstr "候補の詳細を表示"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Validate Template"
+msgstr "ROS テンプレート検証"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Template Parameters"
+msgstr "ROS テンプレートパラメーター"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Preview Stack"
+msgstr "ROS スタックプレビュー"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Estimate Cost"
+msgstr "ROS コスト見積もり"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -4260,6 +4280,20 @@ msgstr "ROS スタック"
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid "Calling ROS template tool for {template_url}..."
+msgstr "{template_url} の ROS テンプレートツールを呼び出しています..."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated {tool_name} tool "
+"instead of aliyun_api. Do not call the raw ROS template API directly."
+msgstr ""
+"{action} の ROS パイプライン呼び出しでは、aliyun_api ではなく専用ツール {tool_name} "
+"を使用する必要があります。生の ROS テンプレート API を直接呼び出さないでください。"
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""
 "ROS template calls must use TemplateURL instead of TemplateBody. Save the"
@@ -4268,6 +4302,17 @@ msgid ""
 msgstr ""
 "ROS テンプレート呼び出しでは TemplateBody ではなく TemplateURL "
 "を使用する必要があります。テンプレートをファイルに保存し、ローカルファイルパスまたは OSS/HTTP URL などを "
+"params.TemplateURL として渡してください。"
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must pass params.TemplateURL. Save the "
+"template to a file and pass params.TemplateURL, for example a local file "
+"path or OSS/HTTP URL."
+msgstr ""
+"ROS パイプラインで {action} を呼び出す場合は、params.TemplateURL "
+"を渡す必要があります。テンプレートをファイルに保存し、ローカルファイルパスまたは OSS/HTTP URL などを "
 "params.TemplateURL として渡してください。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -2833,6 +2833,11 @@ msgstr "ROS スタックプレビュー"
 msgid "ROS Estimate Cost"
 msgstr "ROS コスト見積もり"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "ROS Deploy"
+msgstr "ROS デプロイ"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -3250,6 +3255,62 @@ msgstr "テンプレートファイルのパスは作業ディレクトリの外
 msgid "[Image input]"
 msgstr "[画像入力]"
 
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{error_code}; recommended action: {action}"
+msgstr "{error_code}; 推奨アクション: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Create ROS stack: {target}"
+msgstr "ROS スタックを作成: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Continue ROS stack creation: {target}"
+msgstr "ROS スタックの作成を続行: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Delete failed ROS stack and create replacement: {target}"
+msgstr "失敗した ROS スタックを削除して代替を作成: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid ""
+"ROS stack {stack_id} was not created by the current selling deployment "
+"step."
+msgstr "ROS スタック {stack_id} は現在の販売デプロイ手順で作成されたものではありません。"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "matched {behavior} rule: {rule}"
+msgstr "一致した {behavior} ルール: {rule}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "Allow {}?"
+msgstr "{} を許可しますか？"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Missing required field: {}"
+msgstr "必須フィールドがありません: {}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Template file is not readable: {template_url}: {error}"
+msgstr "テンプレートファイルを読み取れません: {template_url}: {error}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Invalid action '{}'. Supported actions: {}"
+msgstr "無効なアクション '{}'. サポートされているアクション: {}"
+
 #: src/iac_code/pipeline/selling/tools/show_candidate_detail_tool.py
 msgid ""
 "Display candidate details (summary and cost breakdown) in the comparison "
@@ -3592,13 +3653,6 @@ msgstr "無効な --permission-mode {!r} です。有効な値: {}"
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "一致した確認ルール: {}"
-
-#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
-#: src/iac_code/tools/bash/bash_tool.py
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
-msgid "Allow {}?"
-msgstr "{} を許可しますか？"
 
 #: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
@@ -4211,11 +4265,6 @@ msgstr "Aliyun API"
 
 #: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
-msgid "matched {behavior} rule: {rule}"
-msgstr "一致した {behavior} ルール: {rule}"
-
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "呼び出しに成功しました（RequestId: {request_id}）"
 
@@ -4293,6 +4342,15 @@ msgid ""
 msgstr ""
 "{action} の ROS パイプライン呼び出しでは、aliyun_api ではなく専用ツール {tool_name} "
 "を使用する必要があります。生の ROS テンプレート API を直接呼び出さないでください。"
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated ros_deploy tool "
+"instead of aliyun_api. Do not call the raw ROS deployment API directly."
+msgstr ""
+"{action} の ROS パイプライン呼び出しでは、aliyun_api ではなく専用の ros_deploy "
+"ツールを使用する必要があります。生の ROS デプロイ API を直接呼び出さないでください。"
 
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4344,6 +4344,31 @@ msgid ""
 msgstr "テンプレートの {fmt} 解析結果がオブジェクト（dict）ではありません。テンプレートの形式を確認してください"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', but CidrBlock references parameter '{cidr_param}' with a "
+"Default. Remove Parameters.{cidr_param}.Default and let deployment "
+"parameters choose a non-overlapping CIDR after VpcId is selected."
+msgstr ""
+"リソース '{name}' は既存 VPC パラメーター '{vpc_param}' 内に VSwitch を作成しますが、CidrBlock は"
+" Default を持つパラメーター '{cidr_param}' "
+"を参照しています。Parameters.{cidr_param}.Default を削除し、VpcId "
+"の選択後にデプロイメントパラメーターで重複しない CIDR を選択させてください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', so CidrBlock must not be a static value. Remove the fixed "
+"CidrBlock and let deployment parameters choose a non-overlapping CIDR "
+"after VpcId is selected."
+msgstr ""
+"リソース '{name}' は既存 VPC パラメーター '{vpc_param}' 内に VSwitch を作成するため、CidrBlock "
+"を静的な値にしてはいけません。固定の CidrBlock を削除し、VpcId の選択後にデプロイメントパラメーターで重複しない CIDR "
+"を選択させてください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -2906,6 +2906,26 @@ msgstr "Mostrar diagrama de arquitetura"
 msgid "Show candidate details"
 msgstr "Mostrar detalhes do candidato"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Validate Template"
+msgstr "Validar modelo ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Template Parameters"
+msgstr "Parâmetros do modelo ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Preview Stack"
+msgstr "Prévia da pilha ROS"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Estimate Cost"
+msgstr "Estimativa de custo ROS"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -4419,6 +4439,21 @@ msgstr "ROS Stack"
 msgid "CloudStackInstances"
 msgstr "CloudStackInstances"
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid "Calling ROS template tool for {template_url}..."
+msgstr "Chamando a ferramenta de modelo ROS para {template_url}..."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated {tool_name} tool "
+"instead of aliyun_api. Do not call the raw ROS template API directly."
+msgstr ""
+"As chamadas ROS em pipeline para {action} devem usar a ferramenta "
+"dedicada {tool_name} em vez de aliyun_api. Não chame diretamente a API "
+"bruta de modelo ROS."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""
 "ROS template calls must use TemplateURL instead of TemplateBody. Save the"
@@ -4428,6 +4463,18 @@ msgstr ""
 "As chamadas de modelo ROS devem usar TemplateURL em vez de TemplateBody. "
 "Salve o modelo em um arquivo e passe params.TemplateURL, por exemplo um "
 "caminho de arquivo local ou uma URL OSS/HTTP."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must pass params.TemplateURL. Save the "
+"template to a file and pass params.TemplateURL, for example a local file "
+"path or OSS/HTTP URL."
+msgstr ""
+"As chamadas de pipeline ROS para {action} devem passar "
+"params.TemplateURL. Salve o modelo em um arquivo e passe "
+"params.TemplateURL, por exemplo um caminho de arquivo local ou uma URL "
+"OSS/HTTP."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4507,6 +4507,33 @@ msgstr ""
 "verifique o formato do modelo"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', but CidrBlock references parameter '{cidr_param}' with a "
+"Default. Remove Parameters.{cidr_param}.Default and let deployment "
+"parameters choose a non-overlapping CIDR after VpcId is selected."
+msgstr ""
+"O recurso '{name}' cria um VSwitch no parâmetro de VPC existente "
+"'{vpc_param}', mas CidrBlock referencia o parâmetro '{cidr_param}' com um"
+" Default. Remova Parameters.{cidr_param}.Default e permita que os "
+"parâmetros de implantação escolham um CIDR sem sobreposição depois que "
+"VpcId for selecionado."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', so CidrBlock must not be a static value. Remove the fixed "
+"CidrBlock and let deployment parameters choose a non-overlapping CIDR "
+"after VpcId is selected."
+msgstr ""
+"O recurso '{name}' cria um VSwitch no parâmetro de VPC existente "
+"'{vpc_param}', portanto CidrBlock não deve ser um valor estático. Remova "
+"o CidrBlock fixo e permita que os parâmetros de implantação escolham um "
+"CIDR sem sobreposição depois que VpcId for selecionado."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -2926,6 +2926,11 @@ msgstr "Prévia da pilha ROS"
 msgid "ROS Estimate Cost"
 msgstr "Estimativa de custo ROS"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "ROS Deploy"
+msgstr "Implantação ROS"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -3390,6 +3395,64 @@ msgstr "O caminho do arquivo de template não pode sair do diretório de trabalh
 msgid "[Image input]"
 msgstr "[Entrada de imagem]"
 
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{error_code}; recommended action: {action}"
+msgstr "{error_code}; ação recomendada: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Create ROS stack: {target}"
+msgstr "Criar pilha ROS: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Continue ROS stack creation: {target}"
+msgstr "Continuar a criação da pilha ROS: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Delete failed ROS stack and create replacement: {target}"
+msgstr "Excluir a pilha ROS com falha e criar uma substituta: {target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid ""
+"ROS stack {stack_id} was not created by the current selling deployment "
+"step."
+msgstr ""
+"A pilha ROS {stack_id} não foi criada pela etapa de implantação de vendas"
+" atual."
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "matched {behavior} rule: {rule}"
+msgstr "Regra {behavior} correspondente: {rule}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "Allow {}?"
+msgstr "Permitir {}?"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Missing required field: {}"
+msgstr "Campo obrigatório ausente: {}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Template file is not readable: {template_url}: {error}"
+msgstr "Não é possível ler o arquivo de modelo: {template_url}: {error}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Invalid action '{}'. Supported actions: {}"
+msgstr "Ação inválida '{}'. Ações compatíveis: {}"
+
 #: src/iac_code/pipeline/selling/tools/show_candidate_detail_tool.py
 msgid ""
 "Display candidate details (summary and cost breakdown) in the comparison "
@@ -3742,13 +3805,6 @@ msgstr "--permission-mode inválido {!r}. Valores válidos: {}"
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "Regra(s) de consulta correspondente(s): {}"
-
-#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
-#: src/iac_code/tools/bash/bash_tool.py
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
-msgid "Allow {}?"
-msgstr "Permitir {}?"
 
 #: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
@@ -4368,11 +4424,6 @@ msgstr "Aliyun API"
 
 #: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
-msgid "matched {behavior} rule: {rule}"
-msgstr "Regra {behavior} correspondente: {rule}"
-
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "Chamada bem-sucedida (RequestId: {request_id})"
 
@@ -4453,6 +4504,16 @@ msgstr ""
 "As chamadas ROS em pipeline para {action} devem usar a ferramenta "
 "dedicada {tool_name} em vez de aliyun_api. Não chame diretamente a API "
 "bruta de modelo ROS."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated ros_deploy tool "
+"instead of aliyun_api. Do not call the raw ROS deployment API directly."
+msgstr ""
+"As chamadas ROS em pipeline para {action} devem usar a ferramenta "
+"dedicada ros_deploy em vez de aliyun_api. Não chame diretamente a API "
+"bruta de implantação ROS."
 
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4290,6 +4290,29 @@ msgid ""
 msgstr "模板 {fmt} 解析结果不是对象（dict），请检查模板格式"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', but CidrBlock references parameter '{cidr_param}' with a "
+"Default. Remove Parameters.{cidr_param}.Default and let deployment "
+"parameters choose a non-overlapping CIDR after VpcId is selected."
+msgstr ""
+"资源 '{name}' 在已有 VPC 参数 '{vpc_param}' 中创建 VSwitch，但 CidrBlock 引用了带 Default"
+" 的参数 '{cidr_param}'。请移除 Parameters.{cidr_param}.Default，并在选择 VpcId "
+"后让部署参数选择不重叠的 CIDR。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+#, python-brace-format
+msgid ""
+"Resource '{name}' creates a VSwitch in existing VPC parameter "
+"'{vpc_param}', so CidrBlock must not be a static value. Remove the fixed "
+"CidrBlock and let deployment parameters choose a non-overlapping CIDR "
+"after VpcId is selected."
+msgstr ""
+"资源 '{name}' 在已有 VPC 参数 '{vpc_param}' 中创建 VSwitch，因此 CidrBlock "
+"不能是静态值。请移除固定的 CidrBlock，并在选择 VpcId 后让部署参数选择不重叠的 CIDR。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "Template is missing ROSTemplateFormatVersion (ROS templates must include "
 "this field, e.g. '2015-09-01')"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -2809,6 +2809,11 @@ msgstr "ROS 资源栈预览"
 msgid "ROS Estimate Cost"
 msgstr "ROS 费用估算"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "ROS Deploy"
+msgstr "ROS 部署"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -3210,6 +3215,62 @@ msgstr "模板文件路径不能跳出工作目录"
 msgid "[Image input]"
 msgstr "[图片输入]"
 
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{error_code}; recommended action: {action}"
+msgstr "{error_code}；推荐操作：{action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Create ROS stack: {target}"
+msgstr "创建 ROS 资源栈：{target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Continue ROS stack creation: {target}"
+msgstr "继续创建 ROS 资源栈：{target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Delete failed ROS stack and create replacement: {target}"
+msgstr "删除失败的 ROS 资源栈并创建替代资源栈：{target}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid ""
+"ROS stack {stack_id} was not created by the current selling deployment "
+"step."
+msgstr "ROS 资源栈 {stack_id} 不是由当前售卖部署步骤创建的。"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "matched {behavior} rule: {rule}"
+msgstr "匹配到 {behavior} 规则：{rule}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
+#: src/iac_code/tools/bash/bash_tool.py
+#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
+#, python-brace-format
+msgid "Allow {}?"
+msgstr "允许 {}？"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Missing required field: {}"
+msgstr "缺少必填字段：{}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Template file is not readable: {template_url}: {error}"
+msgstr "模板文件不可读取：{template_url}：{error}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "Invalid action '{}'. Supported actions: {}"
+msgstr "无效操作“{}”。支持的操作：{}"
+
 #: src/iac_code/pipeline/selling/tools/show_candidate_detail_tool.py
 msgid ""
 "Display candidate details (summary and cost breakdown) in the comparison "
@@ -3549,13 +3610,6 @@ msgstr "无效的 --permission-mode {!r}。有效值：{}"
 #, python-brace-format
 msgid "matched ask rule(s): {}"
 msgstr "匹配到询问规则：{}"
-
-#: src/iac_code/services/permissions/pipeline.py src/iac_code/tools/base.py
-#: src/iac_code/tools/bash/bash_tool.py
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
-msgid "Allow {}?"
-msgstr "允许 {}？"
 
 #: src/iac_code/services/providers/aliyun.py
 msgid "Alibaba Cloud OAuth site is missing."
@@ -4159,11 +4213,6 @@ msgstr "阿里云 API"
 
 #: src/iac_code/tools/cloud/aliyun/aliyun_api.py
 #, python-brace-format
-msgid "matched {behavior} rule: {rule}"
-msgstr "匹配到 {behavior} 规则：{rule}"
-
-#: src/iac_code/tools/cloud/aliyun/aliyun_api.py
-#, python-brace-format
 msgid "Call succeeded (RequestId: {request_id})"
 msgstr "调用成功（RequestId: {request_id}）"
 
@@ -4241,6 +4290,15 @@ msgid ""
 msgstr ""
 "ROS pipeline 调用 {action} 时必须使用专用的 {tool_name} 工具，而不是 aliyun_api。不要直接调用原始 "
 "ROS 模板 API。"
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated ros_deploy tool "
+"instead of aliyun_api. Do not call the raw ROS deployment API directly."
+msgstr ""
+"ROS pipeline 调用 {action} 时必须使用专用的 ros_deploy 工具，而不是 aliyun_api。不要直接调用原始 "
+"ROS 部署 API。"
 
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -2789,6 +2789,26 @@ msgstr "展示架构图"
 msgid "Show candidate details"
 msgstr "展示方案详情"
 
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Validate Template"
+msgstr "ROS 模板校验"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Template Parameters"
+msgstr "ROS 模板参数推荐"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Preview Stack"
+msgstr "ROS 资源栈预览"
+
+#: src/iac_code/pipeline/display_names.py
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+msgid "ROS Estimate Cost"
+msgstr "ROS 费用估算"
+
 #: src/iac_code/pipeline/engine/ask_user_question_tool.py
 msgid ""
 "Pipeline-only tool that asks the user to choose an option or type "
@@ -4208,6 +4228,20 @@ msgstr "ROS 资源栈"
 msgid "CloudStackInstances"
 msgstr "云资源栈实例"
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid "Calling ROS template tool for {template_url}..."
+msgstr "正在为 {template_url} 调用 ROS 模板工具..."
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must use the dedicated {tool_name} tool "
+"instead of aliyun_api. Do not call the raw ROS template API directly."
+msgstr ""
+"ROS pipeline 调用 {action} 时必须使用专用的 {tool_name} 工具，而不是 aliyun_api。不要直接调用原始 "
+"ROS 模板 API。"
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 msgid ""
 "ROS template calls must use TemplateURL instead of TemplateBody. Save the"
@@ -4215,6 +4249,16 @@ msgid ""
 " path or OSS/HTTP URL."
 msgstr ""
 "ROS 模板调用必须使用 TemplateURL，而不能使用 TemplateBody。请将模板保存到文件，并传入 "
+"params.TemplateURL，例如本地文件路径或 OSS/HTTP URL。"
+
+#: src/iac_code/tools/cloud/aliyun/template_source.py
+#, python-brace-format
+msgid ""
+"ROS pipeline calls for {action} must pass params.TemplateURL. Save the "
+"template to a file and pass params.TemplateURL, for example a local file "
+"path or OSS/HTTP URL."
+msgstr ""
+"ROS pipeline 调用 {action} 必须传入 params.TemplateURL。请将模板保存到文件，并传入 "
 "params.TemplateURL，例如本地文件路径或 OSS/HTTP URL。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py

--- a/src/iac_code/pipeline/display_names.py
+++ b/src/iac_code/pipeline/display_names.py
@@ -61,6 +61,7 @@ def _known_tool_names() -> dict[str, str]:
         "ros_get_template_parameter_constraints": _("ROS Template Parameters"),
         "ros_preview_template": _("ROS Preview Stack"),
         "ros_estimate_template_cost": _("ROS Estimate Cost"),
+        "ros_deploy": _("ROS Deploy"),
     }
 
 

--- a/src/iac_code/pipeline/display_names.py
+++ b/src/iac_code/pipeline/display_names.py
@@ -57,6 +57,10 @@ def _known_tool_names() -> dict[str, str]:
         "ask_user_question": _("Ask user question"),
         "show_architecture_diagram": _("Show architecture diagram"),
         "show_candidate_detail": _("Show candidate details"),
+        "ros_validate_template": _("ROS Validate Template"),
+        "ros_get_template_parameter_constraints": _("ROS Template Parameters"),
+        "ros_preview_template": _("ROS Preview Stack"),
+        "ros_estimate_template_cost": _("ROS Estimate Cost"),
     }
 
 

--- a/src/iac_code/pipeline/engine/completion_guard_state.py
+++ b/src/iac_code/pipeline/engine/completion_guard_state.py
@@ -31,8 +31,8 @@ def record_completion_guard_tool_result(
         if tool_name == "ask_user_question":
             _record_ask_user_question(state, content, is_error=is_error)
             return
-        if tool_name == "ros_stack":
-            _record_ros_stack(state, tool_input, content, is_error=is_error)
+        if tool_name in {"ros_stack", "ros_deploy"}:
+            _record_stack_tool(state, tool_name, tool_input, content, is_error=is_error)
     except Exception:
         logger.warning("Failed to rebuild completion guard state", exc_info=True)
 
@@ -53,21 +53,37 @@ def _record_ask_user_question(state: dict[str, Any], content: Any, *, is_error: 
     tool_results["ask_user_question"] = parsed
 
 
-def _record_ros_stack(state: dict[str, Any], tool_input: dict[str, Any], content: Any, *, is_error: bool) -> None:
+def _record_stack_tool(
+    state: dict[str, Any], tool_name: str, tool_input: dict[str, Any], content: Any, *, is_error: bool
+) -> None:
     parsed = _json_object(content)
     if parsed is None:
         return
     records: list[dict[str, Any]] = state.setdefault("tool_result_records", [])
     record = {
-        "tool_name": "ros_stack",
+        "tool_name": tool_name,
         "input": dict(tool_input),
         "result": parsed,
         "is_error": bool(is_error),
     }
     records.append(record)
-    state.setdefault("tool_results", {})["ros_stack"] = parsed
+    state.setdefault("tool_results", {})[tool_name] = parsed
+    if tool_name == "ros_deploy":
+        _record_ros_deploy_owned_stack(state, tool_input, parsed)
     if not is_error:
-        state.setdefault("successful_tools", set()).add("ros_stack")
+        state.setdefault("successful_tools", set()).add(tool_name)
+
+
+def _record_ros_deploy_owned_stack(state: dict[str, Any], tool_input: dict[str, Any], result: dict[str, Any]) -> None:
+    action = tool_input.get("action")
+    if action not in {"create", "delete_and_create"}:
+        return
+    stack_id = result.get("stack_id")
+    if not isinstance(stack_id, str) or not stack_id:
+        return
+    owned = state.setdefault("ros_deploy_owned_stack_ids", {})
+    if isinstance(owned, dict):
+        owned[stack_id] = {"action": action}
 
 
 def _json_object(value: Any) -> dict[str, Any] | None:

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -477,6 +477,8 @@ class StepExecutor:
             resolved_sections,
             cwd=self._cwd or "",
             memory_content=memory_content,
+            provider_display=self._runtime_provider_display(),
+            model=self._runtime_model(),
         )
 
         prompt_file = step.prompt_file_for_surface(self._surface)
@@ -490,6 +492,26 @@ class StepExecutor:
 
         parts = [p for p in [base_prompt, skill_content, rendered_step_prompt] if p]
         return "\n\n---\n\n".join(parts)
+
+    def _runtime_provider_display(self) -> str:
+        getter = getattr(self._provider_manager, "get_provider_display", None)
+        if not callable(getter):
+            return ""
+        try:
+            display = getter()
+        except Exception:
+            return ""
+        return display if isinstance(display, str) else ""
+
+    def _runtime_model(self) -> str:
+        getter = getattr(self._provider_manager, "get_model_name", None)
+        if not callable(getter):
+            return ""
+        try:
+            model = getter()
+        except Exception:
+            return ""
+        return model if isinstance(model, str) else ""
 
     def _resolve_auto_trigger_skills(self, step: StepSpec) -> list[Any] | None:
         """问题 2：step 自带 skill 时，禁用 auto_trigger（避免重复加载）。"""

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -353,6 +353,11 @@ class StepExecutor:
             completion_guard_state["successful_tools"].update(seed.get("successful_tools", set()))
             completion_guard_state["tool_results"].update(seed.get("tool_results", {}))
             completion_guard_state["tool_result_records"].extend(seed.get("tool_result_records", []))
+            owned_stack_ids = seed.get("ros_deploy_owned_stack_ids")
+            if isinstance(owned_stack_ids, dict):
+                completion_guard_state.setdefault("ros_deploy_owned_stack_ids", {}).update(
+                    copy.deepcopy(owned_stack_ids)
+                )
 
         build_tool_kwargs: dict[str, Any] = {
             "rollback_targets": rollback_targets,

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -785,6 +785,8 @@ class StepExecutor:
             if tool_cls is not None:
                 if name == "ask_user_question":
                     registry.register(AskUserQuestionTool(completion_guard_state))
+                elif name == "ros_deploy":
+                    registry.register(tool_cls(completion_guard_state=completion_guard_state))
                 else:
                     registry.register(tool_cls())
 

--- a/src/iac_code/pipeline/selling/hooks/deploying.py
+++ b/src/iac_code/pipeline/selling/hooks/deploying.py
@@ -97,6 +97,10 @@ def normalize_selected_plan(
     effective_parameters = _effective_deployment_parameters(resolution.result, selected.parameter_overrides)
     if effective_parameters:
         plan["effective_deployment_parameters"] = effective_parameters
+    plan["preview_ready_for_create"] = _preview_ready_for_create(
+        selected_candidate_result=resolution.result,
+        template_url=template_url,
+    )
     plan["cost_estimate_parameter_overridden"] = bool(selected.parameter_overrides)
     return plan
 
@@ -156,6 +160,34 @@ def _effective_deployment_parameters(
                 parameters.update(deployment_parameters)
     parameters.update(parameter_overrides)
     return parameters
+
+
+def _preview_ready_for_create(
+    *,
+    selected_candidate_result: dict[str, Any] | None,
+    template_url: str,
+) -> bool:
+    if not template_url or not isinstance(selected_candidate_result, dict):
+        return False
+
+    cost = selected_candidate_result.get("cost")
+    if not isinstance(cost, dict):
+        return False
+    if cost.get("missing_deployment_parameters"):
+        return False
+
+    preview_validation = cost.get("preview_validation")
+    if not isinstance(preview_validation, dict):
+        return False
+    if preview_validation.get("succeeded") is not True:
+        return False
+    if preview_validation.get("template_url") != template_url:
+        return False
+
+    preview_parameters = preview_validation.get("parameters")
+    if not isinstance(preview_parameters, dict):
+        return False
+    return True
 
 
 def on_enter(ctx: PipelineContext) -> None:

--- a/src/iac_code/pipeline/selling/hooks/deploying.py
+++ b/src/iac_code/pipeline/selling/hooks/deploying.py
@@ -90,12 +90,33 @@ def normalize_selected_plan(
     plan["selection_valid"] = True
     plan["selected_candidate"] = resolution.candidate
     plan["selected_candidate_result"] = resolution.result
+    template_url = _template_url_from_resolution(resolution.candidate, resolution.result)
+    if template_url:
+        plan["template_url"] = template_url
     plan["parameter_overrides"] = dict(selected.parameter_overrides)
     effective_parameters = _effective_deployment_parameters(resolution.result, selected.parameter_overrides)
     if effective_parameters:
         plan["effective_deployment_parameters"] = effective_parameters
     plan["cost_estimate_parameter_overridden"] = bool(selected.parameter_overrides)
     return plan
+
+
+def _template_url_from_resolution(
+    selected_candidate: dict[str, Any] | None,
+    selected_candidate_result: dict[str, Any] | None,
+) -> str:
+    if isinstance(selected_candidate, dict):
+        output_path = selected_candidate.get("output_path")
+        if isinstance(output_path, str) and output_path:
+            return output_path
+
+    if isinstance(selected_candidate_result, dict):
+        template = selected_candidate_result.get("template")
+        if isinstance(template, dict):
+            file_path = template.get("file_path")
+            if isinstance(file_path, str) and file_path:
+                return file_path
+    return ""
 
 
 def _selection_payload(plan: dict[str, Any]) -> Any:

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -74,6 +74,7 @@ sub_pipelines:
         tools:
           include: []
           exclude: [write_memory]
+        inject_tools: [ros_validate_template]
 
       - id: reviewing
         description: "审查模板的安全性和最佳实践"
@@ -84,8 +85,9 @@ sub_pipelines:
         prompt: prompts/reviewing.md
         context_fields: [template]
         tools:
-          include: [-]
+          include: [ros_validate_template]
           exclude: []
+        inject_tools: [ros_validate_template]
 
       - id: cost_estimating
         description: "评估模板的资源成本"
@@ -101,6 +103,11 @@ sub_pipelines:
         tools:
           include: []
           exclude: [bash, write_memory]
+        inject_tools:
+          - ros_validate_template
+          - ros_get_template_parameter_constraints
+          - ros_preview_template
+          - ros_estimate_template_cost
 
 steps:
   - id: intent_parsing
@@ -266,3 +273,4 @@ steps:
     tools:
       include: []
       exclude: [write_memory]
+    inject_tools: [ros_validate_template]

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -26,12 +26,12 @@ on_complete:
 
 # --- Base Prompt Sections ---
 # 控制注入到每个 step system prompt 前的通用 section。
-# 可用 section: identity, system, env, cloud_config, tools, doing_tasks, actions, output_style
+# 可用 section: identity, system, env, cloud_config, tools, runtime_context, doing_tasks, actions, output_style
 # 解析规则: include 为空 = 全部可用 section; exclude 从中移除指定项。
-# 不配置此字段时，默认: [identity, system, env, cloud_config, tools]
+# 不配置此字段时，默认: [identity, system, env, cloud_config, tools, runtime_context]
 # Step 级同名字段可覆盖（整体替换，非合并）。
 base_prompt_sections:
-  include: [identity, system, env, cloud_config, tools, doing_tasks, actions, output_style]
+  include: [identity, system, env, cloud_config, tools, runtime_context, doing_tasks, actions, output_style]
   exclude: []
 
 feature_flags:
@@ -170,7 +170,7 @@ steps:
           free_text: clarification_text
         message: "这个输入不是部署/云资源需求，需要先让用户重新输入部署目标或确认暂不处理。"
     base_prompt_sections:
-      include: [identity, system, env, cloud_config, output_style]
+      include: [identity, system, env, cloud_config, runtime_context, output_style]
       exclude: []
 
   - id: architecture_planning

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -264,13 +264,13 @@ steps:
           status: success
         required_conclusion_field: stack_id
         require_tool_result:
-          tool: ros_stack
-          action_in: [CreateStack, ContinueCreateStack]
+          tool: ros_deploy
+          action_in: [create, continue_create, delete_and_create]
           is_success: true
           status_in: [CREATE_COMPLETE]
           match_conclusion_field: stack_id
-        message: "部署成功必须等待 ros_stack CreateStack 返回 CREATE_COMPLETE。"
+        message: "部署成功必须等待 ros_deploy 返回 CREATE_COMPLETE。"
     tools:
       include: []
-      exclude: [write_memory]
-    inject_tools: [ros_validate_template]
+      exclude: [write_memory, ros_stack]
+    inject_tools: [ros_validate_template, ros_deploy]

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -22,5 +22,7 @@
 ## 输出
 API 调用完成后调用 `complete_step` 提交费用预估。
 
+若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。
+
 ## 注意事项
 - 不要读取项目文件或记忆，所需的上下文已在上方提供。

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -1,10 +1,18 @@
 # 步骤：成本预估
 
-你正在为候选方案预估部署费用。优先通过 `aliyun_api(product="ros", action="PreviewStack")` 形成 Preview-Validated Pricing Parameter Set，不要使用 `ros_stack` 执行 `PreviewStack`；PreviewStack 不是硬门禁，若完整部署参数暂时无法自动补齐，记录参数缺口后可用当前已选参数调用 ROS `GetTemplateEstimateCost` API 获取费用预估。
+你正在为候选方案预估部署费用。优先通过 `ros_preview_template` 形成 Preview-Validated Pricing Parameter Set，不要使用 `ros_stack` 执行预览；PreviewStack 不是硬门禁，若完整部署参数暂时无法自动补齐，记录参数缺口后可用当前已选参数调用 `ros_estimate_template_cost` 获取费用预估。
 
 ## 模板信息
 - 文件路径：`{template.file_path}`
 - 地域：`{template.region}`
+
+## ROS 模板来源
+- 本步骤的模板文件路径已经确定为 `{template.file_path}`。
+- 查询参数约束时调用 `ros_get_template_parameter_constraints`，必须传 `template_url = "{template.file_path}"`，可选 `parameters` 传当前已知参数字典。
+- 预览模板时调用 `ros_preview_template`，必须传 `template_url = "{template.file_path}"`、`stack_name` 和 `parameters` 字典。
+- 询价时调用 `ros_estimate_template_cost`，必须传 `template_url = "{template.file_path}"` 和 `parameters` 字典。
+- 如果修复模板后需要校验，调用 `ros_validate_template`，必须传同一个 `template_url = "{template.file_path}"`。
+- 不要调用 `aliyun_api` 的 ROS `GetTemplateParameterConstraints`、`PreviewStack`、`GetTemplateEstimateCost` 或 `ValidateTemplate` 接口；不要传 `TemplateBody`、`TemplateId` 或 `TemplateScratchId`。
 
 ## 禁止事项
 - **不要**自行估算费用

--- a/src/iac_code/pipeline/selling/prompts/deploying.md
+++ b/src/iac_code/pipeline/selling/prompts/deploying.md
@@ -24,6 +24,11 @@
 {selected_plan}
 ```
 
+## ROS 模板来源
+本步骤已选定模板文件路径：`{selected_plan.template_url}`。
+
+调用 `ros_validate_template` 校验时，必须传 `template_url = "{selected_plan.template_url}"`。调用 `ros_stack` 的 `CreateStack` / `UpdateStack` 时，必须传 `params.TemplateURL = "{selected_plan.template_url}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口；不要传 `params.TemplateBody`、`TemplateId` 或 `TemplateScratchId`；不要省略 `params.TemplateURL`。
+
 ## 所有候选方案的评估数据
 `selected_plan.selection_valid` 为 `true` 时，使用 `selected_plan.selected_candidate` 和
 `selected_plan.selected_candidate_result` 中的模板、费用、审查信息进行部署。

--- a/src/iac_code/pipeline/selling/prompts/deploying.md
+++ b/src/iac_code/pipeline/selling/prompts/deploying.md
@@ -5,13 +5,13 @@
 ## 部署执行
 用户已在上一步确认选择了该方案，该选择等价于本步骤的部署确认。不要再次询问是否确认部署，也不要询问是否确认部署参数。`selected_plan.preview_ready_for_create` 为 `true` 时按快速创建路径执行，快速创建路径见技能；否则按常规部署路径执行。
 
-上述确认只适用于部署执行，不适用于删除已有 Stack。删除请求本身不等于删除确认；只有用户明确回复“确认删除”“我确认删除”等删除确认语句，或上下文显式提供 `delete_confirmed: true` 时，才可执行删除。未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`。
+本步骤的部署与失败恢复入口仅为 `ros_deploy`，不要绕过它调用原始 ROS 部署生命周期接口。删除约束和失败恢复策略见技能。
 
 ## 原始用户需求与约束
 部署时必须继续遵守原始用户需求中的地域、资源命名、StackName、是否复用已有资源等约束。如果这些约束与候选方案、模板文件名或默认参数冲突，以原始用户需求为准。
 
-调用 `ros_stack` 的 `CreateStack` 前必须逐项核对工具参数：
-- 如果原始用户需求、`intent.non_functional.stack_name`、`intent.user_message_summary` 或 `intent.additional_notes` 中明确指定了资源栈名称，`params.StackName` 必须精确等于该名称。
+调用 `ros_deploy` 的 `create` 或 `delete_and_create` 前必须逐项核对工具参数：
+- 如果原始用户需求、`intent.non_functional.stack_name`、`intent.user_message_summary` 或 `intent.additional_notes` 中明确指定了资源栈名称，`stack_name` 必须精确等于该名称。
 - 不要把模板文件名、候选方案名或默认名称误当成用户指定的 StackName。
 - 用户未明确指定 StackName 时，按部署工具和产品既有命名策略处理。
 
@@ -27,7 +27,7 @@
 ## ROS 模板来源
 本步骤已选定模板文件路径：`{selected_plan.template_url}`。
 
-需要调用 `ros_validate_template` 校验时，必须传 `template_url = "{selected_plan.template_url}"`。调用 `ros_stack` 的 `CreateStack` / `UpdateStack` 时，必须传 `params.TemplateURL = "{selected_plan.template_url}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口；不要传 `params.TemplateBody`、`TemplateId` 或 `TemplateScratchId`；不要省略 `params.TemplateURL`。
+需要调用 `ros_validate_template` 校验时，必须传 `template_url = "{selected_plan.template_url}"`。调用 `ros_deploy` 时，必须传 `template_url = "{selected_plan.template_url}"`。不要通过 `aliyun_api` 调用 ROS 模板校验或部署生命周期接口；不要传 `TemplateBody`、`TemplateId` 或 `TemplateScratchId`；不要省略 `template_url`。
 
 ## 所有候选方案的评估数据
 `selected_plan.selection_valid` 为 `true` 时，使用 `selected_plan.selected_candidate` 和
@@ -47,7 +47,7 @@
 
 ## 错误处理
 - 模板校验失败 → 就地修复模板后重试（最多 5 轮）
-- CreateStack 失败后，如果修改模板 → 重新调用 `ros_validate_template`，通过后再 ContinueCreateStack 或重试；只调整部署参数时由 CreateStack 校验
+- 部署失败 → 按技能的 `ros_deploy` 恢复策略处理；只调整部署参数时由 `ros_deploy` 的部署调用做最终校验
 - 架构层面必须变更（如产品组合不可行）→ rollback_request 到 `architecture_planning`
 
 ## 注意事项

--- a/src/iac_code/pipeline/selling/prompts/deploying.md
+++ b/src/iac_code/pipeline/selling/prompts/deploying.md
@@ -3,7 +3,7 @@
 你正在执行 AI 售卖流程的最终步骤：将用户选择的方案模板部署到阿里云。
 
 ## 部署执行
-用户已在上一步确认选择了该方案，该选择等价于本步骤的部署确认。不要再次询问是否确认部署，也不要询问是否确认部署参数。完成模板校验、可用性查询和参数装配后，直接调用 `ros_stack` 执行部署。
+用户已在上一步确认选择了该方案，该选择等价于本步骤的部署确认。不要再次询问是否确认部署，也不要询问是否确认部署参数。`selected_plan.preview_ready_for_create` 为 `true` 时按快速创建路径执行，快速创建路径见技能；否则按常规部署路径执行。
 
 上述确认只适用于部署执行，不适用于删除已有 Stack。删除请求本身不等于删除确认；只有用户明确回复“确认删除”“我确认删除”等删除确认语句，或上下文显式提供 `delete_confirmed: true` 时，才可执行删除。未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`。
 
@@ -27,7 +27,7 @@
 ## ROS 模板来源
 本步骤已选定模板文件路径：`{selected_plan.template_url}`。
 
-调用 `ros_validate_template` 校验时，必须传 `template_url = "{selected_plan.template_url}"`。调用 `ros_stack` 的 `CreateStack` / `UpdateStack` 时，必须传 `params.TemplateURL = "{selected_plan.template_url}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口；不要传 `params.TemplateBody`、`TemplateId` 或 `TemplateScratchId`；不要省略 `params.TemplateURL`。
+需要调用 `ros_validate_template` 校验时，必须传 `template_url = "{selected_plan.template_url}"`。调用 `ros_stack` 的 `CreateStack` / `UpdateStack` 时，必须传 `params.TemplateURL = "{selected_plan.template_url}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口；不要传 `params.TemplateBody`、`TemplateId` 或 `TemplateScratchId`；不要省略 `params.TemplateURL`。
 
 ## 所有候选方案的评估数据
 `selected_plan.selection_valid` 为 `true` 时，使用 `selected_plan.selected_candidate` 和
@@ -47,6 +47,7 @@
 
 ## 错误处理
 - 模板校验失败 → 就地修复模板后重试（最多 5 轮）
+- CreateStack 失败后，如果修改模板 → 重新调用 `ros_validate_template`，通过后再 ContinueCreateStack 或重试；只调整部署参数时由 CreateStack 校验
 - 架构层面必须变更（如产品组合不可行）→ rollback_request 到 `architecture_planning`
 
 ## 注意事项

--- a/src/iac_code/pipeline/selling/prompts/template_generating.md
+++ b/src/iac_code/pipeline/selling/prompts/template_generating.md
@@ -18,6 +18,9 @@
 2. 如果 `templates/` 目录不存在，先创建它。
 3. **必须先写文件，再调用 `complete_step`。**
 
+## ROS 模板来源
+生成后的模板文件路径就是 `{candidate.output_path}`。调用 `ros_validate_template` 校验时，必须传 `template_url = "{candidate.output_path}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口，不要传 `TemplateBody`、`TemplateId` 或 `TemplateScratchId`。
+
 ## 输出
 文件写入完成后调用 `complete_step` 提交结论。
 

--- a/src/iac_code/pipeline/selling/prompts/template_generating.md
+++ b/src/iac_code/pipeline/selling/prompts/template_generating.md
@@ -14,9 +14,8 @@
 ```
 
 ## 文件写入
-1. 将生成的模板以 **YAML 格式**写入 `{candidate.output_path}`（相对于工作目录）。
-2. 如果 `templates/` 目录不存在，先创建它。
-3. **必须先写文件，再调用 `complete_step`。**
+1. 直接调用 `write_file` 将生成的模板以 **YAML 格式**写入 `{candidate.output_path}`（相对于工作目录）；`write_file` 会自动创建父目录，无需提前创建目录。
+2. **必须先写文件，再调用 `complete_step`。**
 
 ## ROS 模板来源
 生成后的模板文件路径就是 `{candidate.output_path}`。调用 `ros_validate_template` 校验时，必须传 `template_url = "{candidate.output_path}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口，不要传 `TemplateBody`、`TemplateId` 或 `TemplateScratchId`。

--- a/src/iac_code/pipeline/selling/references/cloud-products
+++ b/src/iac_code/pipeline/selling/references/cloud-products
@@ -1,0 +1,1 @@
+../../../skills/bundled/iac_aliyun/references/cloud-products

--- a/src/iac_code/pipeline/selling/references/ros-template.md
+++ b/src/iac_code/pipeline/selling/references/ros-template.md
@@ -1,0 +1,1 @@
+../../../skills/bundled/iac_aliyun/references/ros-template.md

--- a/src/iac_code/pipeline/selling/references/template-parameter-recommendation.md
+++ b/src/iac_code/pipeline/selling/references/template-parameter-recommendation.md
@@ -1,0 +1,158 @@
+# 已有模板参数推荐
+
+用户已有 ROS 可部署模板，要求在 `CreateStack` 前推荐、补全或预览参数时使用本流程。
+
+## 适用范围
+
+- 支持：ROS 原生模板；ROS Terraform 类型模板（`Transform: Aliyun::Terraform-*` / `Aliyun::OpenTofu-*`）。
+- 不支持：纯 Terraform 工作目录（先按 [terraform-template.md](terraform-template.md) 用 `tf2ros.py` 打包）；`UpdateStack`、`ContinueCreateStack`、栈组、栈实例。
+
+## 核心原则
+
+- 仅推荐 `CreateStack` 前的新建栈参数，由 skill 编排专用 ROS 模板工具和必要的只读资源查询。
+- `PreviewStack` 是预览验证门槛，不是部署成功保证。通过的参数集称为 **Preview-Validated Parameter Set**：同一地域、`StackName`、模板来源、共享栈操作参数下成立。
+- 原始约束快照与 API 响应只在 agent 上下文持有，不写文件；用户要求保存时只能保存脱敏后的摘要。
+- 密码类参数可在用户要求时生成合规随机值，报告与日志中只显示 `***` / `<redacted>`。
+- 不编造外部资源、账号资源、AccessKey/Secret/Token/Webhook/LicenseKey/证书/真实域名/已有资源 ID。
+- 敏感值、资源 ID、公网地址、账号 ID、控制台 URL 必须脱敏。
+
+## 流程
+
+### 1. 确认输入
+
+| 项 | 来源 |
+|---|---|
+| 模板 | 本地/远程模板路径或对话中的产物；调用专用工具时传给 `template_url` |
+| 地域 | 用户指定 → 工具默认地域 → 询问用户 |
+| `StackName` | 用户指定 → 由模板描述/文件名生成安全名称 |
+| 共享操作参数 | 至少 `DisableRollback: true` |
+
+`PreviewStack` 与后续 `CreateStack` 的模板来源、地域、`StackName`、`DisableRollback`、参数必须一致。
+
+### 2. 读取模板
+
+ROS 原生：`Parameters`（类型/描述/Label/Default/NoEcho/AllowedValues/AssociationProperty）、`Resources` 中的参数引用、`Metadata` 分组、`Outputs`。
+
+ROS Terraform 类型：顶层 `Transform` / `Workspace`、`.tf` 的 `variable`、variable `description` 中的 AssociationProperty/Metadata/Label JSON、`.metadata` 分组、resource/data source 引用。注意 data source 索引风险（`data.*.ids.0`、`zones[0]`、`images.0.id`）：若过滤条件硬编码且未参数化，预览失败属于模板问题。
+
+输出内部参数清单：参数名、含义、必填、敏感、默认值、引用位置、来源分类（API 约束 / 可推断 / 可生成测试值 / 外部输入 / 用户必须确认的已有资源）。
+
+### 3. 提取用户偏好
+
+| 关键词 | 倾向 |
+|---|---|
+| 低成本 / 测试 / 便宜点 | 小规格、按量付费、低档磁盘、减少可选付费资源 |
+| 生产 / 稳定 / 高可用 | 避免过小规格，多可用区 |
+| 已有资源 | 优先 API 返回或用户提供的已有 VPC/VSwitch/SG/Bucket/KeyPair |
+| 安全 / 不要公网 | 私网、私有权限、避免公网暴露 |
+
+偏好只能在合法候选内删减或排序，不能覆盖 API 硬约束。
+
+### 4. 调用 ros_get_template_parameter_constraints
+
+```python
+ros_get_template_parameter_constraints(
+    template_url="/absolute/path/to/template.yml",
+    # 后续可带已选参数继续求解
+    parameters={"ZoneId": "cn-hangzhou-h", "InstanceType": "ecs.e-c1m1.large"},
+    # 已有具体地域时传 region_id；否则使用工具默认地域
+    region_id="cn-hangzhou",
+)
+```
+
+`parameters` 使用字典；不要手动展开成 `Parameters.N.ParameterKey`，也不要用 `ParametersOrder.N` 求解（仅控制台填写顺序提示）。
+
+ROS Terraform 类型模板若返回 `TerraformStackNotSupported` / `QueryErrors` / 无可用约束：解析 variable AssociationProperty 与 Metadata → 调用产品可用性 API 或资源类型定义 → 按偏好生成候选 → 用 `ros_preview_template` 兜底。失败若来自 data source 固定筛选或空列表，按模板问题报告。
+
+### 5. 保留原始约束快照（仅上下文）
+
+字段：参数名、原始 `AllowedValues`、`AssociationParameterNames`、`Behavior` / `BehaviorReason`、`IllegalValueByParameterConstraints`、`IllegalValueByRules`、`NotSupportResources`、`QueryErrors`，以及本地模板中的引用证据。展示前必须脱敏。
+
+### 6. 对 AllowedValues 做偏好预筛选
+
+- 只能删除或排序 API 返回的值，不能创造新值。
+- 保留足够候选用于回溯；记录每个被删值的原因。
+- 预筛后为空时恢复原始候选并标记偏好冲突。
+
+### 7. 联动求解与回溯
+
+可逆搜索：
+
+1. 优先选择被依赖、候选少、出现在 `AssociationParameterNames` 中的参数。
+2. 选当前最高优先级候选 → 带部分参数再次调 `ros_get_template_parameter_constraints`。
+3. 新返回的 `AllowedValues` 与剩余候选求交。
+4. 任一必填参数无候选 → 记录原因并回退。
+5. 直到所有可自动推荐参数有值，或遇到不可代填的外部输入。
+
+内部状态（不写文件）：原始快照、当前预筛候选、当前组合、已尝试值、被拒原因、最新约束响应。
+
+### 8. 处理无 AllowedValues 的参数
+
+读取 `Behavior` / `BehaviorReason` / `NotSupportResources` / `QueryErrors`，定位模板引用（`Ref`、`${Param}`、嵌套属性、Terraform 引用），必要时查资源属性定义（ROS `GetResourceType` / IaCService 的 Terraform 资源类型定义）。按下表分类：
+
+| 类别 | 示例 |
+|---|---|
+| 可推断配置 | 本模板创建资源的名称、CIDR、布尔、小数值、非敏感字符串、模板支持的安全默认值 |
+| 可生成测试输入 | ECS/RDS/Redis/RocketMQ/WordPress 等普通密码（参数名/`NoEcho`/AssociationProperty/描述/资源属性表明是密码，且用户要求代理准备） |
+| 外部 / 账号特定 ❌ 不得编造 | `VpcId`、`VSwitchId`、`SecurityGroupId`、`KeyPairName`、已有 `InstanceId`；真实域名/ICP/DNS/证书；Token/Webhook/AK/SK/LicenseKey/ARMS/MSE 等凭证 |
+
+生成的密码必须满足模板长度、复杂度、`AllowedPattern`、`ConstraintDescription`，日志或临时配置含明文时测试后必须脱敏或删除。
+
+已有资源参数：只读查询可在用户确认后校验；模板会修改资源、DNS、安全组或 RunCommand 的，必须显式确认资源与影响，不自动选择账号内资源。
+
+### 9. ros_preview_template 预览验证
+
+```python
+ros_preview_template(
+    template_url="/absolute/path/to/template.yml",
+    stack_name="final-intended-stack-name",
+    parameters={"ZoneId": "cn-hangzhou-h", "InstanceType": "ecs.e-c1m1.large"},
+    # 已有具体地域时传 region_id；否则使用工具默认地域
+    region_id="cn-hangzhou",
+)
+```
+
+- 模板来源、地域、`stack_name` 和参数必须与后续 `CreateStack` 一致；`DisableRollback` 等仅部署工具支持的参数在部署步骤保持一致。
+- 成功 → 形成 Preview-Validated Parameter Set。
+- 失败 → 记录组合与错误，回到第 6/7 步。
+- 最多尝试 5 个组合；5 次失败后停止，总结冲突并询问用户。
+- 失败来自外部输入缺失 → 停止并要求用户提供，不用占位值伪造。
+- 失败来自模板固定配置（不存在的条件名、data source 空列表、硬编码规格不可用）→ 按模板问题报告。
+
+### 10. 可选询价
+
+`PreviewStack` 成功后，用户准备部署或询问成本时调用 `ros_estimate_template_cost`。询价失败不丢弃 Preview-Validated Parameter Set，仅展示原因。
+
+### 11. 展示结果
+
+- 模板来源、地域、最终 `StackName`、共享操作参数（如 `DisableRollback`）。
+- 推荐参数值（敏感值脱敏）；每个参数的来源（API `AllowedValues` / 可推断 / 生成的测试密码 / 用户提供 / 外部未提供）与理由。
+- `PreviewStack` 状态、资源摘要。
+- 外部输入缺口与用户需提供内容。
+- 是否执行 `CreateStack` 的确认问题。
+
+### 12. CreateStack
+
+同时满足才能进入写操作：
+
+- 已形成 Preview-Validated Parameter Set。
+- 用户确认；高成本、多地域、修改已有资源、RunCommand、DNS/证书/域名操作单独说明影响。
+- `CreateStack` 与 `PreviewStack` 的模板来源、地域、`StackName`、`DisableRollback`、参数一致。
+
+部署后注意：
+
+- 报告中的 NoEcho/密码、公网地址、资源 ID、控制台 URL 必须脱敏。
+- 不要把 `CREATE_COMPLETE` 当作任务结束信号；按用户意图判断是否需要清理或后续验证。
+
+## 失败分类
+
+| 类别 | 含义 |
+|---|---|
+| 参数不可行 | 候选被约束拒绝、依赖组合无交集、Preview 回溯耗尽 |
+| 模板问题 | 语法/条件名错误、Terraform data source 空列表、硬编码规格/地域不可用、Output 引用错误 |
+| 外部输入缺失 | LicenseKey、Token、证书、真实域名、已有资源 ID 等不可代填 |
+| 供应商/API/库存异常 | RDS `InternalError`、定价计划缺失、临时 API 错误 |
+| 应用初始化失败 | `ALIYUN::ECS::RunCommand`、SAE 部署任务、WaitCondition 超时 |
+| 清理失败 | 删除超时、残留安全组/ServerGroup/依赖资源，需补充清理与最终确认 |
+
+Preview 成功但 Create 失败时，先判断失败是否来自 provider/API、模板资源关系、应用脚本或清理流程，不要直接否定推荐参数。

--- a/src/iac_code/pipeline/selling/references/template-parameter-recommendation.md
+++ b/src/iac_code/pipeline/selling/references/template-parameter-recommendation.md
@@ -10,7 +10,7 @@
 ## 核心原则
 
 - 仅推荐 `CreateStack` 前的新建栈参数，由 skill 编排专用 ROS 模板工具和必要的只读资源查询。
-- `PreviewStack` 是预览验证门槛，不是部署成功保证。通过的参数集称为 **Preview-Validated Parameter Set**：同一地域、`StackName`、模板来源、共享栈操作参数下成立。
+- `PreviewStack` 是预览验证门槛，不是部署成功保证。通过的参数集称为 **Preview-Validated Parameter Set**：表示指定模板来源在当时参数集下可预览。
 - 原始约束快照与 API 响应只在 agent 上下文持有，不写文件；用户要求保存时只能保存脱敏后的摘要。
 - 密码类参数可在用户要求时生成合规随机值，报告与日志中只显示 `***` / `<redacted>`。
 - 不编造外部资源、账号资源、AccessKey/Secret/Token/Webhook/LicenseKey/证书/真实域名/已有资源 ID。
@@ -27,7 +27,7 @@
 | `StackName` | 用户指定 → 由模板描述/文件名生成安全名称 |
 | 共享操作参数 | 至少 `DisableRollback: true` |
 
-`PreviewStack` 与后续 `CreateStack` 的模板来源、地域、`StackName`、`DisableRollback`、参数必须一致。
+本流程输出的预览证明只用于说明模板来源已通过预览；后续选择或部署阶段可以调整部署参数，最终参数由 `CreateStack` 校验。
 
 ### 2. 读取模板
 
@@ -112,7 +112,7 @@ ros_preview_template(
 )
 ```
 
-- 模板来源、地域、`stack_name` 和参数必须与后续 `CreateStack` 一致；`DisableRollback` 等仅部署工具支持的参数在部署步骤保持一致。
+- 预览成功证明记录本次 `template_url` 与预览时使用的参数集；后续选择或部署阶段调整参数时，不需要因此重做 `PreviewStack`。
 - 成功 → 形成 Preview-Validated Parameter Set。
 - 失败 → 记录组合与错误，回到第 6/7 步。
 - 最多尝试 5 个组合；5 次失败后停止，总结冲突并询问用户。
@@ -135,9 +135,9 @@ ros_preview_template(
 
 同时满足才能进入写操作：
 
-- 已形成 Preview-Validated Parameter Set。
+- 已形成 Preview-Validated Parameter Set，且没有完整部署参数缺口。
 - 用户确认；高成本、多地域、修改已有资源、RunCommand、DNS/证书/域名操作单独说明影响。
-- `CreateStack` 与 `PreviewStack` 的模板来源、地域、`StackName`、`DisableRollback`、参数一致。
+- 部署时使用最终确认的模板来源和部署参数；最终参数由 `CreateStack` 校验。
 
 部署后注意：
 

--- a/src/iac_code/pipeline/selling/references/template-parameters.md
+++ b/src/iac_code/pipeline/selling/references/template-parameters.md
@@ -1,0 +1,1 @@
+../../../skills/bundled/iac_aliyun/references/template-parameters.md

--- a/src/iac_code/pipeline/selling/references/terraform-template.md
+++ b/src/iac_code/pipeline/selling/references/terraform-template.md
@@ -1,0 +1,1 @@
+../../../skills/bundled/iac_aliyun/references/terraform-template.md

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -5,7 +5,7 @@ when_to_use: 当需要对阿里云 ROS 模板进行费用预估时
 user_invocable: false
 conclusion_schema:
   type: object
-  required: [monthly_estimate, currency, resources, template_fixed, deployment_parameters]
+  required: [monthly_estimate, currency, resources, template_fixed, deployment_parameters, preview_validation]
   additionalProperties: false
   properties:
     monthly_estimate:
@@ -29,6 +29,39 @@ conclusion_schema:
     deployment_parameters:
       type: object
       description: 当前已选、已验证或已用于询价并传递给 deploying 的模板参数字典；可由后续选择阶段补充覆盖
+    preview_validation:
+      type: object
+      required: [succeeded]
+      additionalProperties: false
+      description: ros_preview_template 的结构化成功证明；deploying 仅在模板路径匹配且没有部署参数缺口时跳过例行校验并直接 CreateStack
+      properties:
+        succeeded:
+          type: boolean
+        template_url:
+          type: string
+        parameters:
+          type: object
+        region_id:
+          type: string
+        request_id:
+          type: string
+        error:
+          type: string
+      allOf:
+        - if:
+            properties:
+              succeeded:
+                const: true
+            required: [succeeded]
+          then:
+            required: [template_url, parameters]
+        - if:
+            properties:
+              succeeded:
+                const: false
+            required: [succeeded]
+          then:
+            required: [error]
     missing_deployment_parameters:
       type: array
       description: PreviewStack 或最终部署仍缺少、需要用户在后续选择阶段补充的参数
@@ -64,7 +97,7 @@ conclusion_schema:
 4. **调用询价工具** — 优先使用 Preview-Validated Pricing Parameter Set；若 PreviewStack 因完整部署参数缺口无法通过，可用当前已选或可用于询价的参数调用 `ros_estimate_template_cost`
 5. **按需修复问题** — 仅当询价失败且错误指向模板问题，或你必须修复/改写模板时，修改模板并写回原文件路径
 6. **修改后校验并重新询价** — 调用 `ros_validate_template` 校验改动；通过后调用 `ros_estimate_template_cost` 重新询价；失败则修复重试（最多 7 轮）
-7. **结构化传递参数** — 在 `complete_step.conclusion.deployment_parameters` 输出当前已选或已用于询价的参数字典；在 `missing_deployment_parameters` 输出仍需用户补充的完整部署参数缺口
+7. **结构化传递参数** — 在 `complete_step.conclusion.deployment_parameters` 输出当前已选或已用于询价的参数字典；在 `preview_validation` 输出预览成功证明；在 `missing_deployment_parameters` 输出仍需用户补充的完整部署参数缺口
 8. **输出结果** — 汇总费用并调用 `complete_step`
 
 ## 按需校验模板
@@ -104,7 +137,7 @@ PreviewStack 不是硬门禁。它要求完整部署参数，常比询价工具�
 - VpcId、VSwitchId、SecurityGroupId、KeyPairName 等已有资源参数：先查询约束或只读资源候选；API 返回候选不是编造，可作为参数候选参与回溯与 PreviewStack。没有上下文值、模板 Default、用户提供值或 API 返回候选时，才按外部输入缺失处理。
 - 只能在合法候选内筛选或排序，不得编造 API 未返回的库存值；LicenseKey、Token、证书、真实域名等外部输入不得编造。不要仅因参数名是 VpcId、VSwitchId、SecurityGroupId 或 KeyPairName 就跳过参数推荐并直接停止询价。
 - `PreviewStack` 因候选组合不可行失败时，按 reference 的回溯规则更换候选；因外部输入缺失失败时，记录缺口，不用占位值伪造，并按上方软门禁规则决定是否继续询价。
-- 最终得到的参数集不写入模板 `Default`；将当前已选、已验证或已用于询价的参数作为结构化数据放入 `complete_step.conclusion.deployment_parameters`，传递给 deploying。模板 Default 只是参数求解的输入来源之一，不是跨步骤传参介质。
+- 最终得到的参数集不写入模板 `Default`；将当前已选、已验证或已用于询价的参数作为结构化数据放入 `complete_step.conclusion.deployment_parameters`，传递给 deploying。`ros_preview_template` 成功时，还必须把 `succeeded: true`、同一个 `template_url` 和预览时使用的 `parameters` 写入 `complete_step.conclusion.preview_validation`；deploying 用它判断同一模板是否已完成预览验证，实际部署参数由 CreateStack 做最终校验。模板 Default 只是参数求解的输入来源之一，不是跨步骤传参介质。
 - PreviewStack 成功但询价失败时，不要丢弃 Preview-Validated Pricing Parameter Set；仍在 `deployment_parameters` 输出该参数集，同时如实报告询价失败原因。
 
 ## 调用询价 API
@@ -163,6 +196,7 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 - `cost` 字段为字符串，包含金额和计费周期（如 "¥800/月"、"¥0.5/小时"、"¥0"）
 - 若修复了模板，设置 `template_fixed: true` 并在 `fix_summary` 中说明修复内容；仅形成或输出 `deployment_parameters` 不算模板修复
 - `deployment_parameters` 填当前已选、已验证或已用于 `ros_estimate_template_cost` 的参数字典；PreviewStack 成功但询价失败时仍填该参数集；没有任何可用参数时填 `{}`
+- `preview_validation` 填 `ros_preview_template` 的结构化状态：成功时填 `{"succeeded": true, "template_url": "<当前模板文件路径>", "parameters": <预览通过的同一参数字典>}`；失败或未执行时填 `{"succeeded": false, "error": "<原因>"}`
 - `missing_deployment_parameters` 填完整部署或 PreviewStack 仍缺少的参数及原因；没有缺口时可省略或填 `[]`
 - `parameter_set_summary` 可简要说明参数来源、可用性筛选、PreviewStack 验证结果以及是否使用软门禁继续询价
 - 询价失败时 `monthly_estimate` 填 "询价失败"，`resources` 为空数组，`error` 说明原因

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iac-aliyun-cost
-description: 使用 ROS GetTemplateEstimateCost API 预估 ROS 模板的月度部署费用，支持按需修复和校验模板问题
+description: 使用专用 ROS 模板询价工具预估 ROS 模板的月度部署费用，支持按需修复和校验模板问题
 when_to_use: 当需要对阿里云 ROS 模板进行费用预估时
 user_invocable: false
 conclusion_schema:
@@ -52,18 +52,18 @@ conclusion_schema:
 
 # ROS 模板成本预估
 
-使用阿里云 ROS `GetTemplateEstimateCost` API 预估部署费用。
+使用专用 ROS 模板询价工具预估部署费用。
 
-前一步已完成模板校验；本步骤避免在成本预估前重复校验模板。首次询价前优先按参数推荐流程形成 Preview-Validated Pricing Parameter Set，再调用询价 API。PreviewStack 不是硬门禁；完整部署参数暂时无法自动形成时，仍可用当前已选参数调用询价 API，并把缺口留给后续选择阶段补充。只有在修复或改写模板后，才调用 `ValidateTemplate` 校验改动。
+前一步已完成模板校验；本步骤避免在成本预估前重复校验模板。首次询价前优先按参数推荐流程形成 Preview-Validated Pricing Parameter Set，再调用 `ros_estimate_template_cost`。PreviewStack 不是硬门禁；完整部署参数暂时无法自动形成时，仍可用当前已选参数调用 `ros_estimate_template_cost`，并把缺口留给后续选择阶段补充。只有在修复或改写模板后，才调用 `ros_validate_template` 校验改动。
 
 ## 执行流程
 
 1. **解析模板** — 从上下文的 `template` 字段获取模板内容和文件路径
 2. **提取参数** — 从模板 Parameters 中提取所有参数及其默认值
 3. **推荐并预览验证询价参数** — 按「询价参数推荐与传递」优先形成 Preview-Validated Pricing Parameter Set，不得跳过约束求解直接编造库存值
-4. **调用询价 API** — 优先使用 Preview-Validated Pricing Parameter Set；若 PreviewStack 因完整部署参数缺口无法通过，可用当前已选或可用于询价的参数调用 `GetTemplateEstimateCost`
+4. **调用询价工具** — 优先使用 Preview-Validated Pricing Parameter Set；若 PreviewStack 因完整部署参数缺口无法通过，可用当前已选或可用于询价的参数调用 `ros_estimate_template_cost`
 5. **按需修复问题** — 仅当询价失败且错误指向模板问题，或你必须修复/改写模板时，修改模板并写回原文件路径
-6. **修改后校验并重新询价** — 调用 `ValidateTemplate` 校验改动；通过后调用 `GetTemplateEstimateCost` 重新询价；失败则修复重试（最多 7 轮）
+6. **修改后校验并重新询价** — 调用 `ros_validate_template` 校验改动；通过后调用 `ros_estimate_template_cost` 重新询价；失败则修复重试（最多 7 轮）
 7. **结构化传递参数** — 在 `complete_step.conclusion.deployment_parameters` 输出当前已选或已用于询价的参数字典；在 `missing_deployment_parameters` 输出仍需用户补充的完整部署参数缺口
 8. **输出结果** — 汇总费用并调用 `complete_step`
 
@@ -77,11 +77,9 @@ conclusion_schema:
 
 校验方法：
 ```
-aliyun_api(
-    product="ros",
-    action="ValidateTemplate",
-    params={"TemplateURL": "<模板文件路径>"},
-    region_id="<地域>"
+ros_validate_template(
+    template_url="/absolute/path/to/current-template.yml",
+    region_id="cn-hangzhou",  # 已有具体地域时传；否则省略使用工具默认地域
 )
 ```
 
@@ -91,18 +89,18 @@ aliyun_api(
 3. 修复模板并**写回原文件路径**（后续部署步骤从此路径读取，不写回会导致后续步骤使用错误模板）
 4. 重新校验（最多 7 轮）
 
-> **TemplateURL 支持本地文件路径**：`TemplateURL` 可传本地路径（如 `/tmp/template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
+> **模板路径支持本地文件**：`template_url` 可传本地路径（如 `/tmp/template.yml`）。避免将大模板内容直接作为参数传递。
 
 ## 询价参数推荐与传递
 
-缺少 Default 或上下文值时，按 [references/template-parameter-recommendation.md](references/template-parameter-recommendation.md) 的参数推荐规则求解，并优先通过 `aliyun_api(product="ros", action="PreviewStack")` 形成 **Preview-Validated Pricing Parameter Set**。不要使用 `ros_stack` 执行 `PreviewStack`；本步骤只验证参数与模板可预览，不执行部署确认或 `CreateStack`。
+缺少 Default 或上下文值时，按 [references/template-parameter-recommendation.md](references/template-parameter-recommendation.md) 的参数推荐规则求解，并优先通过 `ros_preview_template` 形成 **Preview-Validated Pricing Parameter Set**。不要使用 `ros_stack` 执行 `PreviewStack`；本步骤只验证参数与模板可预览，不执行部署确认或 `CreateStack`。
 
-PreviewStack 必须传 StackName；调用 PreviewStack 前，必须先确定唯一 `StackName` 并传入 `PreviewStack` 参数。`StackName` 使用候选方案或服务简名作为前缀，并追加时间或 6 位小写字母/数字随机串后缀（如 `ai-app-20260623-a1b2c3`），避免重名。该 `StackName` 是 ROS API 参数，不写入模板 `Parameters`，不放入 `deployment_parameters`。
+PreviewStack 必须传 StackName；调用 `ros_preview_template` 前，必须先确定唯一 `stack_name`。`stack_name` 使用候选方案或服务简名作为前缀，并追加时间或 6 位小写字母/数字随机串后缀（如 `ai-app-20260623-a1b2c3`），避免重名。该 `stack_name` 是预览工具参数，不写入模板 `parameters`，不放入 `deployment_parameters`。
 
-PreviewStack 不是硬门禁。它要求完整部署参数，常比 `GetTemplateEstimateCost` 需要更多外部输入；如果完整部署参数无法自动补齐、或 PreviewStack 因外部参数缺口失败，但已有参数足以询价，则可以调用 `GetTemplateEstimateCost` 估算费用。此时必须在 `parameter_set_summary` 说明 PreviewStack 状态，在 `missing_deployment_parameters` 列出缺口，后续选择阶段可通过 `parameter_overrides` 补齐，deploying 再做最终部署校验。
+PreviewStack 不是硬门禁。它要求完整部署参数，常比询价工具需要更多外部输入；如果完整部署参数无法自动补齐、或 PreviewStack 因外部参数缺口失败，但已有参数足以询价，则可以调用 `ros_estimate_template_cost` 估算费用。此时必须在 `parameter_set_summary` 说明 PreviewStack 状态，在 `missing_deployment_parameters` 列出缺口，后续选择阶段可通过 `parameter_overrides` 补齐，deploying 再做最终部署校验。
 
 本步骤的裁剪规则：
-- 优先使用上下文已有值和模板 Default；库存相关参数缺值时，先通过 `GetTemplateParameterConstraints` 获取合法 `AllowedValues`，必要时再按 [references/cloud-products/](references/cloud-products/) 的可用性 API 与选型策略补足。
+- 优先使用上下文已有值和模板 Default；库存相关参数缺值时，先通过 `ros_get_template_parameter_constraints` 获取合法 `AllowedValues`，必要时再按 [references/cloud-products/](references/cloud-products/) 的可用性 API 与选型策略补足。
 - VpcId、VSwitchId、SecurityGroupId、KeyPairName 等已有资源参数：先查询约束或只读资源候选；API 返回候选不是编造，可作为参数候选参与回溯与 PreviewStack。没有上下文值、模板 Default、用户提供值或 API 返回候选时，才按外部输入缺失处理。
 - 只能在合法候选内筛选或排序，不得编造 API 未返回的库存值；LicenseKey、Token、证书、真实域名等外部输入不得编造。不要仅因参数名是 VpcId、VSwitchId、SecurityGroupId 或 KeyPairName 就跳过参数推荐并直接停止询价。
 - `PreviewStack` 因候选组合不可行失败时，按 reference 的回溯规则更换候选；因外部输入缺失失败时，记录缺口，不用占位值伪造，并按上方软门禁规则决定是否继续询价。
@@ -111,20 +109,16 @@ PreviewStack 不是硬门禁。它要求完整部署参数，常比 `GetTemplate
 
 ## 调用询价 API
 
-通过 `TemplateURL` 传递模板文件路径（不要用 `TemplateBody` 内联模板内容，模板可能很大）。ROS API 的 `Parameters` 直接传字典格式，工具会自动展开为 API 所需的平铺参数；不要手动展开：
+通过 `template_url` 传递模板文件路径（不要用 `TemplateBody` 内联模板内容，模板可能很大）。`parameters` 直接传字典格式；不要手动展开：
 
 ```python
-aliyun_api(
-    product="ros",
-    action="GetTemplateEstimateCost",
-    params={
-        "TemplateURL": "/tmp/ros-template.yml",
-        "Parameters": {
-            "ZoneId": "cn-hangzhou-k",
-            "InstanceType": "ecs.g7.large",
-            "ImageId": "centos_stream_9_x64_20G_alibase_20260414.vhd",
-            "SystemDiskCategory": "cloud_essd",
-        },
+ros_estimate_template_cost(
+    template_url="/tmp/ros-template.yml",
+    parameters={
+        "ZoneId": "cn-hangzhou-k",
+        "InstanceType": "ecs.g7.large",
+        "ImageId": "centos_stream_9_x64_20G_alibase_20260414.vhd",
+        "SystemDiskCategory": "cloud_essd",
     },
     region_id="cn-hangzhou",
 )
@@ -155,7 +149,7 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 
 ## 重要约束
 
-- **必须**使用 `aliyun_api` 工具调用 ROS API — 不要自行估算费用
+- **必须**使用 `ros_get_template_parameter_constraints`、`ros_preview_template`、`ros_estimate_template_cost`、`ros_validate_template` 处理 ROS 模板参数约束、预览、询价和校验；不要直接调用 `aliyun_api` 的对应 ROS 模板 API
 - **不要**搜索定价文档或使用 `aliyun_doc_search`
 - **不要**使用 bash 执行本地命令
 - 询价失败时报告错误原因，不要编造费用数据
@@ -168,7 +162,7 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 补充说明：
 - `cost` 字段为字符串，包含金额和计费周期（如 "¥800/月"、"¥0.5/小时"、"¥0"）
 - 若修复了模板，设置 `template_fixed: true` 并在 `fix_summary` 中说明修复内容；仅形成或输出 `deployment_parameters` 不算模板修复
-- `deployment_parameters` 填当前已选、已验证或已用于 `GetTemplateEstimateCost` 的参数字典；PreviewStack 成功但询价失败时仍填该参数集；没有任何可用参数时填 `{}`
+- `deployment_parameters` 填当前已选、已验证或已用于 `ros_estimate_template_cost` 的参数字典；PreviewStack 成功但询价失败时仍填该参数集；没有任何可用参数时填 `{}`
 - `missing_deployment_parameters` 填完整部署或 PreviewStack 仍缺少的参数及原因；没有缺口时可省略或填 `[]`
 - `parameter_set_summary` 可简要说明参数来源、可用性筛选、PreviewStack 验证结果以及是否使用软门禁继续询价
 - 询价失败时 `monthly_estimate` 填 "询价失败"，`resources` 为空数组，`error` 说明原因

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/evals.json
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "iac-aliyun-cost",
-  "description": "验证成本预估技能：正确调用专用 ROS 模板询价工具、parameters 字典格式、参数推荐传递、模板按需校验修复、错误处理",
+  "description": "验证成本预估技能：正确调用专用 ROS 模板询价工具、parameters 字典格式、参数推荐传递、preview_validation 预览证明、模板按需校验修复、错误处理",
   "evals": [
     {
       "id": 1,
@@ -11,7 +11,7 @@
         "file_path": "templates/1-simple-ecs.yml",
         "region": "cn-hangzhou"
       },
-      "expected_behavior": "先形成 Preview-Validated Pricing Parameter Set，再调用 ros_estimate_template_cost，parameters 以字典形式传递，并在 conclusion.deployment_parameters 输出同一参数集",
+      "expected_behavior": "先形成 Preview-Validated Pricing Parameter Set，再调用 ros_estimate_template_cost，parameters 以字典形式传递，并在 conclusion.deployment_parameters 和 conclusion.preview_validation 输出同一参数集",
       "assertions": [
         {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
         {"name": "uses_estimate_cost_tool", "check": "调用了 ros_estimate_template_cost"},
@@ -19,6 +19,7 @@
         {"name": "uses_template_url", "check": "通过 template_url 传递模板文件路径而非内联模板内容"},
         {"name": "outputs_monthly_estimate", "check": "conclusion 中包含 monthly_estimate 和 resources 费用明细"},
         {"name": "outputs_deployment_parameters", "check": "conclusion.deployment_parameters 包含最终用于询价的参数字典，供 deploying 使用"},
+        {"name": "outputs_preview_validation", "check": "conclusion.preview_validation.succeeded 为 true，且 template_url 和 parameters 与 ros_preview_template 调用一致"},
         {"name": "no_doc_search", "check": "不调用 aliyun_doc_search 或搜索定价文档"}
       ]
     },
@@ -71,13 +72,14 @@
         "region": "cn-shanghai",
         "description": "仅 VPC+OSS 的模板，OSS 可能不支持询价"
       },
-      "expected_behavior": "PreviewStack 成功但询价失败（如 OSS 不支持询价）时，应报告错误而不编造费用，同时不丢弃已验证的 deployment_parameters",
+      "expected_behavior": "PreviewStack 成功但询价失败（如 OSS 不支持询价）时，应报告错误而不编造费用，同时不丢弃已验证的 deployment_parameters 和 preview_validation",
       "assertions": [
         {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
         {"name": "attempts_pricing", "check": "尝试调用了 ros_estimate_template_cost"},
         {"name": "reports_error_honestly", "check": "如果 API 返回错误，如实报告错误原因"},
         {"name": "no_fabricated_cost", "check": "不编造费用数据"},
         {"name": "keeps_preview_parameters", "check": "PreviewStack 成功但询价失败时不丢弃 deployment_parameters"},
+        {"name": "keeps_preview_validation", "check": "PreviewStack 成功但询价失败时 conclusion.preview_validation.succeeded 仍为 true"},
         {"name": "error_in_conclusion", "check": "conclusion 中包含 error 字段说明失败原因"}
       ]
     },
@@ -110,13 +112,14 @@
         "region": "cn-hangzhou",
         "description": "PreviewStack 需要完整的已有网络参数，但 ECS 费用可先基于规格和磁盘参数估算"
       },
-      "expected_behavior": "优先尝试参数推荐和 PreviewStack；如果 VpcId/VSwitchId/SecurityGroupId 无法自动补齐，PreviewStack 不是硬门禁，不要直接终止。可用 ZoneId、InstanceType、ImageId、SystemDiskCategory 等当前可询价参数调用 ros_estimate_template_cost，并在 conclusion.missing_deployment_parameters 中列出仍需用户通过选择阶段 parameter_overrides 补充的完整部署参数缺口",
+      "expected_behavior": "优先尝试参数推荐和 PreviewStack；如果 VpcId/VSwitchId/SecurityGroupId 无法自动补齐，PreviewStack 不是硬门禁，不要直接终止。可用 ZoneId、InstanceType、ImageId、SystemDiskCategory 等当前可询价参数调用 ros_estimate_template_cost，并在 conclusion.missing_deployment_parameters 中列出仍需用户通过选择阶段 parameter_overrides 补充的完整部署参数缺口，同时将 conclusion.preview_validation.succeeded 置为 false",
       "assertions": [
         {"name": "preview_is_soft_gate", "check": "明确说明 PreviewStack 不是硬门禁，不能仅因完整部署参数暂缺就停止询价"},
         {"name": "attempts_pricing_with_available_params", "check": "调用 ros_estimate_template_cost，用当前已选或可用于询价的参数估算费用"},
         {"name": "reports_missing_deployment_parameters", "check": "conclusion.missing_deployment_parameters 包含 VpcId、VSwitchId、SecurityGroupId 等缺口"},
         {"name": "outputs_partial_deployment_parameters", "check": "conclusion.deployment_parameters 保留已用于询价的 ZoneId、InstanceType、ImageId、SystemDiskCategory"},
-        {"name": "mentions_later_overrides", "check": "说明用户后续可在选择阶段通过 parameter_overrides 补充缺失参数"}
+        {"name": "mentions_later_overrides", "check": "说明用户后续可在选择阶段通过 parameter_overrides 补充缺失参数"},
+        {"name": "marks_preview_validation_failed", "check": "完整部署参数缺失导致 PreviewStack 未通过时，conclusion.preview_validation.succeeded 为 false"}
       ]
     },
     {

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/evals.json
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "iac-aliyun-cost",
-  "description": "验证成本预估技能：正确调用 GetTemplateEstimateCost API、Parameters 字典格式、参数推荐传递、模板按需校验修复、错误处理",
+  "description": "验证成本预估技能：正确调用专用 ROS 模板询价工具、parameters 字典格式、参数推荐传递、模板按需校验修复、错误处理",
   "evals": [
     {
       "id": 1,
@@ -11,12 +11,12 @@
         "file_path": "templates/1-simple-ecs.yml",
         "region": "cn-hangzhou"
       },
-      "expected_behavior": "先形成 Preview-Validated Pricing Parameter Set，再调用 GetTemplateEstimateCost，Parameters 以字典形式传递，并在 conclusion.deployment_parameters 输出同一参数集",
+      "expected_behavior": "先形成 Preview-Validated Pricing Parameter Set，再调用 ros_estimate_template_cost，parameters 以字典形式传递，并在 conclusion.deployment_parameters 输出同一参数集",
       "assertions": [
-        {"name": "uses_preview_stack_api", "check": "PreviewStack 通过 aliyun_api(product=\"ros\", action=\"PreviewStack\") 调用，不使用 ros_stack"},
-        {"name": "uses_estimate_cost_api", "check": "调用了 GetTemplateEstimateCost API"},
-        {"name": "params_dictionary", "check": "参数使用 Parameters 字典格式传递，由工具展开 API 参数"},
-        {"name": "uses_template_url", "check": "通过 TemplateURL 传递模板文件路径而非内联模板内容"},
+        {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
+        {"name": "uses_estimate_cost_tool", "check": "调用了 ros_estimate_template_cost"},
+        {"name": "params_dictionary", "check": "参数使用 parameters 字典格式传递"},
+        {"name": "uses_template_url", "check": "通过 template_url 传递模板文件路径而非内联模板内容"},
         {"name": "outputs_monthly_estimate", "check": "conclusion 中包含 monthly_estimate 和 resources 费用明细"},
         {"name": "outputs_deployment_parameters", "check": "conclusion.deployment_parameters 包含最终用于询价的参数字典，供 deploying 使用"},
         {"name": "no_doc_search", "check": "不调用 aliyun_doc_search 或搜索定价文档"}
@@ -31,10 +31,10 @@
         "file_path": "templates/2-ecs-rds.yml",
         "region": "cn-beijing"
       },
-      "expected_behavior": "ECS 和 RDS 的参数都通过 Parameters 字典传入询价 API，费用明细分别列出，并输出 deployment_parameters",
+      "expected_behavior": "ECS 和 RDS 的参数都通过 parameters 字典传入询价工具，费用明细分别列出，并输出 deployment_parameters",
       "assertions": [
-        {"name": "uses_preview_stack_api", "check": "PreviewStack 通过 aliyun_api(product=\"ros\", action=\"PreviewStack\") 调用，不使用 ros_stack"},
-        {"name": "uses_estimate_cost_api", "check": "调用了 GetTemplateEstimateCost API"},
+        {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
+        {"name": "uses_estimate_cost_tool", "check": "调用了 ros_estimate_template_cost"},
         {"name": "all_params_included", "check": "所有 6 个参数（ZoneId、InstanceType、ImageId、SystemDiskCategory、DBInstanceClass、DBInstanceStorageType）都传入 API"},
         {"name": "multi_resource_breakdown", "check": "费用明细中分别列出了 ECS 和 RDS 的费用"},
         {"name": "outputs_deployment_parameters", "check": "conclusion.deployment_parameters 包含最终用于询价的完整参数字典"},
@@ -53,8 +53,8 @@
       },
       "expected_behavior": "先形成 Preview-Validated Pricing Parameter Set 并调用询价；当询价失败且错误指向模板问题时，修复（补 CidrBlock、修正 ImageId 参数引用），再校验改动并重新询价",
       "assertions": [
-        {"name": "uses_preview_stack_api", "check": "PreviewStack 通过 aliyun_api(product=\"ros\", action=\"PreviewStack\") 调用，不使用 ros_stack"},
-        {"name": "validates_after_template_change", "check": "仅在修复或改写模板后调用 ValidateTemplate 校验改动"},
+        {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
+        {"name": "validates_after_template_change", "check": "仅在修复或改写模板后调用 ros_validate_template 校验改动"},
         {"name": "fixes_template", "check": "修复了模板中的错误（VSwitch CidrBlock、ImageId 参数引用）"},
         {"name": "writes_back", "check": "修复后将模板写回文件"},
         {"name": "retries_after_fix", "check": "修复并校验通过后重新询价"},
@@ -73,8 +73,8 @@
       },
       "expected_behavior": "PreviewStack 成功但询价失败（如 OSS 不支持询价）时，应报告错误而不编造费用，同时不丢弃已验证的 deployment_parameters",
       "assertions": [
-        {"name": "uses_preview_stack_api", "check": "PreviewStack 通过 aliyun_api(product=\"ros\", action=\"PreviewStack\") 调用，不使用 ros_stack"},
-        {"name": "attempts_pricing", "check": "尝试调用了 GetTemplateEstimateCost API"},
+        {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
+        {"name": "attempts_pricing", "check": "尝试调用了 ros_estimate_template_cost"},
         {"name": "reports_error_honestly", "check": "如果 API 返回错误，如实报告错误原因"},
         {"name": "no_fabricated_cost", "check": "不编造费用数据"},
         {"name": "keeps_preview_parameters", "check": "PreviewStack 成功但询价失败时不丢弃 deployment_parameters"},
@@ -91,12 +91,12 @@
         "region": "cn-hangzhou",
         "description": "VpcId 和 ZoneId 都没有 Default，VpcId 是已有资源参数"
       },
-      "expected_behavior": "先通过 GetTemplateParameterConstraints 或只读资源候选求解 VpcId/ZoneId；API 返回候选不是编造，可用于 PreviewStack。不要仅因 VpcId 是已有资源参数就直接停止询价；PreviewStack 成功后调用 GetTemplateEstimateCost，并输出 deployment_parameters",
+      "expected_behavior": "先通过 ros_get_template_parameter_constraints 或只读资源候选求解 VpcId/ZoneId；API 返回候选不是编造，可用于 PreviewStack。不要仅因 VpcId 是已有资源参数就直接停止询价；PreviewStack 成功后调用 ros_estimate_template_cost，并输出 deployment_parameters",
       "assertions": [
-        {"name": "queries_parameter_constraints", "check": "调用 GetTemplateParameterConstraints 或等价只读查询获取 VpcId/ZoneId 候选"},
+        {"name": "queries_parameter_constraints", "check": "调用 ros_get_template_parameter_constraints 或等价只读查询获取 VpcId/ZoneId 候选"},
         {"name": "api_candidates_not_fabricated", "check": "明确区分 API 返回候选不是编造，不把 VpcId 名称本身当作停止条件"},
-        {"name": "uses_preview_stack_api", "check": "PreviewStack 通过 aliyun_api(product=\"ros\", action=\"PreviewStack\") 调用，不使用 ros_stack"},
-        {"name": "attempts_pricing", "check": "PreviewStack 成功后调用 GetTemplateEstimateCost API"},
+        {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
+        {"name": "attempts_pricing", "check": "PreviewStack 成功后调用 ros_estimate_template_cost"},
         {"name": "outputs_deployment_parameters", "check": "conclusion.deployment_parameters 包含最终用于 PreviewStack 的 VpcId 和 ZoneId"}
       ]
     },
@@ -110,10 +110,10 @@
         "region": "cn-hangzhou",
         "description": "PreviewStack 需要完整的已有网络参数，但 ECS 费用可先基于规格和磁盘参数估算"
       },
-      "expected_behavior": "优先尝试参数推荐和 PreviewStack；如果 VpcId/VSwitchId/SecurityGroupId 无法自动补齐，PreviewStack 不是硬门禁，不要直接终止。可用 ZoneId、InstanceType、ImageId、SystemDiskCategory 等当前可询价参数调用 GetTemplateEstimateCost，并在 conclusion.missing_deployment_parameters 中列出仍需用户通过选择阶段 parameter_overrides 补充的完整部署参数缺口",
+      "expected_behavior": "优先尝试参数推荐和 PreviewStack；如果 VpcId/VSwitchId/SecurityGroupId 无法自动补齐，PreviewStack 不是硬门禁，不要直接终止。可用 ZoneId、InstanceType、ImageId、SystemDiskCategory 等当前可询价参数调用 ros_estimate_template_cost，并在 conclusion.missing_deployment_parameters 中列出仍需用户通过选择阶段 parameter_overrides 补充的完整部署参数缺口",
       "assertions": [
         {"name": "preview_is_soft_gate", "check": "明确说明 PreviewStack 不是硬门禁，不能仅因完整部署参数暂缺就停止询价"},
-        {"name": "attempts_pricing_with_available_params", "check": "调用 GetTemplateEstimateCost，用当前已选或可用于询价的参数估算费用"},
+        {"name": "attempts_pricing_with_available_params", "check": "调用 ros_estimate_template_cost，用当前已选或可用于询价的参数估算费用"},
         {"name": "reports_missing_deployment_parameters", "check": "conclusion.missing_deployment_parameters 包含 VpcId、VSwitchId、SecurityGroupId 等缺口"},
         {"name": "outputs_partial_deployment_parameters", "check": "conclusion.deployment_parameters 保留已用于询价的 ZoneId、InstanceType、ImageId、SystemDiskCategory"},
         {"name": "mentions_later_overrides", "check": "说明用户后续可在选择阶段通过 parameter_overrides 补充缺失参数"}
@@ -130,8 +130,8 @@
       },
       "expected_behavior": "正确处理多资源模板，费用明细包含 ECS（x2）和 SLB",
       "assertions": [
-        {"name": "uses_preview_stack_api", "check": "PreviewStack 通过 aliyun_api(product=\"ros\", action=\"PreviewStack\") 调用，不使用 ros_stack"},
-        {"name": "uses_estimate_cost_api", "check": "调用了 GetTemplateEstimateCost API"},
+        {"name": "uses_preview_stack_tool", "check": "PreviewStack 通过 ros_preview_template 调用，不使用 ros_stack"},
+        {"name": "uses_estimate_cost_tool", "check": "调用了 ros_estimate_template_cost"},
         {"name": "includes_ecs_and_slb", "check": "费用明细中包含 ECS 和 SLB 的费用"},
         {"name": "ecs_count_reflected", "check": "ECS 费用描述中体现了 2 台实例（MaxAmount=2）"},
         {"name": "no_terraform", "check": "整个过程不涉及 Terraform 相关内容"}

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/references
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/references
@@ -1,1 +1,1 @@
-../../../../skills/bundled/iac_aliyun/references
+../../references

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -63,13 +63,15 @@ conclusion_schema:
 - 删除请求本身不等于删除确认。只有用户明确回复“确认删除”“我确认删除”等删除确认语句，或上下文显式提供 `delete_confirmed: true` 时，才可执行删除；未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`。
 - `status: cancelled` 只表示用户明确取消部署，不得用 status: cancelled 表示等待用户确认。
 
-## 模板校验
+## 快速创建与模板校验
 
-部署前必须校验模板文件。调用 `ros_validate_template` 校验，`template_url` 使用当前步骤 prompt 中已选定的具体模板文件路径；已有具体地域时传 `region_id`，否则使用工具默认地域。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口。校验失败时分析错误原因，查 GetResourceType Schema（如需），修复模板文件后重试（最多 5 轮）。模板文件会被后续步骤依赖，必须确保其内容正确后再继续。
+- `selected_plan.preview_ready_for_create` 为 `true` 时，表示成本步骤已对同一模板路径完成预览验证，且没有完整部署参数缺口；部署时直接调用 `ros_stack` 执行 `CreateStack`，跳过例行 `ros_validate_template`，并跳过例行可用性查询。用户覆盖后的最终部署参数由 CreateStack 做最终校验。
+- 否则，部署前必须校验模板文件。调用 `ros_validate_template` 校验，`template_url` 使用当前步骤 prompt 中已选定的具体模板文件路径；已有具体地域时传 `region_id`，否则使用工具默认地域。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口。校验失败时分析错误原因，查 GetResourceType Schema（如需），修复模板文件后重试（最多 5 轮）。模板文件会被后续步骤依赖，必须确保其内容正确后再继续。
+- CreateStack 失败后，如果需要修改模板，成本步骤的预览验证已失效；修复后必须重新调用 `ros_validate_template`，通过后再 ContinueCreateStack 或重试。只调整部署参数时，不需要为了参数变化补跑 `ros_validate_template`；最终参数由 CreateStack 校验。
 
 ## 可用性查询
 
-当用户确认执行以下操作时，**必须先查询可用性**：
+快速创建路径已跳过例行可用性查询。其他情况下，当用户确认执行以下操作时，**必须先查询可用性**：
 
 | 操作 | 查询范围 |
 |------|----------|

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: iac-aliyun-deploying
-description: 阿里云 ROS 模板部署技能，负责可用性查询、执行部署/更新/删除/继续创建等 Stack 操作
-when_to_use: 当用户确认部署 ROS 模板、更新 Stack、删除 Stack 时
+description: 阿里云 ROS 模板部署技能，负责可用性查询、执行部署与失败恢复
+when_to_use: 当用户确认部署 ROS 模板时
 user_invocable: false
 conclusion_schema:
   type: object
@@ -43,7 +43,7 @@ conclusion_schema:
 
 # 阿里云 ROS 部署技能
 
-负责将 ROS 模板部署到阿里云，包括可用性查询和 Stack 生命周期管理。
+负责将 ROS 模板部署到阿里云，包括可用性查询和部署失败恢复。
 
 ## 地域
 
@@ -59,15 +59,15 @@ conclusion_schema:
 写操作必须有用户确认，但确认来源可以是上层 pipeline：
 - 当 pipeline prompt 明确说明用户已确认选择/部署时，表示 pipeline 已完成部署确认，不要再次请求用户确认。
 - 在已确认的 pipeline 部署步骤中，可展示将使用的 VPC、可用区、网段、Stack 名等参数摘要，但展示后必须继续执行部署，不要询问“是否确认部署”或“是否确认部署参数”。
-- 仅当本技能被用户直接触发，或删除/更新等高风险操作没有上层确认时，才需要先询问用户确认；删除/更新操作使用 ⚠️ 警告措辞。
-- 删除请求本身不等于删除确认。只有用户明确回复“确认删除”“我确认删除”等删除确认语句，或上下文显式提供 `delete_confirmed: true` 时，才可执行删除；未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`。
+- 仅当本技能被用户直接触发，或更新等高风险操作没有上层确认时，才需要先询问用户确认；更新操作使用 ⚠️ 警告措辞。
+- 本步骤通过 `ros_deploy` 恢复失败部署。`delete_and_create` 只允许删除本步骤创建的失败 Stack；非本步骤创建的 Stack（例如通过 ListStacks 查到的 Stack）不得删除。如用户请求删除其他 Stack，必须另走明确“确认删除”的删除流程，不得在本步骤执行。
 - `status: cancelled` 只表示用户明确取消部署，不得用 status: cancelled 表示等待用户确认。
 
 ## 快速创建与模板校验
 
-- `selected_plan.preview_ready_for_create` 为 `true` 时，表示成本步骤已对同一模板路径完成预览验证，且没有完整部署参数缺口；部署时直接调用 `ros_stack` 执行 `CreateStack`，跳过例行 `ros_validate_template`，并跳过例行可用性查询。用户覆盖后的最终部署参数由 CreateStack 做最终校验。
-- 否则，部署前必须校验模板文件。调用 `ros_validate_template` 校验，`template_url` 使用当前步骤 prompt 中已选定的具体模板文件路径；已有具体地域时传 `region_id`，否则使用工具默认地域。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口。校验失败时分析错误原因，查 GetResourceType Schema（如需），修复模板文件后重试（最多 5 轮）。模板文件会被后续步骤依赖，必须确保其内容正确后再继续。
-- CreateStack 失败后，如果需要修改模板，成本步骤的预览验证已失效；修复后必须重新调用 `ros_validate_template`，通过后再 ContinueCreateStack 或重试。只调整部署参数时，不需要为了参数变化补跑 `ros_validate_template`；最终参数由 CreateStack 校验。
+- `selected_plan.preview_ready_for_create` 为 `true` 时，表示成本步骤已对同一模板路径完成预览验证，且没有完整部署参数缺口；部署时直接调用 `ros_deploy` 的 `create`，跳过例行 `ros_validate_template`，并跳过例行可用性查询。用户覆盖后的最终部署参数由 `ros_deploy` 的部署调用做最终校验。
+- 否则，部署前必须校验模板文件。调用 `ros_validate_template` 校验，`template_url` 使用当前步骤 prompt 中已选定的具体模板文件路径；已有具体地域时传 `region_id`，否则使用工具默认地域。不要通过 `aliyun_api` 调用 ROS 模板校验或部署生命周期接口。校验失败时分析错误原因，查 GetResourceType Schema（如需），修复模板文件后重试（最多 5 轮）。模板文件会被后续步骤依赖，必须确保其内容正确后再继续。
+- `ros_deploy` 的 `create` 失败后，如果需要修改模板，成本步骤的预览验证已失效；修复后必须重新调用 `ros_validate_template`，通过后再调用 `ros_deploy` 的 `continue_create`。只调整部署参数时，不需要为了参数变化补跑 `ros_validate_template`；最终参数由 `ros_deploy` 的部署调用校验。
 
 ## 可用性查询
 
@@ -75,9 +75,9 @@ conclusion_schema:
 
 | 操作 | 查询范围 |
 |------|----------|
-| CreateStack | 全量查询所有库存相关 Parameters |
-| ContinueCreateStack | 查询失败资源相关的 Parameters |
-| UpdateStack | 查询变更涉及的 Parameters |
+| ros_deploy create | 全量查询所有库存相关 Parameters |
+| ros_deploy continue_create | 查询失败资源相关的 Parameters |
+| ros_deploy delete_and_create | 按替代创建参数全量查询库存相关 Parameters |
 
 查询步骤：
 1. 解析模板 Parameters，识别库存相关参数及对应产品
@@ -89,35 +89,44 @@ conclusion_schema:
 
 ## 部署参数装配
 
-CreateStack 前按以下优先级确定 `Parameters`：
+调用 `ros_deploy` 的 `create` 前按以下优先级确定 `parameters`：
 
 1. `selected_plan.effective_deployment_parameters` 非空时，直接作为最终部署参数集。
 2. 否则使用 `selected_plan.selected_candidate_result.cost.deployment_parameters`。
 3. 仍缺少模板必填参数时，使用模板 Default 或上下文已有值补足；无法补足时返回 `status: failed` 或通过 rollback_request 回到 `confirm_and_select`。
 
-装配参数时不得改写模板 `Default`，不得编造缺失的外部输入（LicenseKey、Token、证书、真实域名、已有资源 ID、VpcId、VSwitchId、SecurityGroupId、KeyPairName 等）。参数不可用或 CreateStack 无法成功时，优先调整非用户指定参数；仍无法成功创建资源栈时，才可调整用户指定参数。部署步骤不计算费用。
+装配参数时不得改写模板 `Default`，不得编造缺失的外部输入（LicenseKey、Token、证书、真实域名、已有资源 ID、VpcId、VSwitchId、SecurityGroupId、KeyPairName 等）。参数不可用或部署调用无法成功时，优先调整非用户指定参数；仍无法成功创建资源栈时，才可调整用户指定参数。部署步骤不计算费用。
 
 ## StackName
 
-新建 Stack 时，一开始就确定唯一 `StackName`，并传给 `CreateStack`。`StackName` 使用方案或服务简名作为前缀，并追加时间或 6 位小写字母/数字随机串后缀（如 `ai-app-20260623-a1b2c3`），避免重名。
+新建 Stack 时，一开始就确定唯一 `StackName`，并作为 `stack_name` 传给 `ros_deploy` 的 `create`。`StackName` 使用方案或服务简名作为前缀，并追加时间或 6 位小写字母/数字随机串后缀（如 `ai-app-20260623-a1b2c3`），避免重名。
 
-- CreateStack 必须传 StackName，不要省略，不要使用容易重复的固定名称。
-- `UpdateStack`、`ContinueCreateStack`、`DeleteStack` 面向已有 Stack 时，使用上下文中的现有 Stack 标识，不要生成新的 StackName。
+- `ros_deploy` 的 `create` 必须传 `stack_name`，不要省略，不要使用容易重复的固定名称。
+- `ros_deploy` 的 `continue_create` 面向已有失败 Stack 时，使用 `create` 失败结果中的 Stack 标识，不要生成新的 StackName。
+- `ros_deploy` 的 `delete_and_create` 面向已有失败 Stack 时，`stack_id` 使用旧失败 Stack 标识；`stack_name` 使用替代创建目标的名称。
 
 ## 执行部署
 
-- 使用 ros_stack 工具执行 CreateStack/UpdateStack/ContinueCreateStack/DeleteStack，禁止用 Bash
-- CreateStack 必须传 `DisableRollback: true`
-- CreateStack 使用装配后的 `Parameters` 字典；不要手动展开为 `Parameters.N.ParameterKey`
+- 使用 `ros_deploy` 工具执行 `create` / `continue_create` / `delete_and_create`，禁止用 Bash
+- `ros_deploy` 的 `create` 会使用 `DisableRollback: true`
+- `ros_deploy` 使用装配后的 `parameters` 字典；不要手动展开为 `Parameters.N.ParameterKey`
 
-> **TemplateURL 支持本地文件路径**：ros_stack 中 TemplateURL 可传本地文件路径（如 `/tmp/template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
+> **template_url 支持本地文件路径**：`ros_deploy` 中 `template_url` 可传本地文件路径（如 `/tmp/template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
 
 ## 错误处理
 
 ### 部署失败
 分析错误原因：
 - 权限/配额 → 告知用户处理
-- 模板/参数 → 修复后 ContinueCreateStack（不重新 CreateStack）
+- 模板/参数 → 修复后调用 `ros_deploy` 的 `continue_create`
+- `continue_create` 返回 `ContinueCreateStackValidationFailed` → 告知用户需要重建本步骤创建的失败 Stack，再调用 `ros_deploy` 的 `delete_and_create`
+
+### 删除并重建
+仅在 `continue_create` 返回 `ContinueCreateStackValidationFailed` 后使用 `delete_and_create`。调用时：
+- `stack_id` 指向本步骤创建的旧失败 Stack，不得使用通过查询发现的其他 Stack
+- `stack_name`、`template_url`、`parameters`、`region_id` 使用替代创建目标
+- 工具会先确认替代创建参数和模板可用，再删除旧失败 Stack 后创建新的 Stack
+- 成功后最终结果使用新 Stack 的 `stack_id`，不要把旧 `stack_id` 当成部署成功结果
 
 ## 资源和文档搜索
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -65,7 +65,7 @@ conclusion_schema:
 
 ## 模板校验
 
-部署前必须校验模板文件。调用 aliyun_api(product="ros", action="ValidateTemplate", params={"TemplateURL": <模板文件路径>}) 校验。校验失败时分析错误原因，查 GetResourceType Schema（如需），修复模板文件后重试（最多 5 轮）。模板文件会被后续步骤依赖，必须确保其内容正确后再继续。
+部署前必须校验模板文件。调用 `ros_validate_template` 校验，`template_url` 使用当前步骤 prompt 中已选定的具体模板文件路径；已有具体地域时传 `region_id`，否则使用工具默认地域。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口。校验失败时分析错误原因，查 GetResourceType Schema（如需），修复模板文件后重试（最多 5 轮）。模板文件会被后续步骤依赖，必须确保其内容正确后再继续。
 
 ## 可用性查询
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
@@ -18,10 +18,10 @@
           "SystemDiskCategory": "cloud_essd"
         }
       },
-      "expected_behavior": "使用 ros_stack 工具 CreateStack，传入 DisableRollback: true，部署前向用户确认",
+      "expected_behavior": "使用 ros_deploy 工具 create，工具内部使用 DisableRollback: true，部署前向用户确认",
       "assertions": [
-        {"name": "uses_ros_stack", "check": "调用了 ros_stack 工具而非 aliyun_api 或 bash"},
-        {"name": "disable_rollback", "check": "CreateStack 参数中包含 DisableRollback: true"},
+        {"name": "uses_ros_deploy", "check": "调用了 ros_deploy 工具而非 ros_stack、aliyun_api 或 bash"},
+        {"name": "uses_create_action", "check": "ros_deploy action 为 create"},
         {"name": "user_confirmation", "check": "部署前向用户展示了确认信息"},
         {"name": "no_terraform", "check": "不包含 terraform init/apply 等 Terraform CLI 步骤"}
       ]
@@ -63,11 +63,11 @@
         "stack_status": "CREATE_FAILED",
         "status_reason": "The resource ALIYUN::ECS::InstanceGroup is CREATE_FAILED: InstanceType ecs.g7.large is out of stock in zone cn-hangzhou-h"
       },
-      "expected_behavior": "分析错误，重新查询可用性换可用区，使用 ContinueCreateStack 而非重新 CreateStack",
+      "expected_behavior": "分析错误，重新查询可用性换可用区，使用 ros_deploy 的 continue_create 而非直接重新 create",
       "assertions": [
-        {"name": "uses_continue_create", "check": "使用 ContinueCreateStack 而非重新 CreateStack"},
+        {"name": "uses_continue_create", "check": "使用 ros_deploy 的 continue_create"},
         {"name": "re_queries_availability", "check": "重新查询了可用区的 ECS 库存"},
-        {"name": "no_delete_and_recreate", "check": "不删除原 Stack 再重建"}
+        {"name": "no_delete_and_recreate", "check": "未收到 ContinueCreateStackValidationFailed 前不使用 delete_and_create"}
       ]
     },
     {
@@ -83,10 +83,10 @@
           "InstanceType": "ecs.g7.xlarge"
         }
       },
-      "expected_behavior": "使用 ⚠️ 警告措辞确认更新操作，查询变更涉及参数的可用性后执行 UpdateStack",
+      "expected_behavior": "部署步骤不处理更新已有 Stack；告知用户该步骤只处理所选方案部署",
       "assertions": [
-        {"name": "warning_before_update", "check": "使用了警告措辞（⚠️ 或「注意」等）提醒用户更新操作的影响"},
-        {"name": "uses_update_stack", "check": "调用 ros_stack 的 UpdateStack 操作"}
+        {"name": "no_update_stack", "check": "不调用 UpdateStack"},
+        {"name": "reports_scope", "check": "说明当前部署步骤只处理所选方案部署"}
       ]
     },
     {
@@ -98,11 +98,11 @@
         "region": "cn-hangzhou",
         "stack_id": "stack-to-delete-456"
       },
-      "expected_behavior": "使用 ⚠️ 警告措辞强调删除不可逆，等待用户明确确认；未确认前不调用 ros_stack DeleteStack",
+      "expected_behavior": "部署步骤不删除非本步骤创建的 Stack；告知用户需要走明确删除流程",
       "assertions": [
-        {"name": "deletion_warning", "check": "使用了 ⚠️ 警告措辞强调删除操作不可逆"},
-        {"name": "user_confirmation", "check": "等待用户明确确认后才执行删除"},
-        {"name": "no_delete_without_confirmation", "check": "未收到明确确认前不调用 ros_stack 的 DeleteStack 操作"}
+        {"name": "no_delete_stack", "check": "不调用 DeleteStack"},
+        {"name": "no_delete_and_create", "check": "不调用 ros_deploy 的 delete_and_create"},
+        {"name": "reports_scope", "check": "说明非本步骤创建的 Stack 不得在部署步骤删除"}
       ]
     },
     {
@@ -180,11 +180,11 @@
         "stack_id": "stack-to-delete-456",
         "delete_confirmed": true
       },
-      "expected_behavior": "用户已明确确认删除后，使用 ros_stack DeleteStack 执行删除，并报告删除请求已提交",
+      "expected_behavior": "即使用户确认删除，部署步骤也不删除非本步骤创建的 Stack；告知用户需要走明确删除流程",
       "assertions": [
-        {"name": "deletion_warning", "check": "使用了 ⚠️ 警告措辞强调删除操作不可逆"},
-        {"name": "uses_delete_stack", "check": "调用 ros_stack 的 DeleteStack 操作"},
-        {"name": "completed_success", "check": "调用 complete_step 且 status 为 success"}
+        {"name": "no_delete_stack", "check": "不调用 DeleteStack"},
+        {"name": "no_delete_and_create", "check": "不调用 ros_deploy 的 delete_and_create"},
+        {"name": "reports_scope", "check": "说明当前部署步骤不能删除非本步骤创建的 Stack"}
       ]
     },
     {
@@ -216,12 +216,12 @@
           }
         }
       },
-      "expected_behavior": "selected_plan.preview_ready_for_create 为 true 时，直接调用 ros_stack CreateStack，跳过例行 ros_validate_template 和跳过例行可用性查询",
+      "expected_behavior": "selected_plan.preview_ready_for_create 为 true 时，直接调用 ros_deploy create，跳过例行 ros_validate_template 和跳过例行可用性查询",
       "assertions": [
-        {"name": "uses_direct_create_stack", "check": "直接调用 ros_stack 的 CreateStack"},
+        {"name": "uses_direct_create_stack", "check": "直接调用 ros_deploy 的 create"},
         {"name": "skips_routine_validation", "check": "跳过例行 ros_validate_template"},
         {"name": "skips_routine_availability_query", "check": "跳过例行可用性查询"},
-        {"name": "uses_template_url", "check": "CreateStack 参数中使用 params.TemplateURL，不使用 params.TemplateBody"}
+        {"name": "uses_template_url", "check": "ros_deploy 参数中使用 template_url，不使用 TemplateBody"}
       ]
     }
   ]

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
@@ -186,6 +186,43 @@
         {"name": "uses_delete_stack", "check": "调用 ros_stack 的 DeleteStack 操作"},
         {"name": "completed_success", "check": "调用 complete_step 且 status 为 success"}
       ]
+    },
+    {
+      "id": 10,
+      "name": "create-stack-preview-ready-fast-path",
+      "prompt": "确认部署该方案到阿里云",
+      "selected_plan": {
+        "selection_valid": true,
+        "template_url": "{TMPDIR}/ros-vpc-ecs-template.yml",
+        "preview_ready_for_create": true,
+        "effective_deployment_parameters": {
+          "ZoneId": "cn-hangzhou-k",
+          "InstanceType": "ecs.g7.large",
+          "ImageId": "centos_stream_9_x64_20G_alibase_20260414.vhd",
+          "SystemDiskCategory": "cloud_essd"
+        },
+        "selected_candidate_result": {
+          "cost": {
+            "preview_validation": {
+              "succeeded": true,
+              "template_url": "{TMPDIR}/ros-vpc-ecs-template.yml",
+              "parameters": {
+                "ZoneId": "cn-hangzhou-k",
+                "InstanceType": "ecs.g7.large",
+                "ImageId": "centos_stream_9_x64_20G_alibase_20260414.vhd",
+                "SystemDiskCategory": "cloud_essd"
+              }
+            }
+          }
+        }
+      },
+      "expected_behavior": "selected_plan.preview_ready_for_create 为 true 时，直接调用 ros_stack CreateStack，跳过例行 ros_validate_template 和跳过例行可用性查询",
+      "assertions": [
+        {"name": "uses_direct_create_stack", "check": "直接调用 ros_stack 的 CreateStack"},
+        {"name": "skips_routine_validation", "check": "跳过例行 ros_validate_template"},
+        {"name": "skips_routine_availability_query", "check": "跳过例行可用性查询"},
+        {"name": "uses_template_url", "check": "CreateStack 参数中使用 params.TemplateURL，不使用 params.TemplateBody"}
+      ]
     }
   ]
 }

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
@@ -162,11 +162,11 @@
         },
         "validation_error": "Property VpcName is invalid: the value length must be 2~128"
       },
-      "expected_behavior": "先调用 ValidateTemplate 校验模板，发现错误后修复模板文件并重新校验，通过后再继续部署流程",
+      "expected_behavior": "先调用 ros_validate_template 校验模板，发现错误后修复模板文件并重新校验，通过后再继续部署流程",
       "assertions": [
-        {"name": "calls_validate_template", "check": "调用了 aliyun_api ValidateTemplate 校验模板"},
+        {"name": "calls_validate_template", "check": "调用了 ros_validate_template 校验模板"},
         {"name": "fixes_template_file", "check": "发现校验错误后修复了模板文件内容"},
-        {"name": "re_validates_after_fix", "check": "修复后重新调用 ValidateTemplate 确认通过"},
+        {"name": "re_validates_after_fix", "check": "修复后重新调用 ros_validate_template 确认通过"},
         {"name": "deploys_after_validation", "check": "校验通过后才继续执行部署流程"}
       ]
     },

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/references
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/references
@@ -1,1 +1,1 @@
-../../../../skills/bundled/iac_aliyun/references
+../../references

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-review/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-review/SKILL.md
@@ -56,7 +56,7 @@ conclusion_schema:
 4. **模板正确性**
    - 资源依赖是否正确（DependsOn）
    - 引用的可用区是否存在于目标地域
-   - 模板语法是否合法（可通过 `aliyun_api` 调用 ROS `ValidateTemplate` 校验）
+   - 模板语法是否合法（可通过 `ros_validate_template` 校验）
 
 ## 行为规则
 
@@ -67,7 +67,7 @@ conclusion_schema:
 
 ## 可选工具使用
 
-- 可调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口校验模板语法
+- 可调用 `ros_validate_template` 校验模板语法
 - 不需要调用其他工具
 
 ## 输出

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -41,11 +41,11 @@ conclusion_schema:
 2. 查阅 [references/cloud-products/](references/cloud-products/) 下对应产品文件，了解选型策略和库存相关属性
 3. **必须**阅读 [references/ros-template.md](references/ros-template.md)，了解 ROS 模板最佳实践，未阅读不得生成模板
 4. 生成 ROS YAML 模板（库存相关属性按 [references/cloud-products/](references/cloud-products/) 与 [references/template-parameters.md](references/template-parameters.md) 定义为 Parameters，所有 Parameters 必须添加 AssociationProperty）并写入文件
-5. 调用 aliyun_api(product="ros", action="ValidateTemplate", params={"TemplateURL": <模板文件路径>}) 校验
+5. 调用 `ros_validate_template` 校验；`template_url` 使用刚写入的模板文件路径，已有具体地域时传 `region_id`，否则使用工具默认地域
 6. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
 7. 校验通过 → 完成
 
-> **TemplateURL 支持本地文件路径**：aliyun_api（product=ros）中，TemplateURL 可传本地文件路径（如 `/tmp/template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
+> **模板路径支持本地文件**：`ros_validate_template` 的 `template_url` 可传本地文件路径（如 `/tmp/template.yml`）。避免将大模板内容直接作为参数传递。
 
 ## 资源生命周期约束
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/references
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/references
@@ -1,1 +1,1 @@
-../../../../skills/bundled/iac_aliyun/references
+../../references

--- a/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+++ b/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
@@ -1,0 +1,558 @@
+"""Selling pipeline ROS deployment orchestration tool."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from iac_code.i18n import _
+from iac_code.services.permissions.rule_scope import scope_for_rule_source
+from iac_code.tools.base import Tool, ToolContext, ToolResult
+from iac_code.tools.cloud.aliyun.ros_stack import RosStack
+from iac_code.tools.cloud.aliyun.template_source import is_remote_template_url
+from iac_code.tools.path_safety import check_read_path, resolve_read_path
+from iac_code.types.permissions import (
+    PermissionAuditMetadata,
+    PermissionDecisionReason,
+    PermissionResult,
+    PermissionRuleValue,
+    ToolPermissionContext,
+)
+
+_OWNED_STACKS_KEY = "ros_deploy_owned_stack_ids"
+_ACTIONS = ("create", "continue_create", "delete_and_create")
+_SAFE_RULE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,255}$")
+_RULE_SOURCE_ORDER = {
+    "cli_arg": 5,
+    "session": 4,
+    "local_settings": 3,
+    "project_settings": 2,
+    "user_settings": 1,
+}
+
+
+def _json_object(value: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _string_value(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _safe_rule_segment(value: str) -> bool:
+    return bool(_SAFE_RULE_SEGMENT.fullmatch(value))
+
+
+def _parse_rule(rule: str) -> tuple[str, str] | None:
+    prefix = "ros_deploy("
+    if not rule.startswith(prefix) or not rule.endswith(")"):
+        return None
+    inner = rule[len(prefix) : -1]
+    if inner.count(":") != 1:
+        return None
+    action, target = inner.split(":", 1)
+    if action not in _ACTIONS:
+        return None
+    if not _safe_rule_segment(target):
+        return None
+    return action, target
+
+
+class RosDeployTool(Tool):
+    """Deploy and recover ROS stacks for the selling pipeline."""
+
+    def __init__(self, completion_guard_state: dict[str, Any] | None = None) -> None:
+        self._completion_guard_state = completion_guard_state if completion_guard_state is not None else {}
+
+    @property
+    def name(self) -> str:
+        return "ros_deploy"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Deploy a ROS template in the selling pipeline. Use create for the initial stack, continue_create for "
+            "failed stacks created by this step, and delete_and_create only after ContinueCreateStackValidationFailed."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": list(_ACTIONS),
+                    "description": "Deployment action to perform.",
+                },
+                "stack_name": {
+                    "type": "string",
+                    "description": "StackName for create and delete_and_create.",
+                },
+                "stack_id": {
+                    "type": "string",
+                    "description": "Failed stack ID for continue_create or delete_and_create.",
+                },
+                "template_url": {
+                    "type": "string",
+                    "description": "Local file path, OSS URL, or HTTP(S) URL for the ROS template.",
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "Template parameters as a plain key/value object.",
+                    "propertyNames": {"not": {"pattern": r"^Parameters\."}},
+                },
+                "region_id": {
+                    "type": "string",
+                    "description": "Alibaba Cloud region ID. Defaults to the configured region.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        }
+
+    @property
+    def supports_blanket_allow(self) -> bool:
+        return False
+
+    def user_facing_name(self, input: dict | None = None) -> str:
+        return _("ROS Deploy")
+
+    def render_tool_use_message(self, input: dict, *, verbose: bool = False) -> str | None:
+        action = _string_value(input.get("action"))
+        target = self._rule_target(input)
+        return " ".join(part for part in (action, target) if part)
+
+    def render_tool_result_message(self, output: str, *, is_error: bool = False, verbose: bool = False) -> str | None:
+        parsed = _json_object(output)
+        if is_error and parsed is not None and parsed.get("error_code"):
+            message = _string_value(parsed.get("message"))
+            recommended_action = _string_value(parsed.get("recommended_action"))
+            detail = _string_value(parsed.get("error_code"))
+            if recommended_action:
+                detail = _("{error_code}; recommended action: {action}").format(
+                    error_code=detail,
+                    action=recommended_action,
+                )
+            if message:
+                detail = f"{detail}: {message}"
+            return detail
+        return RosStack().render_tool_result_message(output, is_error=is_error, verbose=verbose)
+
+    def needs_event_queue(self) -> bool:
+        return True
+
+    def is_concurrency_safe(self, tool_input: dict[str, Any]) -> bool:
+        return False
+
+    def is_destructive(self, input: dict | None = None) -> bool:
+        return True
+
+    def _new_stack_tool(self) -> RosStack:
+        return RosStack()
+
+    def _owned_stacks(self) -> dict[str, Any]:
+        stacks = self._completion_guard_state.setdefault(_OWNED_STACKS_KEY, {})
+        if not isinstance(stacks, dict):
+            stacks = {}
+            self._completion_guard_state[_OWNED_STACKS_KEY] = stacks
+        return stacks
+
+    def _record_owned_stack(self, stack_id: str, *, action: str) -> None:
+        if not stack_id:
+            return
+        self._owned_stacks()[stack_id] = {"action": action}
+
+    def _is_owned_stack(self, stack_id: str) -> bool:
+        return bool(stack_id and stack_id in self._owned_stacks())
+
+    def _rule_target(self, input: dict) -> str:
+        action = _string_value(input.get("action"))
+        if action == "create":
+            return _string_value(input.get("stack_name"))
+        if action in {"continue_create", "delete_and_create"}:
+            return _string_value(input.get("stack_id"))
+        return ""
+
+    def _rule_content(self, input: dict) -> str | None:
+        action = _string_value(input.get("action"))
+        target = self._rule_target(input)
+        if action not in _ACTIONS or not _safe_rule_segment(target):
+            return None
+        return f"{action}:{target}"
+
+    def _rule_display_text(self, input: dict) -> str | None:
+        action = _string_value(input.get("action"))
+        target = self._rule_target(input)
+        if action not in _ACTIONS or not _safe_rule_segment(target):
+            return None
+        if action == "create":
+            return _("Create ROS stack: {target}").format(target=target)
+        if action == "continue_create":
+            return _("Continue ROS stack creation: {target}").format(target=target)
+        return _("Delete failed ROS stack and create replacement: {target}").format(target=target)
+
+    def _operation_metadata(self, input: dict) -> dict[str, object]:
+        operation: dict[str, object] = {}
+        action = _string_value(input.get("action"))
+        target = self._rule_target(input)
+        region = _string_value(input.get("region_id"))
+        if action:
+            operation["action"] = action
+        if target and _safe_rule_segment(target):
+            operation["stack_id" if action != "create" else "stack_name"] = target
+        if region and _safe_rule_segment(region):
+            operation["region"] = region
+        return operation
+
+    def _audit(
+        self,
+        input: dict,
+        *,
+        scope: str,
+        rule_source: str | None = None,
+        rule: str | None = None,
+        reason: PermissionDecisionReason | None = None,
+    ) -> PermissionAuditMetadata:
+        return PermissionAuditMetadata(
+            scope=scope,
+            source="permission_pipeline",
+            rule_source=rule_source,
+            rule=rule,
+            reason_type=reason.type if reason else None,
+            reason_detail=reason.detail if reason else None,
+            is_read_only=False,
+            operation=self._operation_metadata(input),
+        )
+
+    def _local_template_url_permission_error(
+        self,
+        input: dict,
+        context: ToolPermissionContext,
+    ) -> PermissionResult | None:
+        template_url = _string_value(input.get("template_url"))
+        if not template_url or is_remote_template_url(template_url):
+            return None
+
+        decision = check_read_path(
+            template_url,
+            cwd=context.cwd or ".",
+            additional_directories=context.additional_directories,
+            trusted_read_directories=context.trusted_read_directories,
+            relative_read_directories=context.relative_read_directories,
+        )
+        if decision.behavior == "allow":
+            return None
+
+        permission = decision.to_permission_result()
+        suggestions = None
+        if rule_content := self._rule_content(input):
+            suggestions = [
+                PermissionRuleValue(
+                    tool_name=self.name,
+                    rule_content=rule_content,
+                    display_text=self._rule_display_text(input),
+                )
+            ]
+        return PermissionResult(
+            behavior=permission.behavior,
+            message=permission.message,
+            reason=permission.reason,
+            suggestions=suggestions,
+            audit=self._audit(input, scope="once", reason=permission.reason),
+        )
+
+    def _matching_rule(self, input: dict, rules_by_source: dict[str, list[str]]) -> tuple[str, str] | None:
+        action = _string_value(input.get("action"))
+        target = self._rule_target(input)
+        if action not in _ACTIONS or not _safe_rule_segment(target):
+            return None
+
+        best: tuple[tuple[int, int], str, str] | None = None
+        for source, rules in rules_by_source.items():
+            for index, rule in enumerate(rules):
+                parsed = _parse_rule(rule)
+                if parsed is None:
+                    continue
+                action_pattern, target_pattern = parsed
+                if action_pattern != action:
+                    continue
+                if not fnmatch.fnmatchcase(target, target_pattern):
+                    continue
+                score = (_RULE_SOURCE_ORDER.get(source, 0), -index)
+                rule_content = f"{action_pattern}:{target_pattern}"
+                if best is None or score > best[0]:
+                    best = (score, source, rule_content)
+        if best is None:
+            return None
+        return best[1], best[2]
+
+    def _unowned_stack_permission_error(self, input: dict) -> PermissionResult | None:
+        action = _string_value(input.get("action"))
+        if action not in {"continue_create", "delete_and_create"}:
+            return None
+        stack_id = _string_value(input.get("stack_id"))
+        if self._is_owned_stack(stack_id):
+            return None
+        reason = PermissionDecisionReason(
+            type="unowned_ros_stack",
+            detail="stack was not created by the current selling deployment step",
+        )
+        message = _("ROS stack {stack_id} was not created by the current selling deployment step.").format(
+            stack_id=stack_id or "<missing>"
+        )
+        return PermissionResult(
+            behavior="deny",
+            message=message,
+            reason=reason,
+            audit=self._audit(input, scope="once", reason=reason),
+        )
+
+    async def check_permissions(self, input: dict, context=None) -> PermissionResult:
+        if not isinstance(context, ToolPermissionContext):
+            context = ToolPermissionContext(cwd=context.get("cwd", "") if isinstance(context, dict) else "")
+
+        if unowned := self._unowned_stack_permission_error(input):
+            return unowned
+
+        for behavior, rules_by_source in (("deny", context.deny_rules),):
+            match = self._matching_rule(input, rules_by_source)
+            if match is None:
+                continue
+            rule_source, rule = match
+            detail = _("matched {behavior} rule: {rule}").format(behavior=behavior, rule=rule)
+            reason = PermissionDecisionReason(type="rule", detail=detail)
+            return PermissionResult(
+                behavior=behavior,
+                message=detail,
+                reason=reason,
+                audit=self._audit(
+                    input,
+                    scope=scope_for_rule_source(rule_source),
+                    rule_source=rule_source,
+                    rule=rule,
+                    reason=reason,
+                    ),
+                )
+
+        if template_permission := self._local_template_url_permission_error(input, context):
+            return template_permission
+
+        for behavior, rules_by_source in (("ask", context.ask_rules), ("allow", context.allow_rules)):
+            match = self._matching_rule(input, rules_by_source)
+            if match is None:
+                continue
+            rule_source, rule = match
+            detail = _("matched {behavior} rule: {rule}").format(behavior=behavior, rule=rule)
+            reason = PermissionDecisionReason(type="rule", detail=detail)
+            return PermissionResult(
+                behavior=behavior,
+                message=detail,
+                reason=reason,
+                audit=self._audit(
+                    input,
+                    scope=scope_for_rule_source(rule_source),
+                    rule_source=rule_source,
+                    rule=rule,
+                    reason=reason,
+                ),
+            )
+
+        reason = PermissionDecisionReason(
+            type="untrusted_write",
+            detail="ROS deployment operation may modify cloud resources",
+        )
+        suggestions = None
+        if rule_content := self._rule_content(input):
+            suggestions = [
+                PermissionRuleValue(
+                    tool_name=self.name,
+                    rule_content=rule_content,
+                    display_text=self._rule_display_text(input),
+                )
+            ]
+        return PermissionResult(
+            behavior="ask",
+            message=_("Allow {}?").format(self.user_facing_name(input)),
+            reason=reason,
+            suggestions=suggestions,
+            audit=self._audit(input, scope="once", reason=reason),
+        )
+
+    @staticmethod
+    def _require(value: str, field_name: str) -> ToolResult | None:
+        if value:
+            return None
+        return ToolResult.error(_("Missing required field: {}").format(field_name))
+
+    @staticmethod
+    def _parameters(input: dict) -> dict[str, Any]:
+        parameters = input.get("parameters")
+        return dict(parameters) if isinstance(parameters, dict) else {}
+
+    @staticmethod
+    def _resolve_template_url(template_url: str, context: ToolContext) -> str:
+        if is_remote_template_url(template_url):
+            return template_url
+        return resolve_read_path(
+            template_url,
+            context.cwd or ".",
+            relative_read_directories=context.relative_read_directories,
+        )
+
+    def _create_stack_input(self, input: dict, context: ToolContext) -> ToolResult | dict[str, Any]:
+        stack_name = _string_value(input.get("stack_name"))
+        template_url = _string_value(input.get("template_url"))
+        if error := self._require(stack_name, "stack_name"):
+            return error
+        if error := self._require(template_url, "template_url"):
+            return error
+        params: dict[str, Any] = {
+            "StackName": stack_name,
+            "DisableRollback": True,
+            "TemplateURL": self._resolve_template_url(template_url, context),
+        }
+        if parameters := self._parameters(input):
+            params["Parameters"] = parameters
+        tool_input: dict[str, Any] = {"action": "CreateStack", "params": params}
+        if region_id := _string_value(input.get("region_id")):
+            tool_input["region_id"] = region_id
+        return tool_input
+
+    def _continue_stack_input(self, input: dict, context: ToolContext) -> ToolResult | dict[str, Any]:
+        stack_id = _string_value(input.get("stack_id"))
+        template_url = _string_value(input.get("template_url"))
+        if error := self._require(stack_id, "stack_id"):
+            return error
+        if error := self._require(template_url, "template_url"):
+            return error
+        if not self._is_owned_stack(stack_id):
+            return ToolResult.error(
+                _("ROS stack {stack_id} was not created by the current selling deployment step.").format(
+                    stack_id=stack_id
+                )
+            )
+        params: dict[str, Any] = {
+            "StackId": stack_id,
+            "Mode": "Recreate",
+            "RecreatingOptions": ["AutoRecreatingResources"],
+            "TemplateURL": self._resolve_template_url(template_url, context),
+        }
+        if parameters := self._parameters(input):
+            params["Parameters"] = parameters
+        tool_input: dict[str, Any] = {"action": "ContinueCreateStack", "params": params}
+        if region_id := _string_value(input.get("region_id")):
+            tool_input["region_id"] = region_id
+        return tool_input
+
+    def _delete_stack_input(self, input: dict) -> ToolResult | dict[str, Any]:
+        stack_id = _string_value(input.get("stack_id"))
+        if error := self._require(stack_id, "stack_id"):
+            return error
+        if not self._is_owned_stack(stack_id):
+            return ToolResult.error(
+                _("ROS stack {stack_id} was not created by the current selling deployment step.").format(
+                    stack_id=stack_id
+                )
+            )
+        tool_input: dict[str, Any] = {"action": "DeleteStack", "params": {"StackId": stack_id}}
+        if region_id := _string_value(input.get("region_id")):
+            tool_input["region_id"] = region_id
+        return tool_input
+
+    @staticmethod
+    def _preflight_local_template(input: dict, context: ToolContext) -> ToolResult | None:
+        template_url = _string_value(input.get("template_url"))
+        if not template_url or is_remote_template_url(template_url):
+            return None
+        try:
+            template_path = resolve_read_path(
+                template_url,
+                context.cwd or ".",
+                relative_read_directories=context.relative_read_directories,
+            )
+            Path(template_path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return ToolResult.error(
+                _("Template file is not readable: {template_url}: {error}").format(
+                    template_url=template_url,
+                    error=str(exc),
+                )
+            )
+        return None
+
+    def _record_result_stack(self, result: ToolResult, *, action: str) -> None:
+        parsed = _json_object(result.content)
+        stack_id = _string_value(parsed.get("stack_id")) if parsed is not None else ""
+        if not stack_id and isinstance(result.metadata, dict):
+            stack_id = _string_value(result.metadata.get("stack_id"))
+        self._record_owned_stack(stack_id, action=action)
+
+    @staticmethod
+    def _continue_validation_failure(result: ToolResult) -> bool:
+        return result.is_error and "ContinueCreateStackValidationFailed" in result.content
+
+    @staticmethod
+    def _continue_validation_failure_result(stack_id: str, content: str) -> ToolResult:
+        return ToolResult.error(
+            json.dumps(
+                {
+                    "stack_id": stack_id,
+                    "error_code": "ContinueCreateStackValidationFailed",
+                    "recommended_action": "delete_and_create",
+                    "message": content,
+                },
+                ensure_ascii=False,
+            )
+        )
+
+    async def _call_stack(self, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+        return await self._new_stack_tool().execute(tool_input=tool_input, context=context)
+
+    async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+        action = _string_value(tool_input.get("action"))
+        if action not in _ACTIONS:
+            return ToolResult.error(_("Invalid action '{}'. Supported actions: {}").format(action, list(_ACTIONS)))
+
+        if action == "create":
+            create_input = self._create_stack_input(tool_input, context)
+            if isinstance(create_input, ToolResult):
+                return create_input
+            result = await self._call_stack(create_input, context)
+            self._record_result_stack(result, action="create")
+            return result
+
+        if action == "continue_create":
+            continue_input = self._continue_stack_input(tool_input, context)
+            if isinstance(continue_input, ToolResult):
+                return continue_input
+            result = await self._call_stack(continue_input, context)
+            if self._continue_validation_failure(result):
+                return self._continue_validation_failure_result(
+                    _string_value(tool_input.get("stack_id")), result.content
+                )
+            self._record_result_stack(result, action="continue_create")
+            return result
+
+        create_input = self._create_stack_input(tool_input, context)
+        if isinstance(create_input, ToolResult):
+            return create_input
+
+        delete_input = self._delete_stack_input(tool_input)
+        if isinstance(delete_input, ToolResult):
+            return delete_input
+        if error := self._preflight_local_template(tool_input, context):
+            return error
+        delete_result = await self._call_stack(delete_input, context)
+        if delete_result.is_error:
+            return delete_result
+        create_result = await self._call_stack(create_input, context)
+        self._record_result_stack(create_result, action="delete_and_create")
+        return create_result

--- a/src/iac_code/pipeline/selling/tools/ros_template_tools.py
+++ b/src/iac_code/pipeline/selling/tools/ros_template_tools.py
@@ -1,0 +1,17 @@
+"""Selling pipeline-local ROS template tools."""
+
+from __future__ import annotations
+
+from iac_code.tools.cloud.aliyun.ros_template_tools import (
+    RosEstimateTemplateCostTool,
+    RosGetTemplateParameterConstraintsTool,
+    RosPreviewTemplateTool,
+    RosValidateTemplateTool,
+)
+
+__all__ = [
+    "RosEstimateTemplateCostTool",
+    "RosGetTemplateParameterConstraintsTool",
+    "RosPreviewTemplateTool",
+    "RosValidateTemplateTool",
+]

--- a/src/iac_code/services/agent_factory.py
+++ b/src/iac_code/services/agent_factory.py
@@ -142,11 +142,25 @@ def create_agent_runtime(options: AgentFactoryOptions) -> AgentRuntime:
 
     notification_queue = NotificationQueue()
 
+    def runtime_provider_display() -> str:
+        try:
+            return provider_manager.get_provider_display()
+        except Exception:
+            return ""
+
+    def runtime_model() -> str:
+        try:
+            return provider_manager.get_model_name()
+        except Exception:
+            return model
+
     def build_base_system_prompt() -> str:
         return build_system_prompt(
             cwd=cwd,
             memory_context=memory_runtime.build_memory_context(),
             current_time=runtime_current_time,
+            provider_display=runtime_provider_display(),
+            model=runtime_model(),
         )
 
     base_system_prompt = build_base_system_prompt()
@@ -294,6 +308,8 @@ def create_agent_runtime(options: AgentFactoryOptions) -> AgentRuntime:
                 memory_context=memory_runtime.build_memory_context(),
                 skill_listing=skill_listing_holder["value"],
                 current_time=runtime_current_time,
+                provider_display=runtime_provider_display(),
+                model=runtime_model(),
             )
 
         agent_loop = AgentLoop(

--- a/src/iac_code/services/permissions/loader.py
+++ b/src/iac_code/services/permissions/loader.py
@@ -252,5 +252,6 @@ def load_permission_context(
         ask_rules=ask_rules,
         additional_directories=additional_directories,
         trusted_read_directories=[],
+        relative_read_directories=[],
         audit_settings=audit_settings,
     )

--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -25,7 +25,11 @@ from iac_code.services.telemetry import add_metric, log_event
 from iac_code.services.telemetry.names import Events, Metrics
 from iac_code.services.telemetry.sanitize import sanitize_error_message
 from iac_code.tools.base import ToolContext, ToolResult
-from iac_code.tools.cloud.aliyun.template_source import reject_template_body_param
+from iac_code.tools.cloud.aliyun.template_source import (
+    is_remote_template_url,
+    reject_pipeline_dedicated_ros_template_action,
+    reject_pipeline_template_source_params,
+)
 from iac_code.tools.cloud.aliyun.user_agent import build_user_agent
 from iac_code.tools.cloud.base_api import BaseCloudApi
 from iac_code.types.permissions import (
@@ -711,10 +715,12 @@ class AliyunApi(BaseCloudApi):
 
         # ROS: TemplateURL as local file path → read into TemplateBody
         if product == "ros":
-            if error := reject_template_body_param(params, pipeline_mode=context.pipeline_mode):
+            if error := reject_pipeline_dedicated_ros_template_action(action, pipeline_mode=context.pipeline_mode):
+                return ToolResult.error(error)
+            if error := reject_pipeline_template_source_params(action, params, pipeline_mode=context.pipeline_mode):
                 return ToolResult.error(error)
             template_url = params.get("TemplateURL", "")
-            if template_url and not template_url.startswith(("http://", "https://", "oss://")):
+            if template_url and not is_remote_template_url(template_url):
                 params["TemplateBody"] = Path(template_url).read_text(encoding="utf-8")
                 del params["TemplateURL"]
 

--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -27,6 +27,7 @@ from iac_code.services.telemetry.sanitize import sanitize_error_message
 from iac_code.tools.base import ToolContext, ToolResult
 from iac_code.tools.cloud.aliyun.template_source import (
     is_remote_template_url,
+    reject_pipeline_dedicated_ros_deployment_action,
     reject_pipeline_dedicated_ros_template_action,
     reject_pipeline_template_source_params,
 )
@@ -716,6 +717,8 @@ class AliyunApi(BaseCloudApi):
         # ROS: TemplateURL as local file path → read into TemplateBody
         if product == "ros":
             if error := reject_pipeline_dedicated_ros_template_action(action, pipeline_mode=context.pipeline_mode):
+                return ToolResult.error(error)
+            if error := reject_pipeline_dedicated_ros_deployment_action(action, pipeline_mode=context.pipeline_mode):
                 return ToolResult.error(error)
             if error := reject_pipeline_template_source_params(action, params, pipeline_mode=context.pipeline_mode):
                 return ToolResult.error(error)

--- a/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+++ b/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
@@ -18,6 +18,10 @@ _RESOURCE_TYPE_CORRECTIONS: dict[str, str] = {
 }
 
 _TERRAFORM_TRANSFORM_PREFIXES = ("Aliyun::Terraform-", "Aliyun::OpenTofu-")
+_EXISTING_VPC_ASSOCIATION_PROPERTIES = {
+    "ALIYUN::ECS::VPC::VPCId",
+    "ALIYUN::VPC::VPCId",
+}
 
 _TEMPLATE_BODY_ACTIONS = [
     "ValidateTemplate",
@@ -94,10 +98,65 @@ def _is_terraform(data: dict) -> bool:
     return any(isinstance(v, str) and v.startswith(_TERRAFORM_TRANSFORM_PREFIXES) for v in values)
 
 
+def _ref_name(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    ref = value.get("Ref")
+    return ref if isinstance(ref, str) and ref else None
+
+
+def _parameter_definition(parameters: dict[str, Any], name: str | None) -> dict[str, Any] | None:
+    if not name:
+        return None
+    parameter = parameters.get(name)
+    return parameter if isinstance(parameter, dict) else None
+
+
+def _is_existing_vpc_parameter(parameters: dict[str, Any], name: str | None) -> bool:
+    parameter = _parameter_definition(parameters, name)
+    if parameter is None:
+        return False
+    return parameter.get("AssociationProperty") in _EXISTING_VPC_ASSOCIATION_PROPERTIES
+
+
+def _validate_existing_vpc_vswitch_cidr(name: str, resource: dict, parameters: dict[str, Any]) -> list[str]:
+    properties = resource.get("Properties")
+    if not isinstance(properties, dict):
+        return []
+    vpc_param = _ref_name(properties.get("VpcId"))
+    if not _is_existing_vpc_parameter(parameters, vpc_param):
+        return []
+
+    cidr_block = properties.get("CidrBlock")
+    cidr_param = _ref_name(cidr_block)
+    cidr_parameter = _parameter_definition(parameters, cidr_param)
+    if cidr_parameter is not None and cidr_parameter.get("Default") is not None:
+        return [
+            _(
+                "Resource '{name}' creates a VSwitch in existing VPC parameter '{vpc_param}', "
+                "but CidrBlock references parameter '{cidr_param}' with a Default. "
+                "Remove Parameters.{cidr_param}.Default and let deployment parameters choose a non-overlapping CIDR "
+                "after VpcId is selected."
+            ).format(name=name, vpc_param=vpc_param, cidr_param=cidr_param)
+        ]
+    if isinstance(cidr_block, str) and cidr_block.strip():
+        return [
+            _(
+                "Resource '{name}' creates a VSwitch in existing VPC parameter '{vpc_param}', "
+                "so CidrBlock must not be a static value. Remove the fixed CidrBlock and let deployment parameters "
+                "choose a non-overlapping CIDR after VpcId is selected."
+            ).format(name=name, vpc_param=vpc_param)
+        ]
+    return []
+
+
 def _validate_structure(data: dict) -> list[str]:
     """Validate ROS template structure. Return list of error messages."""
     errors: list[str] = []
     is_tf = _is_terraform(data)
+    parameters = data.get("Parameters")
+    if not isinstance(parameters, dict):
+        parameters = {}
 
     if "ROSTemplateFormatVersion" not in data:
         errors.append(
@@ -130,6 +189,8 @@ def _validate_structure(data: dict) -> list[str]:
                             name=name, wrong=rtype, correct=correct
                         )
                     )
+                if rtype == "ALIYUN::ECS::VSwitch":
+                    errors.extend(_validate_existing_vpc_vswitch_cidr(name, resource, parameters))
 
     return errors
 

--- a/src/iac_code/tools/cloud/aliyun/ros_stack.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_stack.py
@@ -24,7 +24,11 @@ from iac_code.services.telemetry.sanitize import (
 )
 from iac_code.tools.base import ToolContext
 from iac_code.tools.cloud.aliyun.ros_client import RosClientFactory
-from iac_code.tools.cloud.aliyun.template_source import is_remote_template_url, reject_pipeline_template_source_params
+from iac_code.tools.cloud.aliyun.template_source import (
+    is_remote_template_url,
+    reject_pipeline_dedicated_ros_deployment_action,
+    reject_pipeline_template_source_params,
+)
 from iac_code.tools.cloud.base_stack import BaseCloudStack
 from iac_code.tools.cloud.types import ResourceStatus, StackStatus
 from iac_code.tools.path_safety import resolve_candidate
@@ -485,6 +489,8 @@ class RosStack(BaseCloudStack):
         pipeline_mode: bool = False,
         cwd: str | None = None,
     ) -> str:
+        if error := reject_pipeline_dedicated_ros_deployment_action(action, pipeline_mode=pipeline_mode):
+            raise ValueError(error)
         if error := reject_pipeline_template_source_params(action, params, pipeline_mode=pipeline_mode):
             raise ValueError(error)
         client = self._get_client(region)
@@ -511,6 +517,7 @@ class RosStack(BaseCloudStack):
         elif action == "UpdateStack":
             return await self._handle_update_stack(client, params, region)
         elif action == "ContinueCreateStack":
+            _normalize_stack_parameters_for_sdk(params)
             request = ros_models.ContinueCreateStackRequest().from_map(params)
             response = await asyncio.to_thread(client.continue_create_stack, request)
             return response.body.stack_id

--- a/src/iac_code/tools/cloud/aliyun/ros_stack.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_stack.py
@@ -24,11 +24,10 @@ from iac_code.services.telemetry.sanitize import (
 )
 from iac_code.tools.base import ToolContext
 from iac_code.tools.cloud.aliyun.ros_client import RosClientFactory
-from iac_code.tools.cloud.aliyun.template_source import reject_template_body_param
+from iac_code.tools.cloud.aliyun.template_source import is_remote_template_url, reject_pipeline_template_source_params
 from iac_code.tools.cloud.base_stack import BaseCloudStack
 from iac_code.tools.cloud.types import ResourceStatus, StackStatus
-
-_URL_SCHEMES = ("http://", "https://", "oss://")
+from iac_code.tools.path_safety import resolve_candidate
 
 # Telemetry helpers
 _TERRAFORM_TRANSFORM_PREFIXES = ("Aliyun::Terraform-", "Aliyun::OpenTofu-")
@@ -475,10 +474,18 @@ class RosStack(BaseCloudStack):
         return RosClientFactory.create(cred, region_id=region)
 
     def _call_action_kwargs(self, context: ToolContext) -> dict[str, Any]:
-        return {"pipeline_mode": context.pipeline_mode}
+        return {"pipeline_mode": context.pipeline_mode, "cwd": context.cwd}
 
-    async def call_action(self, action: str, params: dict, region: str, *, pipeline_mode: bool = False) -> str:
-        if error := reject_template_body_param(params, pipeline_mode=pipeline_mode):
+    async def call_action(
+        self,
+        action: str,
+        params: dict,
+        region: str,
+        *,
+        pipeline_mode: bool = False,
+        cwd: str | None = None,
+    ) -> str:
+        if error := reject_pipeline_template_source_params(action, params, pipeline_mode=pipeline_mode):
             raise ValueError(error)
         client = self._get_client(region)
         # Ensure RegionId is always in params for the API request
@@ -486,8 +493,8 @@ class RosStack(BaseCloudStack):
             params.setdefault("RegionId", region)
         # TemplateURL as local file path → read into TemplateBody
         template_url = params.get("TemplateURL", "")
-        if template_url and not template_url.startswith(_URL_SCHEMES):
-            params["TemplateBody"] = Path(template_url).read_text(encoding="utf-8")
+        if template_url and not is_remote_template_url(template_url):
+            params["TemplateBody"] = Path(resolve_candidate(template_url, cwd or ".")).read_text(encoding="utf-8")
             del params["TemplateURL"]
         # TemplateBody must be a JSON string; non-pipeline callers may still pass a dict.
         if isinstance(params.get("TemplateBody"), dict):

--- a/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
@@ -10,7 +10,7 @@ from iac_code.i18n import _
 from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.tools.cloud.aliyun.aliyun_api import AliyunApi
 from iac_code.tools.cloud.aliyun.template_source import is_remote_template_url
-from iac_code.tools.path_safety import check_read_path, resolve_candidate
+from iac_code.tools.path_safety import check_read_path, resolve_read_path
 from iac_code.types.permissions import PermissionResult, ToolPermissionContext
 
 _TEMPLATE_URL_PROPERTY = {
@@ -69,7 +69,11 @@ def _is_local_template_url(template_url: str) -> bool:
 
 def _resolve_template_url_for_api(template_url: str, context: ToolContext) -> str:
     if _is_local_template_url(template_url):
-        return resolve_candidate(template_url, context.cwd)
+        return resolve_read_path(
+            template_url,
+            context.cwd,
+            relative_read_directories=context.relative_read_directories,
+        )
     return template_url
 
 
@@ -147,6 +151,7 @@ class _RosTemplateTool(Tool):
             cwd=context.cwd,
             additional_directories=context.additional_directories,
             trusted_read_directories=context.trusted_read_directories,
+            relative_read_directories=context.relative_read_directories,
         )
         if decision.behavior == "allow":
             return None

--- a/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
@@ -1,0 +1,351 @@
+"""Dedicated ROS template tools with narrow input schemas."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from typing import Any
+
+from iac_code.i18n import _
+from iac_code.tools.base import Tool, ToolContext, ToolResult
+from iac_code.tools.cloud.aliyun.aliyun_api import AliyunApi
+from iac_code.tools.cloud.aliyun.template_source import is_remote_template_url
+from iac_code.tools.path_safety import check_read_path, resolve_candidate
+from iac_code.types.permissions import PermissionResult, ToolPermissionContext
+
+_TEMPLATE_URL_PROPERTY = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Local file path, OSS URL, or HTTP(S) URL for the ROS template. Maps to ROS TemplateURL.",
+}
+_REGION_ID_PROPERTY = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Alibaba Cloud region ID, for example cn-hangzhou. Defaults to the configured region.",
+}
+_PARAMETERS_PROPERTY = {
+    "type": "object",
+    "description": (
+        "Template parameters as a plain key/value object. Do not use ROS flat Parameters.N.ParameterKey fields."
+    ),
+    "propertyNames": {"not": {"pattern": r"^Parameters\."}},
+}
+_TOOL_ACTIONS = {
+    "ros_validate_template": "ValidateTemplate",
+    "ros_get_template_parameter_constraints": "GetTemplateParameterConstraints",
+    "ros_preview_template": "PreviewStack",
+    "ros_estimate_template_cost": "GetTemplateEstimateCost",
+}
+
+
+def _schema(
+    *,
+    properties: dict[str, Any],
+    required: list[str],
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _copy_delegate_context(context: ToolContext) -> ToolContext:
+    return ToolContext(
+        cwd=context.cwd,
+        event_queue=context.event_queue,
+        tool_use_id=context.tool_use_id,
+        additional_directories=context.additional_directories,
+        trusted_read_directories=context.trusted_read_directories,
+        relative_read_directories=context.relative_read_directories,
+        pipeline_mode=False,
+    )
+
+
+def _is_local_template_url(template_url: str) -> bool:
+    return not is_remote_template_url(template_url)
+
+
+def _resolve_template_url_for_api(template_url: str, context: ToolContext) -> str:
+    if _is_local_template_url(template_url):
+        return resolve_candidate(template_url, context.cwd)
+    return template_url
+
+
+def render_ros_template_tool_result_message(
+    tool_name: str,
+    output: str,
+    *,
+    is_error: bool = False,
+    verbose: bool = False,
+) -> str | None:
+    action = _TOOL_ACTIONS.get(tool_name)
+    if action is None:
+        return None
+
+    aliyun_api = AliyunApi()
+    if not is_error and not verbose:
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            aliyun_api._last_action = action
+            aliyun_api._last_result = parsed
+    return aliyun_api.render_tool_result_message(output, is_error=is_error, verbose=verbose)
+
+
+class _RosTemplateTool(Tool):
+    action: str
+
+    def _aliyun_tool_input(self, *, tool_input: dict[str, Any], params: dict[str, Any] | None = None) -> dict[str, Any]:
+        aliyun_input: dict[str, Any] = {
+            "product": "ros",
+            "action": self.action,
+        }
+        if params is not None:
+            aliyun_input["params"] = params
+        if region_id := tool_input.get("region_id"):
+            aliyun_input["region_id"] = region_id
+        return aliyun_input
+
+    async def _call_ros_api(
+        self,
+        *,
+        tool_input: dict[str, Any],
+        context: ToolContext,
+        params: dict[str, Any],
+    ) -> ToolResult:
+        params = dict(params)
+        template_url = params.get("TemplateURL")
+        if isinstance(template_url, str) and template_url:
+            params["TemplateURL"] = _resolve_template_url_for_api(template_url, context)
+        aliyun_api = AliyunApi()
+        result = await aliyun_api.execute(
+            tool_input=self._aliyun_tool_input(tool_input=tool_input, params=params),
+            context=_copy_delegate_context(context),
+        )
+        self._last_action = getattr(aliyun_api, "_last_action", "")
+        self._last_result = getattr(aliyun_api, "_last_result", None)
+        return result
+
+    def is_read_only(self, input: dict | None = None) -> bool:
+        return True
+
+    def _check_local_template_url_read_permission(
+        self,
+        input: dict,
+        context: ToolPermissionContext,
+    ) -> PermissionResult | None:
+        template_url = input.get("template_url")
+        if not isinstance(template_url, str) or not template_url or not _is_local_template_url(template_url):
+            return None
+
+        decision = check_read_path(
+            template_url,
+            cwd=context.cwd,
+            additional_directories=context.additional_directories,
+            trusted_read_directories=context.trusted_read_directories,
+        )
+        if decision.behavior == "allow":
+            return None
+        return decision.to_permission_result()
+
+    @staticmethod
+    def _with_aliyun_audit(path_result: PermissionResult, aliyun_result: PermissionResult) -> PermissionResult:
+        if aliyun_result.audit is None:
+            return path_result
+        reason_type = path_result.reason.type if path_result.reason is not None else None
+        reason_detail = path_result.reason.detail if path_result.reason is not None else None
+        return PermissionResult(
+            behavior=path_result.behavior,
+            message=path_result.message,
+            reason=path_result.reason,
+            suggestions=path_result.suggestions,
+            audit=replace(
+                aliyun_result.audit,
+                scope="once",
+                rule_source=None,
+                rule=None,
+                reason_type=reason_type,
+                reason_detail=reason_detail,
+            ),
+        )
+
+    async def check_permissions(self, input: dict, context=None):
+        aliyun_result = await AliyunApi().check_permissions(self._aliyun_tool_input(tool_input=input), context)
+        if aliyun_result.behavior == "deny":
+            return aliyun_result
+
+        if isinstance(context, ToolPermissionContext):
+            if path_result := self._check_local_template_url_read_permission(input, context):
+                return self._with_aliyun_audit(path_result, aliyun_result)
+
+        return aliyun_result
+
+    def render_tool_use_message(self, input: dict, *, verbose: bool = False) -> str | None:
+        return input.get("template_url")
+
+    def render_tool_result_message(self, output: str, *, is_error: bool = False, verbose: bool = False) -> str | None:
+        return render_ros_template_tool_result_message(self.name, output, is_error=is_error, verbose=verbose)
+
+    def get_activity_description(self, input: dict | None = None) -> str | None:
+        if input is None:
+            return None
+        template_url = input.get("template_url", "")
+        return _("Calling ROS template tool for {template_url}...").format(template_url=template_url)
+
+    def streaming_preview_fields(self) -> list[str]:
+        return ["template_url"]
+
+
+class RosValidateTemplateTool(_RosTemplateTool):
+    action = "ValidateTemplate"
+
+    @property
+    def name(self) -> str:
+        return "ros_validate_template"
+
+    @property
+    def description(self) -> str:
+        return "Validate a ROS template by template_url. Use this instead of aliyun_api ValidateTemplate."
+
+    def user_facing_name(self, input: dict | None = None) -> str:
+        return _("ROS Validate Template")
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return _schema(
+            properties={
+                "template_url": _TEMPLATE_URL_PROPERTY,
+                "region_id": _REGION_ID_PROPERTY,
+            },
+            required=["template_url"],
+        )
+
+    async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+        return await self._call_ros_api(
+            tool_input=tool_input,
+            context=context,
+            params={"TemplateURL": tool_input["template_url"]},
+        )
+
+
+class RosGetTemplateParameterConstraintsTool(_RosTemplateTool):
+    action = "GetTemplateParameterConstraints"
+
+    @property
+    def name(self) -> str:
+        return "ros_get_template_parameter_constraints"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get ROS template parameter constraints by template_url and optional parameters. "
+            "Use this instead of aliyun_api GetTemplateParameterConstraints."
+        )
+
+    def user_facing_name(self, input: dict | None = None) -> str:
+        return _("ROS Template Parameters")
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return _schema(
+            properties={
+                "template_url": _TEMPLATE_URL_PROPERTY,
+                "region_id": _REGION_ID_PROPERTY,
+                "parameters": _PARAMETERS_PROPERTY,
+            },
+            required=["template_url"],
+        )
+
+    async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+        params: dict[str, Any] = {"TemplateURL": tool_input["template_url"]}
+        if "parameters" in tool_input:
+            params["Parameters"] = dict(tool_input["parameters"])
+        return await self._call_ros_api(tool_input=tool_input, context=context, params=params)
+
+
+class RosPreviewTemplateTool(_RosTemplateTool):
+    action = "PreviewStack"
+
+    @property
+    def name(self) -> str:
+        return "ros_preview_template"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Preview a ROS template stack by template_url, stack_name, and parameters. "
+            "Use instead of aliyun_api PreviewStack."
+        )
+
+    def user_facing_name(self, input: dict | None = None) -> str:
+        return _("ROS Preview Stack")
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return _schema(
+            properties={
+                "template_url": _TEMPLATE_URL_PROPERTY,
+                "region_id": _REGION_ID_PROPERTY,
+                "stack_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Unique preview stack name. This is not a template parameter.",
+                },
+                "parameters": _PARAMETERS_PROPERTY,
+            },
+            required=["template_url", "stack_name", "parameters"],
+        )
+
+    async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+        return await self._call_ros_api(
+            tool_input=tool_input,
+            context=context,
+            params={
+                "TemplateURL": tool_input["template_url"],
+                "StackName": tool_input["stack_name"],
+                "Parameters": dict(tool_input["parameters"]),
+            },
+        )
+
+
+class RosEstimateTemplateCostTool(_RosTemplateTool):
+    action = "GetTemplateEstimateCost"
+
+    @property
+    def name(self) -> str:
+        return "ros_estimate_template_cost"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Estimate ROS template cost by template_url and parameters. "
+            "Use this instead of aliyun_api GetTemplateEstimateCost."
+        )
+
+    def user_facing_name(self, input: dict | None = None) -> str:
+        return _("ROS Estimate Cost")
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return _schema(
+            properties={
+                "template_url": _TEMPLATE_URL_PROPERTY,
+                "region_id": _REGION_ID_PROPERTY,
+                "parameters": _PARAMETERS_PROPERTY,
+            },
+            required=["template_url", "parameters"],
+        )
+
+    async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+        return await self._call_ros_api(
+            tool_input=tool_input,
+            context=context,
+            params={
+                "TemplateURL": tool_input["template_url"],
+                "Parameters": dict(tool_input["parameters"]),
+            },
+        )

--- a/src/iac_code/tools/cloud/aliyun/template_source.py
+++ b/src/iac_code/tools/cloud/aliyun/template_source.py
@@ -6,6 +6,48 @@ from typing import Any
 
 from iac_code.i18n import _
 
+REMOTE_TEMPLATE_URL_PREFIXES = ("http://", "https://", "oss://")
+
+PIPELINE_TEMPLATE_URL_ACTIONS = frozenset(
+    {
+        "CreateChangeSet",
+        "CreateStack",
+        "CreateStackGroup",
+        "GetTemplateEstimateCost",
+        "GetTemplateParameterConstraints",
+        "GetTemplateSummary",
+        "PreviewStack",
+        "UpdateStack",
+        "UpdateStackGroup",
+        "ValidateTemplate",
+    }
+)
+
+PIPELINE_DEDICATED_ROS_TEMPLATE_TOOLS = {
+    "validatetemplate": "ros_validate_template",
+    "gettemplateparameterconstraints": "ros_get_template_parameter_constraints",
+    "previewstack": "ros_preview_template",
+    "gettemplateestimatecost": "ros_estimate_template_cost",
+}
+
+
+def is_remote_template_url(template_url: str) -> bool:
+    """Return True when TemplateURL points to a remote URL rather than a local file."""
+    return template_url.lower().startswith(REMOTE_TEMPLATE_URL_PREFIXES)
+
+
+def reject_pipeline_dedicated_ros_template_action(action: str, *, pipeline_mode: bool) -> str | None:
+    """Return an error when pipeline callers use raw ROS template APIs."""
+    if not pipeline_mode:
+        return None
+    tool_name = PIPELINE_DEDICATED_ROS_TEMPLATE_TOOLS.get(action.lower())
+    if tool_name is None:
+        return None
+    return _(
+        "ROS pipeline calls for {action} must use the dedicated {tool_name} tool instead of aliyun_api. "
+        "Do not call the raw ROS template API directly."
+    ).format(action=action, tool_name=tool_name)
+
 
 def reject_template_body_param(params: dict[str, Any], *, pipeline_mode: bool) -> str | None:
     """Return an error message when a caller provides TemplateBody directly."""
@@ -15,3 +57,17 @@ def reject_template_body_param(params: dict[str, Any], *, pipeline_mode: bool) -
         "ROS template calls must use TemplateURL instead of TemplateBody. "
         "Save the template to a file and pass params.TemplateURL, for example a local file path or OSS/HTTP URL."
     )
+
+
+def reject_pipeline_template_source_params(action: str, params: dict[str, Any], *, pipeline_mode: bool) -> str | None:
+    """Return an error message when pipeline ROS template calls do not use TemplateURL."""
+    if not pipeline_mode or action not in PIPELINE_TEMPLATE_URL_ACTIONS:
+        return None
+    if error := reject_template_body_param(params, pipeline_mode=pipeline_mode):
+        return error
+    if "TemplateURL" in params:
+        return None
+    return _(
+        "ROS pipeline calls for {action} must pass params.TemplateURL. "
+        "Save the template to a file and pass params.TemplateURL, for example a local file path or OSS/HTTP URL."
+    ).format(action=action)

--- a/src/iac_code/tools/cloud/aliyun/template_source.py
+++ b/src/iac_code/tools/cloud/aliyun/template_source.py
@@ -30,6 +30,15 @@ PIPELINE_DEDICATED_ROS_TEMPLATE_TOOLS = {
     "gettemplateestimatecost": "ros_estimate_template_cost",
 }
 
+PIPELINE_DEDICATED_ROS_DEPLOYMENT_ACTIONS = frozenset(
+    {
+        "createstack",
+        "continuecreatestack",
+        "deletestack",
+        "updatestack",
+    }
+)
+
 
 def is_remote_template_url(template_url: str) -> bool:
     """Return True when TemplateURL points to a remote URL rather than a local file."""
@@ -47,6 +56,18 @@ def reject_pipeline_dedicated_ros_template_action(action: str, *, pipeline_mode:
         "ROS pipeline calls for {action} must use the dedicated {tool_name} tool instead of aliyun_api. "
         "Do not call the raw ROS template API directly."
     ).format(action=action, tool_name=tool_name)
+
+
+def reject_pipeline_dedicated_ros_deployment_action(action: str, *, pipeline_mode: bool) -> str | None:
+    """Return an error when pipeline callers use raw ROS deployment APIs."""
+    if not pipeline_mode:
+        return None
+    if action.lower() not in PIPELINE_DEDICATED_ROS_DEPLOYMENT_ACTIONS:
+        return None
+    return _(
+        "ROS pipeline calls for {action} must use the dedicated ros_deploy tool instead of aliyun_api. "
+        "Do not call the raw ROS deployment API directly."
+    ).format(action=action)
 
 
 def reject_template_body_param(params: dict[str, Any], *, pipeline_mode: bool) -> str | None:

--- a/src/iac_code/tools/cloud/base_stack.py
+++ b/src/iac_code/tools/cloud/base_stack.py
@@ -201,6 +201,28 @@ class BaseCloudStack(Tool):
             msg = msg[:idx]
         return msg.strip()
 
+    def _started_stack_metadata(
+        self,
+        action: str,
+        params: dict,
+        region: str,
+        stack_id: str,
+        *,
+        error_stage: str | None = None,
+    ) -> dict[str, str]:
+        metadata = {
+            "provider": self.provider_name,
+            "action": action,
+            "stack_id": stack_id,
+            "region_id": region,
+        }
+        stack_name = params.get("StackName") or params.get("stack_name")
+        if stack_name:
+            metadata["stack_name"] = str(stack_name)
+        if error_stage:
+            metadata["error_stage"] = error_stage
+        return metadata
+
     def render_tool_result_message(self, output: str, *, is_error: bool = False, verbose: bool = False) -> str | None:
         if verbose:
             return output.strip()
@@ -257,7 +279,17 @@ class BaseCloudStack(Tool):
                         self.on_polling_error(action, params, region, stack_id, "status", e)
                     except Exception:
                         pass
-                    return ToolResult.error(f"[GetStackStatus] {e}")
+                    return ToolResult(
+                        content=f"[GetStackStatus] {e}",
+                        is_error=True,
+                        metadata=self._started_stack_metadata(
+                            action,
+                            params,
+                            region,
+                            stack_id,
+                            error_stage="status",
+                        ),
+                    )
 
                 try:
                     resources = await self.get_stack_resources(stack_id, region)
@@ -269,7 +301,17 @@ class BaseCloudStack(Tool):
                             self.on_polling_error(action, params, region, stack_id, "resources", e)
                         except Exception:
                             pass
-                        return ToolResult.error(f"[GetStackResources] {e}")
+                        return ToolResult(
+                            content=f"[GetStackResources] {e}",
+                            is_error=True,
+                            metadata=self._started_stack_metadata(
+                                action,
+                                params,
+                                region,
+                                stack_id,
+                                error_stage="resources",
+                            ),
+                        )
 
                 elapsed = int(time.monotonic() - start_time)
 

--- a/src/iac_code/tools/cloud/registry.py
+++ b/src/iac_code/tools/cloud/registry.py
@@ -9,6 +9,10 @@ if TYPE_CHECKING:
 ALIYUN_TOOL_NAMES = (
     "aliyun_api",
     "aliyun_doc_search",
+    "ros_validate_template",
+    "ros_get_template_parameter_constraints",
+    "ros_preview_template",
+    "ros_estimate_template_cost",
     "ros_stack",
     "ros_stack_instances",
 )

--- a/src/iac_code/tools/glob.py
+++ b/src/iac_code/tools/glob.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import fnmatch
 import os
 from pathlib import Path
 from typing import Any
 
 from iac_code.i18n import _
 from iac_code.tools.base import Tool, ToolContext, ToolResult
-from iac_code.tools.path_safety import check_read_path
+from iac_code.tools.path_safety import check_read_path, get_iac_code_application_root, resolve_read_path
 from iac_code.types.permissions import PermissionDecisionReason, PermissionResult, ToolPermissionContext
 from iac_code.utils.platform import normalize_user_path
 
@@ -18,11 +19,111 @@ def _glob_pattern_may_escape_root(pattern: str) -> bool:
     return os.path.isabs(normalized) or any(part == ".." for part in normalized.split("/"))
 
 
-def _search_root(path: str, cwd: str) -> Path:
+def _search_root(path: str, cwd: str, *, relative_read_directories: list[str] | None = None) -> Path:
     root = Path(normalize_user_path(path))
     if not root.is_absolute():
-        root = Path(cwd) / root
+        root = Path(resolve_read_path(str(root), cwd, relative_read_directories=relative_read_directories))
     return root
+
+
+def _glob_pattern_parts(pattern: str) -> tuple[str, ...]:
+    normalized = normalize_user_path(pattern).replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return tuple(part for part in normalized.split("/") if part and part != ".")
+
+
+def _pattern_contains_recursive_glob(pattern: str) -> bool:
+    return "**" in _glob_pattern_parts(pattern)
+
+
+def _path_is_under_real_root(path: str, root: str) -> bool:
+    path_r = os.path.realpath(path)
+    root_r = os.path.realpath(root)
+    if path_r == root_r:
+        return True
+    return path_r.startswith(root_r.rstrip(os.sep) + os.sep)
+
+
+def _path_is_under_any_real_root(path: str, roots: list[str]) -> bool:
+    return any(_path_is_under_real_root(path, root) for root in roots if root)
+
+
+def _matches_glob_pattern(relative_path: str, pattern: str) -> bool:
+    path_parts = tuple(part for part in relative_path.replace("\\", "/").split("/") if part and part != ".")
+    pattern_parts = _glob_pattern_parts(pattern)
+    if not pattern_parts:
+        return False
+
+    def match(pattern_index: int, path_index: int) -> bool:
+        if pattern_index == len(pattern_parts):
+            return path_index == len(path_parts)
+
+        pattern_part = pattern_parts[pattern_index]
+        if pattern_part == "**":
+            return match(pattern_index + 1, path_index) or (
+                path_index < len(path_parts) and match(pattern_index, path_index + 1)
+            )
+
+        return (
+            path_index < len(path_parts)
+            and fnmatch.fnmatchcase(path_parts[path_index], pattern_part)
+            and match(pattern_index + 1, path_index + 1)
+        )
+
+    return match(0, 0)
+
+
+def _allowed_roots(
+    search_root: Path, *, additional_directories: list[str], trusted_read_directories: list[str]
+) -> list[str]:
+    return [
+        str(search_root),
+        *additional_directories,
+        *trusted_read_directories,
+        str(get_iac_code_application_root()),
+    ]
+
+
+def _glob_matches(
+    search_root: Path,
+    pattern: str,
+    *,
+    allowed_roots: list[str] | None = None,
+) -> tuple[list[Path], list[Path]]:
+    if not _pattern_contains_recursive_glob(pattern):
+        return [p for p in search_root.glob(pattern) if p.is_file()], []
+
+    matches: list[Path] = []
+    unsafe_directories: list[Path] = []
+    visited_dirs: set[str] = set()
+
+    for dirpath, dirnames, filenames in os.walk(search_root, followlinks=True):
+        dir_real = os.path.realpath(dirpath)
+        if dir_real in visited_dirs:
+            dirnames[:] = []
+            continue
+        visited_dirs.add(dir_real)
+
+        safe_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            child = Path(dirpath) / dirname
+            if allowed_roots is not None and not _path_is_under_any_real_root(str(child), allowed_roots):
+                unsafe_directories.append(child)
+                continue
+            safe_dirnames.append(dirname)
+        dirnames[:] = safe_dirnames
+
+        for filename in sorted(filenames):
+            path = Path(dirpath) / filename
+            try:
+                relative_path = path.relative_to(search_root)
+            except ValueError:
+                continue
+            if _matches_glob_pattern(str(relative_path), pattern) and path.is_file():
+                matches.append(path)
+
+    return matches, unsafe_directories
 
 
 class GlobTool(Tool):
@@ -57,11 +158,9 @@ class GlobTool(Tool):
 
     async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         pattern = tool_input["pattern"]
-        path = normalize_user_path(tool_input.get("path", context.cwd))
+        path = tool_input.get("path", context.cwd)
 
-        search_root = Path(path)
-        if not search_root.is_absolute():
-            search_root = Path(context.cwd) / path
+        search_root = _search_root(path, context.cwd, relative_read_directories=context.relative_read_directories)
 
         if not search_root.exists():
             return ToolResult.error(f"Path not found: {path}")
@@ -70,7 +169,12 @@ class GlobTool(Tool):
             return ToolResult.error(f"Not a directory: {path}")
 
         try:
-            matches = [p for p in search_root.glob(pattern) if p.is_file()]
+            allowed_roots = _allowed_roots(
+                search_root,
+                additional_directories=context.additional_directories,
+                trusted_read_directories=context.trusted_read_directories,
+            )
+            matches, _ = _glob_matches(search_root, pattern, allowed_roots=allowed_roots)
         except Exception as e:
             return ToolResult.error(f"Error during glob: {e}")
 
@@ -94,6 +198,7 @@ class GlobTool(Tool):
             cwd=context.cwd,
             additional_directories=context.additional_directories,
             trusted_read_directories=context.trusted_read_directories,
+            relative_read_directories=context.relative_read_directories,
         )
         if decision.behavior == "allow":
             pattern = input.get("pattern", "")
@@ -105,8 +210,28 @@ class GlobTool(Tool):
                     reason=PermissionDecisionReason(type="path_constraint", detail=detail),
                 )
             try:
-                matches = [p for p in _search_root(path, context.cwd).glob(pattern) if p.is_file()]
+                search_root = _search_root(
+                    path,
+                    context.cwd,
+                    relative_read_directories=context.relative_read_directories,
+                )
+                matches, unsafe_directories = _glob_matches(
+                    search_root,
+                    pattern,
+                    allowed_roots=_allowed_roots(
+                        search_root,
+                        additional_directories=context.additional_directories,
+                        trusted_read_directories=context.trusted_read_directories,
+                    ),
+                )
             except Exception:
+                detail = _("glob pattern outside allowed directories")
+                return PermissionResult(
+                    behavior="ask",
+                    message=detail,
+                    reason=PermissionDecisionReason(type="path_constraint", detail=detail),
+                )
+            if unsafe_directories:
                 detail = _("glob pattern outside allowed directories")
                 return PermissionResult(
                     behavior="ask",
@@ -119,6 +244,7 @@ class GlobTool(Tool):
                     cwd=context.cwd,
                     additional_directories=context.additional_directories,
                     trusted_read_directories=context.trusted_read_directories,
+                    relative_read_directories=context.relative_read_directories,
                 )
                 if match_decision.behavior == "ask":
                     return match_decision.to_permission_result()

--- a/src/iac_code/tools/grep.py
+++ b/src/iac_code/tools/grep.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from iac_code.i18n import _
 from iac_code.tools.base import Tool, ToolContext, ToolResult
-from iac_code.tools.path_safety import check_read_path
+from iac_code.tools.path_safety import check_read_path, get_iac_code_application_root, resolve_read_path_with_source
 from iac_code.types.permissions import PermissionResult, ToolPermissionContext
 from iac_code.utils.platform import normalize_user_path
 
@@ -111,6 +111,10 @@ def _path_is_under_real_root(path: str, root: str) -> bool:
     return path_r.startswith(root_r.rstrip("/") + "/")
 
 
+def _path_is_under_any_real_root(path: str, roots: list[str]) -> bool:
+    return any(_path_is_under_real_root(path, root) for root in roots if root)
+
+
 async def _run_rg(
     pattern: str,
     path: str,
@@ -177,6 +181,7 @@ def _python_grep(
     case_insensitive: bool = False,
     output_mode: str = "files_with_matches",
     max_results: int = 100,
+    allowed_roots: list[str] | None = None,
 ) -> str:
     """Pure-Python fallback for grep using re + os.walk."""
     flags = re.IGNORECASE if case_insensitive else 0
@@ -188,10 +193,20 @@ def _python_grep(
     results: list[str] = []
     files_matched = 0
     search_root = os.path.realpath(path)
+    safe_roots = [search_root, *(allowed_roots or [])]
+    visited_dirs: set[str] = set()
 
-    for dirpath, _dirnames, filenames in os.walk(path):
+    for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
         if files_matched >= max_results:
             break
+        dir_real = os.path.realpath(dirpath)
+        if dir_real in visited_dirs:
+            dirnames[:] = []
+            continue
+        visited_dirs.add(dir_real)
+        dirnames[:] = [
+            dirname for dirname in dirnames if _path_is_under_any_real_root(os.path.join(dirpath, dirname), safe_roots)
+        ]
         for filename in sorted(filenames):
             if files_matched >= max_results:
                 break
@@ -199,7 +214,7 @@ def _python_grep(
             relative_path = os.path.relpath(filepath, path)
             if glob and not _matches_path_glob(relative_path, glob):
                 continue
-            if not _path_is_under_real_root(filepath, search_root):
+            if not _path_is_under_any_real_root(filepath, safe_roots):
                 continue
             try:
                 with open(filepath, encoding="utf-8", errors="replace") as fh:
@@ -282,20 +297,29 @@ class GrepTool(Tool):
 
     async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         pattern: str = tool_input["pattern"]
-        path: str = normalize_user_path(tool_input.get("path", context.cwd))
+        raw_path: str = normalize_user_path(tool_input.get("path", context.cwd))
         glob: str | None = tool_input.get("glob")
         case_insensitive: bool = bool(tool_input.get("case_insensitive", False))
         output_mode: str = tool_input.get("output_mode", "files_with_matches")
         max_results: int = int(tool_input.get("max_results", 100))
 
-        # Resolve relative paths against cwd
-        if not os.path.isabs(path):
-            path = os.path.join(context.cwd, path)
+        resolution = resolve_read_path_with_source(
+            raw_path,
+            context.cwd,
+            relative_read_directories=context.relative_read_directories,
+        )
+        path = resolution.path
 
         if not os.path.exists(path):
             return ToolResult.error(f"Path not found: {path}")
 
-        if _is_rg_available():
+        allowed_roots = [
+            path,
+            *context.additional_directories,
+            *context.trusted_read_directories,
+            str(get_iac_code_application_root()),
+        ]
+        if _is_rg_available() and not resolution.used_relative_root:
             returncode, stdout, stderr = await _run_rg(
                 pattern,
                 path,
@@ -316,6 +340,7 @@ class GrepTool(Tool):
                 case_insensitive=case_insensitive,
                 output_mode=output_mode,
                 max_results=max_results,
+                allowed_roots=allowed_roots,
             ).strip()
 
         if not output:
@@ -337,6 +362,7 @@ class GrepTool(Tool):
             cwd=context.cwd,
             additional_directories=context.additional_directories,
             trusted_read_directories=context.trusted_read_directories,
+            relative_read_directories=context.relative_read_directories,
         )
         if decision.behavior == "allow":
             return PermissionResult(behavior="allow")

--- a/src/iac_code/tools/grep.py
+++ b/src/iac_code/tools/grep.py
@@ -115,6 +115,20 @@ def _path_is_under_any_real_root(path: str, roots: list[str]) -> bool:
     return any(_path_is_under_real_root(path, root) for root in roots if root)
 
 
+def _contains_directory_symlink(path: str) -> bool:
+    if not os.path.isdir(path):
+        return False
+    if os.path.islink(path):
+        return True
+
+    for dirpath, dirnames, _filenames in os.walk(path, followlinks=False):
+        for dirname in dirnames:
+            child = os.path.join(dirpath, dirname)
+            if os.path.islink(child) and os.path.isdir(child):
+                return True
+    return False
+
+
 async def _run_rg(
     pattern: str,
     path: str,
@@ -319,7 +333,7 @@ class GrepTool(Tool):
             *context.trusted_read_directories,
             str(get_iac_code_application_root()),
         ]
-        if _is_rg_available() and not resolution.used_relative_root:
+        if _is_rg_available() and not resolution.used_relative_root and not _contains_directory_symlink(path):
             returncode, stdout, stderr = await _run_rg(
                 pattern,
                 path,

--- a/src/iac_code/tools/list_files.py
+++ b/src/iac_code/tools/list_files.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from iac_code.i18n import _
 from iac_code.tools.base import Tool, ToolContext, ToolResult
-from iac_code.tools.path_safety import check_read_path
+from iac_code.tools.path_safety import check_read_path, resolve_read_path
 from iac_code.types.permissions import PermissionResult, ToolPermissionContext
 from iac_code.utils.platform import normalize_user_path
 
@@ -39,10 +39,12 @@ class ListFilesTool(Tool):
         }
 
     async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
-        path = normalize_user_path(tool_input.get("path", context.cwd))
-
-        if not os.path.isabs(path):
-            path = os.path.join(context.cwd, path)
+        raw_path = normalize_user_path(tool_input.get("path", context.cwd))
+        path = (
+            resolve_read_path(raw_path, context.cwd, relative_read_directories=context.relative_read_directories)
+            if raw_path
+            else context.cwd
+        )
 
         if not os.path.exists(path):
             return ToolResult.error(f"Path not found: {path}")
@@ -84,6 +86,7 @@ class ListFilesTool(Tool):
             cwd=context.cwd,
             additional_directories=context.additional_directories,
             trusted_read_directories=context.trusted_read_directories,
+            relative_read_directories=context.relative_read_directories,
         )
         if decision.behavior == "allow":
             return PermissionResult(behavior="allow")

--- a/src/iac_code/tools/path_safety.py
+++ b/src/iac_code/tools/path_safety.py
@@ -102,6 +102,14 @@ class ReadPathDecision:
         )
 
 
+@dataclass(frozen=True)
+class ReadPathResolution:
+    """Resolved read path and whether it came from a relative read root."""
+
+    path: str
+    used_relative_root: bool = False
+
+
 def _build_sensitive_lookups(
     sensitive_paths: Sequence[str] = SENSITIVE_PATHS,
     *,
@@ -148,9 +156,52 @@ def is_sensitive_path(path: str) -> bool:
 def resolve_candidate(path: str, cwd: str) -> str:
     """Resolve a user-supplied path relative to cwd for safety checks."""
     normalized_path = os.path.expanduser(normalize_user_path(path))
+    return _resolve_normalized_candidate(normalized_path, cwd)
+
+
+def _resolve_normalized_candidate(normalized_path: str, cwd: str) -> str:
     if os.path.isabs(normalized_path):
         return os.path.realpath(normalized_path)
     return os.path.realpath(os.path.join(cwd, normalized_path))
+
+
+def resolve_read_path_with_source(
+    path: str,
+    cwd: str,
+    *,
+    relative_read_directories: list[str] | None = None,
+) -> ReadPathResolution:
+    """Resolve a read path from cwd, then from explicit relative read roots.
+
+    Relative read roots let bundled/pipeline skills use stable links like
+    ``references/foo.md`` even when the user's cwd is a project directory.
+    Symlinks are followed by ``resolve_candidate``; permission checks must
+    validate the final real path before execution.
+    """
+    normalized_path = os.path.expanduser(normalize_user_path(path))
+    primary = _resolve_normalized_candidate(normalized_path, cwd)
+    if os.path.isabs(normalized_path) or os.path.exists(primary):
+        return ReadPathResolution(path=primary)
+
+    for root in relative_read_directories or []:
+        candidate = _resolve_normalized_candidate(normalized_path, root)
+        if os.path.exists(candidate):
+            return ReadPathResolution(path=candidate, used_relative_root=True)
+
+    return ReadPathResolution(path=primary)
+
+
+def resolve_read_path(
+    path: str,
+    cwd: str,
+    *,
+    relative_read_directories: list[str] | None = None,
+) -> str:
+    return resolve_read_path_with_source(
+        path,
+        cwd,
+        relative_read_directories=relative_read_directories,
+    ).path
 
 
 def get_iac_code_application_root() -> Path:
@@ -215,9 +266,14 @@ def check_read_path(
     cwd: str,
     additional_directories: list[str],
     trusted_read_directories: list[str],
+    relative_read_directories: list[str] | None = None,
 ) -> ReadPathDecision:
     """Decide whether a read path is safe or should ask for confirmation."""
-    resolved = resolve_candidate(path, cwd)
+    resolved = resolve_read_path(
+        path,
+        cwd,
+        relative_read_directories=relative_read_directories,
+    )
 
     if _is_in_allowed_roots(resolved, trusted_read_directories):
         return ReadPathDecision("allow")

--- a/src/iac_code/tools/read_file.py
+++ b/src/iac_code/tools/read_file.py
@@ -7,12 +7,17 @@ import os
 from typing import Any
 
 from iac_code.i18n import _
+from iac_code.tools import path_safety
 from iac_code.tools.base import Tool, ToolContext, ToolResult
-from iac_code.tools.path_safety import _path_is_under, check_read_path, resolve_candidate
+from iac_code.tools.path_safety import check_read_path, resolve_read_path
 from iac_code.types.permissions import PermissionDecisionReason, PermissionResult, ToolPermissionContext
 
 MAX_READ_BYTES = 10 * 1024 * 1024
 MAX_READ_LINES = 50_000
+
+
+def _path_is_under(path: str, root: str) -> bool:
+    return path_safety._path_is_under(path, root)
 
 
 def _resolve_input_path(
@@ -21,15 +26,7 @@ def _resolve_input_path(
     *,
     relative_read_directories: list[str] | None = None,
 ) -> str:
-    primary = resolve_candidate(path, cwd)
-    if os.path.isabs(os.path.expanduser(path)) or os.path.exists(primary):
-        return primary
-
-    for root in relative_read_directories or []:
-        candidate = resolve_candidate(path, root)
-        if _path_is_under(candidate, root) and os.path.exists(candidate):
-            return candidate
-    return primary
+    return resolve_read_path(path, cwd, relative_read_directories=relative_read_directories)
 
 
 class ReadFileTool(Tool):
@@ -92,6 +89,7 @@ class ReadFileTool(Tool):
             cwd=context.cwd,
             additional_directories=context.additional_directories,
             trusted_read_directories=context.trusted_read_directories,
+            relative_read_directories=context.relative_read_directories,
         )
         if decision.behavior == "allow":
             return PermissionResult(behavior="allow")

--- a/src/iac_code/types/permissions.py
+++ b/src/iac_code/types/permissions.py
@@ -34,6 +34,11 @@ class PermissionRuleValue:
 
     tool_name: str
     rule_content: str
+    display_text: str | None = None
+
+    def display_label(self) -> str:
+        """Return the user-facing label for this rule."""
+        return self.display_text or self.rule_content
 
 
 @dataclass

--- a/src/iac_code/types/permissions.py
+++ b/src/iac_code/types/permissions.py
@@ -98,6 +98,7 @@ class ToolPermissionContext:
     ask_rules: dict[str, list[str]] = field(default_factory=dict)
     additional_directories: list[str] = field(default_factory=list)
     trusted_read_directories: list[str] = field(default_factory=list)
+    relative_read_directories: list[str] = field(default_factory=list)
     audit_settings: PermissionAuditSettings = field(default_factory=PermissionAuditSettings)
 
 

--- a/src/iac_code/types/stream_events.py
+++ b/src/iac_code/types/stream_events.py
@@ -119,6 +119,7 @@ class ToolResultEvent:
     result: str
     is_error: bool = False
     metadata: dict[str, Any] | None = None
+    public_path_roots: list[dict[str, str]] | None = None
     type: Literal["tool_result"] = "tool_result"
 
 

--- a/src/iac_code/ui/renderer.py
+++ b/src/iac_code/ui/renderer.py
@@ -1344,7 +1344,7 @@ class Renderer:
                 # ── Stack progress ─────────────────────────────
                 elif isinstance(event, StackProgressEvent):
                     for rec in tool_records.values():
-                        if rec.tool_name == "ros_stack" and not rec.done:
+                        if rec.tool_name in {"ros_stack", "ros_deploy"} and not rec.done:
                             rec.progress_renderable = self._render_stack_progress(event)
                             break
                     _ensure_live()
@@ -1643,6 +1643,9 @@ class Renderer:
                 return None
             return ", ".join(f"{suggestion.tool_name}({suggestion.rule_content})" for suggestion in suggestions)
 
+        def _suggestion_display() -> str:
+            return ", ".join(suggestion.display_label() for suggestion in suggestions)
+
         # Short-circuit on cached sticky decisions — no prompt, no input read.
         cached = lookup_permission(cache, tool_name)
         if cached == "always_allow" and tool_name == "aliyun_api" and is_non_read_only:
@@ -1693,7 +1696,7 @@ class Renderer:
             else []
         )
         if suggestions:
-            rules_display = ", ".join(s.rule_content for s in suggestions)
+            rules_display = _suggestion_display()
             options.append(
                 TextOption(
                     label=_('Yes, always allow "{rule}" (this session)').format(rule=rules_display),
@@ -1708,7 +1711,7 @@ class Renderer:
         )
 
         if suggestions:
-            rules_display = ", ".join(s.rule_content for s in suggestions)
+            rules_display = _suggestion_display()
             options.append(
                 TextOption(
                     label=_('No, always deny "{rule}" (this session)').format(rule=rules_display),

--- a/src/iac_code/ui/renderer.py
+++ b/src/iac_code/ui/renderer.py
@@ -88,6 +88,18 @@ def _display_tool_name(tool_name: str, candidate: str | None = None) -> str:
     return known_tool_display_name(tool_name) or candidate or tool_name
 
 
+def _known_tool_result_message(
+    tool_name: str,
+    output: str,
+    *,
+    is_error: bool = False,
+    verbose: bool = False,
+) -> str | None:
+    from iac_code.tools.cloud.aliyun.ros_template_tools import render_ros_template_tool_result_message
+
+    return render_ros_template_tool_result_message(tool_name, output, is_error=is_error, verbose=verbose)
+
+
 def _permission_detail_text(tool_name: str, tool_input: dict[str, Any], tool: Any | None) -> str | None:
     if tool_name == "aliyun_api":
         summary = json.dumps(build_input_summary(tool_name, tool_input), ensure_ascii=False, sort_keys=True)
@@ -763,6 +775,13 @@ class Renderer:
         if tool:
             result_text = tool.render_tool_result_message(
                 rec.result or "", is_error=rec.is_error, verbose=self._verbose
+            )
+        if result_text is None and rec.result:
+            result_text = _known_tool_result_message(
+                rec.tool_name,
+                rec.result,
+                is_error=rec.is_error,
+                verbose=self._verbose,
             )
         if result_text is None and rec.result:
             result_text = rec.result

--- a/src/iac_code/ui/repl.py
+++ b/src/iac_code/ui/repl.py
@@ -230,6 +230,8 @@ class InlineREPL:
                     cwd=os.getcwd(),
                     memory_context=memory_context,
                     current_time=self._runtime_current_time,
+                    provider_display=self._status_provider_display(),
+                    model=self._status_model(self._current_model),
                 ),
                 notification_queue=self._notification_queue,
             )
@@ -281,6 +283,8 @@ class InlineREPL:
                 memory_context=memory_context,
                 skill_listing=self._skill_listing,
                 current_time=self._runtime_current_time,
+                provider_display=self._status_provider_display(),
+                model=self._status_model(self._current_model),
             ),
             tool_registry=self.tool_registry,
             session_storage=self._session_storage,
@@ -612,6 +616,8 @@ class InlineREPL:
             memory_context=self._refresh_memory_context(),
             skill_listing=getattr(self, "_skill_listing", ""),
             current_time=getattr(self, "_runtime_current_time", None),
+            provider_display=self._status_provider_display(),
+            model=self._status_model(getattr(self, "_current_model", "")),
         )
 
     def _refresh_system_prompt(self) -> str:
@@ -662,6 +668,8 @@ class InlineREPL:
                     cwd=cwd,
                     memory_context=memory_context,
                     current_time=self._runtime_current_time,
+                    provider_display=self._status_provider_display(),
+                    model=self._status_model(self._current_model),
                 ),
             )
         )

--- a/src/iac_code/ui/repl.py
+++ b/src/iac_code/ui/repl.py
@@ -5055,9 +5055,10 @@ class InlineREPL:
         return totals
 
     def _status_provider_display(self) -> str:
-        if hasattr(self._provider_manager, "get_provider_display"):
+        provider_manager = getattr(self, "_provider_manager", None)
+        if hasattr(provider_manager, "get_provider_display"):
             try:
-                display = self._provider_manager.get_provider_display()
+                display = provider_manager.get_provider_display()
             except Exception:
                 display = ""
             if isinstance(display, str) and display:
@@ -5071,9 +5072,10 @@ class InlineREPL:
         return key
 
     def _status_model(self, fallback: str) -> str:
-        if hasattr(self._provider_manager, "get_model_name"):
+        provider_manager = getattr(self, "_provider_manager", None)
+        if hasattr(provider_manager, "get_model_name"):
             try:
-                model = self._provider_manager.get_model_name()
+                model = provider_manager.get_model_name()
             except Exception:
                 model = ""
             if isinstance(model, str) and model:

--- a/src/iac_code/utils/public_errors.py
+++ b/src/iac_code/utils/public_errors.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import hashlib
 import ntpath
 import re
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote, unquote, urlsplit
 
 from iac_code.i18n import _
+from iac_code.utils.public_paths import relativize_public_file_uri, sanitize_public_paths
 
 _SECRET_VALUE_PATTERN = r"""(?:\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}|"[^"]*"|'[^']*'|[^\s,;}]+)"""
 
@@ -100,7 +102,10 @@ _PATH_PATTERNS = (
     re.compile(r"/workspaces/[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),
     re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:/[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),
     re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:\\[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),
-    re.compile(r"\\\\[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),
+    re.compile(
+        r"""\\\\u[0-9A-Fa-f]{4}\\(?!\\u[0-9A-Fa-f]{4})(?=[^\r\n,;:)"'\]}\\])[^\r\n,;:)\"']*?""" + _PATH_END_PATTERN
+    ),
+    re.compile(r"\\\\(?!u[0-9A-Fa-f]{4})[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),
     re.compile(r"(?<!:)//[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),
 )
 
@@ -150,11 +155,16 @@ def public_error(
     return PublicError(summary=summary, details=details, error_id=error_id)
 
 
-def sanitize_public_text(value: Any, *, fallback_summary: str | None = None) -> str:
+def sanitize_public_text(
+    value: Any,
+    *,
+    fallback_summary: str | None = None,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> str:
     if fallback_summary is None:
         fallback_summary = _("Unknown error")
     raw_summary = str(value) if value is not None else ""
-    return _sanitize_public_summary(raw_summary) or fallback_summary
+    return _sanitize_public_summary(raw_summary, public_path_roots=public_path_roots) or fallback_summary
 
 
 def _error_id(*, error_type: str, summary: str) -> str:
@@ -162,18 +172,18 @@ def _error_id(*, error_type: str, summary: str) -> str:
     return digest[:12]
 
 
-def _sanitize_public_summary(value: str) -> str:
+def _sanitize_public_summary(value: str, *, public_path_roots: Iterable[Mapping[str, str]] | None = None) -> str:
     protected, placeholders = _replace_public_artifact_uri_tokens(value)
-    protected = _replace_file_uri_tokens(protected)
-    sanitized = _apply_public_patterns(protected)
+    protected = _replace_file_uri_tokens(protected, public_path_roots=public_path_roots)
+    sanitized = _apply_public_patterns(protected, public_path_roots=public_path_roots)
 
     decoded_raw = unquote(protected)
     decoded, decoded_placeholders = _replace_public_artifact_uri_tokens(
         decoded_raw, prefix="__IAC_CODE_PUBLIC_DECODED_URI_"
     )
-    decoded = _replace_file_uri_tokens(decoded)
+    decoded = _replace_file_uri_tokens(decoded, public_path_roots=public_path_roots)
     if decoded_raw != protected:
-        decoded_sanitized = _apply_public_patterns(decoded)
+        decoded_sanitized = _apply_public_patterns(decoded, public_path_roots=public_path_roots)
         if decoded != decoded_raw or decoded_sanitized != decoded:
             sanitized = decoded_sanitized
             placeholders.update(decoded_placeholders)
@@ -183,7 +193,7 @@ def _sanitize_public_summary(value: str) -> str:
     return sanitized
 
 
-def _apply_public_patterns(value: str) -> str:
+def _apply_public_patterns(value: str, *, public_path_roots: Iterable[Mapping[str, str]] | None = None) -> str:
     sanitized = value
     for pattern in _SECRET_PATTERNS:
         if pattern.groups:
@@ -195,18 +205,22 @@ def _apply_public_patterns(value: str) -> str:
         sanitized,
     )
     sanitized = _SECRET_ASSIGNMENT_PATTERN.sub(lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", sanitized)
+    sanitized = sanitize_public_paths(sanitized, public_path_roots)
     for pattern in _PATH_PATTERNS:
         sanitized = pattern.sub("[PATH]", sanitized)
     return sanitized
 
 
-def _replace_file_uri_tokens(value: str) -> str:
+def _replace_file_uri_tokens(value: str, *, public_path_roots: Iterable[Mapping[str, str]] | None = None) -> str:
     def replace_file_uri(match: re.Match[str]) -> str:
         uri = match.group(0)
         trailing = ""
         while uri and uri[-1] in ".,:!?":
             trailing = uri[-1] + trailing
             uri = uri[:-1]
+        public_path = relativize_public_file_uri(uri, public_path_roots)
+        if public_path is not None:
+            return f"{public_path}{trailing}"
         return f"[PATH]{trailing}"
 
     return _FILE_URI_TEXT_PATTERN.sub(replace_file_uri, value)

--- a/src/iac_code/utils/public_errors.py
+++ b/src/iac_code/utils/public_errors.py
@@ -87,7 +87,14 @@ _WINDOWS_RESERVED_DIGIT_TRANSLATION = str.maketrans(
         "\N{SUPERSCRIPT THREE}": "3",
     }
 )
-_PATH_END_PATTERN = r"""(?=""" + _CONNECTOR_TOKEN_END_PATTERN + r"""|$|[\r\n,;:)"'])"""
+_ABSOLUTE_PATH_TOKEN_END_PATTERN = r"""\s+(?=(?:/(?!/)|[A-Za-z]:[\\/]|\\\\))"""
+_PATH_END_PATTERN = (
+    r"""(?="""
+    + _CONNECTOR_TOKEN_END_PATTERN
+    + r"""|"""
+    + _ABSOLUTE_PATH_TOKEN_END_PATTERN
+    + r"""|$|[\r\n,;:)"'])"""
+)
 _PATH_PATTERNS = (
     re.compile(r"~[/\\]\.iac-code[/\\]?[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),
     re.compile(r"\$HOME[/\\]\.iac-code[/\\]?[^\r\n,;:)\"']*?" + _PATH_END_PATTERN),

--- a/src/iac_code/utils/public_paths.py
+++ b/src/iac_code/utils/public_paths.py
@@ -1,0 +1,215 @@
+"""Public path rendering helpers for external event payloads."""
+
+from __future__ import annotations
+
+import ntpath
+import os
+import posixpath
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from urllib.parse import unquote, urlsplit
+
+_CONNECTOR_TOKEN_END_PATTERN = r"""\s+(?:and|at|because|for|from|in|on|to|with)\b(?=\s+[A-Za-z0-9_.-]+\s*[:=])"""
+_PATH_END_PATTERN = r"""(?=""" + _CONNECTOR_TOKEN_END_PATTERN + r"""|$|[\r\n,;:)"'])"""
+_POSIX_PATH_TEXT_PATTERN = re.compile(r"""(?<![A-Za-z0-9._~%:/\]-])/(?!/)[^\r\n,;:)\"']*?""" + _PATH_END_PATTERN)
+_WINDOWS_UNICODE_LIKE_UNC_PATH_TEXT_PATTERN = re.compile(
+    r"""(?<![A-Za-z0-9])\\\\u[0-9A-Fa-f]{4}\\(?!\\u[0-9A-Fa-f]{4})(?=[^\r\n,;:)"'\]}\\])"""
+    r"""[^\r\n,;:)\"']*?""" + _PATH_END_PATTERN
+)
+_WINDOWS_PATH_TEXT_PATTERN = re.compile(
+    r"""(?<![A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\(?!u[0-9A-Fa-f]{4}))[^\r\n,;:)\"']*?""" + _PATH_END_PATTERN
+)
+_ABSOLUTE_PATH_AFTER_SPACE_PATTERN = re.compile(r"""(\s+)(?=(?:/(?!/)|[A-Za-z]:[\\/]|\\\\))""")
+
+_TRUSTED_ROOT_LABEL = "[trusted]"
+_WORKSPACE_ROOT_LABEL = "."
+_CONFIG_ROOT_LABEL = "$IAC_CODE_CONFIG_DIR"
+
+
+@dataclass(frozen=True)
+class _NormalizedRoot:
+    norm_path: str
+    label: str
+    windows: bool
+    order: int
+
+
+def build_public_path_roots(
+    *,
+    cwd: str,
+    additional_directories: Iterable[str] | None = None,
+    trusted_read_directories: Iterable[str] | None = None,
+    relative_read_directories: Iterable[str] | None = None,
+    include_config_dir: bool = True,
+) -> list[dict[str, str]]:
+    """Build public path roots from the runtime's trusted path context."""
+
+    roots: list[dict[str, str]] = []
+
+    def add(path: object, label: str) -> None:
+        if path is None:
+            return
+        text = str(path).strip()
+        if text:
+            roots.append({"path": text, "label": label})
+
+    add(cwd, _WORKSPACE_ROOT_LABEL)
+    if include_config_dir:
+        from iac_code.config import get_config_dir
+
+        add(get_config_dir(), _CONFIG_ROOT_LABEL)
+    for root in additional_directories or []:
+        add(root, _TRUSTED_ROOT_LABEL)
+    for root in trusted_read_directories or []:
+        add(root, _TRUSTED_ROOT_LABEL)
+    for root in relative_read_directories or []:
+        add(root, _TRUSTED_ROOT_LABEL)
+    return roots
+
+
+def sanitize_public_paths(value: str, public_path_roots: Iterable[Mapping[str, str]] | None) -> str:
+    """Replace absolute paths under public roots with root-relative labels."""
+
+    roots = _normalize_public_path_roots(public_path_roots)
+    if not roots:
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        return _sanitize_public_path_token(match.group(0), roots)
+
+    sanitized = _WINDOWS_UNICODE_LIKE_UNC_PATH_TEXT_PATTERN.sub(replace, value)
+    sanitized = _WINDOWS_PATH_TEXT_PATTERN.sub(replace, sanitized)
+    return _POSIX_PATH_TEXT_PATTERN.sub(replace, sanitized)
+
+
+def _sanitize_public_path_token(token: str, roots: list[_NormalizedRoot]) -> str:
+    parts = _ABSOLUTE_PATH_AFTER_SPACE_PATTERN.split(token)
+    if len(parts) == 1:
+        return _relativize_public_path(token, roots) or "[PATH]"
+    rendered: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        if part.isspace():
+            rendered.append(part)
+            continue
+        rendered.append(_relativize_public_path(part, roots) or "[PATH]")
+    return "".join(rendered)
+
+
+def relativize_public_file_uri(uri: str, public_path_roots: Iterable[Mapping[str, str]] | None) -> str | None:
+    """Return a public relative path for a file URI when it is under a public root."""
+
+    roots = _normalize_public_path_roots(public_path_roots)
+    if not roots:
+        return None
+    parsed = urlsplit(uri)
+    if parsed.scheme.lower() != "file":
+        return None
+    path = unquote(parsed.path or "")
+    if parsed.netloc and parsed.netloc.lower() != "localhost":
+        if _looks_like_windows_drive(parsed.netloc):
+            path = parsed.netloc + path
+        elif path:
+            path = f"//{parsed.netloc}{path}"
+    if re.match(r"^/[A-Za-z]:[\\/]", path):
+        path = path[1:]
+    return _relativize_public_path(path, roots)
+
+
+def relativize_public_path(
+    path: str,
+    public_path_roots: Iterable[Mapping[str, str]] | None,
+) -> str | None:
+    """Return a public root-relative path, choosing the shortest matching root."""
+
+    roots = _normalize_public_path_roots(public_path_roots)
+    return _relativize_public_path(path, roots)
+
+
+def _relativize_public_path(path: str, roots: list[_NormalizedRoot]) -> str | None:
+    if not roots:
+        return None
+    windows = _is_windows_path(path)
+    candidates = _candidate_norm_paths(path, windows=windows)
+    matches: list[tuple[int, int, _NormalizedRoot, str]] = []
+    for token_norm in candidates:
+        for root in roots:
+            if root.windows != windows:
+                continue
+            if _path_is_under_root(token_norm, root.norm_path, windows=windows):
+                matches.append((len(root.norm_path), root.order, root, token_norm))
+    if not matches:
+        return None
+
+    _, _, root, token_norm = min(matches, key=lambda item: (item[0], item[1]))
+    module = ntpath if windows else posixpath
+    rel = module.relpath(token_norm, root.norm_path)
+    rel = "" if rel == "." else rel.replace("\\", "/")
+    if root.label == _WORKSPACE_ROOT_LABEL:
+        return "." if not rel else f"./{rel}"
+    return root.label if not rel else f"{root.label}/{rel}"
+
+
+def _normalize_public_path_roots(public_path_roots: Iterable[Mapping[str, str]] | None) -> list[_NormalizedRoot]:
+    roots: list[_NormalizedRoot] = []
+    seen: set[tuple[str, str, bool]] = set()
+    for order, root in enumerate(public_path_roots or []):
+        raw_path = str(root.get("path") or "").strip()
+        if not raw_path:
+            continue
+        label = str(root.get("label") or _TRUSTED_ROOT_LABEL).strip() or _TRUSTED_ROOT_LABEL
+        windows = _is_windows_path(raw_path)
+        for norm_path in _candidate_norm_paths(raw_path, windows=windows):
+            key = (norm_path, label, windows)
+            if key in seen:
+                continue
+            seen.add(key)
+            roots.append(_NormalizedRoot(norm_path=norm_path, label=label, windows=windows, order=order))
+    return roots
+
+
+def _candidate_norm_paths(path: str, *, windows: bool) -> list[str]:
+    expanded = os.path.expandvars(os.path.expanduser(path))
+    if windows:
+        norm = _normalize_windows_path(expanded)
+        return [norm] if norm else []
+
+    absolute = os.path.abspath(expanded)
+    candidates = [_normalize_posix_path(absolute)]
+    real = _normalize_posix_path(os.path.realpath(absolute))
+    if real not in candidates:
+        candidates.append(real)
+    return [candidate for candidate in candidates if candidate]
+
+
+def _normalize_windows_path(path: str) -> str:
+    normalized = ntpath.normcase(ntpath.normpath(path.replace("/", "\\")))
+    if normalized not in {"\\", "\\\\"} and not re.match(r"^[a-z]:\\$", normalized):
+        normalized = normalized.rstrip("\\")
+    return normalized
+
+
+def _normalize_posix_path(path: str) -> str:
+    normalized = posixpath.normpath(path)
+    if normalized != "/":
+        normalized = normalized.rstrip("/")
+    return normalized
+
+
+def _path_is_under_root(path: str, root: str, *, windows: bool) -> bool:
+    if path == root:
+        return True
+    sep = "\\" if windows else "/"
+    if root == sep or re.match(r"^[a-z]:\\$", root):
+        return path.startswith(root)
+    return path.startswith(root + sep)
+
+
+def _is_windows_path(path: str) -> bool:
+    return bool(ntpath.splitdrive(path)[0] or path.startswith("\\\\"))
+
+
+def _looks_like_windows_drive(value: str) -> bool:
+    return bool(re.match(r"^[A-Za-z]:$", value))

--- a/src/iac_code/utils/public_paths.py
+++ b/src/iac_code/utils/public_paths.py
@@ -11,7 +11,14 @@ from dataclasses import dataclass
 from urllib.parse import unquote, urlsplit
 
 _CONNECTOR_TOKEN_END_PATTERN = r"""\s+(?:and|at|because|for|from|in|on|to|with)\b(?=\s+[A-Za-z0-9_.-]+\s*[:=])"""
-_PATH_END_PATTERN = r"""(?=""" + _CONNECTOR_TOKEN_END_PATTERN + r"""|$|[\r\n,;:)"'])"""
+_ABSOLUTE_PATH_TOKEN_END_PATTERN = r"""\s+(?=(?:/(?!/)|[A-Za-z]:[\\/]|\\\\))"""
+_PATH_END_PATTERN = (
+    r"""(?="""
+    + _CONNECTOR_TOKEN_END_PATTERN
+    + r"""|"""
+    + _ABSOLUTE_PATH_TOKEN_END_PATTERN
+    + r"""|$|[\r\n,;:)"'])"""
+)
 _POSIX_PATH_TEXT_PATTERN = re.compile(r"""(?<![A-Za-z0-9._~%:/\]-])/(?!/)[^\r\n,;:)\"']*?""" + _PATH_END_PATTERN)
 _WINDOWS_UNICODE_LIKE_UNC_PATH_TEXT_PATTERN = re.compile(
     r"""(?<![A-Za-z0-9])\\\\u[0-9A-Fa-f]{4}\\(?!\\u[0-9A-Fa-f]{4})(?=[^\r\n,;:)"'\]}\\])"""
@@ -144,9 +151,7 @@ def _relativize_public_path(path: str, roots: list[_NormalizedRoot]) -> str | No
         return None
 
     _, _, root, token_norm = min(matches, key=lambda item: (item[0], item[1]))
-    module = ntpath if windows else posixpath
-    rel = module.relpath(token_norm, root.norm_path)
-    rel = "" if rel == "." else rel.replace("\\", "/")
+    rel = _relative_path_under_root(token_norm, root.norm_path, windows=windows)
     if root.label == _WORKSPACE_ROOT_LABEL:
         return "." if not rel else f"./{rel}"
     return root.label if not rel else f"{root.label}/{rel}"
@@ -176,10 +181,15 @@ def _candidate_norm_paths(path: str, *, windows: bool) -> list[str]:
         norm = _normalize_windows_path(expanded)
         return [norm] if norm else []
 
-    absolute = os.path.abspath(expanded)
+    if expanded.startswith("/"):
+        absolute = posixpath.normpath(expanded)
+        real_path = posixpath.realpath(absolute)
+    else:
+        absolute = os.path.abspath(expanded)
+        real_path = os.path.realpath(absolute)
     candidates = [_normalize_posix_path(absolute)]
-    real = _normalize_posix_path(os.path.realpath(absolute))
-    if real not in candidates:
+    real = _normalize_posix_path(real_path)
+    if real.startswith("/") and real not in candidates:
         candidates.append(real)
     return [candidate for candidate in candidates if candidate]
 
@@ -205,6 +215,19 @@ def _path_is_under_root(path: str, root: str, *, windows: bool) -> bool:
     if root == sep or re.match(r"^[a-z]:\\$", root):
         return path.startswith(root)
     return path.startswith(root + sep)
+
+
+def _relative_path_under_root(path: str, root: str, *, windows: bool) -> str:
+    if path == root:
+        return ""
+    sep = "\\" if windows else "/"
+    if root == sep:
+        rel = path.lstrip(sep)
+    elif windows and re.match(r"^[a-z]:\\$", root):
+        rel = path[len(root) :].lstrip("\\/")
+    else:
+        rel = path[len(root.rstrip(sep) + sep) :]
+    return rel.replace("\\", "/")
 
 
 def _is_windows_path(path: str) -> bool:

--- a/tests/a2a/test_artifacts.py
+++ b/tests/a2a/test_artifacts.py
@@ -207,6 +207,30 @@ def test_sanitize_public_artifact_text_decodes_percent_encoded_local_paths() -> 
     assert ".iac-code" not in sanitized
 
 
+def test_sanitize_public_artifact_text_relativizes_file_uri_under_public_root() -> None:
+    roots = [{"path": "/Users/alice/project", "label": "."}]
+
+    sanitized = sanitize_public_artifact_text(
+        "see file:///Users/alice/project/output/template.yaml",
+        public_path_roots=roots,
+    )
+
+    assert sanitized == "see ./output/template.yaml"
+    assert "/Users/alice" not in sanitized
+
+
+def test_sanitize_public_artifact_text_relativizes_localhost_file_uri_under_public_root() -> None:
+    roots = [{"path": "/Users/alice/project", "label": "."}]
+
+    sanitized = sanitize_public_artifact_text(
+        "see file://localhost/Users/alice/project/output/template.yaml",
+        public_path_roots=roots,
+    )
+
+    assert sanitized == "see ./output/template.yaml"
+    assert "/Users/alice" not in sanitized
+
+
 def test_sanitize_public_artifact_text_redacts_raw_file_uri_with_spaces() -> None:
     value = r"failed at file:///Users/Alice and Bob/.iac-code/projects/demo/template.yaml and next"
 
@@ -262,6 +286,181 @@ def test_sanitize_public_tool_output_handles_artifacts_containers_and_sensitive_
         "api_key": "[REDACTED]",
         "note": "stored at [PATH]\nnext",
     }
+
+
+def test_sanitize_public_tool_output_relativizes_paths_under_public_roots() -> None:
+    output = sanitize_public_tool_output_data(
+        "STDOUT:\n"
+        "/Users/alice/project/src/app.py:12\n"
+        "/Users/alice/.iac-code/tool-results/session-1/result.txt\n"
+        "/Volumes/shared/templates/base.yaml\n"
+        "/Users/alice/private/secret.txt\n"
+        "Exit code: 0",
+        public_path_roots=[
+            {"path": "/Users/alice/project", "label": "."},
+            {"path": "/Users/alice/.iac-code", "label": "$IAC_CODE_CONFIG_DIR"},
+            {"path": "/Volumes/shared/templates", "label": "[trusted]"},
+        ],
+    )
+
+    assert output == (
+        "STDOUT:\n"
+        "./src/app.py:12\n"
+        "$IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt\n"
+        "[trusted]/base.yaml\n"
+        "[PATH]\n"
+        "Exit code: 0"
+    )
+
+
+def test_sanitize_public_tool_output_relativizes_path_keys_under_public_roots() -> None:
+    output = sanitize_public_tool_output_data(
+        {
+            "/Users/alice/project/src/app.py": "workspace",
+            "/Users/alice/.iac-code/tool-results/session-1/result.txt": "config",
+            "/Volumes/shared/templates/base.yaml": "trusted",
+            "/opt/private/config.txt": "outside",
+            "nested": {"/Users/alice/project/output.yaml": "nested"},
+        },
+        public_path_roots=[
+            {"path": "/Users/alice/project", "label": "."},
+            {"path": "/Users/alice/.iac-code", "label": "$IAC_CODE_CONFIG_DIR"},
+            {"path": "/Volumes/shared/templates", "label": "[trusted]"},
+        ],
+    )
+
+    assert output == {
+        "./src/app.py": "workspace",
+        "$IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt": "config",
+        "[trusted]/base.yaml": "trusted",
+        "[PATH]": "outside",
+        "nested": {"./output.yaml": "nested"},
+    }
+
+
+def test_sanitize_public_tool_output_redacts_sensitive_keys_that_also_contain_paths() -> None:
+    output = sanitize_public_tool_output_data(
+        {
+            "password_file /Users/alice/project/config.txt": "super-secret",
+            "/Users/alice/project/config.txt password_file": "suffix-secret",
+            "file:///Users/alice/project/config-uri.txt password_file": "uri-suffix-secret",
+        },
+        public_path_roots=[{"path": "/Users/alice/project", "label": "."}],
+    )
+
+    assert output == {
+        "password_file ./config.txt": "[REDACTED]",
+        "./config.txt password_file": "[REDACTED]",
+        "./config-uri.txt password_file": "[REDACTED]",
+    }
+
+
+def test_sanitize_public_artifact_data_relativizes_path_keys_under_public_roots() -> None:
+    output = sanitize_public_artifact_data(
+        {
+            "filename": "result.txt",
+            "metadata": {
+                "/Users/alice/project/template.yaml": "workspace",
+                "/Volumes/shared/templates/base.yaml": "trusted",
+            },
+        },
+        public_path_roots=[
+            {"path": "/Users/alice/project", "label": "."},
+            {"path": "/Volumes/shared/templates", "label": "[trusted]"},
+        ],
+    )
+
+    assert output == {
+        "filename": "result.txt",
+        "metadata": {
+            "./template.yaml": "workspace",
+            "[trusted]/base.yaml": "trusted",
+        },
+    }
+
+
+def test_sanitize_public_artifact_data_redacts_sensitive_keys_that_also_contain_paths() -> None:
+    output = sanitize_public_artifact_data(
+        {
+            "metadata": {
+                "password_file /Users/alice/project/config.txt": "super-secret",
+                "/Users/alice/project/config.txt password_file": "suffix-secret",
+            }
+        },
+        public_path_roots=[{"path": "/Users/alice/project", "label": "."}],
+    )
+
+    assert output == {
+        "metadata": {
+            "password_file ./config.txt": "[REDACTED]",
+            "./config.txt password_file": "[REDACTED]",
+        }
+    }
+
+
+def test_sanitize_public_tool_output_redacts_unmatched_absolute_paths_without_touching_urls() -> None:
+    output = sanitize_public_tool_output_data(
+        "files:\n"
+        "/opt/private/secret.txt\n"
+        "/mnt/data/foo.txt\n"
+        "/Volumes/shared/secret.txt\n"
+        "https://example.com/docs/template.yaml\n"
+        "path=/srv/app/config.yaml",
+        public_path_roots=[{"path": "/Users/alice/project", "label": "."}],
+    )
+
+    assert output == ("files:\n[PATH]\n[PATH]\n[PATH]\nhttps://example.com/docs/template.yaml\npath=[PATH]")
+
+
+def test_sanitize_public_tool_output_preserves_json_unicode_escapes() -> None:
+    output = sanitize_public_tool_output_data(
+        r'{"Label": "{\"en\": \"VPC\", \"zh-cn\": \"\\u4e13\\u6709\\u7f51\\u7edc\"}"}',
+        public_path_roots=[{"path": "/Users/alice/project", "label": "."}],
+    )
+
+    assert output == r'{"Label": "{\"en\": \"VPC\", \"zh-cn\": \"\\u4e13\\u6709\\u7f51\\u7edc\"}"}'
+
+
+def test_sanitize_public_tool_output_uses_shortest_matching_public_root() -> None:
+    output = sanitize_public_tool_output_data(
+        "/repo/subdir/file.yaml",
+        public_path_roots=[
+            {"path": "/repo", "label": "."},
+            {"path": "/repo/subdir", "label": "[trusted]"},
+        ],
+    )
+
+    assert output == "./subdir/file.yaml"
+
+
+def test_sanitize_public_tool_output_relativizes_windows_paths_under_public_roots() -> None:
+    output = sanitize_public_tool_output_data(
+        r"C:\Users\alice\project\src\app.py:12",
+        public_path_roots=[{"path": r"C:\Users\alice\project", "label": "."}],
+    )
+
+    assert output == "./src/app.py:12"
+    assert "C:\\Users\\alice" not in output
+
+
+def test_sanitize_public_tool_output_relativizes_unc_paths_under_public_roots() -> None:
+    output = sanitize_public_tool_output_data(
+        r"\\server\share\dir\file.txt",
+        public_path_roots=[{"path": r"\\server\share", "label": "[trusted]"}],
+    )
+
+    assert output == "[trusted]/dir/file.txt"
+    assert "\\\\server\\share" not in output
+
+
+def test_sanitize_public_tool_output_relativizes_unc_paths_with_unicode_like_server_names() -> None:
+    output = sanitize_public_tool_output_data(
+        r"\\u1234\share\dir\file.txt",
+        public_path_roots=[{"path": r"\\u1234\share", "label": "[trusted]"}],
+    )
+
+    assert output == "[trusted]/dir/file.txt"
+    assert r"\\u1234\share" not in output
 
 
 def test_sanitize_public_tool_output_handles_root_artifact_payload_dicts() -> None:

--- a/tests/a2a/test_events.py
+++ b/tests/a2a/test_events.py
@@ -786,6 +786,42 @@ async def test_failed_tool_result_metadata_is_sanitized() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tool_result_metadata_relativizes_paths_under_public_roots() -> None:
+    queue = FakeEventQueue()
+
+    await publish_stream_event(
+        queue,
+        task_id="task-1",
+        context_id="ctx-1",
+        event=ToolResultEvent(
+            tool_use_id="tool-1",
+            tool_name="bash",
+            result=(
+                "STDOUT:\n"
+                "/Users/alice/project/src/app.py:12\n"
+                "/Users/alice/.iac-code/tool-results/session-1/result.txt\n"
+                "/Users/alice/private/secret.txt\n"
+                "Exit code: 0"
+            ),
+            public_path_roots=[
+                {"path": "/Users/alice/project", "label": "."},
+                {"path": "/Users/alice/.iac-code", "label": "$IAC_CODE_CONFIG_DIR"},
+            ],
+        ),
+    )
+
+    dumped = dump(queue.events[0])
+    tool = dumped["metadata"]["iac_code"]["tool"]
+    assert tool["result"] == (
+        "STDOUT:\n./src/app.py:12\n$IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt\n[PATH]\nExit code: 0"
+    )
+    rendered = str(dumped)
+    assert "public_path_roots" not in rendered
+    assert "publicPathRoots" not in rendered
+    assert "/Users/alice" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_failed_tool_result_metadata_redacts_malformed_opaque_artifact_uri() -> None:
     queue = FakeEventQueue()
     malformed_uri = r"iac-code-artifact://artifact-1/C:\Users\alice\.iac-code\projects\demo\template.yaml"

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from a2a.types import TaskStatusUpdateEvent
+from a2a.types import Task, TaskStatusUpdateEvent
 from a2a.utils.errors import InvalidParamsError
 from google.protobuf.json_format import MessageToDict
 
@@ -463,6 +463,48 @@ async def test_executor_canceled_terminal_backup_blocked_records_cancel_intent(
     assert metrics.task_canceled == 1
     assert metrics.executor_error == 0
     assert metrics.task_failed == 0
+
+
+@pytest.mark.asyncio
+async def test_executor_sanitizes_initial_task_echo_paths_without_changing_runtime_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from a2a.types import Message, Part, Role
+
+    config_dir = tmp_path / "config"
+    cwd = tmp_path / "workspace"
+    config_dir.mkdir()
+    cwd.mkdir()
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(config_dir))
+    loop = FakeAgentLoop([TextDeltaEvent(text="ok")])
+    runtime = FakeRuntime(agent_loop=loop, session_id="session-1")
+    monkeypatch.setattr("iac_code.a2a.executor.create_agent_runtime", lambda options: runtime)
+
+    prompt = f"paths: {cwd}/src/app.py {config_dir}/tool-results/session-1/result.txt /opt/iac-code-outside/config.yaml"
+    context = FakeRequestContext(text=prompt, metadata={"iac_code": {"cwd": str(cwd)}})
+    context.message = Message(
+        role=Role.ROLE_USER,
+        parts=[Part(text=prompt)],
+        metadata={"iac_code": {"cwd": str(cwd)}},
+        message_id="msg-paths",
+    )
+
+    queue = FakeEventQueue()
+    executor = IacCodeA2AExecutor(task_store=A2ATaskStore(metrics=NoOpA2AMetrics()), model="qwen3.6-plus")
+
+    await executor.execute(context, queue)
+
+    initial_task = next(event for event in queue.events if isinstance(event, Task))
+    rendered = dump(initial_task)
+    history = rendered["history"][0]
+    assert history["parts"][0]["text"] == (
+        "paths: ./src/app.py $IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt [PATH]"
+    )
+    assert history["metadata"]["iac_code"]["cwd"] == "."
+    assert str(cwd) not in json.dumps(rendered)
+    assert str(config_dir) not in json.dumps(rendered)
+    assert "/opt/iac-code-outside/config.yaml" not in json.dumps(rendered)
+    assert loop.prompts == [prompt]
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_pipeline_debugger_script.py
+++ b/tests/a2a/test_pipeline_debugger_script.py
@@ -1009,6 +1009,56 @@ def test_index_html_groups_normal_a2a_message_deltas_outside_pipeline_steps() ->
         assert expected in html
 
 
+def test_index_html_surfaces_normal_a2a_metadata_events_outside_pipeline_steps() -> None:
+    debugger = load_debugger_module()
+
+    html = debugger.render_index_html(
+        debugger.DebuggerConfig(
+            host="127.0.0.1",
+            port=41880,
+            default_server_url="http://127.0.0.1:41299",
+            default_cwd="/workspace/demo",
+        )
+    )
+
+    for expected in [
+        "function a2aStatusUpdate",
+        "function normalMetadataEventsFromRawItem",
+        "function appendNormalMetadataEvent",
+        "normalMetadataGroups: {}",
+        "metadata.thinking",
+        "metadata.tool",
+        '"normal_thinking_group"',
+        '"normal_tool_event"',
+        "appendNormalMetadataEvent(rawRow || payload);",
+    ]:
+        assert expected in html
+
+
+def test_index_html_backfills_normal_a2a_metadata_when_replaying_existing_tree() -> None:
+    debugger = load_debugger_module()
+
+    html = debugger.render_index_html(
+        debugger.DebuggerConfig(
+            host="127.0.0.1",
+            port=41880,
+            default_server_url="http://127.0.0.1:41299",
+            default_cwd="/workspace/demo",
+        )
+    )
+
+    for expected in [
+        "function executionTreeHasNormalMetadataTimeline",
+        "function rebuildNormalChatTimelineFromRawEvents",
+        "function removeNormalChatNodes",
+        "normal_thinking_group",
+        "normal_tool_event",
+        "if (!executionTreeHasNormalMetadataTimeline(state.executionTree)) {",
+        "rebuildNormalChatTimelineFromRawEvents(state.raw.sse);",
+    ]:
+        assert expected in html
+
+
 def test_index_html_deduplicates_pipeline_events_across_overlapping_streams() -> None:
     debugger = load_debugger_module()
 

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -1260,6 +1260,68 @@ def test_stack_current_changed_emits_after_successful_ros_create_stack() -> None
     }
 
 
+def test_stack_current_changed_emits_after_successful_ros_deploy_recreate() -> None:
+    ctx = _ctx()
+    ctx.emit_stack_events = True
+    translator = PipelineEventTranslator(ctx)
+    translator.translate(
+        PipelineEvent(
+            type=PipelineEventType.STEP_STARTED,
+            step_id="deploying",
+            timestamp=time.time(),
+            data={"index": 5, "total": 5},
+        )
+    )
+    translator.translate(
+        ToolUseEndEvent(
+            tool_use_id="toolu-deploy",
+            name="ros_deploy",
+            input={
+                "action": "delete_and_create",
+                "stack_id": "stack-old",
+                "stack_name": "demo",
+                "template_url": "templates/demo.yml",
+                "region_id": "cn-hangzhou",
+            },
+        )
+    )
+
+    envelopes = translator.translate(
+        ToolResultEvent(
+            tool_use_id="toolu-deploy",
+            tool_name="ros_deploy",
+            result=json.dumps(
+                {
+                    "stack_id": "stack-new",
+                    "stack_name": "demo",
+                    "status": "CREATE_COMPLETE",
+                    "is_success": True,
+                }
+            ),
+            is_error=False,
+        )
+    )
+
+    stack_event = envelopes[0]
+    assert [envelope["eventType"] for envelope in envelopes] == ["stack_current_changed", "tool_result"]
+    assert stack_event["scope"] == "stack"
+    assert stack_event["step"]["id"] == "deploying"
+    assert stack_event["data"] == {
+        "toolName": "ros_deploy",
+        "toolUseId": "toolu-deploy",
+        "provider": "ros",
+        "action": "CreateStack",
+        "deployAction": "delete_and_create",
+        "previousStackId": "stack-old",
+        "regionId": "cn-hangzhou",
+        "stackId": "stack-new",
+        "stackName": "demo",
+        "stackStatus": "CREATE_COMPLETE",
+        "isSuccess": True,
+        "current": True,
+    }
+
+
 def test_stack_current_changed_keeps_current_stack_after_statusless_successful_delete() -> None:
     ctx = _ctx()
     ctx.emit_stack_events = True

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -1079,6 +1079,36 @@ def test_failed_tool_result_payload_is_sanitized() -> None:
     assert "/Users/alice" not in rendered
 
 
+def test_tool_result_payload_relativizes_paths_under_public_roots() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = translator.translate(
+        ToolResultEvent(
+            tool_use_id="toolu-paths",
+            tool_name="bash",
+            result=(
+                "STDOUT:\n"
+                "/Users/alice/project/src/app.py:12\n"
+                "/Users/alice/.iac-code/tool-results/session-1/result.txt\n"
+                "/Users/alice/private/secret.txt\n"
+                "Exit code: 0"
+            ),
+            public_path_roots=[
+                {"path": "/Users/alice/project", "label": "."},
+                {"path": "/Users/alice/.iac-code", "label": "$IAC_CODE_CONFIG_DIR"},
+            ],
+        )
+    )
+
+    assert envelopes[0]["data"]["result"] == (
+        "STDOUT:\n./src/app.py:12\n$IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt\n[PATH]\nExit code: 0"
+    )
+    rendered = json.dumps(envelopes[0], ensure_ascii=False)
+    assert "public_path_roots" not in rendered
+    assert "publicPathRoots" not in rendered
+    assert "/Users/alice" not in rendered
+
+
 def test_tool_result_keeps_valid_opaque_artifact_uri() -> None:
     translator = PipelineEventTranslator(_ctx())
     uri = "iac-code-artifact://artifact-1/template.yaml"

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -36,6 +36,7 @@ from .fakes import FakeEventQueue, FakeRequestContext
 
 RETRY_TEXT = "A temporary error occurred. Please retry."
 AUTH_TEXT = "Authentication required. Configure credentials and retry."
+_A2A_ASYNC_TEST_TIMEOUT = 5
 
 
 def test_active_sidecar_mismatch_error_exposes_jsonrpc_data() -> None:
@@ -946,7 +947,7 @@ async def test_pipeline_executor_reconfigures_cached_runtime_model_and_api_key_p
 
 
 async def _wait_for_output_text(task, expected: str) -> None:
-    for _ in range(100):
+    for _ in range(_A2A_ASYNC_TEST_TIMEOUT * 100):
         if "".join(task.output_text) == expected:
             return
         await asyncio.sleep(0.01)
@@ -954,7 +955,7 @@ async def _wait_for_output_text(task, expected: str) -> None:
 
 
 async def _wait_for_pipeline_event(queue: FakeEventQueue, expected_event_type: str) -> None:
-    for _ in range(100):
+    for _ in range(_A2A_ASYNC_TEST_TIMEOUT * 100):
         for event in queue.events:
             if not isinstance(event, TaskStatusUpdateEvent):
                 continue
@@ -4669,7 +4670,7 @@ async def test_live_paused_interrupt_releases_active_task_and_next_reply_clears_
         ),
         queue,
     )
-    await asyncio.wait_for(first, timeout=1)
+    await asyncio.wait_for(first, timeout=_A2A_ASYNC_TEST_TIMEOUT)
     ctx = await store.get_or_create_context(context_id="ctx-1", cwd=str(tmp_path), runtime_factory=lambda _sid: None)
     assert ctx.active_task_id is None
     assert pipeline.primary_stream.closed is True
@@ -4809,9 +4810,9 @@ async def test_active_pause_continuation_keeps_active_owner_until_continuation_f
         )
     )
     try:
-        await asyncio.wait_for(pipeline.continuation_started.wait(), timeout=1)
+        await asyncio.wait_for(pipeline.continuation_started.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
         pipeline.primary_stream.allow_close.set()
-        await asyncio.wait_for(first, timeout=1)
+        await asyncio.wait_for(first, timeout=_A2A_ASYNC_TEST_TIMEOUT)
 
         ctx = await store.get_or_create_context(
             context_id="ctx-1", cwd=str(tmp_path), runtime_factory=lambda _sid: None
@@ -4821,7 +4822,7 @@ async def test_active_pause_continuation_keeps_active_owner_until_continuation_f
         assert active_task.active_task is continuation
 
         pipeline.finish_continuation.set()
-        await asyncio.wait_for(continuation, timeout=1)
+        await asyncio.wait_for(continuation, timeout=_A2A_ASYNC_TEST_TIMEOUT)
         assert ctx.active_task_id is None
         assert active_task.active_task is None
     finally:
@@ -5129,11 +5130,11 @@ async def test_pipeline_executor_publishes_interrupt_received_before_slow_judge(
         )
     )
     try:
-        await asyncio.wait_for(pipeline.judge_started.wait(), timeout=1)
+        await asyncio.wait_for(pipeline.judge_started.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
         assert [event["eventType"] for event in publisher.journal.read_all()] == ["interrupt_received"]
     finally:
         pipeline.finish_judge.set()
-        await asyncio.wait_for(interrupt_task, timeout=1)
+        await asyncio.wait_for(interrupt_task, timeout=_A2A_ASYNC_TEST_TIMEOUT)
 
     assert [event["eventType"] for event in publisher.journal.read_all()] == [
         "interrupt_received",
@@ -5215,11 +5216,11 @@ async def test_pipeline_executor_stops_at_ask_user_question_without_holding_acti
             prompt="帮我部署网站",
         )
     )
-    await asyncio.wait_for(pipeline.question_ready.wait(), timeout=1)
+    await asyncio.wait_for(pipeline.question_ready.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
     await _wait_for_pipeline_event(queue, "input_required")
 
-    await asyncio.wait_for(runner, timeout=1)
-    await asyncio.wait_for(pipeline.closed.wait(), timeout=1)
+    await asyncio.wait_for(runner, timeout=_A2A_ASYNC_TEST_TIMEOUT)
+    await asyncio.wait_for(pipeline.closed.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
 
     ctx = await store.get_or_create_context(
         context_id="ctx-1",
@@ -7053,7 +7054,7 @@ async def test_parent_hard_interrupt_closes_active_stream_and_restarts(
             prompt="build ecs",
         )
     )
-    await asyncio.wait_for(pipeline.primary_stream.started.wait(), timeout=1)
+    await asyncio.wait_for(pipeline.primary_stream.started.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
     await _wait_for_output_text(active_task, "before interrupt")
 
     try:
@@ -7070,9 +7071,9 @@ async def test_parent_hard_interrupt_closes_active_stream_and_restarts(
             prompt="please change cpu",
         )
 
-        await asyncio.wait_for(pipeline.primary_stream.closed_event.wait(), timeout=1)
+        await asyncio.wait_for(pipeline.primary_stream.closed_event.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
         assert pipeline.primary_stream.closed is True
-        await asyncio.wait_for(runner, timeout=1)
+        await asyncio.wait_for(runner, timeout=_A2A_ASYNC_TEST_TIMEOUT)
         assert pipeline.continue_after_interrupt_calls == 1
         assert "".join(active_task.output_text) == "before interruptafter interrupt"
     finally:
@@ -7168,7 +7169,7 @@ async def test_parent_hard_interrupt_cancels_blocked_async_generator_before_rest
             prompt="build ecs",
         )
     )
-    await asyncio.wait_for(pipeline.generator_blocked.wait(), timeout=1)
+    await asyncio.wait_for(pipeline.generator_blocked.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
 
     try:
         await executor.execute(
@@ -7184,9 +7185,9 @@ async def test_parent_hard_interrupt_cancels_blocked_async_generator_before_rest
             prompt="please change cpu",
         )
 
-        await asyncio.wait_for(pipeline.primary_cancelled.wait(), timeout=1)
-        await asyncio.wait_for(pipeline.primary_closed.wait(), timeout=1)
-        await asyncio.wait_for(runner, timeout=1)
+        await asyncio.wait_for(pipeline.primary_cancelled.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
+        await asyncio.wait_for(pipeline.primary_closed.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
+        await asyncio.wait_for(runner, timeout=_A2A_ASYNC_TEST_TIMEOUT)
         assert pipeline.continue_after_interrupt_calls == 1
         assert "".join(active_task.output_text) == "before interruptafter interrupt"
     finally:
@@ -7255,11 +7256,11 @@ async def test_canceled_pipeline_run_closes_blocked_stream_without_child_task_le
             prompt="build ecs",
         )
     )
-    await asyncio.wait_for(pipeline.generator_blocked.wait(), timeout=1)
+    await asyncio.wait_for(pipeline.generator_blocked.wait(), timeout=_A2A_ASYNC_TEST_TIMEOUT)
 
     try:
         runner.cancel()
-        await asyncio.wait_for(runner, timeout=1)
+        await asyncio.wait_for(runner, timeout=_A2A_ASYNC_TEST_TIMEOUT)
         await asyncio.sleep(0)
 
         pending_coro_names = _pending_coro_names()

--- a/tests/a2a/test_transport_dispatcher.py
+++ b/tests/a2a/test_transport_dispatcher.py
@@ -130,7 +130,7 @@ async def test_dispatcher_stream_redacts_sensitive_message_metadata_echo(monkeyp
 
     echoed_metadata = events[0]["result"]["history"][0]["metadata"]
     assert echoed_metadata["iac_code"] == {
-        "cwd": str(tmp_path),
+        "cwd": ".",
         "iac_code_model": "qwen3.6-plus",
         "iac_code_api_key": "***",
         "alibaba_cloud_access_key_id": "***",

--- a/tests/a2a/test_transport_dispatcher.py
+++ b/tests/a2a/test_transport_dispatcher.py
@@ -16,6 +16,8 @@ from iac_code.types.stream_events import TextDeltaEvent
 
 from .fakes import FakeAgentLoop, FakeRuntime
 
+_STREAM_TEST_TIMEOUT = 5
+
 
 @pytest.mark.asyncio
 async def test_dispatcher_handles_unary_v03_message(monkeypatch, tmp_path) -> None:
@@ -267,7 +269,7 @@ async def test_dispatcher_routes_second_pipeline_stream_as_interrupt(monkeypatch
             first_events.append(event)
 
     first_task = asyncio.create_task(consume_first_stream())
-    await asyncio.wait_for(pipeline.started.wait(), timeout=1)
+    await asyncio.wait_for(pipeline.started.wait(), timeout=_STREAM_TEST_TIMEOUT)
     identity = _active_task_identity(components)
 
     async def consume_second_stream() -> None:
@@ -292,7 +294,7 @@ async def test_dispatcher_routes_second_pipeline_stream_as_interrupt(monkeypatch
             pass
 
     second_task = asyncio.create_task(consume_second_stream())
-    for _ in range(100):
+    for _ in range(_STREAM_TEST_TIMEOUT * 100):
         if pipeline.interrupts:
             break
         await asyncio.sleep(0.01)
@@ -302,7 +304,7 @@ async def test_dispatcher_routes_second_pipeline_stream_as_interrupt(monkeypatch
         event_types = [event["eventType"] for event in A2APipelineJournal(pipeline.session.session_dir).read_all()]
         assert "interrupt_received" in event_types
         assert "interrupt_classified" in event_types
-        await asyncio.wait_for(second_task, timeout=1)
+        await asyncio.wait_for(second_task, timeout=_STREAM_TEST_TIMEOUT)
     finally:
         if not second_task.done():
             second_task.cancel()
@@ -311,7 +313,7 @@ async def test_dispatcher_routes_second_pipeline_stream_as_interrupt(monkeypatch
             except asyncio.CancelledError:
                 pass
         pipeline.release.set()
-        await asyncio.wait_for(first_task, timeout=1)
+        await asyncio.wait_for(first_task, timeout=_STREAM_TEST_TIMEOUT)
         await dispatcher.aclose()
         await components.aclose()
 
@@ -422,7 +424,7 @@ async def test_active_message_stream_cancellation_cancels_producer() -> None:
     stream_task.cancel()
 
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(stream_task, timeout=1)
+        await asyncio.wait_for(stream_task, timeout=_STREAM_TEST_TIMEOUT)
     assert producer_cancelled.is_set()
     assert active_task._reference_count == 0
 

--- a/tests/acp/test_convert.py
+++ b/tests/acp/test_convert.py
@@ -779,6 +779,9 @@ def test_pipeline_tool_call_titles_use_display_names() -> None:
     end_updates = converter.event_to_updates(ToolUseEndEvent(tool_use_id="tc-1", name="complete_step", input={}))
     assert end_updates[0].title == "Complete step"
 
+    ros_start_updates = converter.event_to_updates(ToolUseStartEvent(tool_use_id="tc-2", name="ros_deploy"))
+    assert ros_start_updates[0].title == "ROS Deploy"
+
 
 def test_converter_works_without_turn_state_backward_compatible() -> None:
     """Scenario 11: Without turn_state, converter still processes events normally."""
@@ -933,6 +936,7 @@ def test_tool_kind_mapping_covers_extension_tools() -> None:
     assert _tool_kind("task_get") == "read"
     assert _tool_kind("task_stop") == "execute"
     assert _tool_kind("ros_stack") == "execute"
+    assert _tool_kind("ros_deploy") == "execute"
     assert _tool_kind("ros_stack_instances") == "execute"
     assert _tool_kind("aliyun_doc_search") == "fetch"
 

--- a/tests/acp/test_convert.py
+++ b/tests/acp/test_convert.py
@@ -600,6 +600,26 @@ def test_successful_tool_result_content_is_sanitized() -> None:
     assert updates[1].status == "completed"
 
 
+def test_successful_tool_result_relativizes_public_paths() -> None:
+    converter = ACPEventConverter(turn_id="turn-1")
+    converter.event_to_updates(ToolUseStartEvent(tool_use_id="t1", name="bash"))
+
+    updates = converter.event_to_updates(
+        ToolResultEvent(
+            tool_use_id="t1",
+            tool_name="bash",
+            result="/Users/alice/project/src/app.py\n/Users/alice/private/secret.txt",
+            is_error=False,
+            public_path_roots=[{"path": "/Users/alice/project", "label": "."}],
+        )
+    )
+
+    rendered = str(updates[0].content[0].content.text)
+    assert rendered == "./src/app.py\n[PATH]"
+    assert "/Users/alice" not in rendered
+    assert updates[1].status == "completed"
+
+
 def test_successful_tool_result_dict_is_sanitized_and_serialized() -> None:
     converter = ACPEventConverter(turn_id="turn-1")
     converter.event_to_updates(ToolUseStartEvent(tool_use_id="t1", name="write_file"))

--- a/tests/acp/test_permission_rules.py
+++ b/tests/acp/test_permission_rules.py
@@ -112,6 +112,34 @@ async def test_options_include_rule_suggestions_when_present():
 
 
 @pytest.mark.asyncio
+async def test_options_display_friendly_rule_text_when_present():
+    """Rule-level option IDs stay machine-readable while names use display text."""
+    suggestions = [
+        PermissionRuleValue(
+            tool_name="ros_deploy",
+            rule_content="continue_create:stack-failed",
+            display_text="Continue ROS stack creation: stack-failed",
+        )
+    ]
+    conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
+    session = ACPSession("s1", _FakeLoop(), conn)
+    event = _make_event(tool_name="ros_deploy", suggestions=suggestions)
+
+    await session._request_permission(event)
+
+    option_by_id = {opt.option_id: opt for opt in conn.last_options}
+    assert _PREFIX_ALLOW_RULE + "continue_create:stack-failed" in option_by_id
+    assert _PREFIX_DENY_RULE + "continue_create:stack-failed" in option_by_id
+    assert (
+        "Continue ROS stack creation: stack-failed"
+        in option_by_id[_PREFIX_ALLOW_RULE + "continue_create:stack-failed"].name
+    )
+    assert "continue_create:stack-failed" not in option_by_id[_PREFIX_ALLOW_RULE + "continue_create:stack-failed"].name
+    assert "Suggested rule: Continue ROS stack creation: stack-failed" in conn.last_content
+    assert "Suggested rule: continue_create:stack-failed" not in conn.last_content
+
+
+@pytest.mark.asyncio
 async def test_options_fallback_to_tool_level_without_suggestions():
     """Without suggestions, options include tool-level allow_always."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -88,6 +88,10 @@ class TestBuildSystemPrompt:
     def test_contains_identity_section(self):
         prompt = build_system_prompt(cwd=_TMP)
         assert "AI" in prompt or "assistant" in prompt
+        assert "IaC Code" in prompt
+        assert "iac-code" in prompt
+        assert "AI-powered Infrastructure as Code assistant" in prompt
+        assert "AI 驱动的基础设施即代码助手" not in prompt
 
     def test_contains_environment_section(self):
         prompt = build_system_prompt(cwd=_TMP)
@@ -217,6 +221,45 @@ class TestBuildSystemPrompt:
 
         assert first == second
         assert "- Current time: 2026-06-05 10:00:00" in first
+
+    def test_provider_and_model_line_is_dynamic_near_current_time(self):
+        static, dynamic = split_by_dynamic_boundary(
+            build_system_prompt(
+                cwd=_TMP,
+                current_time="2026-06-05 10:00:00",
+                provider_display="Alibaba Cloud Bailian",
+                model="qwen3.7-max",
+            )
+        )
+
+        runtime_line = "Provider & Model: Alibaba Cloud Bailian / qwen3.7-max"
+        assert "# Runtime Context" in dynamic
+        assert "# Current Time" not in dynamic
+        assert runtime_line not in static
+        assert runtime_line in dynamic
+        assert dynamic.index("- Current time: 2026-06-05 10:00:00") < dynamic.index(runtime_line)
+
+    def test_model_changes_do_not_change_static_cache_prefix(self):
+        first_static, first_dynamic = split_by_dynamic_boundary(
+            build_system_prompt(
+                cwd=_TMP,
+                current_time="2026-06-05 10:00:00",
+                provider_display="Alibaba Cloud Bailian",
+                model="qwen3.7-max",
+            )
+        )
+        second_static, second_dynamic = split_by_dynamic_boundary(
+            build_system_prompt(
+                cwd=_TMP,
+                current_time="2026-06-05 10:00:00",
+                provider_display="Alibaba Cloud Bailian",
+                model="qwen3.7-plus",
+            )
+        )
+
+        assert first_static == second_static
+        assert "Provider & Model: Alibaba Cloud Bailian / qwen3.7-max" in first_dynamic
+        assert "Provider & Model: Alibaba Cloud Bailian / qwen3.7-plus" in second_dynamic
 
 
 class TestSplitByDynamicBoundary:
@@ -355,10 +398,20 @@ class TestBuildBaseSections:
         assert "/some/test/path" in result
 
     def test_default_pipeline_sections_constant(self):
-        assert DEFAULT_PIPELINE_SECTIONS == ["identity", "system", "env", "cloud_config", "tools"]
+        assert DEFAULT_PIPELINE_SECTIONS == ["identity", "system", "env", "cloud_config", "tools", "runtime_context"]
 
     def test_section_builders_has_all_keys(self):
-        expected_keys = {"identity", "system", "env", "cloud_config", "tools", "doing_tasks", "actions", "output_style"}
+        expected_keys = {
+            "identity",
+            "system",
+            "env",
+            "cloud_config",
+            "runtime_context",
+            "tools",
+            "doing_tasks",
+            "actions",
+            "output_style",
+        }
         assert set(SECTION_BUILDERS.keys()) == expected_keys
 
     def test_section_priorities_has_all_keys(self):

--- a/tests/cli/test_output_formats.py
+++ b/tests/cli/test_output_formats.py
@@ -262,6 +262,26 @@ class TestStreamJsonWriter:
         assert data["type"] == "tool_result"
         assert "metadata" not in data
 
+    def test_tool_result_relativizes_public_paths_without_emitting_roots(self) -> None:
+        stream = io.StringIO()
+        writer = StreamJsonWriter(stream)
+        writer.handle(
+            ToolResultEvent(
+                tool_use_id="tu_1",
+                tool_name="bash",
+                result="/Users/alice/project/src/app.py\n/Users/alice/private/secret.txt",
+                public_path_roots=[{"path": "/Users/alice/project", "label": "."}],
+            )
+        )
+
+        data = json.loads(stream.getvalue())
+        rendered = json.dumps(data, ensure_ascii=False)
+        assert data["type"] == "tool_result"
+        assert data["result"] == "./src/app.py\n[PATH]"
+        assert "public_path_roots" not in data
+        assert "publicPathRoots" not in rendered
+        assert "/Users/alice" not in rendered
+
     def test_subagent_tool_event_omits_raw_child_input(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
@@ -597,6 +617,30 @@ class TestStreamJsonWriter:
         assert "hunter2" not in rendered
         assert "/Users/alice" not in rendered
         assert data["metadata"]["step_result"]["error"] == "Schema failed DB_PASSWORD=[REDACTED] at [PATH]"
+
+    def test_failed_tool_result_metadata_relativizes_public_paths(self) -> None:
+        stream = io.StringIO()
+        writer = StreamJsonWriter(stream)
+        writer.handle(
+            ToolResultEvent(
+                tool_use_id="tu_1",
+                tool_name="complete_step",
+                result="Tool failed",
+                is_error=True,
+                metadata={
+                    "step_result": {
+                        "step_id": "x",
+                        "error": "Schema failed at /Users/alice/project/logs/result.txt",
+                    }
+                },
+                public_path_roots=[{"path": "/Users/alice/project", "label": "."}],
+            )
+        )
+
+        data = json.loads(stream.getvalue())
+        rendered = json.dumps(data, ensure_ascii=False)
+        assert "/Users/alice" not in rendered
+        assert data["metadata"]["step_result"]["error"] == "Schema failed at ./logs/result.txt"
 
     def test_finalize_is_noop(self) -> None:
         stream = io.StringIO()

--- a/tests/pipeline/engine/test_loader.py
+++ b/tests/pipeline/engine/test_loader.py
@@ -417,7 +417,14 @@ class TestBasePromptSectionsParsing:
         """)
         _write_pipeline(tmp_path, yaml_content, {"parse.md": "P"})
         loaded = load_pipeline_dir(tmp_path)
-        assert loaded.base_prompt_sections.include == ["identity", "system", "env", "cloud_config", "tools"]
+        assert loaded.base_prompt_sections.include == [
+            "identity",
+            "system",
+            "env",
+            "cloud_config",
+            "tools",
+            "runtime_context",
+        ]
         assert loaded.base_prompt_sections.exclude == []
 
     def test_step_level_sections_override(self, tmp_path):

--- a/tests/pipeline/engine/test_recovery.py
+++ b/tests/pipeline/engine/test_recovery.py
@@ -221,6 +221,92 @@ def test_reconstruct_completion_guard_state_records_ros_stack_results_for_comple
     ]
 
 
+def test_reconstruct_completion_guard_state_records_ros_deploy_results_for_completion_guards():
+    messages = [
+        Message(
+            role="assistant",
+            content=[
+                ToolUseBlock(
+                    id="tu_deploy",
+                    name="ros_deploy",
+                    input={"action": "delete_and_create", "stack_id": "stack-old"},
+                )
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ToolResultBlock(
+                    tool_use_id="tu_deploy",
+                    content=json.dumps(
+                        {
+                            "stack_id": "stack-new",
+                            "stack_name": "demo",
+                            "status": "CREATE_COMPLETE",
+                            "is_success": True,
+                        }
+                    ),
+                    is_error=False,
+                )
+            ],
+        ),
+    ]
+
+    state = reconstruct_completion_guard_state(messages)
+
+    assert state["successful_tools"] == {"ros_deploy"}
+    assert state["tool_results"]["ros_deploy"]["stack_id"] == "stack-new"
+    assert state["tool_result_records"] == [
+        {
+            "tool_name": "ros_deploy",
+            "input": {"action": "delete_and_create", "stack_id": "stack-old"},
+            "result": {
+                "stack_id": "stack-new",
+                "stack_name": "demo",
+                "status": "CREATE_COMPLETE",
+                "is_success": True,
+            },
+            "is_error": False,
+        }
+    ]
+
+
+def test_reconstruct_completion_guard_state_records_ros_deploy_owned_failed_create_stack():
+    messages = [
+        Message(
+            role="assistant",
+            content=[
+                ToolUseBlock(
+                    id="tu_deploy",
+                    name="ros_deploy",
+                    input={"action": "create", "stack_name": "demo"},
+                )
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ToolResultBlock(
+                    tool_use_id="tu_deploy",
+                    content=json.dumps(
+                        {
+                            "stack_id": "stack-failed",
+                            "stack_name": "demo",
+                            "status": "CREATE_FAILED",
+                            "is_success": False,
+                        }
+                    ),
+                    is_error=True,
+                )
+            ],
+        ),
+    ]
+
+    state = reconstruct_completion_guard_state(messages)
+
+    assert state["ros_deploy_owned_stack_ids"]["stack-failed"]["action"] == "create"
+
+
 def test_completion_guard_state_logs_json_parse_failures(caplog):
     caplog.set_level(logging.WARNING, logger="iac_code.pipeline.engine.completion_guard_state")
     state = {}

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -112,6 +112,23 @@ class TestStepExecutorToolSetup:
         assert agent_context.agent_loop is not None
         assert agent_context.agent_loop._pipeline_mode is True
 
+    def test_agent_loop_context_preserves_ros_deploy_owned_stack_ids_from_seed(self, tmp_path):
+        executor = _make_executor(tmp_path)
+        step = _make_step()
+        ctx = PipelineContext(SIMPLE_DEPS)
+        seed = {"ros_deploy_owned_stack_ids": {"stack-failed": {"action": "create"}}}
+
+        agent_context = executor.build_agent_loop_context(
+            step,
+            ctx,
+            "test_session",
+            completion_guard_state_seed=seed,
+        )
+
+        assert agent_context.completion_guard_state["ros_deploy_owned_stack_ids"] == {
+            "stack-failed": {"action": "create"}
+        }
+
     def test_full_tools_when_step_returns_none(self, tmp_path):
         registry = ToolRegistry()
 

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -828,6 +828,39 @@ class TestStepExecutorBaseSections:
         step_pos = prompt.find("# Step Task")
         assert identity_pos < skill_pos < step_pos
 
+    def test_runtime_context_base_section_includes_provider_and_model(self, tmp_path):
+        (tmp_path / "prompts").mkdir(exist_ok=True)
+        (tmp_path / "prompts" / "test.md").write_text("Task", encoding="utf-8")
+
+        step = StepSpec(
+            step_id="test",
+            conclusion_field="result",
+            forward=None,
+            prompt_file="prompts/test.md",
+        )
+        pipeline = LoadedPipeline(
+            name="test",
+            steps=[step],
+            context_dependencies={"result": []},
+            max_rollbacks=3,
+            skills={},
+            base_prompt_sections=IncludeExcludeConfig(include=["runtime_context"]),
+        )
+        provider_manager = MagicMock()
+        provider_manager.get_provider_display.return_value = "Alibaba Cloud Bailian"
+        provider_manager.get_model_name.return_value = "qwen3.7-max"
+        executor = StepExecutor(
+            provider_manager=provider_manager,
+            base_tool_registry=ToolRegistry(),
+            pipeline=pipeline,
+            pipeline_dir=tmp_path,
+        )
+
+        prompt = executor._build_full_system_prompt(step, PipelineContext({"result": []}))
+
+        assert "# Runtime Context" in prompt
+        assert "Provider & Model: Alibaba Cloud Bailian / qwen3.7-max" in prompt
+
     def test_step_level_sections_override_pipeline(self, tmp_path):
         """Step-level base_prompt_sections overrides pipeline-level."""
         (tmp_path / "prompts").mkdir(exist_ok=True)

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import jsonschema
 import pytest
 import yaml
 
@@ -83,6 +84,60 @@ class TestSkillFrontmatter:
         schema = fm["conclusion_schema"]
         assert "missing_deployment_parameters" in schema["properties"]
         assert schema["properties"]["missing_deployment_parameters"]["type"] == "array"
+
+    def test_conclusion_schema_can_report_preview_validation_proof(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+        preview_schema = schema["properties"]["preview_validation"]
+
+        assert preview_schema["type"] == "object"
+        assert preview_schema["properties"]["succeeded"]["type"] == "boolean"
+        assert preview_schema["properties"]["template_url"]["type"] == "string"
+        assert preview_schema["properties"]["parameters"]["type"] == "object"
+
+    def test_conclusion_schema_requires_full_preview_validation_when_succeeded(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+        conclusion = {
+            "monthly_estimate": "¥100/月",
+            "currency": "CNY",
+            "resources": [{"type": "ALIYUN::ECS::InstanceGroup", "cost": "¥100/月"}],
+            "template_fixed": False,
+            "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+            "preview_validation": {
+                "succeeded": True,
+                "template_url": "templates/a.yml",
+                "parameters": {"ZoneId": "cn-hangzhou-k"},
+            },
+        }
+
+        jsonschema.validate(conclusion, schema)
+        missing_template_url = dict(conclusion, preview_validation={"succeeded": True, "parameters": {}})
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(missing_template_url, schema)
+        missing_parameters = dict(conclusion, preview_validation={"succeeded": True, "template_url": "templates/a.yml"})
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(missing_parameters, schema)
+
+    def test_conclusion_schema_requires_error_when_preview_validation_failed(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+        conclusion = {
+            "monthly_estimate": "询价失败",
+            "currency": "CNY",
+            "resources": [],
+            "template_fixed": False,
+            "deployment_parameters": {},
+            "preview_validation": {"succeeded": False, "error": "missing VpcId"},
+        }
+
+        jsonschema.validate(conclusion, schema)
+        missing_error = dict(conclusion, preview_validation={"succeeded": False})
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(missing_error, schema)
 
 
 class TestSkillContentRosOnly:
@@ -169,6 +224,12 @@ class TestSkillContentRosOnly:
         assert "PreviewStack 成功但询价失败" in body
         assert "不要丢弃 Preview-Validated Pricing Parameter Set" in body
         assert "询价失败或外部输入缺失时填 `{}`" not in body
+
+    def test_records_preview_validation_for_downstream_create_stack_fast_path(self, body):
+        assert "preview_validation" in body
+        assert "template_url" in body
+        assert "parameters" in body
+        assert "deploying" in body
 
     def test_preview_stack_is_not_hard_gate_for_pricing(self, body):
         assert "PreviewStack 不是硬门禁" in body
@@ -285,6 +346,16 @@ class TestReferencesExist:
         assert 'action="PreviewStack"' not in content
         assert "调用 `GetTemplateEstimateCost`" not in content
 
+    def test_template_parameter_recommendation_does_not_require_create_stack_to_reuse_preview_inputs(self):
+        reference = _direct_references_dir_or_skip() / "template-parameter-recommendation.md"
+        content = reference.read_text(encoding="utf-8")
+
+        assert "`PreviewStack` 与后续 `CreateStack`" not in content
+        assert "`CreateStack` 与 `PreviewStack`" not in content
+        assert "同一地域" not in content
+        assert "参数必须一致" not in content
+        assert "最终参数由 `CreateStack` 校验" in content
+
 
 class TestSkillDiscovery:
     def test_discovered_by_pipeline_loader(self):
@@ -326,6 +397,11 @@ class TestCostPrompt:
         assert "不是硬门禁" in body
         assert "参数缺口" in body
 
+    def test_prompt_records_preview_validation_for_deploying(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+        assert "preview_validation" in body
+        assert "PreviewStack 成功证明" in body
+
     def test_prompt_names_template_url_value_for_pricing_tools(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")
         assert 'template_url = "{template.file_path}"' in body
@@ -348,6 +424,7 @@ class TestEvalsJson:
         assert "Parameters.<N>.ParameterKey" not in text
         assert "Parameters.1.ParameterKey" not in text
         assert "deployment_parameters" in text
+        assert "preview_validation" in text
 
     def test_evals_do_not_require_validation_before_initial_pricing(self):
         text = EVALS_JSON.read_text(encoding="utf-8")

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -19,6 +19,20 @@ def _direct_references_dir_or_skip() -> Path:
     return references
 
 
+def _is_reference_link_or_placeholder(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    if not path.is_file():
+        return False
+    try:
+        raw_target = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return False
+    if not raw_target or "\n" in raw_target or "\r" in raw_target:
+        return False
+    return (path.parent / raw_target).exists()
+
+
 def _parse_frontmatter(text: str) -> dict:
     """Parse YAML frontmatter from SKILL.md."""
     assert text.startswith("---"), "SKILL.md must start with YAML frontmatter"
@@ -84,21 +98,22 @@ class TestSkillContentRosOnly:
         assert ".tf" not in lower
         assert "tf2ros" not in lower
 
-    def test_contains_estimate_cost_api(self, body):
-        assert "GetTemplateEstimateCost" in body
+    def test_uses_estimate_cost_tool_not_raw_call_instruction(self, body):
+        assert "ros_estimate_template_cost" in body
+        assert "则可以调用 `GetTemplateEstimateCost`" not in body
 
     def test_contains_validate_template(self, body):
-        assert "ValidateTemplate" in body
+        assert "ros_validate_template" in body
 
     def test_skips_validate_template_when_template_unchanged(self, body):
         assert "避免在成本预估前重复校验" in body
 
     def test_validate_template_only_after_template_changes(self, body):
-        assert "只有在修复或改写模板后，才调用 `ValidateTemplate`" in body
+        assert "只有在修复或改写模板后，才调用 `ros_validate_template`" in body
 
     def test_modified_template_flow_names_validation_and_pricing_apis(self, body):
-        assert "调用 `ValidateTemplate` 校验改动" in body
-        assert "通过后调用 `GetTemplateEstimateCost` 重新询价" in body
+        assert "调用 `ros_validate_template` 校验改动" in body
+        assert "通过后调用 `ros_estimate_template_cost` 重新询价" in body
 
     def test_modified_template_retry_limit_is_seven(self, body):
         assert "最多 7 轮" in body
@@ -107,9 +122,8 @@ class TestSkillContentRosOnly:
         assert body.count("只有在修复或改写模板后") == 1
 
     def test_uses_parameters_dictionary_auto_expansion(self, body):
-        assert '"Parameters": {' in body
+        assert "parameters={" in body
         assert "直接传字典格式" in body
-        assert "工具会自动展开" in body
         assert "Parameters.1.ParameterKey" not in body
 
     def test_outputs_pricing_parameters_for_deployment(self, body):
@@ -122,7 +136,7 @@ class TestSkillContentRosOnly:
         assert "Pricing Parameter Set" in body
         assert "Preview-Validated Pricing Parameter Set" in body
         assert "references/template-parameter-recommendation.md" in body
-        assert "GetTemplateParameterConstraints" in body
+        assert "ros_get_template_parameter_constraints" in body
         assert "PreviewStack" in body
         assert "AllowedValues" in body
         assert "不得编造" in body
@@ -136,12 +150,13 @@ class TestSkillContentRosOnly:
         assert "先查询约束或只读资源候选" in body
         assert "不要仅因参数名是 VpcId" in body
 
-    def test_preview_stack_uses_aliyun_api_not_ros_stack(self, body):
-        assert 'aliyun_api(product="ros", action="PreviewStack")' in body
+    def test_preview_stack_uses_dedicated_tool_not_ros_stack(self, body):
+        assert "ros_preview_template" in body
         assert "不要使用 `ros_stack` 执行 `PreviewStack`" in body
 
     def test_preview_stack_must_pass_stack_name_with_random_suffix(self, body):
         assert "PreviewStack 必须传 StackName" in body
+        assert "stack_name" in body
         assert "随机串后缀" in body
         assert "避免重名" in body
 
@@ -158,12 +173,19 @@ class TestSkillContentRosOnly:
     def test_preview_stack_is_not_hard_gate_for_pricing(self, body):
         assert "PreviewStack 不是硬门禁" in body
         assert "完整部署参数" in body
-        assert "GetTemplateEstimateCost" in body
+        assert "ros_estimate_template_cost" in body
         assert "missing_deployment_parameters" in body
         assert "选择阶段" in body and "parameter_overrides" in body
 
     def test_contains_template_url(self, body):
-        assert "TemplateURL" in body
+        assert "template_url" in body
+
+    def test_template_url_source_is_not_duplicated_from_prompt(self, body):
+        assert "模板来源硬约束" not in body
+        assert "params.TemplateURL = <当前模板文件路径>" not in body
+        assert "不要传 `params.TemplateBody`" not in body
+        assert 'template_url="<模板文件路径>"' not in body
+        assert 'region_id="<地域>"' not in body
 
     def test_contains_fix_workflow(self, body):
         assert "修复" in body or "fix" in body.lower()
@@ -221,15 +243,24 @@ class TestReferencesExist:
             return
         assert ref.is_file(), "Windows checkouts may materialize references as a regular symlink placeholder file"
 
-    def test_references_points_to_bundled_iac_aliyun(self):
+    def test_references_points_to_selling_references(self):
         ref = SKILL_DIR / "references"
         if not ref.is_symlink():
             pytest.skip("references is not a symlink in this checkout")
         target = str(ref.readlink()).replace("\\", "/")
-        assert "skills/bundled/iac_aliyun/references" in target
+        assert target == "../../references"
 
     def test_references_resolves_to_dir(self):
         assert _direct_references_dir_or_skip().resolve().is_dir()
+
+    def test_selling_reference_overrides_only_template_parameter_recommendation(self):
+        selling_refs = SKILL_DIR.parents[1] / "references"
+        assert selling_refs.is_dir()
+        assert (selling_refs / "template-parameter-recommendation.md").is_file()
+        assert not (selling_refs / "template-parameter-recommendation.md").is_symlink()
+        assert _is_reference_link_or_placeholder(selling_refs / "ros-template.md")
+        assert _is_reference_link_or_placeholder(selling_refs / "template-parameters.md")
+        assert _is_reference_link_or_placeholder(selling_refs / "cloud-products")
 
     def test_cloud_products_accessible(self):
         cloud_dir = _direct_references_dir_or_skip() / "cloud-products"
@@ -243,6 +274,17 @@ class TestReferencesExist:
     def test_template_parameters_accessible(self):
         assert (_direct_references_dir_or_skip() / "template-parameters.md").is_file()
 
+    def test_template_parameter_recommendation_uses_dedicated_template_tools(self):
+        reference = _direct_references_dir_or_skip() / "template-parameter-recommendation.md"
+        content = reference.read_text(encoding="utf-8")
+
+        assert "ros_get_template_parameter_constraints" in content
+        assert "ros_preview_template" in content
+        assert "ros_estimate_template_cost" in content
+        assert 'action="GetTemplateParameterConstraints"' not in content
+        assert 'action="PreviewStack"' not in content
+        assert "调用 `GetTemplateEstimateCost`" not in content
+
 
 class TestSkillDiscovery:
     def test_discovered_by_pipeline_loader(self):
@@ -252,6 +294,7 @@ class TestSkillDiscovery:
         loaded = load_pipeline_dir(pipeline_dir)
         assert "iac-aliyun-cost" in loaded.skills
         skill_root = Path(loaded.skill_roots["iac-aliyun-cost"])
+        assert skill_root == SKILL_DIR.resolve()
         assert (skill_root / "references" / "ros-template.md").is_file()
         assert (skill_root / "references" / "template-parameters.md").is_file()
 
@@ -274,14 +317,22 @@ class TestCostPrompt:
 
     def test_prompt_names_preview_stack_tool_contract(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")
-        assert 'aliyun_api(product="ros", action="PreviewStack")' in body
-        assert "不要使用 `ros_stack` 执行 `PreviewStack`" in body
+        assert "ros_preview_template" in body
+        assert "不要使用 `ros_stack` 执行预览" in body
 
     def test_prompt_treats_preview_stack_as_soft_gate(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")
         assert "优先通过" in body
         assert "不是硬门禁" in body
         assert "参数缺口" in body
+
+    def test_prompt_names_template_url_value_for_pricing_tools(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+        assert 'template_url = "{template.file_path}"' in body
+        assert "ros_get_template_parameter_constraints" in body
+        assert "ros_preview_template" in body
+        assert "ros_estimate_template_cost" in body
+        assert "不要传 `TemplateBody`" in body
 
 
 class TestEvalsJson:
@@ -310,7 +361,7 @@ class TestEvalsJson:
     def test_evals_assert_preview_stack_api_tool_contract(self):
         data = json.loads(EVALS_JSON.read_text(encoding="utf-8"))
         checks = "\n".join(assertion["check"] for ev in data["evals"] for assertion in ev["assertions"])
-        assert 'aliyun_api(product="ros", action="PreviewStack")' in checks
+        assert "ros_preview_template" in checks
         assert "不使用 ros_stack" in checks
 
     def test_evals_cover_existing_vpc_parameter_recommendation(self):

--- a/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
@@ -82,8 +82,9 @@ class TestSkillContentRosOnly:
         assert ".tf" not in lower
         assert "tf2ros" not in lower
 
-    def test_contains_ros_stack(self, body):
-        assert "ros_stack" in body
+    def test_contains_ros_deploy_without_direct_ros_stack(self, body):
+        assert "ros_deploy" in body
+        assert "ros_stack" not in body
 
     def test_contains_availability_query(self, body):
         assert "可用性查询" in body
@@ -91,7 +92,7 @@ class TestSkillContentRosOnly:
     def test_deploying_uses_parameters_without_preview_recommendation(self, body):
         assert "部署参数装配" in body
         assert "selected_plan.effective_deployment_parameters" in body
-        assert "CreateStack" in body
+        assert "ros_deploy" in body
         assert "GetTemplateParameterConstraints" not in body
         assert "PreviewStack" not in body
         assert "Preview-Validated Parameter Set" not in body
@@ -127,28 +128,33 @@ class TestSkillContentRosOnly:
         assert "UpdateStackInstances" not in body
 
     def test_contains_template_validation(self, body):
-        assert "ValidateTemplate" in body
+        assert "ros_validate_template" in body
         assert "模板校验" in body
+
+    def test_dedicated_tool_boundary_covers_validation_and_deploy_lifecycle(self, body):
+        assert "不要通过 `aliyun_api` 调用 ROS 模板校验或部署生命周期接口" in body
+        assert "ROS `ValidateTemplate` 接口" not in body
 
     def test_preview_ready_path_skips_routine_validation_and_availability(self, body):
         assert body.count("selected_plan.preview_ready_for_create") == 1
-        assert "CreateStack" in body
+        assert "`ros_deploy` 的 `create`" in body
         assert "跳过例行 `ros_validate_template`" in body
         assert "跳过例行可用性查询" in body
 
     def test_create_stack_failure_revalidates_after_template_change_only(self, body):
-        assert "CreateStack 失败" in body
+        assert "`create` 失败" in body
         assert "修改模板" in body
         assert "修改模板或部署参数" not in body
         assert "只调整部署参数" in body
         assert "重新调用 `ros_validate_template`" in body
+        assert "`continue_create`" in body
 
     def test_no_pricing_section(self, body):
         assert "GetTemplateEstimateCost" not in body
         assert "部署前询价" not in body
 
-    def test_contains_create_stack(self, body):
-        assert "CreateStack" in body
+    def test_deploy_tool_create_documents_disable_rollback(self, body):
+        assert "`ros_deploy` 的 `create`" in body
         assert "DisableRollback" in body
 
     def test_template_url_source_is_not_duplicated_from_prompt(self, body):
@@ -160,7 +166,27 @@ class TestSkillContentRosOnly:
         assert "region_id=<地域>" not in body
 
     def test_contains_continue_create(self, body):
-        assert "ContinueCreateStack" in body
+        assert "ContinueCreateStackValidationFailed" in body
+
+    def test_delete_and_create_documents_replacement_flow(self, body):
+        assert "仅在 `continue_create` 返回 `ContinueCreateStackValidationFailed` 后使用 `delete_and_create`" in body
+        assert "先确认替代创建参数和模板可用" in body
+        assert "删除旧失败 Stack 后创建新的 Stack" in body
+        assert "最终结果使用新 Stack 的 `stack_id`" in body
+        assert "不要把旧 `stack_id` 当成部署成功结果" in body
+
+    def test_does_not_present_raw_stack_lifecycle_api_as_call_target(self, body):
+        body_without_error_codes = body.replace("ContinueCreateStackValidationFailed", "")
+        forbidden_phrases = [
+            "CreateStack 前",
+            "传给 `CreateStack`",
+            "CreateStack 必须传",
+            "CreateStack 无法成功",
+            "最终参数由 CreateStack 校验",
+            "| CreateStack |",
+        ]
+        for phrase in forbidden_phrases:
+            assert phrase not in body_without_error_codes
 
     def test_contains_error_handling(self, body):
         assert "部署失败" in body
@@ -186,10 +212,10 @@ class TestSkillContentRosOnly:
         assert "不得用 status: cancelled 表示等待用户确认" in body
 
     def test_delete_requires_explicit_delete_confirmation(self, body):
-        assert "删除请求本身不等于删除确认" in body
-        assert "`delete_confirmed: true`" in body
+        assert "非本步骤创建的 Stack" in body
         assert "确认删除" in body
-        assert "未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`" in body
+        assert "delete_and_create" in body
+        assert "未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`" not in body
 
 
 class TestDeployingPrompt:
@@ -224,22 +250,34 @@ class TestDeployingPrompt:
         for phrase in forbidden:
             assert phrase not in body
 
-    def test_prompt_delete_requires_explicit_delete_confirmation(self):
+    def test_prompt_defers_delete_scope_to_skill(self):
         body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
-        assert "删除请求本身不等于删除确认" in body
-        assert "`delete_confirmed: true`" in body
-        assert "未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`" in body
+        assert "ros_deploy" in body
+        assert "delete_and_create" in body
+        assert "删除约束和失败恢复策略见技能" in body
+        assert "非本步骤创建的 Stack" not in body
+        assert "未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`" not in body
+
+    def test_prompt_does_not_mention_uninjected_ros_stack_tool(self):
+        body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
+        assert "ros_stack" not in body
 
     def test_prompt_names_template_url_value_for_deploy_tools(self):
         body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
         assert 'template_url = "{selected_plan.template_url}"' in body
-        assert 'params.TemplateURL = "{selected_plan.template_url}"' in body
+        assert 'params.TemplateURL = "{selected_plan.template_url}"' not in body
         assert "selected_plan.template_url" in body
         assert "ros_validate_template" in body
-        assert "ValidateTemplate" in body
-        assert "CreateStack" in body
-        assert "不要传 `params.TemplateBody`" in body
+        assert "ros_deploy" in body
+        assert "不要通过 `aliyun_api` 调用 ROS 模板校验或部署生命周期接口" in body
+        assert "ROS `ValidateTemplate` 接口" not in body
+        assert "不要传 `TemplateBody`" in body
         assert "<选中方案模板文件路径>" not in body
+
+    def test_prompt_does_not_present_raw_stack_lifecycle_api_as_call_target(self):
+        body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
+        body_without_error_codes = body.replace("ContinueCreateStackValidationFailed", "")
+        assert "CreateStack" not in body_without_error_codes
 
     def test_prompt_allows_preview_ready_direct_create(self):
         body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
@@ -334,14 +372,16 @@ class TestEvalsJson:
 
         confirmation_eval = evals_by_name["delete-stack-confirmation"]
         confirmation_assertions = {assertion["name"] for assertion in confirmation_eval["assertions"]}
-        assert "user_confirmation" in confirmation_assertions
+        assert "reports_scope" in confirmation_assertions
         assert "uses_delete_stack" not in confirmation_assertions
-        assert "no_delete_without_confirmation" in confirmation_assertions
+        assert "no_delete_stack" in confirmation_assertions
+        assert "no_delete_and_create" in confirmation_assertions
 
         confirmed_eval = evals_by_name["delete-stack-confirmed"]
         confirmed_assertions = {assertion["name"] for assertion in confirmed_eval["assertions"]}
         assert "确认" in confirmed_eval["prompt"]
-        assert "uses_delete_stack" in confirmed_assertions
+        assert "uses_delete_stack" not in confirmed_assertions
+        assert "no_delete_stack" in confirmed_assertions
 
     def test_template_validation_eval_uses_dedicated_tool(self):
         data = json.loads(EVALS_JSON.read_text(encoding="utf-8"))

--- a/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
@@ -130,6 +130,19 @@ class TestSkillContentRosOnly:
         assert "ValidateTemplate" in body
         assert "模板校验" in body
 
+    def test_preview_ready_path_skips_routine_validation_and_availability(self, body):
+        assert body.count("selected_plan.preview_ready_for_create") == 1
+        assert "CreateStack" in body
+        assert "跳过例行 `ros_validate_template`" in body
+        assert "跳过例行可用性查询" in body
+
+    def test_create_stack_failure_revalidates_after_template_change_only(self, body):
+        assert "CreateStack 失败" in body
+        assert "修改模板" in body
+        assert "修改模板或部署参数" not in body
+        assert "只调整部署参数" in body
+        assert "重新调用 `ros_validate_template`" in body
+
     def test_no_pricing_section(self, body):
         assert "GetTemplateEstimateCost" not in body
         assert "部署前询价" not in body
@@ -228,6 +241,12 @@ class TestDeployingPrompt:
         assert "不要传 `params.TemplateBody`" in body
         assert "<选中方案模板文件路径>" not in body
 
+    def test_prompt_allows_preview_ready_direct_create(self):
+        body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
+        assert "`selected_plan.preview_ready_for_create` 为 `true`" in body
+        assert "快速创建路径见技能" in body
+        assert "跳过例行 `ros_validate_template`" not in body
+
 
 class TestSkillDiscovery:
     def test_discovered_by_pipeline_loader(self):
@@ -285,6 +304,12 @@ class TestEvalsJson:
         for ev in data["evals"]:
             prompt_lower = ev["prompt"].lower()
             assert "terraform" not in prompt_lower
+
+    def test_evals_cover_preview_ready_fast_path(self):
+        data = json.loads(EVALS_JSON.read_text(encoding="utf-8"))
+        eval_text = json.dumps(data, ensure_ascii=False)
+        assert "preview_ready_for_create" in eval_text
+        assert "跳过例行" in eval_text
 
     def test_assertions_have_name_and_check(self):
         data = json.loads(EVALS_JSON.read_text(encoding="utf-8"))

--- a/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
@@ -138,6 +138,14 @@ class TestSkillContentRosOnly:
         assert "CreateStack" in body
         assert "DisableRollback" in body
 
+    def test_template_url_source_is_not_duplicated_from_prompt(self, body):
+        assert "模板来源硬约束" not in body
+        assert "prompt 中已渲染" not in body
+        assert "不要传 `params.TemplateBody`" not in body
+        assert "<选中方案模板文件路径>" not in body
+        assert "template_url=<模板文件路径>" not in body
+        assert "region_id=<地域>" not in body
+
     def test_contains_continue_create(self, body):
         assert "ContinueCreateStack" in body
 
@@ -208,6 +216,17 @@ class TestDeployingPrompt:
         assert "删除请求本身不等于删除确认" in body
         assert "`delete_confirmed: true`" in body
         assert "未收到明确删除确认前，不得调用 `ros_stack` 的 `DeleteStack`" in body
+
+    def test_prompt_names_template_url_value_for_deploy_tools(self):
+        body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
+        assert 'template_url = "{selected_plan.template_url}"' in body
+        assert 'params.TemplateURL = "{selected_plan.template_url}"' in body
+        assert "selected_plan.template_url" in body
+        assert "ros_validate_template" in body
+        assert "ValidateTemplate" in body
+        assert "CreateStack" in body
+        assert "不要传 `params.TemplateBody`" in body
+        assert "<选中方案模板文件路径>" not in body
 
 
 class TestSkillDiscovery:
@@ -298,3 +317,12 @@ class TestEvalsJson:
         confirmed_assertions = {assertion["name"] for assertion in confirmed_eval["assertions"]}
         assert "确认" in confirmed_eval["prompt"]
         assert "uses_delete_stack" in confirmed_assertions
+
+    def test_template_validation_eval_uses_dedicated_tool(self):
+        data = json.loads(EVALS_JSON.read_text(encoding="utf-8"))
+        evals_by_name = {ev["name"]: ev for ev in data["evals"]}
+        validation_eval = evals_by_name["template-validation-fix-before-deploy"]
+        eval_text = json.dumps(validation_eval, ensure_ascii=False)
+
+        assert "ros_validate_template" in eval_text
+        assert "aliyun_api ValidateTemplate" not in eval_text

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -16,6 +16,7 @@ SKILL_DIR = (
 )
 SKILL_MD = SKILL_DIR / "SKILL.md"
 EVALS_JSON = SKILL_DIR / "evals.json"
+TEMPLATE_PROMPT_MD = SKILL_DIR.parents[1] / "prompts" / "template_generating.md"
 
 
 def _parse_frontmatter(text: str) -> dict:
@@ -73,7 +74,14 @@ class TestSkillContentRosOnly:
         assert "| ECS | ZoneId, InstanceType" not in body
 
     def test_contains_validation_step(self, body):
-        assert "ValidateTemplate" in body
+        assert "ros_validate_template" in body
+
+    def test_template_url_source_is_not_duplicated_from_prompt(self, body):
+        assert "模板来源硬约束" not in body
+        assert "params.TemplateURL = <候选方案输出路径>" not in body
+        assert "不要传 `params.TemplateBody`" not in body
+        assert "template_url=<模板文件路径>" not in body
+        assert "region_id=<地域>" not in body
 
     def test_must_read_ros_template_reference_before_generation(self, body):
         assert "必须" in body
@@ -131,6 +139,13 @@ class TestSkillDiscovery:
 
 
 class TestSkillPromptRendering:
+    def test_prompt_names_template_url_value_for_validation(self):
+        body = TEMPLATE_PROMPT_MD.read_text(encoding="utf-8")
+        assert 'template_url = "{candidate.output_path}"' in body
+        assert "ros_validate_template" in body
+        assert "ValidateTemplate" in body
+        assert "TemplateBody" in body
+
     def test_full_prompt_includes_skill_base_directory(self, tmp_path):
         from iac_code.pipeline.engine.context import PipelineContext
         from iac_code.pipeline.engine.loader import load_pipeline_dir

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -120,6 +120,13 @@ class TestSkillContentRosOnly:
         assert "已有 VPC 中创建安全组" in body
         assert "forbidden_resources" not in body
 
+    def test_file_write_details_stay_in_step_prompt(self, body):
+        assert "并写入文件" in body
+        assert "write_file" not in body
+        assert "无需提前创建目录" not in body
+        assert "bash" not in body.lower()
+        assert "mkdir" not in body.lower()
+
 
 class TestSkillDiscovery:
     def test_discovered_by_pipeline_loader(self):
@@ -145,6 +152,14 @@ class TestSkillPromptRendering:
         assert "ros_validate_template" in body
         assert "ValidateTemplate" in body
         assert "TemplateBody" in body
+
+    def test_prompt_uses_write_file_without_directory_creation(self):
+        body = TEMPLATE_PROMPT_MD.read_text(encoding="utf-8")
+        assert "write_file" in body
+        assert "无需提前创建目录" in body
+        assert "如果 `templates/` 目录不存在，先创建它" not in body
+        assert "mkdir" not in body.lower()
+        assert "bash" not in body.lower()
 
     def test_full_prompt_includes_skill_base_directory(self, tmp_path):
         from iac_code.pipeline.engine.context import PipelineContext

--- a/tests/pipeline/selling/test_deploying_hook.py
+++ b/tests/pipeline/selling/test_deploying_hook.py
@@ -71,6 +71,135 @@ def test_normalize_selected_plan_preserves_cost_deployment_parameters():
     }
 
 
+def test_normalize_selected_plan_marks_preview_ready_when_preview_matches_template_and_no_params_missing():
+    evaluated_candidates = [
+        {
+            "candidate": {"name": "Ready", "output_path": "templates/a.yml"},
+            "failed": False,
+            "cost": {
+                "deployment_parameters": {"ZoneId": "cn-hangzhou-k", "InstanceType": "ecs.g7.large"},
+                "missing_deployment_parameters": [],
+                "preview_validation": {
+                    "succeeded": True,
+                    "template_url": "templates/a.yml",
+                    "parameters": {"ZoneId": "cn-hangzhou-k", "InstanceType": "ecs.g7.large"},
+                },
+            },
+        }
+    ]
+    selected_plan = {"user_input": encode_selected_candidate("Ready", 0), "options": []}
+
+    normalized = normalize_selected_plan(selected_plan, evaluated_candidates)
+
+    assert normalized["selection_valid"] is True
+    assert normalized["effective_deployment_parameters"] == {
+        "ZoneId": "cn-hangzhou-k",
+        "InstanceType": "ecs.g7.large",
+    }
+    assert normalized["preview_ready_for_create"] is True
+
+
+def test_normalize_selected_plan_ignores_preview_region_when_marking_preview_ready():
+    evaluated_candidates = [
+        {
+            "candidate": {"name": "Ready", "output_path": "templates/a.yml"},
+            "failed": False,
+            "template": {"region": "cn-beijing"},
+            "cost": {
+                "deployment_parameters": {"ZoneId": "cn-beijing-h", "InstanceType": "ecs.g7.large"},
+                "missing_deployment_parameters": [],
+                "preview_validation": {
+                    "succeeded": True,
+                    "template_url": "templates/a.yml",
+                    "region_id": "cn-hangzhou",
+                    "parameters": {"ZoneId": "cn-beijing-h", "InstanceType": "ecs.g7.large"},
+                },
+            },
+        }
+    ]
+    selected_plan = {"user_input": encode_selected_candidate("Ready", 0), "options": []}
+
+    normalized = normalize_selected_plan(selected_plan, evaluated_candidates)
+
+    assert normalized["selection_valid"] is True
+    assert normalized["preview_ready_for_create"] is True
+
+
+def test_normalize_selected_plan_keeps_preview_ready_when_user_overrides_parameters():
+    evaluated_candidates = [
+        {
+            "candidate": {"name": "Changed", "output_path": "templates/a.yml"},
+            "failed": False,
+            "cost": {
+                "deployment_parameters": {"ZoneId": "cn-hangzhou-k", "InstanceType": "ecs.g7.large"},
+                "preview_validation": {
+                    "succeeded": True,
+                    "template_url": "templates/a.yml",
+                    "parameters": {"ZoneId": "cn-hangzhou-k", "InstanceType": "ecs.g7.large"},
+                },
+            },
+        }
+    ]
+    selected_plan = {
+        "user_input": encode_selected_candidate("Changed", 0, {"InstanceType": "ecs.c7.large"}),
+        "options": [],
+    }
+
+    normalized = normalize_selected_plan(selected_plan, evaluated_candidates)
+
+    assert normalized["selection_valid"] is True
+    assert normalized["effective_deployment_parameters"]["InstanceType"] == "ecs.c7.large"
+    assert normalized["preview_ready_for_create"] is True
+
+
+def test_normalize_selected_plan_invalidates_preview_ready_when_template_url_changes():
+    evaluated_candidates = [
+        {
+            "candidate": {"name": "Moved", "output_path": "templates/updated.yml"},
+            "failed": False,
+            "cost": {
+                "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+                "preview_validation": {
+                    "succeeded": True,
+                    "template_url": "templates/original.yml",
+                    "parameters": {"ZoneId": "cn-hangzhou-k"},
+                },
+            },
+        }
+    ]
+    selected_plan = {"user_input": encode_selected_candidate("Moved", 0), "options": []}
+
+    normalized = normalize_selected_plan(selected_plan, evaluated_candidates)
+
+    assert normalized["selection_valid"] is True
+    assert normalized["template_url"] == "templates/updated.yml"
+    assert normalized["preview_ready_for_create"] is False
+
+
+def test_normalize_selected_plan_invalidates_preview_ready_when_deployment_parameters_are_missing():
+    evaluated_candidates = [
+        {
+            "candidate": {"name": "Incomplete", "output_path": "templates/a.yml"},
+            "failed": False,
+            "cost": {
+                "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+                "missing_deployment_parameters": [{"name": "VpcId", "reason": "requires user input"}],
+                "preview_validation": {
+                    "succeeded": True,
+                    "template_url": "templates/a.yml",
+                    "parameters": {"ZoneId": "cn-hangzhou-k"},
+                },
+            },
+        }
+    ]
+    selected_plan = {"user_input": encode_selected_candidate("Incomplete", 0), "options": []}
+
+    normalized = normalize_selected_plan(selected_plan, evaluated_candidates)
+
+    assert normalized["selection_valid"] is True
+    assert normalized["preview_ready_for_create"] is False
+
+
 def test_normalize_selected_plan_applies_user_parameter_overrides():
     evaluated_candidates = [
         {

--- a/tests/pipeline/selling/test_deploying_hook.py
+++ b/tests/pipeline/selling/test_deploying_hook.py
@@ -33,6 +33,23 @@ def test_normalize_selected_plan_adds_resolution_metadata():
     assert normalized["selection_valid"] is True
     assert normalized["selected_candidate"]["output_path"] == "templates/a.yml"
     assert normalized["selection"]["selected_candidate_index"] == 0
+    assert normalized["template_url"] == "templates/a.yml"
+
+
+def test_normalize_selected_plan_falls_back_to_result_template_file_path():
+    evaluated_candidates = [
+        {
+            "candidate": {"name": "Generated"},
+            "template": {"file_path": "templates/generated.yml"},
+            "failed": False,
+        }
+    ]
+    selected_plan = {"user_input": encode_selected_candidate("Generated", 0), "options": []}
+
+    normalized = normalize_selected_plan(selected_plan, evaluated_candidates)
+
+    assert normalized["selection_valid"] is True
+    assert normalized["template_url"] == "templates/generated.yml"
 
 
 def test_normalize_selected_plan_preserves_cost_deployment_parameters():

--- a/tests/pipeline/selling/test_deploying_prompt.py
+++ b/tests/pipeline/selling/test_deploying_prompt.py
@@ -41,7 +41,7 @@ def test_deploying_prompt_preserves_explicit_stack_name_without_e2e_controls() -
 
     assert "intent" in deploying_step.context_fields
     assert stack_name in prompt
-    assert "params.StackName" in prompt
+    assert "stack_name" in prompt
     assert "必须精确等于该名称" in prompt
     assert "用户未明确指定 StackName" in prompt
     assert "禁止省略 `params.StackName`" not in prompt
@@ -71,6 +71,7 @@ def test_deploying_prompt_renders_concrete_template_url() -> None:
         deploying_step.context_fields,
     )
 
-    assert 'params.TemplateURL = "templates/vswitch.yml"' in prompt
+    assert 'template_url = "templates/vswitch.yml"' in prompt
+    assert 'params.TemplateURL = "templates/vswitch.yml"' not in prompt
     assert "<选中方案模板文件路径>" not in prompt
     assert "{selected_plan.template_url}" not in prompt

--- a/tests/pipeline/selling/test_deploying_prompt.py
+++ b/tests/pipeline/selling/test_deploying_prompt.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.loader import load_pipeline_dir
 from iac_code.pipeline.engine.step_spec import render_prompt
+from iac_code.pipeline.engine.ui_contract import encode_selected_candidate
 
 
 def _selling_dir() -> Path:
@@ -47,3 +48,29 @@ def test_deploying_prompt_preserves_explicit_stack_name_without_e2e_controls() -
     assert "vswitch-in-existing-vpc" not in prompt
     assert "部署后是否等待用户继续" not in prompt
     assert "如果无法确定应使用的 StackName，不要调用 `CreateStack`" not in prompt
+
+
+def test_deploying_prompt_renders_concrete_template_url() -> None:
+    selling_dir = _selling_dir()
+    loaded = load_pipeline_dir(selling_dir)
+    deploying_step = next(step for step in loaded.steps if step.step_id == "deploying")
+
+    ctx = PipelineContext(loaded.context_dependencies)
+    ctx.set_conclusion("intent", {"requirement": "创建一个 VSwitch"})
+    ctx.set_conclusion("selected_plan", {"user_input": encode_selected_candidate("existing-vpc-vswitch", 0)})
+    ctx.set_conclusion(
+        "evaluated_candidates",
+        [{"candidate": {"name": "existing-vpc-vswitch", "output_path": "templates/vswitch.yml"}}],
+    )
+
+    assert deploying_step.on_enter is not None
+    deploying_step.on_enter(ctx)
+    prompt = render_prompt(
+        (selling_dir / deploying_step.prompt_file).read_text(encoding="utf-8"),
+        ctx,
+        deploying_step.context_fields,
+    )
+
+    assert 'params.TemplateURL = "templates/vswitch.yml"' in prompt
+    assert "<选中方案模板文件路径>" not in prompt
+    assert "{selected_plan.template_url}" not in prompt

--- a/tests/pipeline/selling/test_memory_policy.py
+++ b/tests/pipeline/selling/test_memory_policy.py
@@ -40,3 +40,11 @@ def test_pipeline_steps_do_not_offer_write_memory_by_default() -> None:
     assert "write_memory" in cost.tools.exclude
     assert deploying.tools is not None
     assert "write_memory" in deploying.tools.exclude
+
+
+def test_reviewing_step_exposes_template_validation_tool_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("IAC_CODE_PIPELINE_SELLING_ENABLE_REVIEWING", "true")
+    reviewing = _sub_step_by_id("evaluate_candidate", "reviewing")
+
+    assert reviewing.tools is not None
+    assert "ros_validate_template" in reviewing.tools.include

--- a/tests/pipeline/selling/test_ros_template_tool_scope.py
+++ b/tests/pipeline/selling/test_ros_template_tool_scope.py
@@ -7,7 +7,7 @@ from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.loader import load_pipeline_dir
 from iac_code.pipeline.engine.step_executor import StepExecutor
 from iac_code.pipeline.engine.step_spec import StepSpec
-from iac_code.tools.base import ToolRegistry
+from iac_code.tools.base import Tool, ToolRegistry
 
 ROS_TEMPLATE_TOOLS = {
     "ros_validate_template",
@@ -25,10 +25,30 @@ def _step_by_id(steps: list[StepSpec], step_id: str) -> StepSpec:
     return next(step for step in steps if step.step_id == step_id)
 
 
-def _registry_for_step(loaded, step: StepSpec):
+class _NamedTool(Tool):
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._name
+
+    @property
+    def input_schema(self) -> dict:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, *, tool_input: dict, context):
+        raise AssertionError("test tool should not execute")
+
+
+def _registry_for_step(loaded, step: StepSpec, *, base_registry: ToolRegistry | None = None):
     executor = StepExecutor(
         provider_manager=MagicMock(),
-        base_tool_registry=ToolRegistry(),
+        base_tool_registry=base_registry or ToolRegistry(),
         pipeline=loaded,
         pipeline_dir=_selling_dir(),
     )
@@ -59,3 +79,38 @@ def test_ros_template_tools_are_only_injected_into_matching_pipeline_steps(monke
     for step_id in ["intent_parsing", "architecture_planning", "evaluate_candidates", "confirm_and_select"]:
         registry = _registry_for_step(loaded, _step_by_id(loaded.steps, step_id))
         assert all(registry.get(name) is None for name in ROS_TEMPLATE_TOOLS)
+
+
+def test_ros_deploy_is_only_injected_into_deploying_step(monkeypatch):
+    monkeypatch.setenv("IAC_CODE_PIPELINE_SELLING_ENABLE_REVIEWING", "true")
+    loaded = load_pipeline_dir(_selling_dir())
+    evaluate_steps = loaded.sub_pipelines["evaluate_candidate"].steps
+
+    deploying_registry = _registry_for_step(loaded, _step_by_id(loaded.steps, "deploying"))
+    assert deploying_registry.get("ros_deploy") is not None
+
+    for step_id in ["template_generating", "reviewing", "cost_estimating"]:
+        registry = _registry_for_step(loaded, _step_by_id(evaluate_steps, step_id))
+        assert registry.get("ros_deploy") is None
+
+    for step_id in ["intent_parsing", "architecture_planning", "evaluate_candidates", "confirm_and_select"]:
+        registry = _registry_for_step(loaded, _step_by_id(loaded.steps, step_id))
+        assert registry.get("ros_deploy") is None
+
+
+def test_deploying_step_excludes_raw_ros_stack_from_base_registry(monkeypatch):
+    monkeypatch.setenv("IAC_CODE_PIPELINE_SELLING_ENABLE_REVIEWING", "true")
+    loaded = load_pipeline_dir(_selling_dir())
+    base_registry = ToolRegistry()
+    base_registry.register(_NamedTool("ros_stack"))
+    base_registry.register(_NamedTool("aliyun_api"))
+
+    deploying_registry = _registry_for_step(
+        loaded,
+        _step_by_id(loaded.steps, "deploying"),
+        base_registry=base_registry,
+    )
+
+    assert deploying_registry.get("ros_deploy") is not None
+    assert deploying_registry.get("ros_stack") is None
+    assert deploying_registry.get("aliyun_api") is not None

--- a/tests/pipeline/selling/test_ros_template_tool_scope.py
+++ b/tests/pipeline/selling/test_ros_template_tool_scope.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from iac_code.pipeline.engine.context import PipelineContext
+from iac_code.pipeline.engine.loader import load_pipeline_dir
+from iac_code.pipeline.engine.step_executor import StepExecutor
+from iac_code.pipeline.engine.step_spec import StepSpec
+from iac_code.tools.base import ToolRegistry
+
+ROS_TEMPLATE_TOOLS = {
+    "ros_validate_template",
+    "ros_get_template_parameter_constraints",
+    "ros_preview_template",
+    "ros_estimate_template_cost",
+}
+
+
+def _selling_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "src" / "iac_code" / "pipeline" / "selling"
+
+
+def _step_by_id(steps: list[StepSpec], step_id: str) -> StepSpec:
+    return next(step for step in steps if step.step_id == step_id)
+
+
+def _registry_for_step(loaded, step: StepSpec):
+    executor = StepExecutor(
+        provider_manager=MagicMock(),
+        base_tool_registry=ToolRegistry(),
+        pipeline=loaded,
+        pipeline_dir=_selling_dir(),
+    )
+    return executor._build_step_tools(step, PipelineContext(loaded.context_dependencies))
+
+
+def test_ros_template_tools_are_only_injected_into_matching_pipeline_steps(monkeypatch):
+    monkeypatch.setenv("IAC_CODE_PIPELINE_SELLING_ENABLE_REVIEWING", "true")
+    loaded = load_pipeline_dir(_selling_dir())
+    evaluate_steps = loaded.sub_pipelines["evaluate_candidate"].steps
+
+    expected_by_step = {
+        "template_generating": {"ros_validate_template"},
+        "reviewing": {"ros_validate_template"},
+        "cost_estimating": ROS_TEMPLATE_TOOLS,
+        "deploying": {"ros_validate_template"},
+    }
+
+    for step_id, expected_tools in expected_by_step.items():
+        step = (
+            _step_by_id(evaluate_steps, step_id)
+            if step_id in {"template_generating", "reviewing", "cost_estimating"}
+            else _step_by_id(loaded.steps, step_id)
+        )
+        registry = _registry_for_step(loaded, step)
+        assert {name for name in ROS_TEMPLATE_TOOLS if registry.get(name) is not None} == expected_tools
+
+    for step_id in ["intent_parsing", "architecture_planning", "evaluate_candidates", "confirm_and_select"]:
+        registry = _registry_for_step(loaded, _step_by_id(loaded.steps, step_id))
+        assert all(registry.get(name) is None for name in ROS_TEMPLATE_TOOLS)

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -122,8 +122,8 @@ def test_deploying_success_requires_create_stack_complete_guard():
     assert guard is not None
     assert guard["required_conclusion_field"] == "stack_id"
     assert guard["require_tool_result"] == {
-        "tool": "ros_stack",
-        "action_in": ["CreateStack", "ContinueCreateStack"],
+        "tool": "ros_deploy",
+        "action_in": ["create", "continue_create", "delete_and_create"],
         "is_success": True,
         "status_in": ["CREATE_COMPLETE"],
         "match_conclusion_field": "stack_id",

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -7,6 +7,15 @@ def _selling_pipeline_dir() -> Path:
     return Path(__file__).resolve().parents[3] / "src" / "iac_code" / "pipeline" / "selling"
 
 
+def test_selling_pipeline_base_sections_include_runtime_context():
+    loaded = load_pipeline_dir(_selling_pipeline_dir())
+    intent = next(step for step in loaded.steps if step.step_id == "intent_parsing")
+
+    assert "runtime_context" in loaded.base_prompt_sections.include
+    assert intent.base_prompt_sections is not None
+    assert "runtime_context" in intent.base_prompt_sections.include
+
+
 def test_confirm_options_schema_requires_candidate_index():
     loaded = load_pipeline_dir(_selling_pipeline_dir())
     confirm = next(step for step in loaded.steps if step.step_id == "confirm_and_select")

--- a/tests/pipeline/selling/tools/test_ros_deploy_tool.py
+++ b/tests/pipeline/selling/tools/test_ros_deploy_tool.py
@@ -1,0 +1,474 @@
+import json
+import os
+
+import pytest
+
+from iac_code.tools.base import ToolContext, ToolResult
+from iac_code.types.permissions import PermissionMode, ToolPermissionContext
+
+
+def _permission_ctx(*, allow=None, mode=PermissionMode.DEFAULT):
+    return ToolPermissionContext(
+        cwd="/tmp",
+        allow_rules=allow or {},
+        mode=mode,
+    )
+
+
+class FakeRosStack:
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls = []
+
+    async def execute(self, *, tool_input, context):
+        self.calls.append((tool_input, context))
+        if not self.results:
+            raise AssertionError("unexpected ros stack call")
+        return self.results.pop(0)
+
+
+def _deploy_tool(monkeypatch, *, guard_state=None, results=None):
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    fake_stack = FakeRosStack(results or [])
+    tool = RosDeployTool(completion_guard_state=guard_state if guard_state is not None else {})
+    monkeypatch.setattr(tool, "_new_stack_tool", lambda: fake_stack)
+    return tool, fake_stack
+
+
+@pytest.mark.asyncio
+async def test_create_records_failed_stack_as_owned_for_recovery(monkeypatch):
+    guard_state = {}
+    tool, fake_stack = _deploy_tool(
+        monkeypatch,
+        guard_state=guard_state,
+        results=[
+            ToolResult.error(
+                json.dumps(
+                    {
+                        "stack_id": "stack-failed",
+                        "stack_name": "demo",
+                        "status": "CREATE_FAILED",
+                        "is_success": False,
+                    }
+                )
+            )
+        ],
+    )
+
+    result = await tool.execute(
+        tool_input={
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "parameters": {"ZoneId": "cn-hangzhou-k"},
+            "region_id": "cn-hangzhou",
+        },
+        context=ToolContext(cwd="/workspace", pipeline_mode=True),
+    )
+
+    assert result.is_error is True
+    assert guard_state["ros_deploy_owned_stack_ids"]["stack-failed"]["action"] == "create"
+    assert fake_stack.calls[0][0] == {
+        "action": "CreateStack",
+        "params": {
+            "StackName": "demo",
+            "DisableRollback": True,
+            "TemplateURL": os.path.realpath("/workspace/templates/demo.yml"),
+            "Parameters": {"ZoneId": "cn-hangzhou-k"},
+        },
+        "region_id": "cn-hangzhou",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_records_started_stack_as_owned_when_polling_fails(monkeypatch):
+    guard_state = {}
+    tool, _fake_stack = _deploy_tool(
+        monkeypatch,
+        guard_state=guard_state,
+        results=[
+            ToolResult(
+                content="[GetStackStatus] status service unavailable",
+                is_error=True,
+                metadata={
+                    "provider": "ros",
+                    "action": "CreateStack",
+                    "stack_id": "stack-started",
+                    "stack_name": "demo",
+                    "region_id": "cn-hangzhou",
+                    "error_stage": "status",
+                },
+            )
+        ],
+    )
+
+    result = await tool.execute(
+        tool_input={
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "region_id": "cn-hangzhou",
+        },
+        context=ToolContext(cwd="/workspace", pipeline_mode=True),
+    )
+
+    assert result.is_error is True
+    assert guard_state["ros_deploy_owned_stack_ids"]["stack-started"]["action"] == "create"
+    permission = await tool.check_permissions(
+        {"action": "continue_create", "stack_id": "stack-started"},
+        _permission_ctx(allow={"session": ["ros_deploy(continue_create:stack-started)"]}),
+    )
+    assert permission.behavior == "allow"
+
+
+@pytest.mark.asyncio
+async def test_continue_create_defaults_to_recreate_with_auto_recreating_resources(monkeypatch):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-failed": {"action": "create"}}}
+    tool, fake_stack = _deploy_tool(
+        monkeypatch,
+        guard_state=guard_state,
+        results=[
+            ToolResult.success(
+                json.dumps(
+                    {
+                        "stack_id": "stack-failed",
+                        "stack_name": "demo",
+                        "status": "CREATE_COMPLETE",
+                        "is_success": True,
+                    }
+                )
+            )
+        ],
+    )
+
+    result = await tool.execute(
+        tool_input={
+            "action": "continue_create",
+            "stack_id": "stack-failed",
+            "template_url": "templates/demo.yml",
+            "parameters": {"ZoneId": "cn-hangzhou-k"},
+            "region_id": "cn-hangzhou",
+        },
+        context=ToolContext(cwd="/workspace", pipeline_mode=True),
+    )
+
+    assert result.is_error is False
+    assert fake_stack.calls[0][0] == {
+        "action": "ContinueCreateStack",
+        "params": {
+            "StackId": "stack-failed",
+            "Mode": "Recreate",
+            "RecreatingOptions": ["AutoRecreatingResources"],
+            "TemplateURL": os.path.realpath("/workspace/templates/demo.yml"),
+            "Parameters": {"ZoneId": "cn-hangzhou-k"},
+        },
+        "region_id": "cn-hangzhou",
+    }
+
+
+@pytest.mark.asyncio
+async def test_continue_validation_failure_recommends_delete_and_create_without_running_it(monkeypatch):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-failed": {"action": "create"}}}
+    tool, fake_stack = _deploy_tool(
+        monkeypatch,
+        guard_state=guard_state,
+        results=[ToolResult.error("[ContinueCreateStack] ContinueCreateStackValidationFailed: cannot continue")],
+    )
+
+    result = await tool.execute(
+        tool_input={
+            "action": "continue_create",
+            "stack_id": "stack-failed",
+            "template_url": "templates/demo.yml",
+            "parameters": {"ZoneId": "cn-hangzhou-k"},
+        },
+        context=ToolContext(cwd="/workspace", pipeline_mode=True),
+    )
+
+    assert result.is_error is True
+    data = json.loads(result.content)
+    assert data["error_code"] == "ContinueCreateStackValidationFailed"
+    assert data["recommended_action"] == "delete_and_create"
+    assert len(fake_stack.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_and_create_rejects_stack_not_created_by_current_pipeline(monkeypatch):
+    tool, fake_stack = _deploy_tool(monkeypatch, guard_state={}, results=[])
+
+    result = await tool.execute(
+        tool_input={
+            "action": "delete_and_create",
+            "stack_id": "stack-from-list-stacks",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+        },
+        context=ToolContext(cwd="/workspace", pipeline_mode=True),
+    )
+
+    assert result.is_error is True
+    assert "not created by the current selling deployment step" in result.content
+    assert fake_stack.calls == []
+
+
+@pytest.mark.asyncio
+async def test_delete_and_create_deletes_owned_stack_then_creates_replacement(monkeypatch, tmp_path):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-old": {"action": "create"}}}
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "demo.yml").write_text("ROSTemplateFormatVersion: '2015-09-01'\n", encoding="utf-8")
+    tool, fake_stack = _deploy_tool(
+        monkeypatch,
+        guard_state=guard_state,
+        results=[
+            ToolResult.success(
+                json.dumps(
+                    {
+                        "stack_id": "stack-old",
+                        "stack_name": "demo",
+                        "status": "DELETE_COMPLETE",
+                        "is_success": True,
+                    }
+                )
+            ),
+            ToolResult.success(
+                json.dumps(
+                    {
+                        "stack_id": "stack-new",
+                        "stack_name": "demo",
+                        "status": "CREATE_COMPLETE",
+                        "is_success": True,
+                    }
+                )
+            ),
+        ],
+    )
+
+    result = await tool.execute(
+        tool_input={
+            "action": "delete_and_create",
+            "stack_id": "stack-old",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "parameters": {"ZoneId": "cn-hangzhou-k"},
+            "region_id": "cn-hangzhou",
+        },
+        context=ToolContext(cwd=str(tmp_path), pipeline_mode=True),
+    )
+
+    assert result.is_error is False
+    assert [call[0]["action"] for call in fake_stack.calls] == ["DeleteStack", "CreateStack"]
+    assert guard_state["ros_deploy_owned_stack_ids"]["stack-new"]["action"] == "delete_and_create"
+    assert json.loads(result.content)["stack_id"] == "stack-new"
+
+
+@pytest.mark.asyncio
+async def test_delete_and_create_validates_replacement_before_delete(monkeypatch):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-old": {"action": "create"}}}
+    tool, fake_stack = _deploy_tool(monkeypatch, guard_state=guard_state, results=[])
+
+    result = await tool.execute(
+        tool_input={
+            "action": "delete_and_create",
+            "stack_id": "stack-old",
+            "stack_name": "demo",
+        },
+        context=ToolContext(cwd="/workspace", pipeline_mode=True),
+    )
+
+    assert result.is_error is True
+    assert "template_url" in result.content
+    assert fake_stack.calls == []
+
+
+@pytest.mark.asyncio
+async def test_delete_and_create_rejects_missing_local_template_before_delete(monkeypatch, tmp_path):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-old": {"action": "create"}}}
+    tool, fake_stack = _deploy_tool(monkeypatch, guard_state=guard_state, results=[])
+
+    result = await tool.execute(
+        tool_input={
+            "action": "delete_and_create",
+            "stack_id": "stack-old",
+            "stack_name": "demo",
+            "template_url": "templates/missing.yml",
+        },
+        context=ToolContext(cwd=str(tmp_path), pipeline_mode=True),
+    )
+
+    assert result.is_error is True
+    assert "templates/missing.yml" in result.content
+    assert fake_stack.calls == []
+
+
+@pytest.mark.asyncio
+async def test_permission_asks_for_continue_create_stack_scoped_rule(monkeypatch):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-failed": {"action": "create"}}}
+    tool, _fake_stack = _deploy_tool(monkeypatch, guard_state=guard_state)
+
+    result = await tool.check_permissions(
+        {"action": "continue_create", "stack_id": "stack-failed"},
+        _permission_ctx(),
+    )
+
+    assert result.behavior == "ask"
+    assert result.suggestions is not None
+    assert result.suggestions[0].tool_name == "ros_deploy"
+    assert result.suggestions[0].rule_content == "continue_create:stack-failed"
+    assert result.suggestions[0].display_text == "Continue ROS stack creation: stack-failed"
+
+
+@pytest.mark.asyncio
+async def test_permission_rule_display_text_uses_friendly_deploy_action_names(monkeypatch):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-old": {"action": "create"}}}
+    tool, _fake_stack = _deploy_tool(monkeypatch, guard_state=guard_state)
+
+    create = await tool.check_permissions(
+        {"action": "create", "stack_name": "demo-stack"},
+        _permission_ctx(),
+    )
+    delete_and_create = await tool.check_permissions(
+        {"action": "delete_and_create", "stack_id": "stack-old"},
+        _permission_ctx(),
+    )
+
+    assert create.suggestions is not None
+    assert create.suggestions[0].rule_content == "create:demo-stack"
+    assert create.suggestions[0].display_text == "Create ROS stack: demo-stack"
+    assert delete_and_create.suggestions is not None
+    assert delete_and_create.suggestions[0].rule_content == "delete_and_create:stack-old"
+    assert delete_and_create.suggestions[0].display_text == "Delete failed ROS stack and create replacement: stack-old"
+
+
+@pytest.mark.asyncio
+async def test_permission_allows_matching_continue_create_stack_rule(monkeypatch):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-failed": {"action": "create"}}}
+    tool, _fake_stack = _deploy_tool(monkeypatch, guard_state=guard_state)
+
+    result = await tool.check_permissions(
+        {"action": "continue_create", "stack_id": "stack-failed"},
+        _permission_ctx(allow={"session": ["ros_deploy(continue_create:stack-failed)"]}),
+    )
+
+    assert result.behavior == "allow"
+
+
+@pytest.mark.asyncio
+async def test_permission_asks_before_reading_local_template_url_outside_allowed_roots_even_with_allow_rule(
+    monkeypatch,
+    tmp_path,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    outside_template = tmp_path / "outside.yml"
+    outside_template.write_text("ROSTemplateFormatVersion: '2015-09-01'\n", encoding="utf-8")
+    tool, _fake_stack = _deploy_tool(monkeypatch)
+
+    result = await tool.check_permissions(
+        {
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": str(outside_template),
+        },
+        ToolPermissionContext(
+            cwd=str(project),
+            allow_rules={"session": ["ros_deploy(create:demo)"]},
+        ),
+    )
+
+    assert result.behavior == "ask"
+    assert result.reason is not None
+    assert result.reason.type == "path_constraint"
+    assert result.suggestions is not None
+    assert result.suggestions[0].rule_content == "create:demo"
+
+
+@pytest.mark.asyncio
+async def test_permission_allows_and_execute_resolves_local_template_url_from_relative_read_root(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    skill_root = tmp_path / "skill"
+    project.mkdir()
+    (skill_root / "templates").mkdir(parents=True)
+    (skill_root / "templates" / "demo.yml").write_text("ROSTemplateFormatVersion: '2015-09-01'\n", encoding="utf-8")
+    tool, fake_stack = _deploy_tool(
+        monkeypatch,
+        results=[ToolResult.success(json.dumps({"stack_id": "stack-new", "is_success": True}))],
+    )
+
+    permission = await tool.check_permissions(
+        {
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+        },
+        ToolPermissionContext(
+            cwd=str(project),
+            allow_rules={"session": ["ros_deploy(create:demo)"]},
+            trusted_read_directories=[str(skill_root)],
+            relative_read_directories=[str(skill_root)],
+        ),
+    )
+    assert permission.behavior == "allow"
+
+    result = await tool.execute(
+        tool_input={
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+        },
+        context=ToolContext(
+            cwd=str(project),
+            trusted_read_directories=[str(skill_root)],
+            relative_read_directories=[str(skill_root)],
+            pipeline_mode=True,
+        ),
+    )
+
+    assert result.is_error is False
+    assert fake_stack.calls[0][0]["params"]["TemplateURL"] == os.path.realpath(skill_root / "templates" / "demo.yml")
+
+
+@pytest.mark.asyncio
+async def test_permission_denies_delete_and_create_for_unowned_stack_even_with_allow_rule(monkeypatch):
+    tool, _fake_stack = _deploy_tool(monkeypatch, guard_state={})
+
+    result = await tool.check_permissions(
+        {"action": "delete_and_create", "stack_id": "stack-from-list-stacks"},
+        _permission_ctx(allow={"session": ["ros_deploy(delete_and_create:stack-from-list-stacks)"]}),
+    )
+
+    assert result.behavior == "deny"
+    assert "not created by the current selling deployment step" in result.message
+
+
+@pytest.mark.asyncio
+async def test_permission_denies_continue_create_for_unowned_stack_even_with_allow_rule(monkeypatch):
+    tool, _fake_stack = _deploy_tool(monkeypatch, guard_state={})
+
+    result = await tool.check_permissions(
+        {"action": "continue_create", "stack_id": "stack-from-list-stacks"},
+        _permission_ctx(allow={"session": ["ros_deploy(continue_create:stack-from-list-stacks)"]}),
+    )
+
+    assert result.behavior == "deny"
+    assert "not created by the current selling deployment step" in result.message
+
+
+def test_continue_validation_failure_result_rendering_mentions_recommended_action():
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    content = json.dumps(
+        {
+            "stack_id": "stack-failed",
+            "error_code": "ContinueCreateStackValidationFailed",
+            "recommended_action": "delete_and_create",
+            "message": "cannot continue",
+        }
+    )
+
+    message = RosDeployTool().render_tool_result_message(content, is_error=True)
+
+    assert message is not None
+    assert "ContinueCreateStackValidationFailed" in message
+    assert "delete_and_create" in message

--- a/tests/services/test_agent_factory.py
+++ b/tests/services/test_agent_factory.py
@@ -369,3 +369,19 @@ def test_system_prompt_refresher_reuses_runtime_current_time(tmp_path, monkeypat
     refreshed_line = _current_time_line(runtime.agent_loop._system_prompt_refresher())
 
     assert refreshed_line == initial_line
+
+
+def test_create_agent_runtime_includes_runtime_provider_and_model(tmp_path, monkeypatch) -> None:
+    from iac_code.agent.system_prompt import split_by_dynamic_boundary
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+
+    runtime = create_agent_runtime(
+        AgentFactoryOptions(model="qwen3.7-max", session_id="runtime-model", cwd=str(tmp_path))
+    )
+
+    static, dynamic = split_by_dynamic_boundary(runtime.agent_loop.system_prompt)
+    runtime_line = "Provider & Model: Alibaba Cloud Bailian / qwen3.7-max"
+    assert runtime_line not in static
+    assert runtime_line in dynamic

--- a/tests/skills/bundled/test_iac_skill.py
+++ b/tests/skills/bundled/test_iac_skill.py
@@ -48,6 +48,16 @@ class TestIacSkill:
         assert "references/template-parameter-recommendation.md" in iac_skill.content
         assert "已有模板参数推荐" in iac_skill.content
 
+    def test_iac_skill_uses_normal_ros_api_tools(self):
+        init_bundled_skills()
+        skills = get_bundled_skills()
+        iac_skill = next(s for s in skills if s.name == "iac-aliyun")
+
+        assert 'aliyun_api(product="ros", action="ValidateTemplate"' in iac_skill.content
+        assert 'aliyun_api(product="ros", action="GetTemplateEstimateCost"' in iac_skill.content
+        assert "ros_validate_template" not in iac_skill.content
+        assert "ros_estimate_template_cost" not in iac_skill.content
+
     def test_iac_skill_delegates_infraguard_work_to_pac_skill(self):
         init_bundled_skills()
         skills = get_bundled_skills()
@@ -72,7 +82,12 @@ class TestIacSkill:
         reference = IAC_SKILL_ROOT / "references" / "template-parameter-recommendation.md"
         assert reference.exists()
         content = reference.read_text(encoding="utf-8")
-        assert "GetTemplateParameterConstraints" in content
+        assert 'action="GetTemplateParameterConstraints"' in content
+        assert 'action="PreviewStack"' in content
+        assert "调用 `GetTemplateEstimateCost`" in content
+        assert "ros_get_template_parameter_constraints" not in content
+        assert "ros_preview_template" not in content
+        assert "ros_estimate_template_cost" not in content
         assert "PreviewStack" in content
         assert "Preview-Validated Parameter Set" in content
         assert "ParametersOrder" in content

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -86,6 +86,11 @@ SESSION_BACKUP_USER_VISIBLE_MSGIDS = {
     "unknown",
 }
 
+ROS_DEPLOYMENT_REJECTION_MSGID = (
+    "ROS pipeline calls for {action} must use the dedicated ros_deploy tool instead of aliyun_api. "
+    "Do not call the raw ROS deployment API directly."
+)
+
 
 def _get_all_msgids_from_pot(pot_file: Path) -> set[str]:
     """Extract all msgids from a .pot template file.
@@ -421,6 +426,32 @@ def test_pipeline_user_visible_translations_are_complete():
                 errors.append(f"{lang_dir.name}: missing translation for {msgid!r}")
             elif msgstr == msgid:
                 errors.append(f"{lang_dir.name}: untranslated placeholder for {msgid!r}")
+
+    assert not errors, "\n".join(errors)
+
+
+def test_ros_deployment_rejection_translations_preserve_format_fields():
+    """The pipeline safety error must not fail while formatting localized text."""
+    language_dirs = _discover_language_dirs()
+    assert language_dirs, "No language directories found"
+
+    errors = []
+    for lang_dir in language_dirs:
+        translations = _get_all_translations_from_po(lang_dir / "LC_MESSAGES" / "messages.po")
+        msgstr = translations.get(ROS_DEPLOYMENT_REJECTION_MSGID, "")
+        if not msgstr:
+            errors.append(f"{lang_dir.name}: missing translation")
+            continue
+        if "{tool_name}" in msgstr:
+            errors.append(f"{lang_dir.name}: stale {{tool_name}} placeholder")
+            continue
+        try:
+            formatted = msgstr.format(action="CreateStack")
+        except (IndexError, KeyError, ValueError) as exc:
+            errors.append(f"{lang_dir.name}: format failed: {exc}")
+            continue
+        if "CreateStack" not in formatted:
+            errors.append(f"{lang_dir.name}: formatted action missing")
 
     assert not errors, "\n".join(errors)
 

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -20,19 +20,26 @@ def _load_setup_module(monkeypatch):
     return module
 
 
+def _assert_expanded_selling_references(package_root: Path, skill_names: tuple[str, ...]) -> None:
+    for skill_name in skill_names:
+        references = package_root / "pipeline" / "selling" / "skills" / skill_name / "references"
+        assert references.is_dir()
+        assert not references.is_symlink()
+        assert (references / "ros-template.md").is_file()
+        assert (references / "template-parameters.md").is_file()
+        assert (references / "cloud-products" / "ecs.md").is_file()
+        recommendation = (references / "template-parameter-recommendation.md").read_text(encoding="utf-8")
+        assert "ros_estimate_template_cost" in recommendation
+        assert 'action="GetTemplateEstimateCost"' not in recommendation
+
+
 def test_selling_skill_references_are_expanded_for_installed_artifacts(monkeypatch, tmp_path):
     setup_module = _load_setup_module(monkeypatch)
     build_lib = tmp_path / "build_lib"
 
     setup_module._copy_selling_skill_references(str(build_lib))
 
-    for skill_name in setup_module.SELLING_IAC_ALIYUN_SKILLS:
-        references = build_lib / "iac_code" / "pipeline" / "selling" / "skills" / skill_name / "references"
-        assert references.is_dir()
-        assert not references.is_symlink()
-        assert (references / "ros-template.md").is_file()
-        assert (references / "template-parameters.md").is_file()
-        assert (references / "cloud-products" / "ecs.md").is_file()
+    _assert_expanded_selling_references(build_lib / "iac_code", setup_module.SELLING_IAC_ALIYUN_SKILLS)
 
 
 def test_selling_skill_references_are_expanded_for_sdist_release_tree(monkeypatch, tmp_path):
@@ -41,13 +48,48 @@ def test_selling_skill_references_are_expanded_for_sdist_release_tree(monkeypatc
 
     setup_module._copy_selling_skill_references_to_sdist_release_tree(str(release_tree))
 
-    for skill_name in setup_module.SELLING_IAC_ALIYUN_SKILLS:
-        references = release_tree / "src" / "iac_code" / "pipeline" / "selling" / "skills" / skill_name / "references"
-        assert references.is_dir()
-        assert not references.is_symlink()
-        assert (references / "ros-template.md").is_file()
-        assert (references / "template-parameters.md").is_file()
-        assert (references / "cloud-products" / "ecs.md").is_file()
+    _assert_expanded_selling_references(release_tree / "src" / "iac_code", setup_module.SELLING_IAC_ALIYUN_SKILLS)
+
+
+def test_selling_skill_references_expand_windows_symlink_placeholder_files(monkeypatch, tmp_path):
+    setup_module = _load_setup_module(monkeypatch)
+    source_root = tmp_path / "src" / "iac_code"
+    selling_refs = source_root / "pipeline" / "selling" / "references"
+    bundled_refs = source_root / "skills" / "bundled" / "iac_aliyun" / "references"
+    cloud_products = bundled_refs / "cloud-products"
+    selling_refs.mkdir(parents=True)
+    cloud_products.mkdir(parents=True)
+    (bundled_refs / "ros-template.md").write_text("real ros template reference", encoding="utf-8")
+    (bundled_refs / "template-parameters.md").write_text("real parameter reference", encoding="utf-8")
+    (cloud_products / "ecs.md").write_text("real ecs reference", encoding="utf-8")
+    (selling_refs / "template-parameter-recommendation.md").write_text(
+        "pipeline ros_estimate_template_cost recommendation",
+        encoding="utf-8",
+    )
+    (selling_refs / "ros-template.md").write_text(
+        "../../../skills/bundled/iac_aliyun/references/ros-template.md",
+        encoding="utf-8",
+    )
+    (selling_refs / "template-parameters.md").write_text(
+        "../../../skills/bundled/iac_aliyun/references/template-parameters.md",
+        encoding="utf-8",
+    )
+    (selling_refs / "cloud-products").write_text(
+        "../../../skills/bundled/iac_aliyun/references/cloud-products",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(setup_module, "SELLING_REFERENCES_DIR", selling_refs)
+    build_lib = tmp_path / "build_lib"
+
+    setup_module._copy_selling_skill_references(str(build_lib))
+
+    package_root = build_lib / "iac_code"
+    _assert_expanded_selling_references(package_root, setup_module.SELLING_IAC_ALIYUN_SKILLS)
+    references = (
+        package_root / "pipeline" / "selling" / "skills" / setup_module.SELLING_IAC_ALIYUN_SKILLS[0] / "references"
+    )
+    assert (references / "ros-template.md").read_text(encoding="utf-8") == "real ros template reference"
+    assert (references / "cloud-products").is_dir()
 
 
 def test_selling_pipeline_python_runtime_files_are_discovered_for_installed_artifacts():

--- a/tests/tools/cloud/aliyun/test_aliyun_api.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api.py
@@ -152,6 +152,38 @@ class TestAliyunApiProperties:
         )
 
 
+class TestAliyunApiPipelineRosTemplateActions:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("action", "expected_tool"),
+        [
+            ("ValidateTemplate", "ros_validate_template"),
+            ("GetTemplateParameterConstraints", "ros_get_template_parameter_constraints"),
+            ("PreviewStack", "ros_preview_template"),
+            ("GetTemplateEstimateCost", "ros_estimate_template_cost"),
+        ],
+    )
+    async def test_pipeline_rejects_raw_ros_template_api_actions(
+        self,
+        api: AliyunApi,
+        action: str,
+        expected_tool: str,
+    ) -> None:
+        result = await api.execute(
+            tool_input={
+                "product": "ros",
+                "action": action,
+                "params": {"TemplateURL": "templates/app.yml"},
+                "region_id": "cn-hangzhou",
+            },
+            context=ToolContext(pipeline_mode=True),
+        )
+
+        assert result.is_error
+        assert expected_tool in result.content
+        assert "aliyun_api" in result.content
+
+
 class TestAliyunApiVersionResolution:
     def test_known_product_resolves_version(self, api: AliyunApi) -> None:
         version = api._resolve_version({"product": "ecs"})
@@ -721,7 +753,7 @@ class TestAliyunApiHooks:
             result = await api.execute(
                 tool_input={
                     "product": "ros",
-                    "action": "ValidateTemplate",
+                    "action": "CreateStack",
                     "params": {"TemplateBody": "{}"},
                     "region_id": "cn-hangzhou",
                 },
@@ -761,6 +793,116 @@ class TestAliyunApiHooks:
 
         assert result.is_error is False
         mock_client.call_api.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ros_template_url_is_required_for_pipeline_template_action(
+        self, api: AliyunApi, context: ToolContext, mock_credentials
+    ) -> None:
+        with patch("iac_code.tools.cloud.aliyun.aliyun_api.OpenApiClient") as mock_open_api_client:
+            result = await api.execute(
+                tool_input={
+                    "product": "ros",
+                    "action": "CreateStack",
+                    "params": {"Parameters": {"ZoneId": "cn-hangzhou-k"}},
+                    "region_id": "cn-hangzhou",
+                },
+                context=ToolContext(pipeline_mode=True),
+            )
+
+        assert result.is_error is True
+        assert "TemplateURL" in result.content
+        assert "CreateStack" in result.content
+        mock_open_api_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("template_source", [{"TemplateId": "tpl-123"}, {"TemplateScratchId": "ts-123"}])
+    async def test_ros_pipeline_template_action_accepts_only_template_url(
+        self, api: AliyunApi, context: ToolContext, mock_credentials, template_source: dict[str, str]
+    ) -> None:
+        with patch("iac_code.tools.cloud.aliyun.aliyun_api.OpenApiClient") as mock_open_api_client:
+            result = await api.execute(
+                tool_input={
+                    "product": "ros",
+                    "action": "CreateStack",
+                    "params": template_source,
+                    "region_id": "cn-hangzhou",
+                },
+                context=ToolContext(pipeline_mode=True),
+            )
+
+        assert result.is_error is True
+        assert "TemplateURL" in result.content
+        mock_open_api_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ros_pipeline_non_template_action_does_not_require_template_url(
+        self, api: AliyunApi, context: ToolContext, mock_credentials
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.call_api.return_value = {"body": {"Stacks": []}}
+
+        with patch("iac_code.tools.cloud.aliyun.aliyun_api.OpenApiClient", return_value=mock_client):
+            result = await api.execute(
+                tool_input={
+                    "product": "ros",
+                    "action": "ListStacks",
+                    "params": {},
+                    "region_id": "cn-hangzhou",
+                },
+                context=ToolContext(pipeline_mode=True),
+            )
+
+        assert result.is_error is False
+        mock_client.call_api.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ros_missing_template_url_is_allowed_outside_pipeline(
+        self, api: AliyunApi, context: ToolContext, mock_credentials
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.call_api.return_value = {"body": {"RequestId": "req-1"}}
+
+        with patch("iac_code.tools.cloud.aliyun.aliyun_api.OpenApiClient", return_value=mock_client):
+            result = await api.execute(
+                tool_input={
+                    "product": "ros",
+                    "action": "GetTemplateEstimateCost",
+                    "params": {"Parameters": {"ZoneId": "cn-hangzhou-k"}},
+                    "region_id": "cn-hangzhou",
+                },
+                context=context,
+            )
+
+        assert result.is_error is False
+        mock_client.call_api.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ros_remote_template_url_scheme_is_case_insensitive(
+        self, api: AliyunApi, context: ToolContext, mock_credentials
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.call_api.return_value = {"body": {"Description": "Valid"}}
+
+        with (
+            patch("iac_code.tools.cloud.aliyun.aliyun_api.OpenApiClient", return_value=mock_client),
+            patch("iac_code.tools.cloud.aliyun.aliyun_api.Path.read_text") as read_text,
+        ):
+            read_text.side_effect = AssertionError("remote TemplateURL should not be read as a local file")
+            result = await api.execute(
+                tool_input={
+                    "product": "ros",
+                    "action": "ValidateTemplate",
+                    "params": {"TemplateURL": "HTTPS://example.com/template.yml"},
+                    "region_id": "cn-hangzhou",
+                },
+                context=context,
+            )
+
+        assert result.is_error is False
+        mock_client.call_api.assert_called_once()
+        request = mock_client.call_api.call_args[0][1]
+        assert request.query["TemplateURL"] == "HTTPS://example.com/template.yml"
+        assert "TemplateBody" not in request.query
 
     @pytest.mark.asyncio
     async def test_hook_blocks_validate_with_wrong_resource_types(

--- a/tests/tools/cloud/aliyun/test_aliyun_api.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api.py
@@ -183,6 +183,23 @@ class TestAliyunApiPipelineRosTemplateActions:
         assert expected_tool in result.content
         assert "aliyun_api" in result.content
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("action", ["CreateStack", "ContinueCreateStack", "DeleteStack", "UpdateStack"])
+    async def test_pipeline_rejects_raw_ros_deployment_api_actions(self, api: AliyunApi, action: str) -> None:
+        result = await api.execute(
+            tool_input={
+                "product": "ros",
+                "action": action,
+                "params": {"TemplateURL": "templates/app.yml", "StackId": "stack-123"},
+                "region_id": "cn-hangzhou",
+            },
+            context=ToolContext(pipeline_mode=True),
+        )
+
+        assert result.is_error
+        assert "ros_deploy" in result.content
+        assert "raw ROS deployment API" in result.content
+
 
 class TestAliyunApiVersionResolution:
     def test_known_product_resolves_version(self, api: AliyunApi) -> None:
@@ -753,7 +770,7 @@ class TestAliyunApiHooks:
             result = await api.execute(
                 tool_input={
                     "product": "ros",
-                    "action": "CreateStack",
+                    "action": "CreateChangeSet",
                     "params": {"TemplateBody": "{}"},
                     "region_id": "cn-hangzhou",
                 },
@@ -802,7 +819,7 @@ class TestAliyunApiHooks:
             result = await api.execute(
                 tool_input={
                     "product": "ros",
-                    "action": "CreateStack",
+                    "action": "CreateChangeSet",
                     "params": {"Parameters": {"ZoneId": "cn-hangzhou-k"}},
                     "region_id": "cn-hangzhou",
                 },
@@ -811,7 +828,7 @@ class TestAliyunApiHooks:
 
         assert result.is_error is True
         assert "TemplateURL" in result.content
-        assert "CreateStack" in result.content
+        assert "CreateChangeSet" in result.content
         mock_open_api_client.assert_not_called()
 
     @pytest.mark.asyncio
@@ -823,7 +840,7 @@ class TestAliyunApiHooks:
             result = await api.execute(
                 tool_input={
                     "product": "ros",
-                    "action": "CreateStack",
+                    "action": "CreateChangeSet",
                     "params": template_source,
                     "region_id": "cn-hangzhou",
                 },

--- a/tests/tools/cloud/aliyun/test_ros_stack.py
+++ b/tests/tools/cloud/aliyun/test_ros_stack.py
@@ -142,7 +142,7 @@ class TestRosStackExecute:
         assert first.resources[0]["resource_type"] == "ALIYUN::ECS::VPC"
 
     @pytest.mark.asyncio
-    async def test_template_body_is_rejected_before_create_stack(self, tool: RosStack, mock_credentials) -> None:
+    async def test_pipeline_create_stack_is_rejected_before_sdk_call(self, tool: RosStack, mock_credentials) -> None:
         mock_client = MagicMock()
 
         with patch("iac_code.tools.cloud.aliyun.ros_stack.RosClientFactory") as mock_factory:
@@ -157,8 +157,7 @@ class TestRosStackExecute:
             )
 
         assert result.is_error is True
-        assert "TemplateBody" in result.content
-        assert "TemplateURL" in result.content
+        assert "ros_deploy" in result.content
         mock_client.create_stack.assert_not_called()
 
     @pytest.mark.asyncio
@@ -303,6 +302,41 @@ class TestRosStackExecute:
 
         assert result.is_error is False
         mock_client.create_stack.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_stack_polling_error_returns_started_stack_metadata(
+        self, tool: RosStack, mock_credentials
+    ) -> None:
+        mock_client = MagicMock()
+
+        create_response = MagicMock()
+        create_response.body.stack_id = "stack-123"
+        mock_client.create_stack.return_value = create_response
+        mock_client.get_stack.side_effect = RuntimeError("status service unavailable")
+
+        with (
+            patch("iac_code.tools.cloud.aliyun.ros_stack.RosClientFactory") as mock_factory,
+            patch("iac_code.tools.cloud.aliyun.api_hooks.run_hooks", return_value=None),
+        ):
+            mock_factory.create.return_value = mock_client
+            result = await tool.execute(
+                tool_input={
+                    "action": "CreateStack",
+                    "params": {"StackName": "test", "TemplateURL": _REMOTE_TEMPLATE_URL},
+                    "region_id": "cn-hangzhou",
+                },
+                context=ToolContext(),
+            )
+
+        assert result.is_error is True
+        assert result.metadata == {
+            "provider": "ros",
+            "action": "CreateStack",
+            "stack_id": "stack-123",
+            "stack_name": "test",
+            "region_id": "cn-hangzhou",
+            "error_stage": "status",
+        }
 
     @pytest.mark.asyncio
     async def test_create_stack_polling_cancellation_cleans_context_and_emits_cancel_telemetry(
@@ -1525,6 +1559,28 @@ class TestRosStackExtra:
         assert result == "stack-fake"
 
     @pytest.mark.asyncio
+    async def test_continue_create_stack_normalizes_parameters_dict(self, stack):
+        client = _FakeRosClient()
+        stack._get_client = lambda region: client
+
+        result = await stack.call_action(
+            "ContinueCreateStack",
+            {
+                "StackId": "sx",
+                "TemplateURL": _REMOTE_TEMPLATE_URL,
+                "Parameters": {"ZoneId": "cn-hangzhou-k", "UseSsl": True},
+            },
+            "cn-hangzhou",
+        )
+
+        assert result == "stack-fake"
+        assert client.continue_create_request is not None
+        assert client.continue_create_request.to_map()["Parameters"] == [
+            {"ParameterKey": "ZoneId", "ParameterValue": "cn-hangzhou-k"},
+            {"ParameterKey": "UseSsl", "ParameterValue": "true"},
+        ]
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("action", "params", "sdk_method"),
         [
@@ -1568,14 +1624,33 @@ class TestRosStackExtra:
         assert result == "stack-fake"
 
     @pytest.mark.asyncio
-    async def test_template_body_dict_is_rejected_in_pipeline(self, stack):
-        with pytest.raises(ValueError, match="TemplateURL"):
+    async def test_create_stack_is_rejected_in_pipeline(self, stack):
+        with pytest.raises(ValueError, match="ros_deploy"):
             await stack.call_action(
                 "CreateStack",
                 {"StackName": "n", "TemplateBody": {"ROSTemplateFormatVersion": "2015-09-01"}},
                 "cn-hangzhou",
                 pipeline_mode=True,
             )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("action", "params"),
+        [
+            ("CreateStack", {"StackName": "n", "TemplateURL": _REMOTE_TEMPLATE_URL}),
+            ("UpdateStack", {"StackId": "sx", "TemplateURL": _REMOTE_TEMPLATE_URL}),
+            ("ContinueCreateStack", {"StackId": "sx", "TemplateURL": _REMOTE_TEMPLATE_URL}),
+            ("DeleteStack", {"StackId": "sx"}),
+        ],
+    )
+    async def test_raw_deployment_actions_are_rejected_in_pipeline_mode(self, stack, monkeypatch, action, params):
+        def fail_client(region):
+            raise AssertionError("raw ROS deployment action should be rejected before client creation")
+
+        monkeypatch.setattr(stack, "_get_client", fail_client)
+
+        with pytest.raises(ValueError, match="ros_deploy"):
+            await stack.call_action(action, dict(params), "cn-hangzhou", pipeline_mode=True)
 
     @pytest.mark.asyncio
     async def test_template_body_dict_to_json_outside_pipeline(self, stack):
@@ -1731,6 +1806,7 @@ class _FakeRosClient:
     def __init__(self):
         self.create_request = None
         self.update_request = None
+        self.continue_create_request = None
 
     def create_stack(self, req):
         self.create_request = req
@@ -1741,6 +1817,7 @@ class _FakeRosClient:
         return _FakeResp("stack-fake")
 
     def continue_create_stack(self, req):
+        self.continue_create_request = req
         return _FakeResp("stack-fake")
 
     def delete_stack(self, req):

--- a/tests/tools/cloud/aliyun/test_ros_stack.py
+++ b/tests/tools/cloud/aliyun/test_ros_stack.py
@@ -497,6 +497,7 @@ class TestRosStackExecute:
         self, tool: RosStack, mock_credentials
     ) -> None:
         mock_client = MagicMock()
+        remote_template_url = "OSS://iac-code-test/template.json"
 
         create_response = MagicMock()
         create_response.body.stack_id = "stack-123"
@@ -518,12 +519,14 @@ class TestRosStackExecute:
         with (
             patch("iac_code.tools.cloud.aliyun.ros_stack.RosClientFactory") as mock_factory,
             patch("iac_code.tools.cloud.aliyun.api_hooks.run_hooks", return_value=None),
+            patch("iac_code.tools.cloud.aliyun.ros_stack.Path.read_text") as read_text,
         ):
+            read_text.side_effect = AssertionError("remote TemplateURL should not be read as a local file")
             mock_factory.create.return_value = mock_client
             result = await tool.execute(
                 tool_input={
                     "action": "CreateStack",
-                    "params": {"StackName": "test", "TemplateURL": _REMOTE_TEMPLATE_URL},
+                    "params": {"StackName": "test", "TemplateURL": remote_template_url},
                     "region_id": "cn-hangzhou",
                 },
                 context=ToolContext(),
@@ -532,7 +535,58 @@ class TestRosStackExecute:
         assert result.is_error is False
         mock_client.create_stack.assert_called_once()
         request = mock_client.create_stack.call_args.args[0]
-        assert request.to_map()["TemplateURL"] == _REMOTE_TEMPLATE_URL
+        assert request.to_map()["TemplateURL"] == remote_template_url
+        data = json.loads(result.content)
+        assert data["status"] == "CREATE_COMPLETE"
+
+    @pytest.mark.asyncio
+    async def test_create_stack_relative_template_url_resolves_from_context_cwd(
+        self, tool: RosStack, mock_credentials, tmp_path, monkeypatch
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        other_cwd = tmp_path / "other"
+        template_dir = workspace / "templates"
+        template_dir.mkdir(parents=True)
+        other_cwd.mkdir()
+        template_body = json.dumps({"ROSTemplateFormatVersion": "2015-09-01", "Resources": {}})
+        (template_dir / "stack.json").write_text(template_body, encoding="utf-8")
+        monkeypatch.chdir(other_cwd)
+
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.body.stack_id = "stack-123"
+        mock_client.create_stack.return_value = create_response
+        get_stack_response = MagicMock()
+        get_stack_response.body.to_map.return_value = {
+            "StackId": "stack-123",
+            "StackName": "test",
+            "Status": "CREATE_COMPLETE",
+            "StatusReason": "",
+        }
+        mock_client.get_stack.return_value = get_stack_response
+        list_resources_response = MagicMock()
+        list_resources_response.body.to_map.return_value = {"Resources": []}
+        mock_client.list_stack_resources.return_value = list_resources_response
+
+        with (
+            patch("iac_code.tools.cloud.aliyun.ros_stack.RosClientFactory") as mock_factory,
+            patch("iac_code.tools.cloud.aliyun.api_hooks.run_hooks", return_value=None),
+        ):
+            mock_factory.create.return_value = mock_client
+            result = await tool.execute(
+                tool_input={
+                    "action": "CreateStack",
+                    "params": {"StackName": "test", "TemplateURL": "templates/stack.json"},
+                    "region_id": "cn-hangzhou",
+                },
+                context=ToolContext(cwd=str(workspace)),
+            )
+
+        assert result.is_error is False
+        request = mock_client.create_stack.call_args.args[0]
+        request_map = request.to_map()
+        assert request_map["TemplateBody"] == template_body
+        assert "TemplateURL" not in request_map
         data = json.loads(result.content)
         assert data["status"] == "CREATE_COMPLETE"
 
@@ -910,6 +964,7 @@ class TestRosStackExecute:
         self, tool: RosStack, mock_credentials
     ) -> None:
         mock_client = MagicMock()
+        remote_template_url = "HTTPS://example.com/template.json"
 
         update_response = MagicMock()
         update_response.body.stack_id = "stack-123"
@@ -931,12 +986,14 @@ class TestRosStackExecute:
         with (
             patch("iac_code.tools.cloud.aliyun.ros_stack.RosClientFactory") as mock_factory,
             patch("iac_code.tools.cloud.aliyun.api_hooks.run_hooks", return_value=None),
+            patch("iac_code.tools.cloud.aliyun.ros_stack.Path.read_text") as read_text,
         ):
+            read_text.side_effect = AssertionError("remote TemplateURL should not be read as a local file")
             mock_factory.create.return_value = mock_client
             result = await tool.execute(
                 tool_input={
                     "action": "UpdateStack",
-                    "params": {"StackId": "stack-123", "TemplateURL": _REMOTE_TEMPLATE_URL},
+                    "params": {"StackId": "stack-123", "TemplateURL": remote_template_url},
                     "region_id": "cn-hangzhou",
                 },
                 context=ToolContext(),
@@ -945,7 +1002,7 @@ class TestRosStackExecute:
         assert result.is_error is False
         mock_client.update_stack.assert_called_once()
         request = mock_client.update_stack.call_args.args[0]
-        assert request.to_map()["TemplateURL"] == _REMOTE_TEMPLATE_URL
+        assert request.to_map()["TemplateURL"] == remote_template_url
         data = json.loads(result.content)
         assert data["status"] == "UPDATE_COMPLETE"
 

--- a/tests/tools/cloud/aliyun/test_ros_template_tools.py
+++ b/tests/tools/cloud/aliyun/test_ros_template_tools.py
@@ -1,0 +1,436 @@
+"""Tests for dedicated ROS template tools."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from iac_code.tools.base import ToolContext, ToolResult
+from iac_code.tools.cloud.aliyun.aliyun_api import AliyunApi
+from iac_code.tools.cloud.aliyun.ros_template_tools import (
+    RosEstimateTemplateCostTool,
+    RosGetTemplateParameterConstraintsTool,
+    RosPreviewTemplateTool,
+    RosValidateTemplateTool,
+)
+from iac_code.types.permissions import ToolPermissionContext
+
+
+def _permission_context(*, deny: dict[str, list[str]] | None = None) -> ToolPermissionContext:
+    return ToolPermissionContext(cwd="/tmp", deny_rules=deny or {})
+
+
+def test_ros_template_tools_do_not_expose_raw_params_or_template_body() -> None:
+    for tool in (
+        RosValidateTemplateTool(),
+        RosGetTemplateParameterConstraintsTool(),
+        RosPreviewTemplateTool(),
+        RosEstimateTemplateCostTool(),
+    ):
+        schema = tool.input_schema
+
+        assert schema["additionalProperties"] is False
+        assert "params" not in schema["properties"]
+        assert "TemplateBody" not in schema["properties"]
+        assert "TemplateURL" not in schema["properties"]
+        assert "TemplateId" not in schema["properties"]
+        assert "TemplateScratchId" not in schema["properties"]
+
+        valid, error = tool.validate_input(
+            {
+                "template_url": "templates/app.yml",
+                "region_id": "cn-hangzhou",
+                **({"stack_name": "preview-stack"} if tool.name == "ros_preview_template" else {}),
+                **({"parameters": {"ZoneId": "cn-hangzhou-k"}} if tool.name != "ros_validate_template" else {}),
+            }
+        )
+        assert valid, error
+
+        valid, error = tool.validate_input(
+            {
+                "template_url": "templates/app.yml",
+                "region_id": "cn-hangzhou",
+                **({"stack_name": "preview-stack"} if tool.name == "ros_preview_template" else {}),
+                **({"parameters": {"ZoneId": "cn-hangzhou-k"}} if tool.name != "ros_validate_template" else {}),
+                "TemplateBody": "ROSTemplateFormatVersion: '2015-09-01'",
+            }
+        )
+        assert not valid
+        assert "Additional properties are not allowed" in error
+
+
+@pytest.mark.parametrize("template_source", ["TemplateId", "TemplateScratchId"])
+def test_ros_template_tools_reject_raw_template_source_fields(template_source: str) -> None:
+    for tool in (
+        RosValidateTemplateTool(),
+        RosGetTemplateParameterConstraintsTool(),
+        RosPreviewTemplateTool(),
+        RosEstimateTemplateCostTool(),
+    ):
+        valid, error = tool.validate_input(
+            {
+                "template_url": "templates/app.yml",
+                **({"stack_name": "preview-stack"} if tool.name == "ros_preview_template" else {}),
+                **({"parameters": {"ZoneId": "cn-hangzhou-k"}} if tool.name != "ros_validate_template" else {}),
+                template_source: "tpl-123",
+            }
+        )
+
+        assert not valid
+        assert "Additional properties are not allowed" in error
+
+
+def test_ros_template_tools_reject_flat_ros_parameter_keys() -> None:
+    tool = RosEstimateTemplateCostTool()
+
+    valid, error = tool.validate_input(
+        {
+            "template_url": "templates/app.yml",
+            "region_id": "cn-hangzhou",
+            "parameters": {
+                "Parameters.1.ParameterKey": "ZoneId",
+                "Parameters.1.ParameterValue": "cn-hangzhou-k",
+            },
+        }
+    )
+
+    assert not valid
+    assert "should not be valid" in error or "does not match" in error
+
+
+def test_ros_template_tools_allow_aliyun_default_region() -> None:
+    for tool in (
+        RosValidateTemplateTool(),
+        RosGetTemplateParameterConstraintsTool(),
+        RosPreviewTemplateTool(),
+        RosEstimateTemplateCostTool(),
+    ):
+        assert "region_id" not in tool.input_schema["required"]
+        valid, error = tool.validate_input(
+            {
+                "template_url": "templates/app.yml",
+                **({"stack_name": "preview-stack"} if tool.name == "ros_preview_template" else {}),
+                **({"parameters": {"ZoneId": "cn-hangzhou-k"}} if tool.name != "ros_validate_template" else {}),
+            }
+        )
+        assert valid, error
+
+
+def test_ros_template_tools_have_distinct_user_facing_names() -> None:
+    assert RosValidateTemplateTool().user_facing_name() == "ROS Validate Template"
+    assert RosGetTemplateParameterConstraintsTool().user_facing_name() == "ROS Template Parameters"
+    assert RosPreviewTemplateTool().user_facing_name() == "ROS Preview Stack"
+    assert RosEstimateTemplateCostTool().user_facing_name() == "ROS Estimate Cost"
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tool_result_display_matches_aliyun_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = RosValidateTemplateTool()
+    raw_output = '{\n  "RequestId": "REQ-42",\n  "Resources": ["long output"]\n}'
+
+    async def fake_execute(self, *, tool_input: dict, context: ToolContext) -> ToolResult:
+        self._last_action = tool_input["action"]
+        self._last_result = {"RequestId": "REQ-42", "Resources": ["long output"]}
+        return ToolResult.success(raw_output)
+
+    monkeypatch.setattr(AliyunApi, "execute", fake_execute)
+
+    result = await tool.execute(
+        tool_input={"template_url": "templates/app.yml"},
+        context=ToolContext(pipeline_mode=True),
+    )
+
+    assert tool.render_tool_result_message(result.content) == "Call succeeded (RequestId: REQ-42)"
+    assert tool.render_tool_result_message(result.content, verbose=True) == raw_output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "tool_input", "expected_action", "expected_params"),
+    [
+        (
+            RosValidateTemplateTool(),
+            {"template_url": "templates/app.yml", "region_id": "cn-hangzhou"},
+            "ValidateTemplate",
+            {"TemplateURL": "templates/app.yml"},
+        ),
+        (
+            RosGetTemplateParameterConstraintsTool(),
+            {
+                "template_url": "templates/app.yml",
+                "region_id": "cn-hangzhou",
+                "parameters": {"ZoneId": "cn-hangzhou-k"},
+            },
+            "GetTemplateParameterConstraints",
+            {"TemplateURL": "templates/app.yml", "Parameters": {"ZoneId": "cn-hangzhou-k"}},
+        ),
+        (
+            RosPreviewTemplateTool(),
+            {
+                "template_url": "templates/app.yml",
+                "region_id": "cn-hangzhou",
+                "stack_name": "preview-stack",
+                "parameters": {"ZoneId": "cn-hangzhou-k"},
+            },
+            "PreviewStack",
+            {
+                "TemplateURL": "templates/app.yml",
+                "StackName": "preview-stack",
+                "Parameters": {"ZoneId": "cn-hangzhou-k"},
+            },
+        ),
+        (
+            RosEstimateTemplateCostTool(),
+            {
+                "template_url": "templates/app.yml",
+                "region_id": "cn-hangzhou",
+                "parameters": {"ZoneId": "cn-hangzhou-k"},
+            },
+            "GetTemplateEstimateCost",
+            {"TemplateURL": "templates/app.yml", "Parameters": {"ZoneId": "cn-hangzhou-k"}},
+        ),
+    ],
+)
+async def test_ros_template_tools_delegate_to_aliyun_api_with_template_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tool,
+    tool_input: dict,
+    expected_action: str,
+    expected_params: dict,
+) -> None:
+    captured: dict = {}
+
+    async def fake_execute(self, *, tool_input: dict, context: ToolContext) -> ToolResult:
+        captured["tool_input"] = tool_input
+        captured["pipeline_mode"] = context.pipeline_mode
+        return ToolResult.success('{"ok": true}')
+
+    monkeypatch.setattr(AliyunApi, "execute", fake_execute)
+
+    context = ToolContext(pipeline_mode=True)
+    result = await tool.execute(tool_input=tool_input, context=context)
+
+    expected_params = dict(expected_params)
+    expected_params["TemplateURL"] = os.path.realpath(os.path.join(context.cwd, expected_params["TemplateURL"]))
+    assert not result.is_error
+    assert captured["tool_input"] == {
+        "product": "ros",
+        "action": expected_action,
+        "params": expected_params,
+        "region_id": "cn-hangzhou",
+    }
+    assert captured["pipeline_mode"] is False
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tool_delegates_without_region_id_for_aliyun_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_execute(self, *, tool_input: dict, context: ToolContext) -> ToolResult:
+        captured["tool_input"] = tool_input
+        return ToolResult.success('{"ok": true}')
+
+    monkeypatch.setattr(AliyunApi, "execute", fake_execute)
+
+    result = await RosValidateTemplateTool().execute(
+        tool_input={"template_url": "templates/app.yml"},
+        context=ToolContext(pipeline_mode=True),
+    )
+
+    assert not result.is_error
+    assert captured["tool_input"] == {
+        "product": "ros",
+        "action": "ValidateTemplate",
+        "params": {"TemplateURL": os.path.realpath("templates/app.yml")},
+    }
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_resolve_local_template_url_from_tool_context_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    captured: dict = {}
+
+    async def fake_execute(self, *, tool_input: dict, context: ToolContext) -> ToolResult:
+        captured["tool_input"] = tool_input
+        return ToolResult.success('{"ok": true}')
+
+    monkeypatch.setattr(AliyunApi, "execute", fake_execute)
+
+    result = await RosValidateTemplateTool().execute(
+        tool_input={"template_url": "templates/app.yml"},
+        context=ToolContext(cwd=str(project), pipeline_mode=True),
+    )
+
+    assert not result.is_error
+    assert captured["tool_input"]["params"] == {
+        "TemplateURL": os.path.realpath(project / "templates" / "app.yml"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_preserve_remote_template_url_when_delegating(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    captured: dict = {}
+
+    async def fake_execute(self, *, tool_input: dict, context: ToolContext) -> ToolResult:
+        captured["tool_input"] = tool_input
+        return ToolResult.success('{"ok": true}')
+
+    monkeypatch.setattr(AliyunApi, "execute", fake_execute)
+
+    result = await RosValidateTemplateTool().execute(
+        tool_input={"template_url": "HTTPS://example.com/template.yml"},
+        context=ToolContext(cwd=str(tmp_path), pipeline_mode=True),
+    )
+
+    assert not result.is_error
+    assert captured["tool_input"]["params"] == {"TemplateURL": "HTTPS://example.com/template.yml"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "tool_input", "expected_action"),
+    [
+        (RosValidateTemplateTool(), {"template_url": "templates/app.yml"}, "ValidateTemplate"),
+        (
+            RosGetTemplateParameterConstraintsTool(),
+            {"template_url": "templates/app.yml", "parameters": {"ZoneId": "cn-hangzhou-k"}},
+            "GetTemplateParameterConstraints",
+        ),
+        (
+            RosPreviewTemplateTool(),
+            {
+                "template_url": "templates/app.yml",
+                "stack_name": "preview-stack",
+                "parameters": {"ZoneId": "cn-hangzhou-k"},
+            },
+            "PreviewStack",
+        ),
+        (
+            RosEstimateTemplateCostTool(),
+            {"template_url": "templates/app.yml", "parameters": {"ZoneId": "cn-hangzhou-k"}},
+            "GetTemplateEstimateCost",
+        ),
+    ],
+)
+async def test_ros_template_tools_delegate_permission_audit_to_aliyun_api(
+    tool,
+    tool_input: dict,
+    expected_action: str,
+) -> None:
+    result = await tool.check_permissions(tool_input, _permission_context())
+
+    assert result.behavior == "allow"
+    assert result.audit is not None
+    assert result.audit.is_read_only is True
+    assert result.audit.operation["product"] == "ros"
+    assert result.audit.operation["action"] == expected_action
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_allow_local_template_url_under_cwd(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = await RosValidateTemplateTool().check_permissions(
+        {"template_url": "templates/app.yml"},
+        ToolPermissionContext(cwd=str(project)),
+    )
+
+    assert result.behavior == "allow"
+    assert result.audit is not None
+    assert result.audit.operation["action"] == "ValidateTemplate"
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_ask_before_reading_local_template_url_outside_cwd(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside_template = tmp_path / "outside.yml"
+
+    result = await RosValidateTemplateTool().check_permissions(
+        {"template_url": str(outside_template)},
+        ToolPermissionContext(cwd=str(project)),
+    )
+
+    assert result.behavior == "ask"
+    assert result.reason is not None
+    assert result.reason.type == "path_constraint"
+    assert result.audit is not None
+    assert result.audit.operation["product"] == "ros"
+    assert result.audit.operation["action"] == "ValidateTemplate"
+    assert result.audit.reason_type == "path_constraint"
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_allow_local_template_url_under_additional_directory(tmp_path) -> None:
+    project = tmp_path / "project"
+    shared = tmp_path / "shared"
+    project.mkdir()
+    shared.mkdir()
+
+    result = await RosValidateTemplateTool().check_permissions(
+        {"template_url": str(shared / "template.yml")},
+        ToolPermissionContext(cwd=str(project), additional_directories=[str(shared)]),
+    )
+
+    assert result.behavior == "allow"
+    assert result.audit is not None
+    assert result.audit.operation["action"] == "ValidateTemplate"
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_allow_local_template_url_under_trusted_read_directory(tmp_path) -> None:
+    project = tmp_path / "project"
+    trusted = tmp_path / "trusted"
+    project.mkdir()
+    trusted.mkdir()
+
+    result = await RosValidateTemplateTool().check_permissions(
+        {"template_url": str(trusted / "template.yml")},
+        ToolPermissionContext(cwd=str(project), trusted_read_directories=[str(trusted)]),
+    )
+
+    assert result.behavior == "allow"
+    assert result.audit is not None
+    assert result.audit.operation["action"] == "ValidateTemplate"
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_ask_before_reading_sensitive_local_template_url(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = await RosValidateTemplateTool().check_permissions(
+        {"template_url": ".env"},
+        ToolPermissionContext(cwd=str(project)),
+    )
+
+    assert result.behavior == "ask"
+    assert result.reason is not None
+    assert result.reason.type == "safety_check"
+
+
+@pytest.mark.asyncio
+async def test_ros_template_tools_honor_aliyun_api_action_deny_rule() -> None:
+    result = await RosPreviewTemplateTool().check_permissions(
+        {
+            "template_url": "templates/app.yml",
+            "stack_name": "preview-stack",
+            "parameters": {"ZoneId": "cn-hangzhou-k"},
+        },
+        _permission_context(deny={"session": ["aliyun_api(ros:PreviewStack)"]}),
+    )
+
+    assert result.behavior == "deny"
+    assert result.audit is not None
+    assert result.audit.rule == "ros:PreviewStack"

--- a/tests/tools/cloud/aliyun/test_ros_validate_hook.py
+++ b/tests/tools/cloud/aliyun/test_ros_validate_hook.py
@@ -120,6 +120,111 @@ class TestValidateStructure:
         errors = _validate_structure(data)
         assert any("ALIYUN::ECS::VPC" in e for e in errors)
 
+    def test_existing_vpc_vswitch_rejects_static_cidr_block_literal(self) -> None:
+        data = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Parameters": {
+                "VpcId": {
+                    "Type": "String",
+                    "AssociationProperty": "ALIYUN::ECS::VPC::VPCId",
+                }
+            },
+            "Resources": {
+                "VSwitch": {
+                    "Type": "ALIYUN::ECS::VSwitch",
+                    "Properties": {
+                        "VpcId": {"Ref": "VpcId"},
+                        "ZoneId": "cn-hangzhou-k",
+                        "CidrBlock": "192.168.0.0/24",
+                    },
+                }
+            },
+        }
+
+        errors = _validate_structure(data)
+
+        assert any("VSwitch" in e and "CidrBlock" in e and "existing VPC" in e for e in errors)
+
+    def test_existing_vpc_vswitch_rejects_cidr_parameter_default(self) -> None:
+        data = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Parameters": {
+                "VpcId": {
+                    "Type": "String",
+                    "AssociationProperty": "ALIYUN::ECS::VPC::VPCId",
+                },
+                "CidrBlock": {
+                    "Type": "String",
+                    "Default": "192.168.0.0/24",
+                },
+            },
+            "Resources": {
+                "VSwitch": {
+                    "Type": "ALIYUN::ECS::VSwitch",
+                    "Properties": {
+                        "VpcId": {"Ref": "VpcId"},
+                        "ZoneId": "cn-hangzhou-k",
+                        "CidrBlock": {"Ref": "CidrBlock"},
+                    },
+                }
+            },
+        }
+
+        errors = _validate_structure(data)
+
+        assert any("CidrBlock" in e and "Default" in e and "existing VPC" in e for e in errors)
+
+    def test_existing_vpc_vswitch_allows_cidr_parameter_without_default(self) -> None:
+        data = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Parameters": {
+                "VpcId": {
+                    "Type": "String",
+                    "AssociationProperty": "ALIYUN::ECS::VPC::VPCId",
+                },
+                "CidrBlock": {
+                    "Type": "String",
+                },
+            },
+            "Resources": {
+                "VSwitch": {
+                    "Type": "ALIYUN::ECS::VSwitch",
+                    "Properties": {
+                        "VpcId": {"Ref": "VpcId"},
+                        "ZoneId": "cn-hangzhou-k",
+                        "CidrBlock": {"Ref": "CidrBlock"},
+                    },
+                }
+            },
+        }
+
+        errors = _validate_structure(data)
+
+        assert errors == []
+
+    def test_new_vpc_vswitch_allows_static_cidr_block_literal(self) -> None:
+        data = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Resources": {
+                "Vpc": {
+                    "Type": "ALIYUN::ECS::VPC",
+                    "Properties": {"CidrBlock": "192.168.0.0/16"},
+                },
+                "VSwitch": {
+                    "Type": "ALIYUN::ECS::VSwitch",
+                    "Properties": {
+                        "VpcId": {"Ref": "Vpc"},
+                        "ZoneId": "cn-hangzhou-k",
+                        "CidrBlock": "192.168.0.0/24",
+                    },
+                },
+            },
+        }
+
+        errors = _validate_structure(data)
+
+        assert errors == []
+
 
 class TestCheckTemplate:
     def test_no_template_body_returns_none(self) -> None:

--- a/tests/tools/cloud/test_registry.py
+++ b/tests/tools/cloud/test_registry.py
@@ -1,6 +1,12 @@
 from unittest.mock import MagicMock
 
 from iac_code.tools.base import ToolRegistry
+from iac_code.tools.cloud.aliyun.ros_template_tools import (
+    RosEstimateTemplateCostTool,
+    RosGetTemplateParameterConstraintsTool,
+    RosPreviewTemplateTool,
+    RosValidateTemplateTool,
+)
 from iac_code.tools.cloud.registry import register_cloud_tools
 
 
@@ -11,6 +17,11 @@ class TestRegisterCloudTools:
         credentials.has_provider.side_effect = lambda name: name == "aliyun"
         register_cloud_tools(registry, credentials)
         assert registry.get("aliyun_api") is not None
+        assert registry.get("aliyun_doc_search") is not None
+        assert registry.get("ros_validate_template") is None
+        assert registry.get("ros_get_template_parameter_constraints") is None
+        assert registry.get("ros_preview_template") is None
+        assert registry.get("ros_estimate_template_cost") is None
         assert registry.get("ros_stack") is not None
         assert registry.get("ros_stack_instances") is not None
 
@@ -21,8 +32,32 @@ class TestRegisterCloudTools:
         register_cloud_tools(registry, credentials)
         assert registry.get("aliyun_api") is None
         assert registry.get("aliyun_doc_search") is None
+        assert registry.get("ros_validate_template") is None
+        assert registry.get("ros_get_template_parameter_constraints") is None
+        assert registry.get("ros_preview_template") is None
+        assert registry.get("ros_estimate_template_cost") is None
         assert registry.get("ros_stack") is None
         assert registry.get("ros_stack_instances") is None
+
+    def test_removes_stale_pipeline_only_ros_template_tools(self):
+        registry = ToolRegistry()
+        registry.register(RosValidateTemplateTool())
+        registry.register(RosGetTemplateParameterConstraintsTool())
+        registry.register(RosPreviewTemplateTool())
+        registry.register(RosEstimateTemplateCostTool())
+        credentials = MagicMock()
+        credentials.has_provider.side_effect = lambda name: name == "aliyun"
+
+        register_cloud_tools(registry, credentials)
+
+        assert registry.get("aliyun_api") is not None
+        assert registry.get("aliyun_doc_search") is not None
+        assert registry.get("ros_validate_template") is None
+        assert registry.get("ros_get_template_parameter_constraints") is None
+        assert registry.get("ros_preview_template") is None
+        assert registry.get("ros_estimate_template_cost") is None
+        assert registry.get("ros_stack") is not None
+        assert registry.get("ros_stack_instances") is not None
 
     def test_removes_stale_aliyun_tools_when_credentials_become_unavailable(self):
         registry = ToolRegistry()
@@ -32,6 +67,10 @@ class TestRegisterCloudTools:
         register_cloud_tools(registry, credentials)
         assert registry.get("aliyun_api") is not None
         assert registry.get("aliyun_doc_search") is not None
+        assert registry.get("ros_validate_template") is None
+        assert registry.get("ros_get_template_parameter_constraints") is None
+        assert registry.get("ros_preview_template") is None
+        assert registry.get("ros_estimate_template_cost") is None
         assert registry.get("ros_stack") is not None
         assert registry.get("ros_stack_instances") is not None
 
@@ -39,5 +78,9 @@ class TestRegisterCloudTools:
 
         assert registry.get("aliyun_api") is None
         assert registry.get("aliyun_doc_search") is None
+        assert registry.get("ros_validate_template") is None
+        assert registry.get("ros_get_template_parameter_constraints") is None
+        assert registry.get("ros_preview_template") is None
+        assert registry.get("ros_estimate_template_cost") is None
         assert registry.get("ros_stack") is None
         assert registry.get("ros_stack_instances") is None

--- a/tests/tools/test_glob.py
+++ b/tests/tools/test_glob.py
@@ -116,7 +116,7 @@ class TestGlobBasics:
 
         assert result.is_error is False
         assert "template-parameter-recommendation.md" in result.content
-        assert "cloud-products/ecs.md" in result.content
+        assert "cloud-products/ecs.md" in result.content.replace("\\", "/")
 
     @pytest.mark.asyncio
     async def test_recursive_glob_permission_asks_for_symlink_escape(self, tool, tmp_path):

--- a/tests/tools/test_glob.py
+++ b/tests/tools/test_glob.py
@@ -74,7 +74,7 @@ class TestGlobBasics:
         selling_refs.mkdir(parents=True)
         (selling_refs / "template-parameter-recommendation.md").write_text("pipeline", encoding="utf-8")
         try:
-            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
+            (skill_root / "references").symlink_to(selling_refs, target_is_directory=True)
         except (OSError, NotImplementedError) as exc:
             pytest.skip(f"Cannot create symlink on this platform: {exc}")
 
@@ -102,11 +102,8 @@ class TestGlobBasics:
         (selling_refs / "template-parameter-recommendation.md").write_text("pipeline", encoding="utf-8")
         (bundled_products / "ecs.md").write_text("ecs", encoding="utf-8")
         try:
-            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
-            (selling_refs / "cloud-products").symlink_to(
-                "../../../skills/bundled/iac_aliyun/references/cloud-products",
-                target_is_directory=True,
-            )
+            (skill_root / "references").symlink_to(selling_refs, target_is_directory=True)
+            (selling_refs / "cloud-products").symlink_to(bundled_products, target_is_directory=True)
         except (OSError, NotImplementedError) as exc:
             pytest.skip(f"Cannot create symlink on this platform: {exc}")
 

--- a/tests/tools/test_glob.py
+++ b/tests/tools/test_glob.py
@@ -4,6 +4,7 @@ import pytest
 
 from iac_code.tools.base import ToolContext
 from iac_code.tools.glob import GlobTool
+from iac_code.types.permissions import ToolPermissionContext
 
 
 @pytest.fixture
@@ -63,6 +64,82 @@ class TestGlobBasics:
         assert "a.py" in result.content
 
     @pytest.mark.asyncio
+    async def test_relative_path_falls_back_to_symlinked_relative_read_directory(self, tool, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        package_root = tmp_path / "iac_code"
+        skill_root = package_root / "pipeline" / "selling" / "skills" / "iac-aliyun-cost"
+        selling_refs = package_root / "pipeline" / "selling" / "references"
+        skill_root.mkdir(parents=True)
+        selling_refs.mkdir(parents=True)
+        (selling_refs / "template-parameter-recommendation.md").write_text("pipeline", encoding="utf-8")
+        try:
+            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        context = ToolContext(
+            cwd=str(workspace),
+            trusted_read_directories=[str(package_root)],
+            relative_read_directories=[str(skill_root)],
+        )
+        result = await tool.execute(tool_input={"pattern": "*.md", "path": "references"}, context=context)
+
+        assert result.is_error is False
+        assert "template-parameter-recommendation.md" in result.content
+
+    @pytest.mark.asyncio
+    async def test_recursive_glob_follows_symlinked_reference_directory(self, tool, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        package_root = tmp_path / "iac_code"
+        skill_root = package_root / "pipeline" / "selling" / "skills" / "iac-aliyun-cost"
+        selling_refs = package_root / "pipeline" / "selling" / "references"
+        bundled_products = package_root / "skills" / "bundled" / "iac_aliyun" / "references" / "cloud-products"
+        skill_root.mkdir(parents=True)
+        selling_refs.mkdir(parents=True)
+        bundled_products.mkdir(parents=True)
+        (selling_refs / "template-parameter-recommendation.md").write_text("pipeline", encoding="utf-8")
+        (bundled_products / "ecs.md").write_text("ecs", encoding="utf-8")
+        try:
+            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
+            (selling_refs / "cloud-products").symlink_to(
+                "../../../skills/bundled/iac_aliyun/references/cloud-products",
+                target_is_directory=True,
+            )
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        context = ToolContext(
+            cwd=str(workspace),
+            trusted_read_directories=[str(package_root)],
+            relative_read_directories=[str(skill_root)],
+        )
+        result = await tool.execute(tool_input={"pattern": "**/*.md", "path": "references"}, context=context)
+
+        assert result.is_error is False
+        assert "template-parameter-recommendation.md" in result.content
+        assert "cloud-products/ecs.md" in result.content
+
+    @pytest.mark.asyncio
+    async def test_recursive_glob_permission_asks_for_symlink_escape(self, tool, tmp_path):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        (outside / "secret.md").write_text("secret", encoding="utf-8")
+        try:
+            (workspace / "outside").symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        context = ToolPermissionContext(cwd=str(workspace))
+        result = await tool.check_permissions({"pattern": "**/*.md", "path": "."}, context)
+
+        assert result.behavior == "ask"
+        assert "outside allowed directories" in result.message
+
+    @pytest.mark.asyncio
     async def test_glob_exception_returned(self, tool, tmp_path, monkeypatch):
         from pathlib import Path
 
@@ -93,7 +170,7 @@ class TestGlobBasics:
         assert result.is_error is False
         from iac_code.tools.glob import normalize_user_path
 
-        normalize_user_path.assert_called_once_with(str(tmp_path))
+        normalize_user_path.assert_any_call(str(tmp_path))
 
 
 class TestGlobRendering:

--- a/tests/tools/test_grep.py
+++ b/tests/tools/test_grep.py
@@ -143,10 +143,8 @@ class TestGrepExecute:
         bundled_reference = bundled_refs / "ros-template.md"
         bundled_reference.write_text("ROSTemplateFormatVersion reference", encoding="utf-8")
         try:
-            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
-            (selling_refs / "ros-template.md").symlink_to(
-                "../../../skills/bundled/iac_aliyun/references/ros-template.md"
-            )
+            (skill_root / "references").symlink_to(selling_refs, target_is_directory=True)
+            (selling_refs / "ros-template.md").symlink_to(bundled_reference)
         except (OSError, NotImplementedError) as exc:
             pytest.skip(f"Cannot create symlink on this platform: {exc}")
 

--- a/tests/tools/test_grep.py
+++ b/tests/tools/test_grep.py
@@ -205,6 +205,29 @@ class TestGrepExecute:
         assert str(package / "nested.py") in result.content
         assert str(tmp_path / "app.py") not in result.content
 
+    async def test_rg_path_with_symlinked_directory_matches_python_fallback(self, tool, tmp_path):
+        if not _is_rg_available():
+            pytest.skip("rg is not available")
+
+        real_refs = tmp_path / "real_refs"
+        real_refs.mkdir()
+        (real_refs / "ros-template.md").write_text("ROSTemplateFormatVersion reference\n", encoding="utf-8")
+        search_root = tmp_path / "search"
+        search_root.mkdir()
+        try:
+            (search_root / "references").symlink_to(real_refs, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        context = ToolContext(cwd=str(tmp_path), trusted_read_directories=[str(real_refs)])
+        result = await tool.execute(
+            tool_input={"pattern": "ROSTemplateFormatVersion", "path": str(search_root)},
+            context=context,
+        )
+
+        assert result.is_error is False
+        assert str(search_root / "references" / "ros-template.md") in result.content
+
 
 class TestGrepRendering:
     def test_render_tool_use_empty(self, tool):

--- a/tests/tools/test_grep.py
+++ b/tests/tools/test_grep.py
@@ -129,6 +129,40 @@ class TestGrepExecute:
         assert result.is_error is True
         assert "not found" in result.content.lower()
 
+    async def test_relative_path_falls_back_to_symlinked_relative_read_directory(self, tool, tmp_path, monkeypatch):
+        monkeypatch.setattr("iac_code.tools.grep._is_rg_available", lambda: False)
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        package_root = tmp_path / "iac_code"
+        skill_root = package_root / "pipeline" / "selling" / "skills" / "iac-aliyun-cost"
+        selling_refs = package_root / "pipeline" / "selling" / "references"
+        bundled_refs = package_root / "skills" / "bundled" / "iac_aliyun" / "references"
+        skill_root.mkdir(parents=True)
+        selling_refs.mkdir(parents=True)
+        bundled_refs.mkdir(parents=True)
+        bundled_reference = bundled_refs / "ros-template.md"
+        bundled_reference.write_text("ROSTemplateFormatVersion reference", encoding="utf-8")
+        try:
+            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
+            (selling_refs / "ros-template.md").symlink_to(
+                "../../../skills/bundled/iac_aliyun/references/ros-template.md"
+            )
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        context = ToolContext(
+            cwd=str(workspace),
+            trusted_read_directories=[str(package_root)],
+            relative_read_directories=[str(skill_root)],
+        )
+        result = await tool.execute(
+            tool_input={"pattern": "ROSTemplateFormatVersion", "path": "references"},
+            context=context,
+        )
+
+        assert result.is_error is False
+        assert str(selling_refs / "ros-template.md") in result.content
+
     async def test_windows_posix_path_conversion(self, tmp_path, tool, monkeypatch):
         (tmp_path / "a.txt").write_text("hello world", encoding="utf-8")
         from unittest.mock import MagicMock

--- a/tests/tools/test_list_files.py
+++ b/tests/tools/test_list_files.py
@@ -116,6 +116,27 @@ class TestListFilesTool:
         assert "nested_file.txt" in result.content
 
     @pytest.mark.asyncio
+    async def test_relative_path_falls_back_to_symlinked_relative_read_directory(self, tmp_path, list_files_tool):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        package_root = tmp_path / "iac_code"
+        skill_root = package_root / "pipeline" / "selling" / "skills" / "iac-aliyun-cost"
+        selling_refs = package_root / "pipeline" / "selling" / "references"
+        skill_root.mkdir(parents=True)
+        selling_refs.mkdir(parents=True)
+        (selling_refs / "template-parameter-recommendation.md").write_text("pipeline", encoding="utf-8")
+        try:
+            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        context = ToolContext(cwd=str(workspace), relative_read_directories=[str(skill_root)])
+        result = await list_files_tool.execute(tool_input={"path": "references"}, context=context)
+
+        assert result.is_error is False
+        assert "template-parameter-recommendation.md" in result.content
+
+    @pytest.mark.asyncio
     async def test_path_is_file_not_directory(self, tmp_path, list_files_tool):
         """Test error when path is a file, not a directory."""
         file_path = tmp_path / "just_a_file.txt"

--- a/tests/tools/test_read_file.py
+++ b/tests/tools/test_read_file.py
@@ -169,6 +169,32 @@ class TestReadFileTool:
         assert f"File: {reference}" in result.content
 
     @pytest.mark.asyncio
+    async def test_relative_path_follows_reference_directory_symlink(self, tmp_path, read_file_tool):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        package_root = tmp_path / "iac_code"
+        skill_root = package_root / "pipeline" / "selling" / "skills" / "iac-aliyun-cost"
+        selling_refs = package_root / "pipeline" / "selling" / "references"
+        skill_root.mkdir(parents=True)
+        selling_refs.mkdir(parents=True)
+        reference = selling_refs / "template-parameter-recommendation.md"
+        reference.write_text("Pipeline recommendation content", encoding="utf-8")
+        try:
+            (skill_root / "references").symlink_to("../../references", target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        context = ToolContext(cwd=str(workspace), relative_read_directories=[str(skill_root)])
+        result = await read_file_tool.execute(
+            tool_input={"path": "references/template-parameter-recommendation.md"},
+            context=context,
+        )
+
+        assert result.is_error is False
+        assert "Pipeline recommendation content" in result.content
+        assert f"File: {reference}" in result.content
+
+    @pytest.mark.asyncio
     async def test_relative_path_does_not_fall_back_to_trusted_read_directory(self, tmp_path, read_file_tool):
         """Trusted read roots should allow explicit reads without changing relative lookup semantics."""
         workspace = tmp_path / "workspace"
@@ -414,6 +440,33 @@ class TestReadFilePermissions:
         )
 
         assert result.behavior == "allow"
+
+    @pytest.mark.asyncio
+    async def test_relative_read_directory_symlink_escape_asks(self, tmp_path, read_file_tool):
+        project = tmp_path / "project"
+        skill_root = tmp_path / "skill"
+        outside = tmp_path / "outside"
+        project.mkdir()
+        skill_root.mkdir()
+        outside.mkdir()
+        (outside / "secret.txt").write_text("secret", encoding="utf-8")
+        try:
+            (skill_root / "references").symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Cannot create symlink on this platform: {exc}")
+
+        result = await read_file_tool.check_permissions(
+            {"path": "references/secret.txt"},
+            ToolPermissionContext(
+                cwd=str(project),
+                trusted_read_directories=[str(skill_root)],
+                relative_read_directories=[str(skill_root)],
+            ),
+        )
+
+        assert result.behavior == "ask"
+        assert result.reason is not None
+        assert result.reason.type == "path_constraint"
 
     @pytest.mark.asyncio
     async def test_file_path_alias_allowed(self, tmp_path, read_file_tool):

--- a/tests/types/test_permissions_types.py
+++ b/tests/types/test_permissions_types.py
@@ -120,6 +120,10 @@ class TestToolPermissionContext:
         ctx = ToolPermissionContext(cwd="/tmp")
         assert ctx.trusted_read_directories == []
 
+    def test_relative_read_directories_default_empty(self):
+        ctx = ToolPermissionContext(cwd="/tmp")
+        assert ctx.relative_read_directories == []
+
     def test_with_rules(self) -> None:
         ctx = ToolPermissionContext(
             mode=PermissionMode.DEFAULT,

--- a/tests/ui/test_renderer_helpers.py
+++ b/tests/ui/test_renderer_helpers.py
@@ -338,6 +338,50 @@ class TestRendererHelpers:
         assert "Complete step" in header.plain
         assert "complete_step" not in header.plain
 
+    def test_render_tool_header_localizes_pipeline_ros_template_tool_name_without_registry_tool(self):
+        renderer = make_renderer()
+        record = _ToolCallRecord(tool_name="ros_estimate_template_cost", tool_input={}, done=True)
+
+        header = renderer._render_tool_header(record)
+
+        assert "ROS Estimate Cost" in header.plain
+        assert "ros_estimate_template_cost" not in header.plain
+
+    def test_render_tool_header_uses_zh_translation_for_ros_parameter_recommendation_tool(self, monkeypatch):
+        from iac_code.i18n import setup_i18n
+
+        monkeypatch.setenv("LANGUAGE", "zh")
+        setup_i18n()
+        try:
+            renderer = make_renderer()
+            record = _ToolCallRecord(
+                tool_name="ros_get_template_parameter_constraints",
+                tool_input={},
+                done=True,
+            )
+
+            header = renderer._render_tool_header(record)
+
+            assert header.plain == "● ROS 模板参数推荐"
+        finally:
+            monkeypatch.setenv("LANGUAGE", "en")
+            setup_i18n()
+
+    def test_render_tool_result_summarizes_pipeline_ros_template_tool_without_registry_tool(self):
+        renderer = make_renderer()
+        record = _ToolCallRecord(
+            tool_name="ros_estimate_template_cost",
+            tool_input={},
+            done=True,
+            result='{\n  "RequestId": "REQ-42",\n  "Resources": ["long output"]\n}',
+        )
+
+        line = renderer._render_tool_result(record)
+
+        assert line is not None
+        assert "Call succeeded (RequestId: REQ-42)" in line.plain
+        assert "Resources" not in line.plain
+
     def test_print_segments_to_scrollback_archives_and_merges_assistant_turns(self):
         renderer = make_renderer()
 

--- a/tests/ui/test_renderer_prompt_permission.py
+++ b/tests/ui/test_renderer_prompt_permission.py
@@ -138,6 +138,45 @@ def _make_event_with_suggestion(tool_name: str = "bash") -> PermissionRequestEve
 
 class TestRuleLevelDeny:
     @pytest.mark.asyncio
+    async def test_rule_suggestion_label_uses_display_text_when_available(self):
+        from iac_code.types.permissions import PermissionResult, PermissionRuleValue
+
+        captured_options = []
+
+        class FakeSelect:
+            def __init__(self, options, **kwargs):
+                captured_options.extend(options)
+
+            def run(self):
+                return "reject_once"
+
+        renderer = _make_renderer(AppStateStore())
+        fut: asyncio.Future[bool] = asyncio.get_event_loop().create_future()
+        event = PermissionRequestEvent(
+            tool_name="ros_deploy",
+            tool_input={"action": "continue_create", "stack_id": "stack-failed"},
+            tool_use_id="t1",
+            response_future=fut,
+            permission_result=PermissionResult(
+                behavior="ask",
+                suggestions=[
+                    PermissionRuleValue(
+                        tool_name="ros_deploy",
+                        rule_content="continue_create:stack-failed",
+                        display_text="Continue ROS stack creation: stack-failed",
+                    )
+                ],
+            ),
+        )
+
+        with patch("iac_code.ui.renderer.Select", FakeSelect):
+            await renderer.prompt_permission(event)
+
+        labels = [option.label for option in captured_options]
+        assert any("Continue ROS stack creation: stack-failed" in label for label in labels)
+        assert not any("continue_create:stack-failed" in label for label in labels)
+
+    @pytest.mark.asyncio
     async def test_always_deny_rule_returns_false(self):
         """Selecting 'always_deny_rule' should return False."""
         import dataclasses

--- a/tests/utils/test_public_paths.py
+++ b/tests/utils/test_public_paths.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ntpath
+
 from iac_code.utils.public_paths import build_public_path_roots, sanitize_public_paths
 
 
@@ -38,3 +40,34 @@ def test_sanitize_public_paths_handles_space_separated_absolute_paths(tmp_path, 
     )
 
     assert sanitized == "paths: ./src/app.py $IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt [PATH]"
+
+
+def test_sanitize_public_paths_handles_space_separated_windows_paths() -> None:
+    roots = [
+        {"path": r"C:\Users\alice\project", "label": "."},
+        {"path": r"C:\Users\alice\config", "label": "$IAC_CODE_CONFIG_DIR"},
+    ]
+
+    value = (
+        r"paths: C:\Users\alice\project\src\app.py "
+        r"C:\Users\alice\config\tool-results\session-1\result.txt "
+        r"C:\outside\config.yaml"
+    )
+    sanitized = sanitize_public_paths(
+        value,
+        roots,
+    )
+
+    assert sanitized == "paths: ./src/app.py $IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt [PATH]"
+
+
+def test_sanitize_public_paths_keeps_posix_roots_platform_independent(monkeypatch) -> None:
+    monkeypatch.setattr("iac_code.utils.public_paths.os.path.abspath", ntpath.abspath)
+    monkeypatch.setattr("iac_code.utils.public_paths.os.path.realpath", ntpath.abspath)
+
+    sanitized = sanitize_public_paths(
+        "paths: /Users/alice/project/src/app.py /Users/alice/project/logs/result.txt",
+        [{"path": "/Users/alice/project", "label": "."}],
+    )
+
+    assert sanitized == "paths: ./src/app.py ./logs/result.txt"

--- a/tests/utils/test_public_paths.py
+++ b/tests/utils/test_public_paths.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from iac_code.utils.public_paths import build_public_path_roots, sanitize_public_paths
+
+
+def test_build_public_path_roots_includes_config_and_trusted_directories(tmp_path, monkeypatch) -> None:
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(config_dir))
+
+    roots = build_public_path_roots(
+        cwd=str(tmp_path / "workspace"),
+        additional_directories=[str(tmp_path / "additional")],
+        trusted_read_directories=[str(config_dir / "tool-results" / "session-1")],
+        relative_read_directories=[str(tmp_path / "skills")],
+    )
+
+    assert roots == [
+        {"path": str(tmp_path / "workspace"), "label": "."},
+        {"path": str(config_dir), "label": "$IAC_CODE_CONFIG_DIR"},
+        {"path": str(tmp_path / "additional"), "label": "[trusted]"},
+        {"path": str(config_dir / "tool-results" / "session-1"), "label": "[trusted]"},
+        {"path": str(tmp_path / "skills"), "label": "[trusted]"},
+    ]
+
+
+def test_sanitize_public_paths_handles_space_separated_absolute_paths(tmp_path, monkeypatch) -> None:
+    config_dir = tmp_path / "config"
+    cwd = tmp_path / "workspace"
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(config_dir))
+    roots = build_public_path_roots(cwd=str(cwd))
+
+    sanitized = sanitize_public_paths(
+        "paths: {} {} /opt/iac-code-outside/config.yaml".format(
+            cwd / "src" / "app.py",
+            config_dir / "tool-results" / "session-1" / "result.txt",
+        ),
+        roots,
+    )
+
+    assert sanitized == "paths: ./src/app.py $IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt [PATH]"


### PR DESCRIPTION
## Summary

This PR collects a set of fixes for IaC Code pipeline/runtime behavior, with the main focus on making the Alibaba Cloud ROS selling pipeline more deterministic and easier for LLMs to drive safely.

The branch addresses several production-facing issues found during interactive testing:

- IaC Code identity and runtime provider/model information were not consistently present in the system prompt.
- ROS selling-pipeline steps could still drift into `TemplateBody` or raw ROS stack APIs even when the intended flow required `TemplateURL`.
- The deployment step repeated validation work after a successful preview, and recovery after failed stack creation was not deterministic enough.
- A2A public events could expose absolute local paths, while the debugger did not surface enough normal-chat event detail for review.
- Pipeline bundled skills needed to share Alibaba Cloud references without duplicating most files, while still allowing a selling-specific parameter recommendation reference.
- VSwitch CIDR defaults could overlap when a generated template was later bound to an existing VPC.
- `grep` behavior differed between environments with and without ripgrep when symlinked directories were present.

## Major Changes

### Runtime Prompt Context

- Adds runtime provider/model metadata to the current-time system prompt section so the model can identify the active provider/model without adding a large prompt block.
- Adds explicit IaC Code identity text so the assistant identifies itself as IaC Code rather than another model/vendor.
- Covers prompt rendering in normal, pipeline, A2A, ACP, headless, and REPL paths through the shared agent factory/system prompt refresh logic.

### ROS TemplateURL Enforcement and Dedicated Pipeline Tools

- Adds dedicated ROS template tools for the selling pipeline:
  - `ros_validate_template`
  - `ros_preview_stack`
  - `ros_get_template_parameter_constraints`
- Restricts these tools to the intended selling-pipeline steps, instead of exposing them globally.
- Blocks direct pipeline use of ROS APIs that should go through the dedicated tools, while leaving generic `aliyun_api` available for other cloud-product calls.
- Updates prompts and bundled selling skills to explicitly pass the rendered selected template URL and avoid `TemplateBody` for ROS selling-pipeline calls.

### Selling Pipeline Deployment Flow

- Adds `ros_deploy` for the selling deployment step and removes direct `ros_stack` usage from that step.
- Encapsulates stack deployment actions with rule-level permission checks:
  - `continue_create:<stack_id>` for continuing a failed stack create.
  - `delete_and_create:<stack_id>` for deleting/recreating a stack created by the current selling deployment step.
- Prefers `ContinueCreateStack` with `RecreatingOptions: ["AutoRecreatingResources"]`, while still allowing delete-and-create fallback for owned stacks when needed.
- Blocks delete/continue/update/create bypasses through raw ROS stack APIs in the selling pipeline deployment step.
- Preserves stack ownership metadata when a stack was created but later polling failed, so recovery can safely continue the same owned stack.
- Preserves `ros_deploy_owned_stack_ids` during fresh complete-step recovery, preventing recovered deployment attempts from losing stack ownership state.

### Deployment Fast Path After Preview

- Records successful preview validation state from the cost/preview step.
- Allows the deployment step to skip redundant `ValidateTemplate`/preview calls when the selected template has already passed preview validation.
- Keeps validation required for current sessions, while avoiding over-supporting old session formats.

### Template Generation and CIDR Guardrails

- Avoids prompting the model to create the `templates/` directory manually during template generation.
- Adds template validation hooks that detect fixed VSwitch CIDR values which may overlap with existing VPC CIDR inputs.
- Adds local guards for both default and fixed VSwitch `CidrBlock` values when an existing VPC is selected.

### A2A Path Redaction and Debugging

- Adds public path sanitization for A2A/public-facing event payloads so workspace/config/trusted-root paths are represented relative to public roots rather than leaking full absolute paths.
- Keeps internal tool arguments, transcript state, and diagnostic state intact so observability and recovery still have real paths where needed.
- Improves the A2A debugger timeline so normal chat can display merged text, thinking deltas, tool calls, and tool results instead of only text deltas.
- Ensures `text_delta` streaming is not rewritten in a way that would break streaming output.

### Bundled Skill References and Packaging

- Adds a selling-specific `references/` directory that mostly uses symlinks to existing bundled Alibaba Cloud references, with only `template-parameter-recommendation.md` customized for the selling pipeline.
- Updates packaging logic to preserve or expand these bundled references correctly in source distributions and wheels, including environments where symlink support is unavailable.
- Updates `read_file`, `glob`, `grep`, and `list_files` behavior/tests around symlinked references and trusted roots.
- Fixes `grep` to fall back to the Python implementation when the search tree contains directory symlinks, avoiding inconsistent ripgrep behavior and preserving allowed-root filtering.

### i18n and UI Labels

- Extracts and translates newly user-visible strings across the supported locales.
- Adds localized labels for the new ROS template/deploy tools and permission rule descriptions.
- Improves display names for ROS template parameter recommendation tooling.

## Compatibility Notes

- The selling pipeline now uses dedicated ROS tools for template validation, preview, parameter constraints, and deployment, while normal mode continues to support the broader ROS/Alibaba Cloud tools.
- Generic Alibaba Cloud API access remains available for non-stack-management operations, such as querying product metadata or checking existing VPC state.
- The public path sanitizer is applied to public-facing events and outputs, not to internal state required for recovery, auditing, or diagnostics.
- The deployment ownership guard only allows continuing or deleting stacks created by the current selling deployment step.

## Validation

Local validation completed before opening this PR:

- `make lint`
- `make test` (`7997 passed, 1 skipped`)
- Targeted regression tests for:
  - A2A path sanitization and debugger rendering
  - ROS template tools and pipeline step scoping
  - ROS deploy ownership, permissions, continue/delete-create behavior, and recovery state
  - Deployment preview validation fast path
  - VSwitch CIDR overlap guardrails
  - Symlinked bundled references and packaging behavior
  - i18n extraction/translation coverage

The pre-push hook also completed AK leak detection without finding data to scan.

## Review Focus

Please pay special attention to:

- Selling-pipeline step tool registration and whether each ROS tool is scoped to the intended step.
- Recovery behavior around failed `CreateStack` / `ContinueCreateStack` flows.
- Public A2A path redaction versus internal observability/recovery data preservation.
- Windows and no-symlink packaging behavior for bundled selling references.
- i18n coverage for newly visible tool names, permission prompts, and error messages.
