### PR TITLE
Update pac-aliyun InfraGuard workflow

### DIFF
--- a/src/iac_code/skills/bundled/pac_aliyun/SKILL.md
+++ b/src/iac_code/skills/bundled/pac_aliyun/SKILL.md
@@ -25,10 +25,18 @@ auto_trigger:
 核心命令：
 ```bash
 infraguard version
-go install github.com/aliyun/infraguard/cmd/infraguard@latest
+infraguard update --check
+GOPROXY=https://mirrors.aliyun.com/goproxy/,direct go install github.com/aliyun/infraguard/cmd/infraguard@latest
+infraguard update
 infraguard policy update
 infraguard policy list
 ```
+
+版本处理：
+- 如果本地没有 `infraguard`，使用带阿里云 Go Proxy 的 `go install` 命令安装。
+- 如果本地 `infraguard` 不是最新版本，先提醒用户需要升级到最新版本。
+- 如果本地版本小于 `0.10.1`，使用带阿里云 Go Proxy 的重装命令升级。
+- 如果本地版本大于等于 `0.10.1`，使用 `infraguard update` 升级。
 
 若用户只是咨询概念，可先简短回答；一旦需要生成、查询、校验或扫描策略，必须先完成懒加载检查。
 

--- a/src/iac_code/skills/bundled/pac_aliyun/references/infraguard-policy-generation.md
+++ b/src/iac_code/skills/bundled/pac_aliyun/references/infraguard-policy-generation.md
@@ -10,24 +10,35 @@ Run this sync before any PAC implementation, generation, validation, or catalog 
    ```bash
    infraguard version
    ```
-2. If the command is missing and the user wants the agent to prepare the local toolchain, install the official CLI:
+2. If the command is missing and the user wants the agent to prepare the local toolchain, install the official CLI through the Alibaba Cloud Go proxy:
    ```bash
-   go install github.com/aliyun/infraguard/cmd/infraguard@latest
+   GOPROXY=https://mirrors.aliyun.com/goproxy/,direct go install github.com/aliyun/infraguard/cmd/infraguard@latest
    ```
-3. Check for policy updates before relying on policy names or behavior:
+   Do not suggest a plain `go install` command that relies on direct GitHub fetches.
+3. If InfraGuard is installed, check whether the local CLI is already the latest version:
+   ```bash
+   infraguard update --check
+   ```
+   If the local version is not latest, tell the user that InfraGuard should be upgraded before PAC work continues:
+   - When the local version is lower than `0.10.1`, upgrade by reinstalling with the Alibaba Cloud Go proxy command above.
+   - When the local version is `0.10.1` or newer, upgrade with:
+     ```bash
+     infraguard update
+     ```
+4. Check for policy updates before relying on policy names or behavior:
    ```bash
    infraguard policy update
    ```
-4. Inspect the current policy catalog from the refreshed tool:
+5. Inspect the current policy catalog from the refreshed tool:
    ```bash
    infraguard policy list
    ```
-5. When generating or editing custom policies, validate the file:
+6. When generating or editing custom policies, validate the file:
    ```bash
    infraguard policy validate path/to/policy.rego
    ```
 
-If a command cannot run because InfraGuard or Go is not installed, explain the missing prerequisite and continue only with user-approved installation or with static guidance.
+If a command cannot run because InfraGuard or Go is not installed, explain the missing prerequisite and continue only with user-approved installation or with static guidance. If the latest-version check cannot run, state that the local InfraGuard freshness is unverified instead of assuming it is current.
 
 ## Policy Lookup
 
@@ -36,18 +47,41 @@ If a command cannot run because InfraGuard or Go is not installed, explain the m
 - Use policy references in scan commands as `rule:aliyun:<name>` or `pack:aliyun:<name>`.
 - Do not infer that a previously known policy still exists; refresh first with `infraguard policy update`.
 
+## Supported Scan Dimensions
+
+When the user prompt mentions one of these dimensions, scan with the matching pack directly:
+
+| Prompt dimension | Pack |
+| --- | --- |
+| 最佳实践, best practice | `pack:aliyun:best-practice` |
+| 合规性, 合规, compliance | `pack:aliyun:compliance` |
+| 成本优化, 成本, cost optimization | `pack:aliyun:cost-optimization` |
+| 弹性能力, 弹性, elasticity | `pack:aliyun:elasticity` |
+| 高可用, 高可用性, high availability | `pack:aliyun:high-availability` |
+| 网络架构, network architecture | `pack:aliyun:network-architecture` |
+| 可运维性, 可运维, operations | `pack:aliyun:operations` |
+| 安全性, 安全, security | `pack:aliyun:security` |
+
+If the prompt mentions multiple supported dimensions, pass one `-p` flag for each matching pack. If the prompt asks for a broad assessment without naming a dimension, ask which dimension to scan or use the most relevant pack inferred from the user's risk statement.
+
 ## Template Scanning
 
 Use InfraGuard scan for ROS templates:
 
 ```bash
-infraguard scan template.yaml -p pack:aliyun:quick-start-compliance-pack
+infraguard scan template.yaml -p pack:aliyun:best-practice
 ```
 
 For automation or downstream analysis, request JSON output:
 
 ```bash
-infraguard scan template.yaml -p rule:aliyun:ecs-instance-no-public-ip --format json
+infraguard scan template.yaml -p pack:aliyun:security --format json
+```
+
+For prompts that mention multiple dimensions, include each matching pack:
+
+```bash
+infraguard scan template.yaml -p pack:aliyun:security -p pack:aliyun:high-availability --format json
 ```
 
 Summaries should include the violating resource, property path, severity, reason, and concrete ROS template change.

