### PR TITLE
fix ros deploy result display

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -49,6 +49,7 @@ msgid "Unknown error"
 msgstr "Unbekannter Fehler"
 
 #: src/iac_code/a2a/artifacts.py src/iac_code/a2a/pipeline_paths.py
+#: src/iac_code/services/session_backup.py
 #: src/iac_code/services/session_layout.py
 #, python-brace-format
 msgid "Unsupported session layout version: {version}"
@@ -612,6 +613,11 @@ msgstr ""
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Fehler: {error}"
+
+#: src/iac_code/cli/headless.py src/iac_code/ui/repl.py
+#, python-brace-format
+msgid "Session not found: {session_id}"
+msgstr "Sitzung nicht gefunden: {session_id}"
 
 #: src/iac_code/cli/headless.py
 #, python-brace-format
@@ -3426,9 +3432,33 @@ msgid "[Image input]"
 msgstr "[Bildeingabe]"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "CIDR block overlapped"
+msgstr "CIDR-Block überschneidet sich"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
 msgid "{error_code}; recommended action: {action}"
 msgstr "{error_code}; empfohlene Aktion: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded ({stack_id})"
+msgstr "{name} erfolgreich erstellt ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded"
+msgstr "{name} erfolgreich erstellt"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason} ({stack_id})"
+msgstr "Erstellung von {name} fehlgeschlagen: {reason} ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason}"
+msgstr "Erstellung von {name} fehlgeschlagen: {reason}"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -5389,11 +5419,6 @@ msgstr "Diese Sitzung fortsetzen mit:"
 #: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "Sitzungs-ID"
-
-#: src/iac_code/ui/repl.py
-#, python-brace-format
-msgid "Session not found: {session_id}"
-msgstr "Sitzung nicht gefunden: {session_id}"
 
 #: src/iac_code/ui/repl.py
 msgid ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -50,6 +50,7 @@ msgid "Unknown error"
 msgstr "Error desconocido"
 
 #: src/iac_code/a2a/artifacts.py src/iac_code/a2a/pipeline_paths.py
+#: src/iac_code/services/session_backup.py
 #: src/iac_code/services/session_layout.py
 #, python-brace-format
 msgid "Unsupported session layout version: {version}"
@@ -618,6 +619,11 @@ msgstr ""
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Error: {error}"
+
+#: src/iac_code/cli/headless.py src/iac_code/ui/repl.py
+#, python-brace-format
+msgid "Session not found: {session_id}"
+msgstr "Sesión no encontrada: {session_id}"
 
 #: src/iac_code/cli/headless.py
 #, python-brace-format
@@ -3418,9 +3424,33 @@ msgid "[Image input]"
 msgstr "[Entrada de imagen]"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "CIDR block overlapped"
+msgstr "Bloque CIDR superpuesto"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
 msgid "{error_code}; recommended action: {action}"
 msgstr "{error_code}; acción recomendada: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded ({stack_id})"
+msgstr "{name} creado correctamente ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded"
+msgstr "{name} creado correctamente"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason} ({stack_id})"
+msgstr "Error al crear {name}: {reason} ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason}"
+msgstr "Error al crear {name}: {reason}"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -5381,11 +5411,6 @@ msgstr "Para reanudar esta sesión, ejecute:"
 #: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "ID de sesión"
-
-#: src/iac_code/ui/repl.py
-#, python-brace-format
-msgid "Session not found: {session_id}"
-msgstr "Sesión no encontrada: {session_id}"
 
 #: src/iac_code/ui/repl.py
 msgid ""

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -50,6 +50,7 @@ msgid "Unknown error"
 msgstr "Erreur inconnue"
 
 #: src/iac_code/a2a/artifacts.py src/iac_code/a2a/pipeline_paths.py
+#: src/iac_code/services/session_backup.py
 #: src/iac_code/services/session_layout.py
 #, python-brace-format
 msgid "Unsupported session layout version: {version}"
@@ -613,6 +614,11 @@ msgstr ""
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Erreur : {error}"
+
+#: src/iac_code/cli/headless.py src/iac_code/ui/repl.py
+#, python-brace-format
+msgid "Session not found: {session_id}"
+msgstr "Session introuvable : {session_id}"
 
 #: src/iac_code/cli/headless.py
 #, python-brace-format
