### PR TITLE
Fix parallel pipeline event scheduling and stack publication

### DIFF
--- a/src/iac_code/a2a/pipeline_events.py
+++ b/src/iac_code/a2a/pipeline_events.py
@@ -19,6 +19,7 @@ from iac_code.types.stream_events import (
     DiagramEvent,
     MCPProgressEvent,
     PermissionRequestEvent,
+    ResourceObservedEvent,
     SubPipelineStreamEvent,
     TextDeltaEvent,
     ThinkingDeltaEvent,
@@ -302,6 +303,9 @@ class PipelineEventTranslator:
             return [self._translate_diagram_event(event)]
         if isinstance(event, ToolResultEvent):
             return self._translate_tool_result_event(event)
+        if isinstance(event, ResourceObservedEvent):
+            envelope = self._translate_resource_observed_event(event)
+            return [] if envelope is None else [envelope]
         if isinstance(event, MCPProgressEvent):
             return [self._translate_parent_scoped_display_event("tool_progress", _mcp_progress_data(event))]
         if isinstance(event, SubPipelineStreamEvent):
@@ -548,6 +552,14 @@ class PipelineEventTranslator:
         stream_event = _innermost_sub_pipeline_stream_event(event)
         state = self._candidate_from_stream_event(stream_event)
         inner = stream_event.inner
+        if isinstance(inner, ResourceObservedEvent):
+            stack_envelope = self._translate_resource_observed_event(inner)
+            if stack_envelope is None:
+                return []
+            self._add_candidate_coordinates(stack_envelope, state)
+            if state.current_step_id is not None:
+                stack_envelope["candidateStep"] = self._candidate_step_coordinate(state, state.current_step_id)
+            return [stack_envelope]
         if isinstance(inner, TextDeltaEvent):
             event_type = "text_delta"
             data = {"text": inner.text}
@@ -717,6 +729,61 @@ class PipelineEventTranslator:
         if self._current_parent_step_id is not None:
             envelope["step"] = self._parent_step_coordinate(self._current_parent_step_id)
         return envelope
+
+    def _translate_resource_observed_event(self, event: ResourceObservedEvent) -> dict[str, Any] | None:
+        data = self._stack_current_changed_data_from_resource_observed(event)
+        if data is None:
+            return None
+        envelope = self._envelope("stack_current_changed", "stack", "working", data)
+        if self._current_parent_step_id is not None:
+            envelope["step"] = self._parent_step_coordinate(self._current_parent_step_id)
+        return envelope
+
+    def _stack_current_changed_data_from_resource_observed(
+        self,
+        event: ResourceObservedEvent,
+    ) -> dict[str, Any] | None:
+        if not self._context.emit_stack_events:
+            return None
+        if event.resource_type != "stack" or not event.resource_id:
+            return None
+
+        record = self._tool_inputs.get(event.tool_use_id or "")
+        tool_input = record.get("input") if isinstance(record, dict) else {}
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        tool_name = _string_or_none(record.get("toolName")) if isinstance(record, dict) else None
+        tool_name = tool_name or event.tool_name
+
+        operation = _stack_operation_from_tool_input(tool_name, tool_input) if tool_name else None
+        provider = event.provider or (operation or {}).get("provider")
+        action = event.action or (operation or {}).get("action")
+        if action not in _STACK_TOOL_ACTIONS:
+            return None
+
+        params = (operation or {}).get("params")
+        if not isinstance(params, dict):
+            params = {}
+        stack_status = _first_string_from_sources((event.metadata,), ("StackStatus", "stackStatus", "status"))
+        if stack_status is None and action == "CreateStack":
+            stack_status = "CREATE_IN_PROGRESS"
+
+        data: dict[str, Any] = {
+            "toolName": tool_name,
+            "toolUseId": event.tool_use_id,
+            "provider": provider,
+            "action": action,
+            "deployAction": (operation or {}).get("deployAction"),
+            "previousStackId": (operation or {}).get("previousStackId"),
+            "regionId": event.region_id or (operation or {}).get("regionId"),
+            "stackId": event.resource_id,
+            "stackName": event.resource_name
+            or _first_string_from_sources((params, tool_input), ("StackName", "stackName", "stack_name", "name")),
+            "stackStatus": stack_status,
+            "isSuccess": True,
+            "current": True,
+        }
+        return {key: value for key, value in data.items() if value is not None}
 
     def _stack_current_changed_data(self, event: ToolResultEvent) -> dict[str, Any] | None:
         if not self._context.emit_stack_events:

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -47,7 +47,13 @@ from iac_code.pipeline.engine.user_input import (
 )
 from iac_code.services.session_backup import BackupReason, SessionBackupBlocked, SessionBackupService
 from iac_code.services.session_metadata import SESSION_JSONL_FILENAME, SESSION_METADATA_FILENAME
-from iac_code.types.stream_events import ResourceObservedEvent, StreamEvent
+from iac_code.types.stream_events import (
+    AskUserQuestionEvent,
+    PermissionRequestEvent,
+    ResourceObservedEvent,
+    StreamEvent,
+    SubPipelineStreamEvent,
+)
 from iac_code.utils.public_errors import sanitize_public_text
 
 logger = logging.getLogger(__name__)
@@ -373,6 +379,29 @@ class CandidateSentinel:
     """Signals that a candidate task has finished."""
 
     candidate_index: int
+
+
+_PARALLEL_PRIORITY_PIPELINE_EVENTS = {
+    PipelineEventType.SUB_PIPELINE_STARTED,
+    PipelineEventType.SUB_STEP_STARTED,
+}
+
+
+def _unwrap_sub_pipeline_stream_event(event: Any) -> Any:
+    while isinstance(event, SubPipelineStreamEvent):
+        event = event.inner
+    return event
+
+
+def _parallel_sub_pipeline_event_priority(event: Any) -> int:
+    if isinstance(event, (PipelineStatePersistenceError, SessionBackupBlocked)):
+        return 0
+    if isinstance(event, PipelineEvent) and event.type in _PARALLEL_PRIORITY_PIPELINE_EVENTS:
+        return 0
+    inner = _unwrap_sub_pipeline_stream_event(event)
+    if isinstance(inner, (PermissionRequestEvent, AskUserQuestionEvent)):
+        return 0
+    return 1
 
 
 @dataclass
@@ -4206,7 +4235,8 @@ class PipelineRunner:
 
         self._active_candidates.clear()
 
-        event_queue: asyncio.Queue = asyncio.Queue()
+        event_queue: asyncio.PriorityQueue[tuple[int, int, Any]] = asyncio.PriorityQueue()
+        event_sequence = 0
         conclusions_by_index: dict[int, dict] = {}
         failed_by_index: dict[int, dict[str, Any]] = {}
         restored_execution = (
@@ -4308,6 +4338,11 @@ class PipelineRunner:
             self._execution.setdefault("candidates", {})[str(i)] = entry
             failed_by_index[i] = dict(entry)
             await self._save_running(step.step_id, reason="parallel candidate failed")
+
+        async def put_candidate_event(event: Any) -> None:
+            nonlocal event_sequence
+            event_sequence += 1
+            await event_queue.put((_parallel_sub_pipeline_event_priority(event), event_sequence, event))
 
         async def run_candidate(
             i: int,
@@ -4451,13 +4486,13 @@ class PipelineRunner:
                         state["error"] = event.data.get("error")
                         state["error_details"] = event.data.get("error_details")
                         await save_candidate_failed(i, state)
-                    await event_queue.put(event)
+                    await put_candidate_event(event)
             except asyncio.CancelledError:
                 logger.debug("Candidate %d cancelled", i)
             except PipelineStatePersistenceError as exc:
-                await event_queue.put(exc)
+                await put_candidate_event(exc)
             except SessionBackupBlocked as exc:
-                await event_queue.put(exc)
+                await put_candidate_event(exc)
             except Exception as exc:
                 failure = public_error_from_exception(exc)
                 error_summary = failure.summary
@@ -4508,9 +4543,9 @@ class PipelineRunner:
                 try:
                     await save_candidate_failed(i, state)
                 except PipelineStatePersistenceError as persistence_exc:
-                    await event_queue.put(persistence_exc)
+                    await put_candidate_event(persistence_exc)
                     return
-                await event_queue.put(
+                await put_candidate_event(
                     PipelineEvent(
                         type=PipelineEventType.SUB_PIPELINE_COMPLETED,
                         step_id=None,
@@ -4529,7 +4564,7 @@ class PipelineRunner:
                 )
             finally:
                 self._active_candidates.pop(i, None)
-                await event_queue.put(CandidateSentinel(candidate_index=i))
+                await put_candidate_event(CandidateSentinel(candidate_index=i))
 
         tasks: list[asyncio.Task | None] = []
         initial_done_count = 0
@@ -4567,7 +4602,7 @@ class PipelineRunner:
             done_count = initial_done_count
             total = len(candidates)
             while done_count < total:
-                event = await event_queue.get()
+                _priority, _sequence, event = await event_queue.get()
                 if isinstance(event, PipelineStatePersistenceError):
                     yield self._persistence_failure_event(event)
                     return

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -10,6 +10,7 @@ import logging
 import os
 import stat
 import time
+from collections import deque
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -381,12 +382,6 @@ class CandidateSentinel:
     candidate_index: int
 
 
-_PARALLEL_PRIORITY_PIPELINE_EVENTS = {
-    PipelineEventType.SUB_PIPELINE_STARTED,
-    PipelineEventType.SUB_STEP_STARTED,
-}
-
-
 def _unwrap_sub_pipeline_stream_event(event: Any) -> Any:
     while isinstance(event, SubPipelineStreamEvent):
         event = event.inner
@@ -395,8 +390,6 @@ def _unwrap_sub_pipeline_stream_event(event: Any) -> Any:
 
 def _parallel_sub_pipeline_event_priority(event: Any) -> int:
     if isinstance(event, (PipelineStatePersistenceError, SessionBackupBlocked)):
-        return 0
-    if isinstance(event, PipelineEvent) and event.type in _PARALLEL_PRIORITY_PIPELINE_EVENTS:
         return 0
     inner = _unwrap_sub_pipeline_stream_event(event)
     if isinstance(inner, (PermissionRequestEvent, AskUserQuestionEvent)):
@@ -4235,7 +4228,9 @@ class PipelineRunner:
 
         self._active_candidates.clear()
 
-        event_queue: asyncio.PriorityQueue[tuple[int, int, Any]] = asyncio.PriorityQueue()
+        candidate_event_queues: list[deque[tuple[int, int, Any]]] = [deque() for _ in candidates]
+        event_available = asyncio.Event()
+        next_candidate_index = 0
         event_sequence = 0
         conclusions_by_index: dict[int, dict] = {}
         failed_by_index: dict[int, dict[str, Any]] = {}
@@ -4339,10 +4334,36 @@ class PipelineRunner:
             failed_by_index[i] = dict(entry)
             await self._save_running(step.step_id, reason="parallel candidate failed")
 
-        async def put_candidate_event(event: Any) -> None:
+        async def put_candidate_event(candidate_index: int, event: Any) -> None:
             nonlocal event_sequence
             event_sequence += 1
-            await event_queue.put((_parallel_sub_pipeline_event_priority(event), event_sequence, event))
+            priority = _parallel_sub_pipeline_event_priority(event)
+            candidate_event_queues[candidate_index].append((priority, event_sequence, event))
+            event_available.set()
+
+        async def get_candidate_event() -> Any:
+            nonlocal next_candidate_index
+            while True:
+                priority_head = min(
+                    (
+                        (candidate_queue[0][1], candidate_index)
+                        for candidate_index, candidate_queue in enumerate(candidate_event_queues)
+                        if candidate_queue and candidate_queue[0][0] == 0
+                    ),
+                    default=None,
+                )
+                if priority_head is not None:
+                    _sequence, candidate_index = priority_head
+                    return candidate_event_queues[candidate_index].popleft()[2]
+
+                for offset in range(len(candidate_event_queues)):
+                    candidate_index = (next_candidate_index + offset) % len(candidate_event_queues)
+                    if candidate_event_queues[candidate_index]:
+                        next_candidate_index = (candidate_index + 1) % len(candidate_event_queues)
+                        return candidate_event_queues[candidate_index].popleft()[2]
+
+                event_available.clear()
+                await event_available.wait()
 
         async def run_candidate(
             i: int,
@@ -4486,13 +4507,13 @@ class PipelineRunner:
                         state["error"] = event.data.get("error")
                         state["error_details"] = event.data.get("error_details")
                         await save_candidate_failed(i, state)
-                    await put_candidate_event(event)
+                    await put_candidate_event(i, event)
             except asyncio.CancelledError:
                 logger.debug("Candidate %d cancelled", i)
             except PipelineStatePersistenceError as exc:
-                await put_candidate_event(exc)
+                await put_candidate_event(i, exc)
             except SessionBackupBlocked as exc:
-                await put_candidate_event(exc)
+                await put_candidate_event(i, exc)
             except Exception as exc:
                 failure = public_error_from_exception(exc)
                 error_summary = failure.summary
@@ -4543,9 +4564,10 @@ class PipelineRunner:
                 try:
                     await save_candidate_failed(i, state)
                 except PipelineStatePersistenceError as persistence_exc:
-                    await put_candidate_event(persistence_exc)
+                    await put_candidate_event(i, persistence_exc)
                     return
                 await put_candidate_event(
+                    i,
                     PipelineEvent(
                         type=PipelineEventType.SUB_PIPELINE_COMPLETED,
                         step_id=None,
@@ -4560,11 +4582,11 @@ class PipelineRunner:
                             "error_summary": error_summary,
                             "error_details": failure.details,
                         },
-                    )
+                    ),
                 )
             finally:
                 self._active_candidates.pop(i, None)
-                await put_candidate_event(CandidateSentinel(candidate_index=i))
+                await put_candidate_event(i, CandidateSentinel(candidate_index=i))
 
         tasks: list[asyncio.Task | None] = []
         initial_done_count = 0
@@ -4602,7 +4624,7 @@ class PipelineRunner:
             done_count = initial_done_count
             total = len(candidates)
             while done_count < total:
-                _priority, _sequence, event = await event_queue.get()
+                event = await get_candidate_event()
                 if isinstance(event, PipelineStatePersistenceError):
                     yield self._persistence_failure_event(event)
                     return

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -16,6 +16,7 @@ from iac_code.types.stream_events import (
     DiagramEvent,
     MCPProgressEvent,
     PermissionRequestEvent,
+    ResourceObservedEvent,
     SubPipelineStreamEvent,
     TextDeltaEvent,
     ThinkingDeltaEvent,
@@ -1253,6 +1254,25 @@ def test_stack_current_changed_is_disabled_by_default() -> None:
     assert [envelope["eventType"] for envelope in envelopes] == ["tool_result"]
 
 
+def test_observed_stack_current_changed_is_disabled_by_default() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = translator.translate(
+        ResourceObservedEvent(
+            provider="ros",
+            resource_type="stack",
+            resource_id="stack-123",
+            resource_name="demo",
+            region_id="cn-hangzhou",
+            action="CreateStack",
+            tool_name="ros_stack",
+            tool_use_id="toolu-stack",
+        )
+    )
+
+    assert envelopes == []
+
+
 def test_failed_tool_result_payload_is_sanitized() -> None:
     translator = PipelineEventTranslator(_ctx())
 
@@ -1512,6 +1532,131 @@ def test_stack_current_changed_emits_after_successful_ros_deploy_recreate() -> N
         "isSuccess": True,
         "current": True,
     }
+
+
+def test_stack_current_changed_emits_when_create_stack_resource_is_observed() -> None:
+    ctx = _ctx()
+    ctx.emit_stack_events = True
+    translator = PipelineEventTranslator(ctx)
+    translator.translate(
+        PipelineEvent(
+            type=PipelineEventType.STEP_STARTED,
+            step_id="deploying",
+            timestamp=time.time(),
+            data={"index": 5, "total": 5},
+        )
+    )
+    translator.translate(
+        ToolUseEndEvent(
+            tool_use_id="toolu-deploy",
+            name="ros_deploy",
+            input={
+                "action": "create",
+                "stack_name": "demo",
+                "template_url": "templates/demo.yml",
+                "region_id": "cn-hangzhou",
+            },
+        )
+    )
+
+    envelopes = translator.translate(
+        ResourceObservedEvent(
+            provider="ros",
+            resource_type="stack",
+            resource_id="stack-123",
+            resource_name="demo",
+            region_id="cn-hangzhou",
+            action="CreateStack",
+            tool_name="ros_stack",
+            tool_use_id="toolu-deploy",
+        )
+    )
+
+    assert len(envelopes) == 1
+    stack_event = envelopes[0]
+    assert stack_event["eventType"] == "stack_current_changed"
+    assert stack_event["scope"] == "stack"
+    assert stack_event["step"]["id"] == "deploying"
+    assert stack_event["data"] == {
+        "toolName": "ros_deploy",
+        "toolUseId": "toolu-deploy",
+        "provider": "ros",
+        "action": "CreateStack",
+        "regionId": "cn-hangzhou",
+        "stackId": "stack-123",
+        "stackName": "demo",
+        "stackStatus": "CREATE_IN_PROGRESS",
+        "isSuccess": True,
+        "current": True,
+    }
+
+
+def test_stack_current_changed_emits_for_observed_resource_in_sub_pipeline() -> None:
+    ctx = _ctx()
+    ctx.emit_stack_events = True
+    translator = PipelineEventTranslator(ctx)
+    translator.translate(
+        PipelineEvent(
+            type=PipelineEventType.STEP_STARTED,
+            step_id="evaluate_candidates",
+            timestamp=time.time(),
+            data={"index": 3, "total": 5},
+        )
+    )
+    translator.translate(
+        PipelineEvent(
+            type=PipelineEventType.SUB_PIPELINE_STARTED,
+            step_id=None,
+            timestamp=time.time(),
+            data={
+                "sub_pipeline_id": "evaluate_candidate_abcd",
+                "candidate_index": 0,
+                "candidate_name": "candidate",
+                "parent_step_id": "evaluate_candidates",
+            },
+        )
+    )
+    translator.translate(
+        SubPipelineStreamEvent(
+            sub_pipeline_id="evaluate_candidate_abcd",
+            candidate_index=0,
+            inner=ToolUseEndEvent(
+                tool_use_id="toolu-deploy",
+                name="ros_deploy",
+                input={
+                    "action": "create",
+                    "stack_name": "demo",
+                    "template_url": "templates/demo.yml",
+                    "region_id": "cn-hangzhou",
+                },
+            ),
+        )
+    )
+
+    envelopes = translator.translate(
+        SubPipelineStreamEvent(
+            sub_pipeline_id="evaluate_candidate_abcd",
+            candidate_index=0,
+            inner=ResourceObservedEvent(
+                provider="ros",
+                resource_type="stack",
+                resource_id="stack-123",
+                resource_name="demo",
+                region_id="cn-hangzhou",
+                action="CreateStack",
+                tool_name="ros_stack",
+                tool_use_id="toolu-deploy",
+            ),
+        )
+    )
+
+    assert len(envelopes) == 1
+    stack_event = envelopes[0]
+    assert stack_event["eventType"] == "stack_current_changed"
+    assert stack_event["step"]["id"] == "evaluate_candidates"
+    assert stack_event["candidate"]["index"] == 0
+    assert stack_event["data"]["stackId"] == "stack-123"
+    assert stack_event["data"]["stackStatus"] == "CREATE_IN_PROGRESS"
 
 
 def test_stack_current_changed_keeps_current_stack_after_statusless_successful_delete() -> None:

--- a/tests/pipeline/engine/test_parallel_streaming.py
+++ b/tests/pipeline/engine/test_parallel_streaming.py
@@ -1,3 +1,4 @@
+import asyncio
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
@@ -5,7 +6,7 @@ import pytest
 
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.pipeline.engine.pipeline_runner import PipelineRunner
-from iac_code.types.stream_events import SubPipelineStreamEvent, TextDeltaEvent
+from iac_code.types.stream_events import PermissionRequestEvent, SubPipelineStreamEvent, TextDeltaEvent
 
 
 class TestSubPipelineStreamEvent:
@@ -235,6 +236,140 @@ class TestSubPipelineExecutorStreaming:
 
 
 class TestPipelineRunnerParallelStreaming:
+    @staticmethod
+    def _unwrap_sub_pipeline_event(event):
+        while isinstance(event, SubPipelineStreamEvent):
+            event = event.inner
+        return event
+
+    @pytest.mark.asyncio
+    async def test_parallel_step_prioritizes_permission_requests_over_streaming_text(self, tmp_path):
+        """Permission requests unblock tools and must not queue behind another candidate's text flood."""
+        (tmp_path / "prompts").mkdir(exist_ok=True)
+        (tmp_path / "prompts" / "arch.md").write_text("Arch", encoding="utf-8")
+        (tmp_path / "prompts" / "eval.md").write_text("Eval", encoding="utf-8")
+        (tmp_path / "prompts" / "template.md").write_text("T", encoding="utf-8")
+        (tmp_path / "pipeline.yaml").write_text(
+            dedent("""\
+            name: test
+            context_dependencies:
+              architecture: []
+              evaluated: [architecture]
+            max_rollbacks: 3
+            sub_pipelines:
+              evaluate_candidate:
+                max_rollbacks: 2
+                iterate_over: architecture.candidates
+                context_fields_from_parent: []
+                steps:
+                  - id: template_gen
+                    conclusion_field: template
+                    forward: null
+                    prompt: prompts/template.md
+                    context_fields: [candidate]
+            steps:
+              - id: arch
+                conclusion_field: architecture
+                forward: eval
+                prompt: prompts/arch.md
+              - id: eval
+                type: parallel_sub_pipeline
+                sub_pipeline: evaluate_candidate
+                conclusion_field: evaluated
+                forward: null
+                prompt: prompts/eval.md
+        """),
+            encoding="utf-8",
+        )
+
+        storage = MagicMock()
+        storage.session_path.return_value = MagicMock()
+        runner = PipelineRunner(
+            pipeline_dir=tmp_path,
+            provider_manager=MagicMock(),
+            base_tool_registry=MagicMock(),
+            session_storage=storage,
+            session_id="test123",
+        )
+        runner.context.set_conclusion("architecture", {"candidates": [{"name": "Plan A"}, {"name": "Plan B"}]})
+        runner.state_machine.advance()
+
+        text_flood_enqueued = asyncio.Event()
+
+        async def fake_streaming(
+            sub_spec,
+            candidate,
+            candidate_index,
+            parent_context,
+            session_id,
+            *,
+            start_from_step=None,
+            preserved_conclusions=None,
+            user_message=None,
+            parent_step_id=None,
+        ):
+            sub_pipeline_id = f"eval_{candidate_index}"
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_PIPELINE_STARTED,
+                step_id=None,
+                timestamp=0,
+                data={
+                    "sub_pipeline_id": sub_pipeline_id,
+                    "candidate_index": candidate_index,
+                    "candidate_name": candidate["name"],
+                    "total_steps": 1,
+                    "sub_pipeline_name": "evaluate_candidate",
+                },
+            )
+            if candidate_index == 0:
+                for i in range(25):
+                    yield SubPipelineStreamEvent(
+                        sub_pipeline_id=sub_pipeline_id,
+                        candidate_index=candidate_index,
+                        inner=TextDeltaEvent(text=f"flood-{i}"),
+                    )
+                text_flood_enqueued.set()
+                await asyncio.sleep(1)
+                return
+
+            await text_flood_enqueued.wait()
+            future: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+            yield SubPipelineStreamEvent(
+                sub_pipeline_id=sub_pipeline_id,
+                candidate_index=candidate_index,
+                inner=PermissionRequestEvent(
+                    tool_name="write_file",
+                    tool_input={"path": "main.tf", "content": "x"},
+                    tool_use_id="toolu-write",
+                    response_future=future,
+                ),
+            )
+            await future
+
+        with patch("iac_code.pipeline.engine.pipeline_runner.SubPipelineExecutor") as mock_exec:
+            instances = [MagicMock(), MagicMock()]
+            for instance in instances:
+                instance.execute_streaming = fake_streaming
+            mock_exec.side_effect = instances
+
+            gen = runner._continue_from_current()
+            seen_before_permission = []
+            try:
+                while True:
+                    event = await asyncio.wait_for(anext(gen), timeout=1)
+                    inner = self._unwrap_sub_pipeline_event(event)
+                    if isinstance(inner, PermissionRequestEvent):
+                        assert inner.response_future is not None
+                        inner.response_future.set_result(True)
+                        break
+                    seen_before_permission.append(event)
+            finally:
+                await gen.aclose()
+
+        assert not any(
+            isinstance(self._unwrap_sub_pipeline_event(event), TextDeltaEvent) for event in seen_before_permission
+        )
+
     @pytest.mark.asyncio
     async def test_parallel_step_yields_events_in_realtime(self, tmp_path):
         """Events should arrive during execution, not batched after gather."""

--- a/tests/pipeline/engine/test_parallel_streaming.py
+++ b/tests/pipeline/engine/test_parallel_streaming.py
@@ -6,7 +6,13 @@ import pytest
 
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.pipeline.engine.pipeline_runner import PipelineRunner
-from iac_code.types.stream_events import PermissionRequestEvent, SubPipelineStreamEvent, TextDeltaEvent
+from iac_code.types.stream_events import (
+    PermissionRequestEvent,
+    ResourceObservedEvent,
+    SubPipelineStreamEvent,
+    TextDeltaEvent,
+    ToolUseEndEvent,
+)
 
 
 class TestSubPipelineStreamEvent:
@@ -243,8 +249,8 @@ class TestPipelineRunnerParallelStreaming:
         return event
 
     @pytest.mark.asyncio
-    async def test_parallel_step_prioritizes_permission_requests_over_streaming_text(self, tmp_path):
-        """Permission requests unblock tools and must not queue behind another candidate's text flood."""
+    async def test_parallel_step_does_not_starve_permission_requests_behind_streaming_text(self, tmp_path):
+        """A text-heavy candidate must not monopolize normal turns before another candidate's permission."""
         (tmp_path / "prompts").mkdir(exist_ok=True)
         (tmp_path / "prompts" / "arch.md").write_text("Arch", encoding="utf-8")
         (tmp_path / "prompts" / "eval.md").write_text("Eval", encoding="utf-8")
@@ -328,11 +334,33 @@ class TestPipelineRunnerParallelStreaming:
                         candidate_index=candidate_index,
                         inner=TextDeltaEvent(text=f"flood-{i}"),
                     )
+                yield PipelineEvent(
+                    type=PipelineEventType.SUB_STEP_STARTED,
+                    step_id="next_step",
+                    timestamp=1,
+                    data={
+                        "sub_pipeline_id": sub_pipeline_id,
+                        "candidate_index": candidate_index,
+                        "candidate_name": candidate["name"],
+                        "step_id": "next_step",
+                        "step_index": 1,
+                        "total_steps": 2,
+                    },
+                )
                 text_flood_enqueued.set()
                 await asyncio.sleep(1)
                 return
 
             await text_flood_enqueued.wait()
+            yield SubPipelineStreamEvent(
+                sub_pipeline_id=sub_pipeline_id,
+                candidate_index=candidate_index,
+                inner=ToolUseEndEvent(
+                    tool_use_id="toolu-write",
+                    name="write_file",
+                    input={"path": "main.tf", "content": "x"},
+                ),
+            )
             future: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
             yield SubPipelineStreamEvent(
                 sub_pipeline_id=sub_pipeline_id,
@@ -366,9 +394,178 @@ class TestPipelineRunnerParallelStreaming:
             finally:
                 await gen.aclose()
 
-        assert not any(
-            isinstance(self._unwrap_sub_pipeline_event(event), TextDeltaEvent) for event in seen_before_permission
+        text_events_before_permission = [
+            event
+            for event in seen_before_permission
+            if isinstance(self._unwrap_sub_pipeline_event(event), TextDeltaEvent)
+        ]
+        assert len(text_events_before_permission) <= 1
+        assert any(
+            isinstance(self._unwrap_sub_pipeline_event(event), ToolUseEndEvent) for event in seen_before_permission
         )
+
+    @pytest.mark.asyncio
+    async def test_parallel_step_preserves_event_order_within_each_candidate(self, tmp_path):
+        """A later step start must not overtake events from the prior step in the same candidate."""
+        (tmp_path / "prompts").mkdir(exist_ok=True)
+        (tmp_path / "prompts" / "arch.md").write_text("Arch", encoding="utf-8")
+        (tmp_path / "prompts" / "eval.md").write_text("Eval", encoding="utf-8")
+        (tmp_path / "prompts" / "template.md").write_text("T", encoding="utf-8")
+        (tmp_path / "pipeline.yaml").write_text(
+            dedent("""\
+            name: test
+            context_dependencies:
+              architecture: []
+              evaluated: [architecture]
+            max_rollbacks: 3
+            sub_pipelines:
+              evaluate_candidate:
+                max_rollbacks: 2
+                iterate_over: architecture.candidates
+                context_fields_from_parent: []
+                steps:
+                  - id: template_gen
+                    conclusion_field: template
+                    forward: null
+                    prompt: prompts/template.md
+                    context_fields: [candidate]
+            steps:
+              - id: arch
+                conclusion_field: architecture
+                forward: eval
+                prompt: prompts/arch.md
+              - id: eval
+                type: parallel_sub_pipeline
+                sub_pipeline: evaluate_candidate
+                conclusion_field: evaluated
+                forward: null
+                prompt: prompts/eval.md
+        """),
+            encoding="utf-8",
+        )
+
+        storage = MagicMock()
+        storage.session_path.return_value = MagicMock()
+        runner = PipelineRunner(
+            pipeline_dir=tmp_path,
+            provider_manager=MagicMock(),
+            base_tool_registry=MagicMock(),
+            session_storage=storage,
+            session_id="test123",
+        )
+        runner.context.set_conclusion("architecture", {"candidates": [{"name": "Plan A"}, {"name": "Plan B"}]})
+        runner.state_machine.advance()
+
+        candidate_events_enqueued = asyncio.Event()
+
+        async def fake_streaming(
+            sub_spec,
+            candidate,
+            candidate_index,
+            parent_context,
+            session_id,
+            *,
+            start_from_step=None,
+            preserved_conclusions=None,
+            user_message=None,
+            parent_step_id=None,
+        ):
+            sub_pipeline_id = f"eval_{candidate_index}"
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_PIPELINE_STARTED,
+                step_id=None,
+                timestamp=0,
+                data={
+                    "sub_pipeline_id": sub_pipeline_id,
+                    "candidate_index": candidate_index,
+                    "candidate_name": candidate["name"],
+                    "total_steps": 2,
+                    "sub_pipeline_name": "evaluate_candidate",
+                },
+            )
+            if candidate_index == 0:
+                await candidate_events_enqueued.wait()
+                return
+
+            step_data = {
+                "sub_pipeline_id": sub_pipeline_id,
+                "candidate_index": candidate_index,
+                "candidate_name": candidate["name"],
+                "total_steps": 2,
+            }
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_STEP_STARTED,
+                step_id="deploy",
+                timestamp=1,
+                data={**step_data, "step_id": "deploy", "step_index": 0},
+            )
+            yield SubPipelineStreamEvent(
+                sub_pipeline_id=sub_pipeline_id,
+                candidate_index=candidate_index,
+                inner=ToolUseEndEvent(
+                    tool_use_id="toolu-deploy",
+                    name="ros_deploy",
+                    input={"action": "create", "stack_name": "demo", "region_id": "cn-hangzhou"},
+                ),
+            )
+            yield SubPipelineStreamEvent(
+                sub_pipeline_id=sub_pipeline_id,
+                candidate_index=candidate_index,
+                inner=ResourceObservedEvent(
+                    provider="ros",
+                    resource_type="stack",
+                    resource_id="stack-123",
+                    resource_name="demo",
+                    region_id="cn-hangzhou",
+                    action="CreateStack",
+                    tool_name="ros_stack",
+                    tool_use_id="toolu-deploy",
+                ),
+            )
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_STEP_COMPLETED,
+                step_id="deploy",
+                timestamp=2,
+                data={**step_data, "step_id": "deploy", "step_index": 0},
+            )
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_STEP_STARTED,
+                step_id="verify",
+                timestamp=3,
+                data={**step_data, "step_id": "verify", "step_index": 1},
+            )
+            candidate_events_enqueued.set()
+
+        with patch("iac_code.pipeline.engine.pipeline_runner.SubPipelineExecutor") as mock_exec:
+            instances = [MagicMock(), MagicMock()]
+            for instance in instances:
+                instance.execute_streaming = fake_streaming
+            mock_exec.side_effect = instances
+            events = [event async for event in runner._continue_from_current()]
+
+        candidate_events = [
+            event
+            for event in events
+            if (
+                isinstance(event, PipelineEvent)
+                and event.data.get("candidate_index") == 1
+                or isinstance(event, SubPipelineStreamEvent)
+                and event.candidate_index == 1
+            )
+        ]
+        event_order = [
+            event.type if isinstance(event, PipelineEvent) else self._unwrap_sub_pipeline_event(event).type
+            for event in candidate_events
+        ]
+
+        assert event_order[:6] == [
+            PipelineEventType.SUB_PIPELINE_STARTED,
+            PipelineEventType.SUB_STEP_STARTED,
+            "tool_use_end",
+            "resource_observed",
+            PipelineEventType.SUB_STEP_COMPLETED,
+            PipelineEventType.SUB_STEP_STARTED,
+        ]
 
     @pytest.mark.asyncio
     async def test_parallel_step_yields_events_in_realtime(self, tmp_path):


### PR DESCRIPTION
## Summary

- publish the ROS stack identity as soon as stack creation starts so downstream A2A state tracks the current stack
- replace the shared parallel sub-pipeline event queue with one FIFO queue per candidate
- select tool-unblocking permission/question heads first while preserving strict ordering within each candidate
- schedule normal candidate heads round-robin to prevent text or thinking streams from starving other candidates
- add regressions for permission latency and same-candidate event ordering

## Root cause

Parallel sub-pipelines previously merged all events through a single queue. A text-heavy candidate could place a large backlog ahead of another candidate's permission request, leaving tools such as `write_file` and `edit_file` waiting for A2A to consume and resolve the request. A global priority queue avoided that starvation but allowed later lifecycle events to overtake earlier events from the same candidate, which could corrupt A2A candidate-step attribution.

The new scheduler only compares candidate queue heads. This preserves candidate-local FIFO ordering while giving normal candidates fair round-robin turns and promptly publishing exposed permission/question events.

## Validation

- `make format`
- `make lint`
- `make translate`
- `make test` (`9244 passed, 1 skipped`)
