### PR TITLE
[codex] fix ros deploy pipeline stack guard

### DIFF
--- a/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+++ b/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
@@ -156,7 +156,7 @@ class RosDeployTool(Tool):
         return True
 
     def _new_stack_tool(self) -> RosStack:
-        return RosStack()
+        return RosStack(allow_pipeline_deployment_actions=True)
 
     def _owned_stacks(self) -> dict[str, Any]:
         stacks = self._completion_guard_state.setdefault(_OWNED_STACKS_KEY, {})
@@ -339,8 +339,8 @@ class RosDeployTool(Tool):
                     rule_source=rule_source,
                     rule=rule,
                     reason=reason,
-                    ),
-                )
+                ),
+            )
 
         if template_permission := self._local_template_url_permission_error(input, context):
             return template_permission

--- a/src/iac_code/tools/cloud/aliyun/ros_stack.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_stack.py
@@ -238,6 +238,9 @@ class RosStack(BaseCloudStack):
 
     poll_interval: int = 5
 
+    def __init__(self, *, allow_pipeline_deployment_actions: bool = False) -> None:
+        self._allow_pipeline_deployment_actions = allow_pipeline_deployment_actions
+
     @property
     def provider_name(self) -> str:
         return "ros"
@@ -478,7 +481,11 @@ class RosStack(BaseCloudStack):
         return RosClientFactory.create(cred, region_id=region)
 
     def _call_action_kwargs(self, context: ToolContext) -> dict[str, Any]:
-        return {"pipeline_mode": context.pipeline_mode, "cwd": context.cwd}
+        return {
+            "pipeline_mode": context.pipeline_mode,
+            "cwd": context.cwd,
+            "allow_pipeline_deployment_actions": self._allow_pipeline_deployment_actions,
+        }
 
     async def call_action(
         self,
@@ -488,8 +495,12 @@ class RosStack(BaseCloudStack):
         *,
         pipeline_mode: bool = False,
         cwd: str | None = None,
+        allow_pipeline_deployment_actions: bool = False,
     ) -> str:
-        if error := reject_pipeline_dedicated_ros_deployment_action(action, pipeline_mode=pipeline_mode):
+        deployment_guard_pipeline_mode = pipeline_mode and not allow_pipeline_deployment_actions
+        if error := reject_pipeline_dedicated_ros_deployment_action(
+            action, pipeline_mode=deployment_guard_pipeline_mode
+        ):
             raise ValueError(error)
         if error := reject_pipeline_template_source_params(action, params, pipeline_mode=pipeline_mode):
             raise ValueError(error)

--- a/tests/pipeline/selling/tools/test_ros_deploy_tool.py
+++ b/tests/pipeline/selling/tools/test_ros_deploy_tool.py
@@ -82,6 +82,37 @@ async def test_create_records_failed_stack_as_owned_for_recovery(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_preserves_pipeline_mode_for_internal_ros_stack(monkeypatch):
+    tool, fake_stack = _deploy_tool(
+        monkeypatch,
+        results=[ToolResult.success(json.dumps({"stack_id": "stack-new", "is_success": True}))],
+    )
+
+    result = await tool.execute(
+        tool_input={
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "region_id": "cn-hangzhou",
+        },
+        context=ToolContext(cwd="/workspace", pipeline_mode=True),
+    )
+
+    assert result.is_error is False
+    assert fake_stack.calls[0][1].pipeline_mode is True
+
+
+def test_internal_ros_stack_allows_deployment_guard_without_clearing_pipeline_mode():
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    stack = RosDeployTool()._new_stack_tool()
+    kwargs = stack._call_action_kwargs(ToolContext(cwd="/workspace", pipeline_mode=True))
+
+    assert kwargs["pipeline_mode"] is True
+    assert kwargs["allow_pipeline_deployment_actions"] is True
+
+
+@pytest.mark.asyncio
 async def test_create_records_started_stack_as_owned_when_polling_fails(monkeypatch):
     guard_state = {}
     tool, _fake_stack = _deploy_tool(

--- a/tests/tools/cloud/aliyun/test_ros_stack.py
+++ b/tests/tools/cloud/aliyun/test_ros_stack.py
@@ -1653,6 +1653,34 @@ class TestRosStackExtra:
             await stack.call_action(action, dict(params), "cn-hangzhou", pipeline_mode=True)
 
     @pytest.mark.asyncio
+    async def test_pipeline_deployment_wrapper_flag_allows_template_url(self, stack):
+        result = await stack.call_action(
+            "CreateStack",
+            {"StackName": "n", "TemplateURL": _REMOTE_TEMPLATE_URL},
+            "cn-hangzhou",
+            pipeline_mode=True,
+            allow_pipeline_deployment_actions=True,
+        )
+
+        assert result == "stack-fake"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_deployment_wrapper_flag_keeps_template_body_rejected(self, stack, monkeypatch):
+        def fail_client(region):
+            raise AssertionError("TemplateBody should be rejected before client creation")
+
+        monkeypatch.setattr(stack, "_get_client", fail_client)
+
+        with pytest.raises(ValueError, match="TemplateURL"):
+            await stack.call_action(
+                "CreateStack",
+                {"StackName": "n", "TemplateBody": {"ROSTemplateFormatVersion": "2015-09-01"}},
+                "cn-hangzhou",
+                pipeline_mode=True,
+                allow_pipeline_deployment_actions=True,
+            )
+
+    @pytest.mark.asyncio
     async def test_template_body_dict_to_json_outside_pipeline(self, stack):
         result = await stack.call_action(
             "CreateStack",


### PR DESCRIPTION
## What changed

- Allow the dedicated `ros_deploy` wrapper to call the lower-level `RosStack` deployment actions without tripping the raw pipeline deployment guard.
- Keep the original pipeline context intact for internal `ros_deploy` calls, so other pipeline-only constraints still apply.
- Add regression coverage for `ros_deploy` delegation and the narrower `RosStack` wrapper flag.

## Why

Pipeline step 5 correctly invokes the dedicated `ros_deploy` tool, but `ros_deploy` reused `RosStack` with the original pipeline context. The lower-level guard then mistook the wrapper-owned `CreateStack` call for a direct raw ROS deployment API call and rejected it.

This keeps the raw pipeline API guard intact for direct `RosStack/CreateStack` usage while allowing the dedicated deployment wrapper to perform its owned internal implementation. The wrapper flag only bypasses the deployment-action guard; template source rules such as rejecting `TemplateBody` in pipeline mode still use the real `pipeline_mode` value.

## Validation

- `uv run pytest tests/pipeline/selling/tools/test_ros_deploy_tool.py tests/tools/cloud/aliyun/test_ros_stack.py::TestRosStackExecute::test_pipeline_create_stack_is_rejected_before_sdk_call tests/tools/cloud/aliyun/test_ros_stack.py::TestRosStackExtra::test_raw_deployment_actions_are_rejected_in_pipeline_mode tests/tools/cloud/aliyun/test_ros_stack.py::TestRosStackExtra::test_pipeline_deployment_wrapper_flag_allows_template_url tests/tools/cloud/aliyun/test_ros_stack.py::TestRosStackExtra::test_pipeline_deployment_wrapper_flag_keeps_template_body_rejected`
- `uv run ruff check src/ tests/`
- `uv run ty check src/`
- `uv run ruff format --check src/iac_code/pipeline/selling/tools/ros_deploy_tool.py src/iac_code/tools/cloud/aliyun/ros_stack.py tests/pipeline/selling/tools/test_ros_deploy_tool.py tests/tools/cloud/aliyun/test_ros_stack.py`