@@ -3423,9 +3429,33 @@ msgid "[Image input]"
 msgstr "[Entrée d'image]"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "CIDR block overlapped"
+msgstr "Bloc CIDR chevauchant"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
 msgid "{error_code}; recommended action: {action}"
 msgstr "{error_code} ; action recommandée : {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded ({stack_id})"
+msgstr "Création de {name} réussie ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded"
+msgstr "Création de {name} réussie"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason} ({stack_id})"
+msgstr "Échec de la création de {name} : {reason} ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason}"
+msgstr "Échec de la création de {name} : {reason}"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -5399,11 +5429,6 @@ msgstr "Pour reprendre cette session :"
 #: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "ID de session"
-
-#: src/iac_code/ui/repl.py
-#, python-brace-format
-msgid "Session not found: {session_id}"
-msgstr "Session introuvable : {session_id}"
 
 #: src/iac_code/ui/repl.py
 msgid ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -45,6 +45,7 @@ msgid "Unknown error"
 msgstr "不明なエラー"
 
 #: src/iac_code/a2a/artifacts.py src/iac_code/a2a/pipeline_paths.py
+#: src/iac_code/services/session_backup.py
 #: src/iac_code/services/session_layout.py
 #, python-brace-format
 msgid "Unsupported session layout version: {version}"
@@ -582,6 +583,11 @@ msgstr ""
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "エラー：{error}"
+
+#: src/iac_code/cli/headless.py src/iac_code/ui/repl.py
+#, python-brace-format
+msgid "Session not found: {session_id}"
+msgstr "セッションが見つかりません：{session_id}"
 
 #: src/iac_code/cli/headless.py
 #, python-brace-format
@@ -3256,9 +3262,33 @@ msgid "[Image input]"
 msgstr "[画像入力]"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "CIDR block overlapped"
+msgstr "CIDR ブロックが重複しています"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
 msgid "{error_code}; recommended action: {action}"
 msgstr "{error_code}; 推奨アクション: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded ({stack_id})"
+msgstr "{name} の作成に成功しました ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded"
+msgstr "{name} の作成に成功しました"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason} ({stack_id})"
+msgstr "{name} の作成に失敗しました: {reason} ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason}"
+msgstr "{name} の作成に失敗しました: {reason}"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -5132,11 +5162,6 @@ msgstr "このセッションを再開するには次を実行してください
 #: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "セッション ID"
-
-#: src/iac_code/ui/repl.py
-#, python-brace-format
-msgid "Session not found: {session_id}"
-msgstr "セッションが見つかりません：{session_id}"
 
 #: src/iac_code/ui/repl.py
 msgid ""

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -49,6 +49,7 @@ msgid "Unknown error"
 msgstr "Erro desconhecido"
 
 #: src/iac_code/a2a/artifacts.py src/iac_code/a2a/pipeline_paths.py
+#: src/iac_code/services/session_backup.py
 #: src/iac_code/services/session_layout.py
 #, python-brace-format
 msgid "Unsupported session layout version: {version}"
@@ -610,6 +611,11 @@ msgstr ""
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "Erro: {error}"
+
+#: src/iac_code/cli/headless.py src/iac_code/ui/repl.py
+#, python-brace-format
+msgid "Session not found: {session_id}"
+msgstr "Sessão não encontrada: {session_id}"
 
 #: src/iac_code/cli/headless.py
 #, python-brace-format
@@ -3396,9 +3402,33 @@ msgid "[Image input]"
 msgstr "[Entrada de imagem]"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "CIDR block overlapped"
+msgstr "Bloco CIDR sobreposto"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
 msgid "{error_code}; recommended action: {action}"
 msgstr "{error_code}; ação recomendada: {action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded ({stack_id})"
+msgstr "{name} criado com sucesso ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded"
+msgstr "{name} criado com sucesso"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason} ({stack_id})"
+msgstr "Falha ao criar {name}: {reason} ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason}"
+msgstr "Falha ao criar {name}: {reason}"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -5339,11 +5369,6 @@ msgstr "Para retomar esta sessão, execute:"
 #: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "ID da sessão"
