### PR TITLE
[codex] add extreme A2A pipeline performance mode

### DIFF
--- a/src/iac_code/a2a/pipeline_performance.py
+++ b/src/iac_code/a2a/pipeline_performance.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+A2A_EXTREME_PERFORMANCE_ENV = "IAC_CODE_A2A_EXTREME_PERFORMANCE"
+
+_FALSE_VALUES = {"0", "false", "no", "off", "disabled"}
+
+
+def a2a_extreme_performance_enabled() -> bool:
+    raw = os.environ.get(A2A_EXTREME_PERFORMANCE_ENV)
+    if raw is None or raw.strip() == "":
+        return True
+    return raw.strip().lower() not in _FALSE_VALUES

--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -19,7 +19,7 @@ from iac_code.pipeline.constants import (
     PIPELINE_EVENT_CLEANUP_STARTED,
 )
 from iac_code.utils.public_errors import sanitize_public_text
-from iac_code.utils.state_io import atomic_write_json
+from iac_code.utils.state_io import atomic_write_json, atomic_write_text
 
 SNAPSHOT_SCHEMA_VERSION = "1.1"
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ class A2APipelineSnapshotStore:
         self.pipeline_dir = Path(pipeline_dir)
         self.path = self.pipeline_dir / "a2a-snapshot.json"
 
-    def save(self, snapshot: dict[str, Any]) -> bool:
+    def save(self, snapshot: dict[str, Any], *, durable: bool = True, compact: bool = False) -> bool:
         previous = self.load()
         next_snapshot = _sanitize_public_snapshot_private_cleanup_fields(snapshot)
         next_snapshot["snapshotVersion"] = _snapshot_version(previous) + 1
@@ -67,7 +67,17 @@ class A2APipelineSnapshotStore:
             return False
 
         try:
-            atomic_write_json(self.path, next_snapshot, durable=True)
+            if compact:
+                content = json.dumps(
+                    next_snapshot,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                    allow_nan=False,
+                )
+                atomic_write_text(self.path, content + "\n", durable=durable)
+            else:
+                atomic_write_json(self.path, next_snapshot, durable=durable)
             return True
         except (OSError, TypeError, ValueError):
             logger.warning("Failed to persist A2A pipeline snapshot to %s", self.path, exc_info=True)