--- a/tests/skills/bundled/test_pac_aliyun_skill.py
+++ b/tests/skills/bundled/test_pac_aliyun_skill.py
@@ -42,7 +42,12 @@ class TestPacAliyunSkill:
         assert "InfraGuard" in pac_skill.content
         assert "references/infraguard-policy-generation.md" in pac_skill.content
         assert "infraguard policy update" in pac_skill.content
-        assert "go install github.com/aliyun/infraguard/cmd/infraguard@latest" in pac_skill.content
+        assert "infraguard update --check" in pac_skill.content
+        assert (
+            "GOPROXY=https://mirrors.aliyun.com/goproxy/,direct "
+            "go install github.com/aliyun/infraguard/cmd/infraguard@latest"
+        ) in pac_skill.content
+        assert "infraguard update" in pac_skill.content
 
     def test_pac_aliyun_reference_requires_lazy_update_before_pac_work(self):
         reference = PAC_SKILL_ROOT / "references" / "infraguard-policy-generation.md"
@@ -50,9 +55,50 @@ class TestPacAliyunSkill:
         content = reference.read_text(encoding="utf-8")
         assert "Lazy InfraGuard Sync" in content
         assert "Run this sync before any PAC implementation, generation, validation, or catalog lookup" in content
+        assert "infraguard update --check" in content
         assert "infraguard policy update" in content
         assert "infraguard policy list" in content
         assert "infraguard policy validate" in content
+        assert "0.10.1" in content
+
+    def test_pac_aliyun_reference_installs_through_aliyun_goproxy(self):
+        reference = PAC_SKILL_ROOT / "references" / "infraguard-policy-generation.md"
+        content = reference.read_text(encoding="utf-8")
+        install_command = (
+            "GOPROXY=https://mirrors.aliyun.com/goproxy/,direct "
+            "go install github.com/aliyun/infraguard/cmd/infraguard@latest"
+        )
+        assert install_command in content
+        assert "\ngo install github.com/aliyun/infraguard/cmd/infraguard@latest" not in content
+
+    def test_pac_aliyun_reference_documents_cli_upgrade_strategy(self):
+        reference = PAC_SKILL_ROOT / "references" / "infraguard-policy-generation.md"
+        content = reference.read_text(encoding="utf-8")
+        assert "If the local version is not latest" in content
+        assert "lower than `0.10.1`" in content
+        assert "reinstalling with the Alibaba Cloud Go proxy command" in content
+        assert "version is `0.10.1` or newer" in content
+        assert "infraguard update" in content
+
+    def test_pac_aliyun_reference_documents_supported_scan_packs(self):
+        reference = PAC_SKILL_ROOT / "references" / "infraguard-policy-generation.md"
+        content = reference.read_text(encoding="utf-8")
+        expected_packs = {
+            "最佳实践": "pack:aliyun:best-practice",
+            "合规性": "pack:aliyun:compliance",
+            "成本优化": "pack:aliyun:cost-optimization",
+            "弹性能力": "pack:aliyun:elasticity",
+            "高可用": "pack:aliyun:high-availability",
+            "网络架构": "pack:aliyun:network-architecture",
+            "可运维性": "pack:aliyun:operations",
+            "安全性": "pack:aliyun:security",
+        }
+        assert "Supported Scan Dimensions" in content
+        for dimension, pack in expected_packs.items():
+            assert dimension in content
+            assert pack in content
+        assert "one `-p` flag for each matching pack" in content
+        assert "quick-start-compliance-pack" not in content
 
     def test_pac_aliyun_assets_do_not_embed_infraguard_policy_catalog(self):
         assets = _pac_aliyun_asset_text()


### PR DESCRIPTION
## Summary
- Route InfraGuard installation through the Alibaba Cloud Go proxy in the pac-aliyun skill guidance.
- Document the local InfraGuard version check and upgrade path around version 0.10.1.
- Map supported scan dimensions to the explicit pack:aliyun packs and cover the guidance with bundled skill tests.

## Validation
- uv run pytest tests/skills/bundled/test_pac_aliyun_skill.py -q
- uv run ruff check tests/skills/bundled/test_pac_aliyun_skill.py
- git diff --check