-
-#: src/iac_code/ui/repl.py
-#, python-brace-format
-msgid "Session not found: {session_id}"
-msgstr "Sessão não encontrada: {session_id}"
 
 #: src/iac_code/ui/repl.py
 msgid ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -45,6 +45,7 @@ msgid "Unknown error"
 msgstr "未知错误"
 
 #: src/iac_code/a2a/artifacts.py src/iac_code/a2a/pipeline_paths.py
+#: src/iac_code/services/session_backup.py
 #: src/iac_code/services/session_layout.py
 #, python-brace-format
 msgid "Unsupported session layout version: {version}"
@@ -578,6 +579,11 @@ msgstr ""
 #, python-brace-format
 msgid "Error: {error}"
 msgstr "错误：{error}"
+
+#: src/iac_code/cli/headless.py src/iac_code/ui/repl.py
+#, python-brace-format
+msgid "Session not found: {session_id}"
+msgstr "会话不存在：{session_id}"
 
 #: src/iac_code/cli/headless.py
 #, python-brace-format
@@ -3216,9 +3222,33 @@ msgid "[Image input]"
 msgstr "[图片输入]"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid "CIDR block overlapped"
+msgstr "CIDR block 已重叠"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
 msgid "{error_code}; recommended action: {action}"
 msgstr "{error_code}；推荐操作：{action}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded ({stack_id})"
+msgstr "{name} 创建成功 ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation succeeded"
+msgstr "{name} 创建成功"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason} ({stack_id})"
+msgstr "{name} 创建失败：{reason} ({stack_id})"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+#, python-brace-format
+msgid "{name} creation failed: {reason}"
+msgstr "{name} 创建失败：{reason}"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -5072,11 +5102,6 @@ msgstr "恢复此会话请运行："
 #: src/iac_code/ui/repl.py
 msgid "Session ID"
 msgstr "会话 ID"
-
-#: src/iac_code/ui/repl.py
-#, python-brace-format
-msgid "Session not found: {session_id}"
-msgstr "会话不存在：{session_id}"
 
 #: src/iac_code/ui/repl.py
 msgid ""

--- a/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+++ b/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
@@ -25,6 +25,9 @@ from iac_code.types.permissions import (
 _OWNED_STACKS_KEY = "ros_deploy_owned_stack_ids"
 _ACTIONS = ("create", "continue_create", "delete_and_create")
 _SAFE_RULE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,255}$")