--- a/src/iac_code/a2a/pipeline_stream.py
+++ b/src/iac_code/a2a/pipeline_stream.py
@@ -20,6 +20,7 @@ from iac_code.a2a.events import (
 from iac_code.a2a.exposure import A2AExposureType, normalize_a2a_exposure_types
 from iac_code.a2a.pipeline_events import PipelineEventTranslator, safe_permission_metadata
 from iac_code.a2a.pipeline_journal import A2APipelineJournal, to_json_safe
+from iac_code.a2a.pipeline_performance import a2a_extreme_performance_enabled
 from iac_code.a2a.pipeline_snapshot import SNAPSHOT_SCHEMA_VERSION, A2APipelineSnapshotStore, reduce_pipeline_events
 from iac_code.pipeline.constants import (
     PIPELINE_EVENT_CLEANUP_COMPLETED,
@@ -76,6 +77,8 @@ _DISPLAY_ONLY_EVENT_TYPES = {
     "text_delta",
     "tool_result",
 }
+_EXTREME_DEFERRED_EVENT_TYPES = {"text_delta", "thinking_delta"}
+_EXTREME_JOURNAL_FLUSH_EVENTS = 512
 _RECOVERY_STATE_SCOPES = {"step", "candidate", "candidateStep", "candidate_step"}
 _RECOVERY_STATE_STATUSES = {"working"}
 
@@ -113,6 +116,7 @@ class PipelineA2AEventPublisher:
         before_enqueue: PipelineBeforeEnqueueHook | None = None,
         after_backup_commit: PipelineAfterBackupCommitHook | None = None,
         backup_commit_gate: PipelineBackupCommitGate | None = None,
+        extreme_performance: bool | None = None,
     ) -> None:
         self.event_queue = event_queue
         self.translator = translator
@@ -131,6 +135,13 @@ class PipelineA2AEventPublisher:
         self._delivery_lock_depth = 0
         self._last_sequence = 0
         self.last_envelope: dict[str, Any] | None = None
+        self.extreme_performance = (
+            a2a_extreme_performance_enabled() if extreme_performance is None else extreme_performance
+        )
+        self._extreme_snapshot_loaded = False
+        self._extreme_snapshot_cache: dict[str, Any] | None = None
+        self._extreme_pending_journal_events: list[dict[str, Any]] = []
+        self._extreme_pending_snapshot_events: list[dict[str, Any]] = []
 
     async def publish(
         self,
@@ -378,7 +389,10 @@ class PipelineA2AEventPublisher:
         async with self._sequence_lock:
             self._annotate_delivery_alias(envelope)
             try:
-                self._ensure_monotonic_sequence(envelope)
+                if self.extreme_performance:
+                    self._ensure_monotonic_sequence_fast(envelope)
+                else:
+                    self._ensure_monotonic_sequence(envelope)
             except _SequenceHighWaterUnavailableError:
                 logger.warning("Skipping A2A pipeline event until journal high-water sequence is readable")
                 return None
@@ -387,6 +401,13 @@ class PipelineA2AEventPublisher:
                 logger.warning("Skipping invalid A2A pipeline envelope: %r", envelope)
                 return None
             durable_required = require_durable_metadata or is_recovery_semantic_event(safe_envelope)
+            if self.extreme_performance:
+                return self._persist_envelope_extreme(
+                    safe_envelope,
+                    artifact_metadata=artifact_metadata,
+                    durable_required=durable_required,
+                    require_journal_metadata=require_journal_metadata,
+                )
             journal_persisted = False
             snapshot_persisted = False
             try:
@@ -416,6 +437,95 @@ class PipelineA2AEventPublisher:
                 logger.warning("Skipping A2A artifact update because pipeline metadata was not persisted")
                 return None
         return safe_envelope
+
+    def _persist_envelope_extreme(
+        self,
+        safe_envelope: dict[str, Any],
+        *,
+        artifact_metadata: dict[str, Any] | None,
+        durable_required: bool,
+        require_journal_metadata: bool,
+    ) -> dict[str, Any] | None:
+        if self._can_defer_extreme_metadata(
+            safe_envelope,
+            artifact_metadata=artifact_metadata,
+            durable_required=durable_required,
+            require_journal_metadata=require_journal_metadata,
+        ):
+            self._extreme_pending_journal_events.append(safe_envelope)
+            self._extreme_pending_snapshot_events.append(safe_envelope)
+            if len(self._extreme_pending_journal_events) >= _EXTREME_JOURNAL_FLUSH_EVENTS:
+                self._flush_extreme_journal_events()
+            return safe_envelope
+
+        journal_persisted = False
+        snapshot_persisted = False
+        self._flush_extreme_journal_events()
+        try:
+            self.journal.append(safe_envelope, durable=False)
+            journal_persisted = True
+        except Exception as exc:
+            logger.warning(
+                "Failed to append A2A pipeline journal event error_type=%s",
+                type(exc).__name__,
+            )
+
+        try:
+            snapshot_events = [*self._extreme_pending_snapshot_events, safe_envelope]
+            snapshot = reduce_pipeline_events(snapshot_events, existing_snapshot=self._extreme_snapshot_base())
+            snapshot_persisted = self.snapshot_store.save(snapshot, durable=False, compact=True)
+            if snapshot_persisted:
+                self._extreme_snapshot_cache = snapshot
+                self._extreme_snapshot_loaded = True
+                self._extreme_pending_snapshot_events.clear()
+                _maybe_inject_test_fault("after_a2a_pipeline_snapshot_saved")
+        except Exception:
+            logger.warning("Failed to persist A2A pipeline snapshot", exc_info=True)
+
+        if require_journal_metadata and not journal_persisted:
+            logger.warning("Skipping A2A pipeline status update because journal metadata was not persisted")
+            return None
+        if durable_required and not (journal_persisted or snapshot_persisted):
+            logger.warning("Skipping A2A pipeline status update because durable metadata was not persisted")
+            return None
+        if artifact_metadata is not None and not (journal_persisted or snapshot_persisted):
+            logger.warning("Skipping A2A artifact update because pipeline metadata was not persisted")
+            return None
+        return safe_envelope
+
+    def _can_defer_extreme_metadata(
+        self,
+        envelope: dict[str, Any],
+        *,
+        artifact_metadata: dict[str, Any] | None,
+        durable_required: bool,
+        require_journal_metadata: bool,
+    ) -> bool:
+        if artifact_metadata is not None or durable_required or require_journal_metadata:
+            return False
+        event_type = envelope.get("eventType")
+        return isinstance(event_type, str) and event_type in _EXTREME_DEFERRED_EVENT_TYPES
+
+    def _flush_extreme_journal_events(self) -> bool:
+        if not self._extreme_pending_journal_events:
+            return True
+        events = list(self._extreme_pending_journal_events)
+        try:
+            self.journal.append_many(events, durable=False)
+        except Exception as exc:
+            logger.warning(
+                "Failed to flush deferred A2A pipeline journal events error_type=%s",
+                type(exc).__name__,
+            )
+            return False
+        self._extreme_pending_journal_events.clear()
+        return True
+
+    def _extreme_snapshot_base(self) -> dict[str, Any] | None:
+        if not self._extreme_snapshot_loaded:
+            self._extreme_snapshot_cache = self.snapshot_store.load()
+            self._extreme_snapshot_loaded = True
+        return self._extreme_snapshot_cache
 
     async def enqueue_persisted(
         self,
@@ -598,6 +708,13 @@ class PipelineA2AEventPublisher:
         if current <= previous:
             envelope["sequence"] = previous + 1
             current = previous + 1
+        self._last_sequence = max(self._last_sequence, current)
+
+    def _ensure_monotonic_sequence_fast(self, envelope: dict[str, Any]) -> None:
+        current = _int_value(envelope.get("sequence"), 0)
+        if current <= self._last_sequence:
+            envelope["sequence"] = self._last_sequence + 1
+            current = self._last_sequence + 1
         self._last_sequence = max(self._last_sequence, current)
 
     def _last_persisted_sequence(self) -> int:

--- a/tests/a2a/test_pipeline_extreme_performance.py
+++ b/tests/a2a/test_pipeline_extreme_performance.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
+from iac_code.a2a.pipeline_journal import A2APipelineJournal
+from iac_code.a2a.pipeline_performance import (
+    A2A_EXTREME_PERFORMANCE_ENV,
+    a2a_extreme_performance_enabled,
+)
+from iac_code.a2a.pipeline_snapshot import A2APipelineSnapshotStore
+from iac_code.a2a.pipeline_stream import PipelineA2AEventPublisher
+from iac_code.types.stream_events import TextDeltaEvent
+
+from .fakes import FakeEventQueue
+
+
+def _publisher(tmp_path: Path) -> tuple[PipelineA2AEventPublisher, FakeEventQueue]:
+    queue = FakeEventQueue()
+    context = PipelineA2AContext(
+        pipeline_run_id="run-1",
+        task_id="task-1",
+        context_id="ctx-1",
+        pipeline_name="selling",
+    )
+    pipeline_dir = tmp_path / "pipeline"
+    publisher = PipelineA2AEventPublisher(
+        event_queue=queue,
+        translator=PipelineEventTranslator(context),
+        journal=A2APipelineJournal(pipeline_dir),
+        snapshot_store=A2APipelineSnapshotStore(pipeline_dir),
+    )
+    return publisher, queue
+
+
+def test_extreme_performance_is_enabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(A2A_EXTREME_PERFORMANCE_ENV, raising=False)
+
+    assert a2a_extreme_performance_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "no", "off", "disabled"])
+def test_extreme_performance_can_be_disabled(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(A2A_EXTREME_PERFORMANCE_ENV, value)
+
+    assert a2a_extreme_performance_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_default_extreme_mode_defers_text_delta_sidecar_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(A2A_EXTREME_PERFORMANCE_ENV, raising=False)
+    publisher, queue = _publisher(tmp_path)
+
+    returned = await publisher.publish(TextDeltaEvent(text="hello"))
+
+    assert returned == "hello"
+    assert len(queue.events) == 1
+    assert publisher.journal.read_all() == []
+    assert publisher.snapshot_store.load() is None
+
+
+@pytest.mark.asyncio
+async def test_default_extreme_mode_flushes_deferred_text_with_next_semantic_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(A2A_EXTREME_PERFORMANCE_ENV, raising=False)
+    publisher, _queue = _publisher(tmp_path)
+
+    await publisher.publish(TextDeltaEvent(text="hello"))
+    await publisher.publish_manual("pipeline_warning", "pipeline", data={"message": "check"})
+
+    journal_events = publisher.journal.read_all()
+    assert [event["eventType"] for event in journal_events] == ["text_delta", "pipeline_warning"]
+    snapshot = publisher.snapshot_store.load()
+    assert snapshot is not None
+    assert snapshot["display"]["messages"][0]["text"] == "hello"
+    assert snapshot["lastSequence"] == journal_events[-1]["sequence"]
+
+
+@pytest.mark.asyncio
+async def test_default_extreme_mode_does_not_replay_journal_for_text_delta(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(A2A_EXTREME_PERFORMANCE_ENV, raising=False)
+    publisher, _queue = _publisher(tmp_path)
+
+    def fail_read_all_repairing_tail() -> list[dict]:
+        raise AssertionError("text delta should not replay the A2A journal")
+
+    publisher.journal.read_all_repairing_tail = fail_read_all_repairing_tail  # type: ignore[method-assign]
+
+    assert await publisher.publish(TextDeltaEvent(text="hello")) == "hello"
+
+
+@pytest.mark.asyncio
+async def test_disabled_extreme_mode_keeps_immediate_text_delta_sidecar_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(A2A_EXTREME_PERFORMANCE_ENV, "0")
+    publisher, _queue = _publisher(tmp_path)
+
+    await publisher.publish(TextDeltaEvent(text="hello"))
+
+    assert publisher.journal.read_all()[0]["data"]["text"] == "hello"
+    snapshot = publisher.snapshot_store.load()
+    assert snapshot is not None
+    assert snapshot["display"]["messages"][0]["text"] == "hello"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ os.environ["LANG"] = "en_US.UTF-8"
 os.environ["NO_COLOR"] = "1"
 os.environ["TERM"] = "dumb"
 
+# Most existing A2A tests assert the reliability-first sidecar behavior where
+# every published event is immediately visible in journal/snapshot files.
+# Product default remains extreme performance; dedicated tests clear this env
+# var to exercise that default.
+os.environ.setdefault("IAC_CODE_A2A_EXTREME_PERFORMANCE", "0")
+
 # Re-initialize i18n with English locale
 from iac_code.i18n import setup_i18n  # noqa: E402
 


### PR DESCRIPTION
## Summary
- Add `IAC_CODE_A2A_EXTREME_PERFORMANCE`, defaulting to enabled unless explicitly set to a false value.
- Defer high-frequency A2A `text_delta` / `thinking_delta` sidecar writes in extreme mode and flush them in batches or when semantic events arrive.
- Add non-durable compact snapshot writes for the fast path while preserving the reliability-first path when the env var is disabled.

## Why
A2A pipeline streaming was paying per-event journal replay, tail scanning, snapshot serialization, and fsync costs. This made A2A much slower than REPL in high-frequency streaming scenarios.

## Validation
- `uv run ruff check src/iac_code/a2a/pipeline_performance.py src/iac_code/a2a/pipeline_snapshot.py src/iac_code/a2a/pipeline_stream.py tests/a2a/test_pipeline_extreme_performance.py tests/conftest.py`
- `uv run ruff format --check src/iac_code/a2a/pipeline_performance.py src/iac_code/a2a/pipeline_snapshot.py src/iac_code/a2a/pipeline_stream.py tests/a2a/test_pipeline_extreme_performance.py tests/conftest.py`
- `uv run ty check src/iac_code/a2a/pipeline_performance.py src/iac_code/a2a/pipeline_snapshot.py src/iac_code/a2a/pipeline_stream.py`
- `uv run pytest tests/a2a/test_pipeline_extreme_performance.py tests/a2a/test_pipeline_stream.py tests/a2a/test_pipeline_executor.py tests/a2a/test_pipeline_journal.py tests/a2a/test_pipeline_recovery.py tests/a2a/test_pipeline_snapshot.py tests/a2a/test_pipeline_events.py tests/a2a/test_executor.py tests/a2a/test_executor_cleanup.py -q` (`458 passed`)

Note: full `make test` was not used as the fresh worktree baseline currently fails because `src/iac_code/i18n/messages.pot` is absent from tracked files.
