### PR TITLE
fix(pipeline): preserve list and discounted prices

### DIFF
--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
@@ -44,6 +44,12 @@
   - `monthly_cost`：月费用（如 "¥200/月"）
 - `total_monthly_cost`：月度总费用（如 "¥1,234/月"）
 
+价格口径必须沿用成本预估步骤的归一化结果。`evaluated_candidates` 中每一项的 `candidate`、`cost`、`template` 是同级字段：
+- `total_monthly_cost` 必须取 `evaluated_candidates[i].cost.monthly_estimate`
+- `cost_items[].monthly_cost` 必须取 `evaluated_candidates[i].cost.resources[].cost`
+
+不要使用 `evaluated_candidates[i].candidate.monthly_estimate`，该字段是架构规划阶段的粗略估算。不要重新询价，也不要重新估算价格。
+
 如果多个方案都需要展示，必须对每个方案都调用一次“架构图 + 方案详情”的并行展示；不要为了架构图优化额外阻塞方案详情展示。
 
 - 不要用文字输出对比表格或方案信息 — 所有展示数据通过上述工具传递

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -22,6 +22,12 @@
 ## 输出
 API 调用完成后调用 `complete_step` 提交费用预估。
 
+`complete_step.conclusion.monthly_estimate` 必须保留两个价格口径：
+- `OriginalAmount` 是原价，按统一月度周期换算并汇总为列表价。
+- `TradeAmount` 是合同优惠后的最终价，按与原价相同的月度周期换算并汇总。
+- 两个字段都存在时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
+- 任一字段缺失时只展示可用价格，并在 `api_raw_summary` 中说明缺失字段；询价失败时仍填写 `"询价失败"`。
+
 若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。
 
 ## 注意事项

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -10,7 +10,7 @@ conclusion_schema:
   properties:
     monthly_estimate:
       type: string
-      description: 月度费用估算（如 ¥1500/月）或 "询价失败"
+      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"
     currency:
       type: string
       enum: [CNY]

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -96,6 +96,16 @@ class TestSkillFrontmatter:
         assert preview_schema["properties"]["template_url"]["type"] == "string"
         assert preview_schema["properties"]["parameters"]["type"] == "object"
 
+    def test_monthly_estimate_schema_describes_list_and_discounted_prices(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        description = fm["conclusion_schema"]["properties"]["monthly_estimate"]["description"]
+
+        assert "列表价" in description
+        assert "合同优惠后" in description
+        assert "OriginalAmount" in description
+        assert "TradeAmount" in description
+
     def test_conclusion_schema_requires_full_preview_validation_when_succeeded(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         fm = _parse_frontmatter(content)
@@ -409,6 +419,15 @@ class TestCostPrompt:
         assert "ros_preview_template" in body
         assert "ros_estimate_template_cost" in body
         assert "不要传 `TemplateBody`" in body
+
+    def test_prompt_requires_list_and_discounted_monthly_prices(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+
+        assert "OriginalAmount" in body
+        assert "TradeAmount" in body
+        assert "列表价" in body
+        assert "合同优惠后" in body
+        assert "monthly_estimate" in body
 
 
 class TestEvalsJson:


### PR DESCRIPTION
## Summary

- require `cost_estimating` to preserve both `OriginalAmount` list price and `TradeAmount` contract-discounted price in `cost.monthly_estimate`
- make the non-A2A `confirm_and_select` prompt read normalized pricing from `evaluated_candidates[i].cost`
- add regression coverage for the dual-price output contract
- leave the A2A prompt unchanged because its presentation is handled by the frontend

## Root cause

The confirmation step could use the architecture candidate's rough `monthly_estimate` instead of the normalized pricing conclusion produced by cost estimation. The cost conclusion schema also did not require both list and contract-discounted prices.

## User impact

Pipeline step 4 now receives and displays the step 3 pricing result with both list and contract-discounted monthly prices instead of falling back to a rough pre-discount estimate.

## Validation

- `uv run pytest tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py tests/pipeline/selling/test_terminal_ui_contract.py -q` (93 passed)
- `make lint` (Ruff and ty passed)