+_ROS_ERROR_CODE_RE = re.compile(r"\bcode:\s*([A-Za-z0-9_.-]+)")
+_WHITESPACE_RE = re.compile(r"\s+")
+_MAX_REASON_CHARS = 80
 _RULE_SOURCE_ORDER = {
     "cli_arg": 5,
     "session": 4,
@@ -44,6 +47,27 @@ def _json_object(value: str) -> dict[str, Any] | None:
 
 def _string_value(value: Any) -> str:
     return value if isinstance(value, str) else ""
+
+
+def _short_stack_id(stack_id: str) -> str:
+    return stack_id[:8] if stack_id else ""
+
+
+def _friendly_ros_error_code(code: str) -> str:
+    if code == "InvalidCidrBlock.Overlapped":
+        return _("CIDR block overlapped")
+    return code
+
+
+def _short_status_reason(status_reason: str) -> str:
+    match = _ROS_ERROR_CODE_RE.search(status_reason)
+    if match is not None:
+        return _friendly_ros_error_code(match.group(1))
+
+    reason = _WHITESPACE_RE.sub(" ", status_reason).strip()
+    if len(reason) > _MAX_REASON_CHARS:
+        return reason[: _MAX_REASON_CHARS - 3].rstrip() + "..."
+    return reason
 
 
 def _safe_rule_segment(value: str) -> bool:
@@ -131,6 +155,9 @@ class RosDeployTool(Tool):
         return " ".join(part for part in (action, target) if part)
 
     def render_tool_result_message(self, output: str, *, is_error: bool = False, verbose: bool = False) -> str | None:
+        if verbose:
+            return output.strip()
+
         parsed = _json_object(output)
         if is_error and parsed is not None and parsed.get("error_code"):
             message = _string_value(parsed.get("message"))
@@ -144,7 +171,39 @@ class RosDeployTool(Tool):
             if message:
                 detail = f"{detail}: {message}"
             return detail
+
+        if parsed is not None:
+            if message := self._render_stack_summary(parsed, is_error=is_error):
+                return message
         return RosStack().render_tool_result_message(output, is_error=is_error, verbose=verbose)
+
+    def _render_stack_summary(self, parsed: dict[str, Any], *, is_error: bool) -> str | None:
+        stack_name = _string_value(parsed.get("stack_name"))
+        stack_id = _string_value(parsed.get("stack_id"))
+        short_id = _short_stack_id(stack_id)
+        name = stack_name or short_id
+        if not name:
+            return None
+
+        is_success = parsed.get("is_success")
+        if is_success is True:
+            if short_id and stack_name:
+                return _("{name} creation succeeded ({stack_id})").format(name=name, stack_id=short_id)
+            return _("{name} creation succeeded").format(name=name)
+
+        if is_success is False or is_error:
+            reason = _short_status_reason(_string_value(parsed.get("status_reason")))
+            if not reason:
+                return None
+            if short_id and stack_name:
+                return _("{name} creation failed: {reason} ({stack_id})").format(
+                    name=name,
+                    reason=reason,
+                    stack_id=short_id,
+                )
+            return _("{name} creation failed: {reason}").format(name=name, reason=reason)
+
+        return None
 
     def needs_event_queue(self) -> bool:
         return True

--- a/src/iac_code/ui/renderer.py
+++ b/src/iac_code/ui/renderer.py
@@ -95,6 +95,11 @@ def _known_tool_result_message(
     is_error: bool = False,
     verbose: bool = False,
 ) -> str | None:
+    if tool_name == "ros_deploy":
+        from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+        return RosDeployTool().render_tool_result_message(output, is_error=is_error, verbose=verbose)
+
     from iac_code.tools.cloud.aliyun.ros_template_tools import render_ros_template_tool_result_message
 
     return render_ros_template_tool_result_message(tool_name, output, is_error=is_error, verbose=verbose)

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -152,23 +152,27 @@ def test_load_context_snapshot_failure_logs_sanitized_warning(monkeypatch: pytes
 @pytest.mark.asyncio
 async def test_context_runtime_factory_runs_outside_mutation_lock() -> None:
     store = A2ATaskStore(metrics=NoOpA2AMetrics(), idle_timeout_seconds=60, cleanup_interval_seconds=300)
+    started = threading.Event()
+    release = threading.Event()
 
     def slow_runtime_factory(session_id: str):
-        time.sleep(0.2)
+        started.set()
+        release.wait(timeout=2)
         return f"rt-{session_id}"
 
-    start = time.monotonic()
     context_task = asyncio.create_task(
         store.get_or_create_context(context_id="ctx-1", cwd="/tmp", runtime_factory=slow_runtime_factory)
     )
-    await asyncio.sleep(0.01)
 
-    await asyncio.wait_for(store.save(sdk_task("task-while-runtime-starts")), timeout=0.1)
-    save_elapsed = time.monotonic() - start
+    try:
+        assert await asyncio.wait_for(asyncio.to_thread(started.wait, 1), timeout=1)
+        await asyncio.wait_for(store.save(sdk_task("task-while-runtime-starts")), timeout=1)
+        assert not context_task.done()
+    finally:
+        release.set()
 
-    context = await context_task
+    context = await asyncio.wait_for(context_task, timeout=1)
     assert context.runtime == f"rt-{context.session_id}"
-    assert save_elapsed < 0.15
 
 
 @pytest.mark.asyncio

--- a/tests/pipeline/selling/tools/test_ros_deploy_tool.py
+++ b/tests/pipeline/selling/tools/test_ros_deploy_tool.py
@@ -503,3 +503,67 @@ def test_continue_validation_failure_result_rendering_mentions_recommended_actio
     assert message is not None
     assert "ContinueCreateStackValidationFailed" in message
     assert "delete_and_create" in message
+
+
+def test_render_tool_result_message_shows_short_success_summary():
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    content = json.dumps(
+        {
+            "stack_id": "a463b158-5429-4a2d-9173-825271c28dcb",
+            "stack_name": "single-vswitch-20260706-k7m3x9",
+            "status": "CREATE_COMPLETE",
+            "status_reason": "Stack CREATE completed successfully",
+            "progress_percentage": 100.0,
+            "elapsed_seconds": 5,
+            "is_success": True,
+        },
+        indent=2,
+    )
+
+    message = RosDeployTool().render_tool_result_message(content)
+
+    assert message == "single-vswitch-20260706-k7m3x9 creation succeeded (a463b158)"
+
+
+def test_render_tool_result_message_shows_short_failure_summary():
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    content = json.dumps(
+        {
+            "stack_id": "a463b158-5429-4a2d-9173-825271c28dcb",
+            "stack_name": "single-vswitch-20260706-k7m3x9",
+            "status": "CREATE_FAILED",
+            "status_reason": (
+                "Resource CREATE failed: VPCResourceException: resources.VSwitch: "
+                "code: InvalidCidrBlock.Overlapped, message: The CIDR block 192.168.200.0/24 "
+                "Overlapped exists CIDR block."
+            ),
+            "progress_percentage": 0.0,
+            "elapsed_seconds": 5,
+            "is_success": False,
+        },
+        indent=2,
+    )
+
+    message = RosDeployTool().render_tool_result_message(content, is_error=True)
+
+    assert message == "single-vswitch-20260706-k7m3x9 creation failed: CIDR block overlapped (a463b158)"
+
+
+def test_render_tool_result_message_keeps_verbose_json():
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    content = json.dumps(
+        {
+            "stack_id": "a463b158-5429-4a2d-9173-825271c28dcb",
+            "stack_name": "single-vswitch-20260706-k7m3x9",
+            "status": "CREATE_COMPLETE",
+            "is_success": True,
+        },
+        indent=2,
+    )
+
+    message = RosDeployTool().render_tool_result_message(content, verbose=True)
+
+    assert message == content

--- a/tests/ui/test_renderer_helpers.py
+++ b/tests/ui/test_renderer_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
@@ -381,6 +382,35 @@ class TestRendererHelpers:
         assert line is not None
         assert "Call succeeded (RequestId: REQ-42)" in line.plain
         assert "Resources" not in line.plain
+
+    def test_render_tool_result_summarizes_pipeline_ros_deploy_without_registry_tool(self):
+        renderer = make_renderer()
+        record = _ToolCallRecord(
+            tool_name="ros_deploy",
+            tool_input={},
+            done=True,
+            is_error=True,
+            result=json.dumps(
+                {
+                    "stack_id": "a463b158-5429-4a2d-9173-825271c28dcb",
+                    "stack_name": "single-vswitch-20260706-k7m3x9",
+                    "status": "CREATE_FAILED",
+                    "status_reason": (
+                        "Resource CREATE failed: VPCResourceException: resources.VSwitch: "
+                        "code: InvalidCidrBlock.Overlapped, message: The CIDR block 192.168.200.0/24 "
+                        "Overlapped exists CIDR block."
+                    ),
+                    "is_success": False,
+                },
+                indent=2,
+            ),
+        )
+
+        line = renderer._render_tool_result(record)
+
+        assert line is not None
+        assert "single-vswitch-20260706-k7m3x9 creation failed: CIDR block overlapped (a463b158)" in line.plain
+        assert "status_reason" not in line.plain
 
     def test_print_segments_to_scrollback_archives_and_merges_assistant_turns(self):
         renderer = make_renderer()


### PR DESCRIPTION
## Summary
- Render `ros_deploy` results as compact success/failure summaries by default while preserving full JSON for verbose output.
- Add renderer fallback for pipeline-injected `ros_deploy` so terminal output no longer falls back to raw JSON.
- Add i18n strings and tests for success, failure, verbose, and renderer fallback paths.

## Verification
- `make format`
- `make lint`
- `make translate`
- `make test`
- `uv run pytest tests/pipeline/selling/tools/test_ros_deploy_tool.py tests/ui/test_renderer_helpers.py -q`