### PR TITLE
Fix ROS template path materialization

### DIFF
--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -530,12 +530,46 @@ def _runtime_json_type_name(value: Any) -> str:
     return "unknown"
 
 
+def _path_is_lexically_under(path: str, root: str) -> bool:
+    path_norm = os.path.normcase(os.path.abspath(path))
+    root_norm = os.path.normcase(os.path.abspath(root))
+    try:
+        return os.path.commonpath((path_norm, root_norm)) == root_norm
+    except ValueError:
+        return False
+
+
+def _materialization_root(root: str) -> tuple[str, str]:
+    logical = os.path.abspath(os.path.expanduser(root or "."))
+    return logical, os.path.realpath(logical)
+
+
+def _absolute_materialization_path(path: str, roots: list[str]) -> Path:
+    absolute = os.path.abspath(path)
+    for root in roots:
+        logical_root, real_root = _materialization_root(root)
+        if not _path_is_lexically_under(absolute, logical_root):
+            continue
+        relative = os.path.relpath(absolute, logical_root)
+        mapped = real_root if relative == "." else os.path.join(real_root, relative)
+        return Path(mapped)
+    return Path(absolute)
+
+
+def _relative_materialization_candidates(path: str, roots: list[str]) -> list[Path]:
+    candidates: list[Path] = []
+    for root in roots:
+        _logical_root, real_root = _materialization_root(root)
+        candidates.append(Path(os.path.abspath(os.path.join(real_root, path))))
+    return candidates
+
+
 def _runtime_materialization_path(path: str, context: ToolContext) -> Path:
     expanded = os.path.expanduser(path)
-    if os.path.isabs(expanded):
-        return Path(os.path.abspath(expanded))
     roots = [context.cwd or ".", *context.relative_read_directories]
-    candidates = [Path(os.path.abspath(os.path.join(root, expanded))) for root in roots]
+    if os.path.isabs(expanded):
+        return _absolute_materialization_path(expanded, roots)
+    candidates = _relative_materialization_candidates(expanded, roots)
     return next((candidate for candidate in candidates if os.path.lexists(candidate)), candidates[0])
 
 

--- a/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
@@ -1729,7 +1729,7 @@ async def test_delegated_local_template_materializes_from_symlinked_logical_cwd(
     logical_cwd = logical_root / "ctx-1"
 
     template_body = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
-    (physical_templates / "template.yml").write_text(template_body, encoding="utf-8")
+    (physical_templates / "template.yml").write_bytes(template_body.encode("utf-8"))
     template_url = (
         "templates/template.yml"
         if template_url_kind == "relative"

--- a/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
@@ -1710,6 +1710,59 @@ async def test_delegated_local_template_is_materialized_only_after_contract_cons
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("template_url_kind", ("relative", "absolute"))
+async def test_delegated_local_template_materializes_from_symlinked_logical_cwd(
+    tmp_path,
+    template_url_kind: str,
+) -> None:
+    from iac_code.tools.cloud.aliyun.runtime import AliyunDelegatedExecutor
+
+    physical_root = tmp_path / "mount-root" / "oss" / "bucket"
+    physical_cwd = physical_root / "ctx-1"
+    physical_templates = physical_cwd / "templates"
+    physical_templates.mkdir(parents=True)
+    logical_root = tmp_path / "workspace"
+    try:
+        logical_root.symlink_to(physical_root, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks are unavailable: {error}")
+    logical_cwd = logical_root / "ctx-1"
+
+    template_body = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
+    (physical_templates / "template.yml").write_text(template_body, encoding="utf-8")
+    template_url = (
+        "templates/template.yml"
+        if template_url_kind == "relative"
+        else str(logical_cwd / "templates" / "template.yml")
+    )
+    contract = _canonical_contract(
+        product="ROS",
+        version="2019-09-10",
+        action="ValidateTemplate",
+    )
+    stages: list[str] = []
+    tool, runtime = _execution_runtime(contract, stages=stages)
+    delegated = AliyunDelegatedExecutor(tool, action="ValidateTemplate")
+    outer_input = {"template_url": template_url, "region_id": "cn-hangzhou"}
+    permission_context = _bound_context(
+        outer_input,
+        tool_name="ros_validate_template",
+        cwd=str(logical_cwd),
+        pipeline_mode=True,
+    )
+
+    permission = await delegated.check_permissions(outer_input, permission_context)
+    assert permission.behavior == "allow"
+    result = await delegated.execute(outer_input, _execution_context(permission_context, permission))
+
+    assert result.is_error is False
+    builder_input = runtime.request_builder.inputs[0]
+    assert builder_input["params"]["TemplateBody"] == template_body
+    assert "TemplateURL" not in builder_input["params"]
+    assert stages.index("contract") < stages.index("materialize") < stages.index("request_builder")
+
+
+@pytest.mark.asyncio
 async def test_delegated_local_template_symlink_fails_before_hooks_and_request_builder(tmp_path) -> None:
     from iac_code.tools.cloud.aliyun.runtime import AliyunDelegatedExecutor
 


### PR DESCRIPTION
## Summary

Fix ROS template body-file materialization so delegated Alibaba Cloud ROS tools resolve local template paths consistently with the workspace read path logic when the logical cwd differs from the physical mount path.

## Root Cause

ROS template API helpers previously joined local `template_url` values against the logical `context.cwd`. In pipeline sessions where the workspace path is a symlink or mount alias, that logical path may not be readable by the materializer even though `read_file` can resolve it through the workspace read roots. This caused local template calls to fail with invalid `body_file` errors.

## Changes

- Map logical workspace roots to their real materialization roots before reading local ROS template files.
- Preserve lexical containment checks for user-supplied relative and absolute paths.
- Add coverage for delegated local template materialization from a symlinked logical cwd for both relative and absolute template paths.

## Validation

- `uv run pytest tests/tools/cloud/aliyun/test_aliyun_api_permissions.py -k 'delegated_local_template'`
- `uv run pytest tests/tools/cloud/aliyun/test_aliyun_api_permissions.py tests/tools/cloud/aliyun/test_ros_template_tools.py`
- `uv run pytest tests/tools/cloud/aliyun/test_aliyun_api.py -k 'local_template_materialization or ros_builtin_alias_preserves_local_template_materialization or hook_passes_correct_resource_types or hook_blocks_validate_with_wrong_resource_types'`
- `uv run ruff check src/iac_code/tools/cloud/aliyun/aliyun_api.py tests/tools/cloud/aliyun/test_aliyun_api_permissions.py`
- `git diff --check`
