### PR TITLE
fix(a2a): recover pipeline waiting input backups

### DIFF
--- a/scripts/a2a/e2e/README.md
+++ b/scripts/a2a/e2e/README.md
@@ -46,6 +46,20 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1
 ```
 
+Run the scenario1 variant that matches the production performance/backup
+configuration and sends the step4 selection without `taskId`:
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
+  --allow-real-cloud \
+  --provider dashscope \
+  --model qwen3.6-plus \
+  --stream-timeout 2400 \
+  --preflight-timeout 60 \
+  --scenario scenario1-performance-backup
+```
+
 Run the full real recovery matrix:
 
 ```bash
@@ -58,6 +72,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --event-timeout 300 \
   --preflight-timeout 60 \
   --scenario scenario1 \
+  --scenario scenario1-performance-backup \
   --scenario selection-waiting \
   --scenario ask-waiting \
   --scenario image-initial \
@@ -101,6 +116,7 @@ the rest of the tests.
 | Scenario | Cut point / special condition | Recovery input | Main assertion |
 | --- | --- | --- | --- |
 | `scenario1` | After pipeline completion and one normal-chat follow-up | Ask what the previous normal-chat question was | Normal-chat history survives restart; VSwitch evidence exists. |
+| `scenario1-performance-backup` | Full `scenario1` with `IAC_CODE_A2A_EXTREME_PERFORMANCE=true` and `IAC_CODE_CONFIG_BACKUP_DIR=<run-dir>/session-backup` | Step4 selection omits `taskId`; later normal-chat recovery also omits `taskId` | Step4 backup snapshot has no stale active task, omitted-`taskId` selection hydrates the recovered task, and full scenario1 completes. |
 | `selection-waiting` | Step 4 waits for candidate selection | `你随便选一个方案。` without `taskId` | Waiting step4 task is recovered and selected; VSwitch evidence exists. |
 | `ask-waiting` | `ask_user_question` waits for user input | Clarification answers without `taskId` | Pending ask input is recovered and pipeline completes; VSwitch evidence exists. |
 | `image-initial` | Initial user message is the static `initial.png` image fixture | Candidate selection text | The image starts the pipeline, reaches step4 selection, completes, and produces VSwitch evidence. |
@@ -165,15 +181,16 @@ When stabilizing changes, run the smaller or more diagnostic cases first:
 
 1. `fault-after-snapshot`
 2. `scenario1`
-3. `selection-waiting`
-4. `ask-waiting`
-5. `image-initial`, `image-ask-waiting`, and `image-selection-waiting`
-6. `image-normal-handoff` and `image-interrupt`
-7. `step1-running` through `step5-running`
-8. `normal-running`
-9. `cancel-step1` through `cancel-step5`
-10. `rollback-step1` through `rollback-step5`
-11. `rollback-step5-cleanup`, then `rollback-step5-cleanup-recovery`
+3. `scenario1-performance-backup`
+4. `selection-waiting`
+5. `ask-waiting`
+6. `image-initial`, `image-ask-waiting`, and `image-selection-waiting`
+7. `image-normal-handoff` and `image-interrupt`
+8. `step1-running` through `step5-running`
+9. `normal-running`
+10. `cancel-step1` through `cancel-step5`
+11. `rollback-step1` through `rollback-step5`
+12. `rollback-step5-cleanup`, then `rollback-step5-cleanup-recovery`
 
 ## Preflight
 

--- a/scripts/a2a/e2e/README.zh-CN.md
+++ b/scripts/a2a/e2e/README.zh-CN.md
@@ -42,6 +42,20 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1
 ```
 
+如果要验证和生产性能/backup 配置一致的 scenario1 变体，并在 step4 选择时不带
+`taskId`，运行：
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
+  --allow-real-cloud \
+  --provider dashscope \
+  --model qwen3.6-plus \
+  --stream-timeout 2400 \
+  --preflight-timeout 60 \
+  --scenario scenario1-performance-backup
+```
+
 如果要跑完整真实恢复矩阵：
 
 ```bash
@@ -54,6 +68,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --event-timeout 300 \
   --preflight-timeout 60 \
   --scenario scenario1 \
+  --scenario scenario1-performance-backup \
   --scenario selection-waiting \
   --scenario ask-waiting \
   --scenario image-initial \
@@ -94,6 +109,7 @@ provider、tool、真实云调用场景默认会被保护住。只有确认要�
 | 场景 | 切点 / 特殊条件 | 恢复时输入 | 主要验收 |
 | --- | --- | --- | --- |
 | `scenario1` | pipeline 完成并完成一轮 normal-chat follow-up 后 | 询问上一条 normal-chat 问题是什么 | normal-chat 历史重启后仍可用；存在 VSwitch 证据。 |
+| `scenario1-performance-backup` | 完整 `scenario1`，并强制 `IAC_CODE_A2A_EXTREME_PERFORMANCE=true`、`IAC_CODE_CONFIG_BACKUP_DIR=<run-dir>/session-backup` | step4 选择不带 `taskId`；后续 normal-chat 恢复也不带 `taskId` | step4 backup 快照没有 stale active task；省略 `taskId` 的选择能 hydrate 到恢复 task；完整 scenario1 通过。 |
 | `selection-waiting` | step4 等待候选方案选择时 | 不带 `taskId` 发送 `你随便选一个方案。` | 能恢复等待中的 step4 task 并完成选择；存在 VSwitch 证据。 |
 | `ask-waiting` | `ask_user_question` 等待用户输入时 | 不带 `taskId` 发送澄清回答 | 能恢复 pending ask 输入并完成 pipeline；存在 VSwitch 证据。 |
 | `image-initial` | 首轮用户消息就是静态 `initial.png` 图片 fixture | 文本选择候选方案 | 图片能启动 pipeline，进入 step4 选择，最终完成并产生 VSwitch 证据。 |
@@ -157,15 +173,16 @@ CLI 覆盖后的文本，才会回退到运行时渲染图片。
 
 1. `fault-after-snapshot`
 2. `scenario1`
-3. `selection-waiting`
-4. `ask-waiting`
-5. `image-initial`、`image-ask-waiting` 和 `image-selection-waiting`
-6. `image-normal-handoff` 和 `image-interrupt`
-7. `step1-running` 到 `step5-running`
-8. `normal-running`
-9. `cancel-step1` 到 `cancel-step5`
-10. `rollback-step1` 到 `rollback-step5`
-11. `rollback-step5-cleanup`，再跑 `rollback-step5-cleanup-recovery`
+3. `scenario1-performance-backup`
+4. `selection-waiting`
+5. `ask-waiting`
+6. `image-initial`、`image-ask-waiting` 和 `image-selection-waiting`
+7. `image-normal-handoff` 和 `image-interrupt`
+8. `step1-running` 到 `step5-running`
+9. `normal-running`
+10. `cancel-step1` 到 `cancel-step5`
+11. `rollback-step1` 到 `rollback-step5`
+12. `rollback-step5-cleanup`，再跑 `rollback-step5-cleanup-recovery`
 
 ## Preflight
 

--- a/scripts/a2a/e2e/run_recovery_scenarios.py
+++ b/scripts/a2a/e2e/run_recovery_scenarios.py
@@ -99,6 +99,7 @@ CLEANUP_EVENT_TYPES = frozenset(
 )
 CLEANUP_ACTIVE_STATUSES = frozenset({"pending", "started", "in_progress", "failed"})
 FAULT_AFTER_SNAPSHOT_POINT = "after_a2a_pipeline_snapshot_saved"
+PERFORMANCE_BACKUP_SCENARIOS = frozenset({"scenario1-performance-backup"})
 IMAGE_TEXT_PROMPT = "请读取图片中的文字，并将图片中的文字作为本轮用户输入执行。"
 STATIC_TEXT_IMAGE_FIXTURE_ROOT = E2E_SCRIPTS_DIR / "fixtures" / "text-images"
 STATIC_TEXT_IMAGE_FIXTURES = {
@@ -479,6 +480,8 @@ class ScenarioHarness:
         self.server_cwd = str(Path(args.server_cwd).expanduser().resolve())
         self.run_dir = _scenario_run_dir(args, scenario)
         self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.notes: list[str] = []
+        self.backup_root: Path | None = None
         self.image_fixtures = TextImageFixtureStore(self.run_dir / "image-fixtures")
         self.workspace_dir = Path(args.cwd).expanduser().resolve() if args.cwd else self.run_dir / "workspace"
         self.workspace_dir.mkdir(parents=True, exist_ok=True)
@@ -497,6 +500,12 @@ class ScenarioHarness:
             model=args.model,
             api_base=args.api_base,
         )
+        if scenario in PERFORMANCE_BACKUP_SCENARIOS:
+            self.backup_root = (self.run_dir / "session-backup").resolve()
+            self.backup_root.mkdir(parents=True, exist_ok=True)
+            self.server_env["IAC_CODE_A2A_EXTREME_PERFORMANCE"] = "true"
+            self.server_env["IAC_CODE_CONFIG_BACKUP_DIR"] = str(self.backup_root)
+            self.notes.append(f"enabled A2A extreme performance and backup dir {self.backup_root}")
         if args.deterministic:
             self.server_env["IAC_CODE_A2A_DETERMINISTIC_RECOVERY"] = "1"
             self.server_env["IAC_CODE_TEST_FAULT_INJECTION"] = "1"
@@ -509,7 +518,6 @@ class ScenarioHarness:
         self.context_id = ""
         self.pipeline_task_id = ""
         self.checks: dict[str, bool] = {}
-        self.notes: list[str] = []
         self.summaries: dict[str, Any] = {}
         self.snapshots: dict[str, Any] = {}
 
@@ -846,6 +854,25 @@ def _run_with_harness(args: argparse.Namespace, scenario: str, callback: Callabl
 
 
 def run_scenario1(args: argparse.Namespace, scenario: str) -> int:
+    return _run_scenario1(args, scenario)
+
+
+def run_scenario1_performance_backup(args: argparse.Namespace, scenario: str) -> int:
+    return _run_scenario1(
+        args,
+        scenario,
+        omit_selection_task_id=True,
+        check_waiting_input_backup=True,
+    )
+
+
+def _run_scenario1(
+    args: argparse.Namespace,
+    scenario: str,
+    *,
+    omit_selection_task_id: bool = False,
+    check_waiting_input_backup: bool = False,
+) -> int:
     def callback(h: ScenarioHarness) -> None:
         initial = h.stream(prompt=args.initial_prompt, name="01-initial", context_id="", task_id="")
         initial = _answer_intervening_ask_inputs(h, initial, name_prefix="01-initial")
@@ -853,7 +880,27 @@ def run_scenario1(args: argparse.Namespace, scenario: str) -> int:
         h.checks["initial input_required is step4 confirm_and_select"] = (
             initial.last_input_required_step_id == "confirm_and_select"
         )
-        selection = h.stream(prompt=args.selection_prompt, name="02-select-candidate")
+        if check_waiting_input_backup:
+            h.checks["performance mode explicitly enabled"] = (
+                h.server_env.get("IAC_CODE_A2A_EXTREME_PERFORMANCE") == "true"
+            )
+            h.checks["backup dir explicitly enabled"] = bool(h.server_env.get("IAC_CODE_CONFIG_BACKUP_DIR"))
+            h.snapshots["step4_backup"] = _waiting_input_backup_snapshots(h)
+            h.checks["step4 backup task is input-required"] = (
+                h.snapshots["step4_backup"].get("task", {}).get("state") == "input-required"
+            )
+            h.checks["step4 backup context has no active task"] = (
+                h.snapshots["step4_backup"].get("context", {}).get("active_task_id") is None
+            )
+        selection = h.stream(
+            prompt=args.selection_prompt,
+            name="02-select-candidate",
+            task_id="" if omit_selection_task_id else None,
+        )
+        if omit_selection_task_id:
+            _add_hydrated_task_checks(h, selection, "selection")
+            h.checks["selection did not report already-working error"] = not _has_already_working_error(selection)
+            h.checks["selection did not report terminal-state error"] = not _has_terminal_state_error(selection)
         h.checks["selection completed pipeline"] = _pipeline_completed(selection)
         h.checks["selection produced normal handoff"] = selection.normal_handoff_ready
         h.snapshots["after_pipeline"] = h.fetch_state("after-pipeline")
@@ -1803,6 +1850,52 @@ def _add_hydrated_task_checks(h: ScenarioHarness, summary: StreamSummary, prefix
     h.checks[f"{prefix} omitted taskId"] = summary.request_task_id == ""
     h.checks[f"{prefix} stayed in recovered context"] = summary.context_id == h.context_id
     h.checks[f"{prefix} hydrated recovered taskId"] = summary.task_id == h.pipeline_task_id
+
+
+def _has_already_working_error(summary: StreamSummary) -> bool:
+    return "Task is already working" in summary.text
+
+
+def _has_terminal_state_error(summary: StreamSummary) -> bool:
+    return "terminal state" in summary.text
+
+
+def _waiting_input_backup_snapshots(h: ScenarioHarness) -> dict[str, Any]:
+    backup_root = getattr(h, "backup_root", None)
+    if backup_root is None:
+        _append_harness_note(h, "cannot inspect backup snapshots: backup root is not configured")
+        return {"error": "backup root is not configured"}
+    cwd, session_id = _pipeline_session_identity(h)
+    if not cwd or not session_id:
+        _append_harness_note(h, "cannot inspect backup snapshots: missing cwd/session_id")
+        return {"error": "missing cwd/session_id"}
+
+    storage = SessionStorage(projects_dir=Path(backup_root) / "projects")
+    deadline = time.monotonic() + 10.0
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            session_dir = storage.v2_session_dir(cwd, session_id)
+            if session_dir is None:
+                last_error = "backup session directory not found"
+            else:
+                task_path = session_dir / "a2a" / "task.json"
+                context_path = session_dir / "a2a" / "context.json"
+                task = json.loads(task_path.read_text(encoding="utf-8"))
+                context = json.loads(context_path.read_text(encoding="utf-8"))
+                if isinstance(task, dict) and isinstance(context, dict):
+                    return {
+                        "sessionDir": str(session_dir),
+                        "task": _redact_json_value(task, h.server_env),
+                        "context": _redact_json_value(context, h.server_env),
+                    }
+                last_error = "backup snapshots are not JSON objects"
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(0.25)
+
+    _append_harness_note(h, f"cannot inspect backup snapshots: {last_error}")
+    return {"error": last_error}
 
 
 def _completed_snapshot_or_stream(h: ScenarioHarness, summary: StreamSummary) -> bool:
@@ -2964,6 +3057,7 @@ _REAL_CLOUD_SCENARIOS = {
     "image-normal-handoff",
     "image-selection-waiting",
     "scenario1",
+    "scenario1-performance-backup",
     "normal-running",
     "ask-waiting",
     "selection-waiting",
@@ -2980,6 +3074,7 @@ _SCENARIOS: dict[str, Callable[[argparse.Namespace, str], int]] = {
     "image-normal-handoff": run_image_normal_handoff,
     "image-selection-waiting": run_image_selection_waiting,
     "scenario1": run_scenario1,
+    "scenario1-performance-backup": run_scenario1_performance_backup,
     "normal-running": run_normal_running,
     "ask-waiting": run_ask_waiting,
     "selection-waiting": run_selection_waiting,

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -324,23 +324,39 @@ class IacCodeA2APipelineExecutor:
             ctx.lock = asyncio.Lock()
 
         if ctx.active_task_id is not None:
-            preserve_active_task = _is_active_task_record(task, ctx.active_task_id)
-            if _is_active_task_request(task, task_id, ctx.active_task_id):
-                with self._request_context(session_id=ctx.session_id):
-                    self._configure_runtime_for_request(ctx.runtime)
-                    routed = await self._route_active_pipeline_interrupt(
+            self._clear_stale_recoverable_active_task(
+                task=task,
+                ctx=ctx,
+                task_id=task_id,
+                context_id=context_id,
+                cwd=cwd,
+            )
+            if ctx.active_task_id is not None:
+                preserve_active_task = _is_active_task_record(task, ctx.active_task_id)
+                if _is_active_task_request(task, task_id, ctx.active_task_id):
+                    with self._request_context(session_id=ctx.session_id):
+                        self._configure_runtime_for_request(ctx.runtime)
+                        routed = await self._route_active_pipeline_interrupt(
+                            event_queue,
+                            task=task,
+                            ctx=ctx,
+                            task_id=task_id,
+                            context_id=context_id,
+                            cwd=cwd,
+                            pipeline_input=pipeline_input,
+                            preserve_task_record=preserve_active_task,
+                        )
+                    if routed:
+                        return True
+                if active_followup_only:
+                    await self._fail_already_active(
                         event_queue,
                         task=task,
-                        ctx=ctx,
                         task_id=task_id,
                         context_id=context_id,
-                        cwd=cwd,
-                        pipeline_input=pipeline_input,
                         preserve_task_record=preserve_active_task,
                     )
-                if routed:
                     return True
-            if active_followup_only:
                 await self._fail_already_active(
                     event_queue,
                     task=task,
@@ -348,15 +364,7 @@ class IacCodeA2APipelineExecutor:
                     context_id=context_id,
                     preserve_task_record=preserve_active_task,
                 )
-                return True
-            await self._fail_already_active(
-                event_queue,
-                task=task,
-                task_id=task_id,
-                context_id=context_id,
-                preserve_task_record=preserve_active_task,
-            )
-            return
+                return
 
         if active_followup_only:
             return False
@@ -679,6 +687,34 @@ class IacCodeA2APipelineExecutor:
         return A2APipelineRuntime(
             agent_runtime=create_agent_runtime(AgentFactoryOptions(model=self._model, session_id=session_id, cwd=cwd)),
         )
+
+    def _clear_stale_recoverable_active_task(
+        self,
+        *,
+        task: Any,
+        ctx: Any,
+        task_id: str,
+        context_id: str,
+        cwd: str,
+    ) -> bool:
+        if not _is_active_task_request(task, task_id, getattr(ctx, "active_task_id", None)):
+            return False
+        if _task_has_live_owner(task):
+            return False
+        try:
+            recoverable_task_id = recoverable_task_id_from_sidecar(
+                cwd=cwd,
+                session_id=ctx.session_id,
+                context_id=context_id,
+            )
+        except Exception:
+            return False
+        if recoverable_task_id != task_id:
+            return False
+        ctx.active_task_id = None
+        ctx.touch()
+        self._task_store.mirror_context(ctx)
+        return True
 
     async def _route_active_pipeline_interrupt(
         self,
@@ -1760,6 +1796,7 @@ class IacCodeA2APipelineExecutor:
             task_snapshot = copy.copy(task)
             task_snapshot.state = state
             context_snapshot = copy.copy(ctx)
+            context_snapshot.active_task_id = None
             self._task_store.mirror_task(task_snapshot)
             self._task_store.mirror_context(context_snapshot)
             return
@@ -3989,6 +4026,11 @@ def _is_active_task_record(task: Any, active_task_id: str | None) -> bool:
 
 def _is_active_task_request(task: Any, task_id: str, active_task_id: str | None) -> bool:
     return _is_active_task_record(task, active_task_id) and task_id == active_task_id
+
+
+def _task_has_live_owner(task: Any) -> bool:
+    active_task = getattr(task, "active_task", None)
+    return active_task is not None and not active_task.done()
 
 
 def _pipeline_sidecar_dir(pipeline: Any, cwd: str, session_id: str) -> Path:

--- a/src/iac_code/a2a/transports/dispatcher.py
+++ b/src/iac_code/a2a/transports/dispatcher.py
@@ -434,12 +434,14 @@ class IacCodeRequestHandler(DefaultRequestHandler):
         self._validate_extensions(context)
         self._validate_pipeline_message_request(params)
         await self._hydrate_recoverable_pipeline_task_id(params)
+        await self._reconcile_recoverable_pipeline_task(params, context)
         return await super().on_message_send(params, context)
 
     async def on_message_send_stream(self, params: SendMessageRequest, context):
         self._validate_extensions(context)
         self._validate_pipeline_message_request(params)
         await self._hydrate_recoverable_pipeline_task_id(params)
+        await self._reconcile_recoverable_pipeline_task(params, context)
         task_id = params.message.task_id or None
         if task_id and isinstance(self.task_store, A2ATaskStore) and await self.task_store.is_task_active(task_id):
             task = await self.task_store.get(task_id, context)
@@ -557,6 +559,47 @@ class IacCodeRequestHandler(DefaultRequestHandler):
             return
         if task_id:
             message.task_id = task_id
+
+    async def _reconcile_recoverable_pipeline_task(self, params: SendMessageRequest, context) -> None:
+        if get_run_mode() is not RunMode.PIPELINE or not isinstance(self.task_store, A2ATaskStore):
+            return
+        message = getattr(params, "message", None)
+        if message is None:
+            return
+        task_id = getattr(message, "task_id", None)
+        if not isinstance(task_id, str) or not task_id:
+            return
+        try:
+            task = await self.task_store.get(task_id, context)
+        except Exception:
+            logger.debug("Failed to load A2A task %s before pipeline reconciliation", task_id, exc_info=True)
+            return
+        if task is None or task.status.state not in TERMINAL_TASK_STATES:
+            return
+
+        context_id = getattr(message, "context_id", None) or getattr(task, "context_id", None)
+        if not isinstance(context_id, str) or not context_id:
+            return
+        try:
+            context_record = await self.task_store.get_context_record(context_id)
+            recoverable_task_id = recoverable_task_id_from_sidecar(
+                cwd=context_record.cwd,
+                session_id=context_record.session_id,
+                context_id=context_id,
+            )
+        except Exception:
+            logger.debug("Failed to inspect recoverable A2A pipeline task %s", task_id, exc_info=True)
+            return
+        if recoverable_task_id != task_id:
+            return
+
+        task.status.CopyFrom(TaskStatus(state=TaskState.Name(TaskState.TASK_STATE_INPUT_REQUIRED)))
+        task.status.timestamp.GetCurrentTime()
+        await self.task_store.save(task, context)
+        if context_record.active_task_id == task_id:
+            context_record.active_task_id = None
+            context_record.touch()
+            self.task_store.mirror_context(context_record)
 
     async def _wait_for_active_message_events(self, active_task) -> None:
         event_queue_agent = getattr(active_task, "_event_queue_agent", None)

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -7526,6 +7526,147 @@ def test_cancel_waiting_input_sidecar_appends_cancel_handoff_as_durable_group(
 
 
 @pytest.mark.asyncio
+async def test_waiting_input_backup_snapshot_drops_active_task_without_mutating_live_context(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import IacCodeA2APipelineExecutor
+
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    task.state = "working"
+    task.active_task = asyncio.current_task()
+    ctx = await store.get_or_create_context(
+        context_id="ctx-1",
+        cwd=str(tmp_path),
+        runtime_factory=lambda _session_id: _fake_runtime(),
+    )
+    ctx.active_task_id = "task-1"
+    store.mirror_task(task)
+    store.mirror_context(ctx)
+
+    executor = IacCodeA2APipelineExecutor(
+        task_store=store,
+        model="qwen3.6-plus",
+        metrics=NoOpA2AMetrics(),
+        artifact_store=None,
+        push_notifier=None,
+        permission_resolver=None,
+        auto_approve_permissions=False,
+        thinking_exposure_types=None,
+    )
+
+    executor._mirror_a2a_snapshots_for_pipeline_publication(
+        {
+            "schemaVersion": "1.0",
+            "eventType": "input_required",
+            "status": "input_required",
+            "taskId": "task-1",
+            "contextId": "ctx-1",
+        },
+        task=task,
+        ctx=ctx,
+    )
+
+    session_dir = SessionStorage().session_dir(str(tmp_path), ctx.session_id)
+    task_snapshot = json.loads((session_dir / "a2a" / "task.json").read_text(encoding="utf-8"))
+    context_snapshot = json.loads((session_dir / "a2a" / "context.json").read_text(encoding="utf-8"))
+
+    assert task_snapshot["state"] == "input-required"
+    assert context_snapshot["active_task_id"] is None
+    assert task.state == "working"
+    assert ctx.active_task_id == "task-1"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_executor_resumes_waiting_input_after_stale_active_task_restore(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from iac_code.a2a.pipeline_executor import IacCodeA2APipelineExecutor
+    from iac_code.a2a.pipeline_paths import a2a_pipeline_dir_for_session
+
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    context_id = "ctx-1"
+    task_id = "task-1"
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    ctx = await store.get_or_create_context(
+        context_id=context_id,
+        cwd=str(cwd),
+        runtime_factory=lambda _session_id: _fake_runtime(),
+    )
+    task = await store.get_or_create_task(task_id=task_id, context_id=context_id)
+    task.state = "input-required"
+    ctx.active_task_id = task_id
+    store.mirror_task(task)
+    store.mirror_context(ctx)
+
+    pipeline_dir = a2a_pipeline_dir_for_session(cwd=str(cwd), session_id=ctx.session_id)
+    pending_input = {
+        "inputId": "input-confirm_and_select-1",
+        "kind": "candidate_selection",
+        "prompt": "请选择方案",
+        "options": [{"name": "方案A", "candidate_index": 0}],
+    }
+    pending_event = {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "eventId": "evt-selection",
+        "sequence": 1,
+        "createdAt": "2026-06-08T10:00:00Z",
+        "eventType": "input_required",
+        "scope": "step",
+        "pipelineRunId": context_id,
+        "taskId": task_id,
+        "contextId": context_id,
+        "pipelineName": "selling",
+        "status": "input_required",
+        "step": {"runId": "step-confirm_and_select-1", "id": "confirm_and_select", "attempt": 1},
+        "input": pending_input,
+        "data": pending_input,
+    }
+    A2APipelineJournal(pipeline_dir).append(pending_event)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([pending_event]))
+
+    session_dir = SessionStorage().session_dir(str(cwd), ctx.session_id)
+    fake_pipeline = FakePipeline([], session_dir=session_dir / "pipeline")
+    fake_pipeline.sidecar_status = "waiting_input"
+    executor = IacCodeA2APipelineExecutor(
+        task_store=store,
+        model="qwen3.6-plus",
+        metrics=NoOpA2AMetrics(),
+        artifact_store=None,
+        push_notifier=None,
+        permission_resolver=None,
+        auto_approve_permissions=False,
+        thinking_exposure_types=None,
+    )
+    monkeypatch.setattr(executor, "_create_pipeline", lambda **_kwargs: fake_pipeline)
+    queue = FakeEventQueue()
+
+    await executor.execute(
+        context=FakeRequestContext(
+            task_id=task_id,
+            context_id=context_id,
+            text="0",
+            metadata={"iac_code": {"cwd": str(cwd)}},
+        ),
+        event_queue=queue,
+        task=task,
+        task_id=task_id,
+        context_id=context_id,
+        cwd=str(cwd),
+        prompt="0",
+    )
+
+    assert fake_pipeline.resume_prompts == ["0"]
+    assert task.state == "input-required"
+    assert ctx.active_task_id is None
+    assert all(
+        event["status"].get("message", {}).get("parts", [{}])[0].get("text") != "Task is already working."
+        for event in _status_events(queue)
+    )
+
+
+@pytest.mark.asyncio
 async def test_cancel_waiting_input_backup_sees_committed_cancel_and_mirrored_task(
     tmp_path: Path,
 ) -> None:

--- a/tests/a2a/test_transport_dispatcher.py
+++ b/tests/a2a/test_transport_dispatcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import json
 from types import SimpleNamespace
 
 import httpx
@@ -9,6 +10,8 @@ from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.types import SubscribeToTaskRequest, Task, TaskState, TaskStatus, TaskStatusUpdateEvent
 
 from iac_code.a2a.pipeline_journal import A2APipelineJournal
+from iac_code.a2a.pipeline_paths import a2a_pipeline_dir_for_session
+from iac_code.a2a.pipeline_snapshot import A2APipelineSnapshotStore, reduce_pipeline_events
 from iac_code.a2a.pipeline_transport_delivery import (
     PipelineTransportDeliveryClosedError,
     bind_pipeline_transport_delivery_tracker,
@@ -26,6 +29,7 @@ from iac_code.a2a.transports.dispatcher import (
     create_runtime_components,
 )
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
+from iac_code.services.session_storage import SessionStorage
 from iac_code.types.stream_events import TextDeltaEvent
 
 from .fakes import FakeAgentLoop, FakeRuntime
@@ -117,6 +121,85 @@ async def test_dispatcher_stream_yields_events(monkeypatch, tmp_path) -> None:
     assert any(event["result"]["status"]["state"] == "working" for event in events)
     assert events[-1]["result"]["status"]["state"] == "input-required"
     await components.aclose()
+
+
+@pytest.mark.asyncio
+async def test_handler_reconciles_terminal_task_when_pipeline_sidecar_is_waiting_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("IAC_CODE_MODE", "pipeline")
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    context_id = "ctx-1"
+    task_id = "task-1"
+    call_context = ServerCallContext()
+    store = A2ATaskStore()
+    ctx = await store.get_or_create_context(
+        context_id=context_id,
+        cwd=str(cwd),
+        runtime_factory=lambda session_id: SimpleNamespace(session_id=session_id),
+    )
+    ctx.active_task_id = task_id
+    store.mirror_context(ctx)
+    await store.save(
+        Task(
+            id=task_id,
+            context_id=context_id,
+            status=TaskStatus(state=TaskState.TASK_STATE_FAILED),
+        ),
+        call_context,
+    )
+
+    pending_input = {
+        "inputId": "input-confirm_and_select-1",
+        "kind": "candidate_selection",
+        "prompt": "请选择方案",
+        "options": [{"name": "方案A", "candidate_index": 0}],
+    }
+    pending_event = {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "eventId": "evt-selection",
+        "sequence": 1,
+        "createdAt": "2026-06-08T10:00:00Z",
+        "eventType": "input_required",
+        "scope": "step",
+        "pipelineRunId": context_id,
+        "taskId": task_id,
+        "contextId": context_id,
+        "pipelineName": "selling",
+        "status": "input_required",
+        "step": {"runId": "step-confirm_and_select-1", "id": "confirm_and_select", "attempt": 1},
+        "input": pending_input,
+        "data": pending_input,
+    }
+    pipeline_dir = a2a_pipeline_dir_for_session(cwd=str(cwd), session_id=ctx.session_id)
+    A2APipelineJournal(pipeline_dir).append(pending_event)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([pending_event]))
+    observed: dict[str, int] = {}
+
+    async def sdk_send(_handler, _params, sdk_context):
+        task = await store.get(task_id, sdk_context)
+        assert task is not None
+        observed["state"] = task.status.state
+        return task
+
+    monkeypatch.setattr(DefaultRequestHandler, "on_message_send", sdk_send)
+    handler = IacCodeRequestHandler.__new__(IacCodeRequestHandler)
+    handler.task_store = store
+    handler._validate_extensions = lambda _context: None
+    handler._validate_pipeline_message_request = lambda _params: None
+    params = SimpleNamespace(message=SimpleNamespace(task_id=task_id, context_id=context_id))
+
+    result = await handler.on_message_send(params, call_context)
+
+    assert isinstance(result, Task)
+    assert observed["state"] == TaskState.TASK_STATE_INPUT_REQUIRED
+    assert result.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+    session_dir = SessionStorage().session_dir(str(cwd), ctx.session_id)
+    context_snapshot = json.loads((session_dir / "a2a" / "context.json").read_text(encoding="utf-8"))
+    assert context_snapshot["active_task_id"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/a2a_e2e/test_run_recovery_scenarios.py
+++ b/tests/a2a_e2e/test_run_recovery_scenarios.py
@@ -245,6 +245,19 @@ def test_image_recovery_scenarios_are_registered() -> None:
         assert scenario in runner._REAL_CLOUD_SCENARIOS
 
 
+def test_scenario1_performance_backup_is_registered_and_requires_real_cloud() -> None:
+    runner = _load_runner()
+
+    assert runner._SCENARIOS["scenario1-performance-backup"] is runner.run_scenario1_performance_backup
+    args = SimpleNamespace(allow_real_cloud=False, deterministic=False)
+    try:
+        runner._validate_scenario_execution(args, "scenario1-performance-backup")
+    except SystemExit as exc:
+        assert "--allow-real-cloud" in str(exc)
+    else:
+        raise AssertionError("scenario1-performance-backup should require --allow-real-cloud")
+
+
 def test_answer_intervening_ask_inputs_reaches_selection(tmp_path: Path) -> None:
     runner = _load_runner()
     initial = runner.StreamSummary(
@@ -600,6 +613,152 @@ def test_fault_after_snapshot_defaults_crash_point(tmp_path: Path) -> None:
     harness = runner.ScenarioHarness(args, scenario="fault-after-snapshot")
 
     assert harness.server_env["IAC_CODE_TEST_CRASH_AT"] == runner.FAULT_AFTER_SNAPSHOT_POINT
+
+
+def test_scenario1_performance_backup_configures_server_env(tmp_path: Path) -> None:
+    runner = _load_runner()
+    args = SimpleNamespace(
+        server_cwd=str(tmp_path),
+        run_dir=str(tmp_path / "run"),
+        run_root=str(tmp_path),
+        cwd="",
+        host="127.0.0.1",
+        port=0,
+        no_auto_approve_permissions=False,
+        provider="",
+        model="",
+        api_base="",
+        deterministic=False,
+        fault_at="",
+    )
+
+    harness = runner.ScenarioHarness(args, scenario="scenario1-performance-backup")
+
+    assert harness.server_env["IAC_CODE_A2A_EXTREME_PERFORMANCE"] == "true"
+    assert harness.server_env["IAC_CODE_CONFIG_BACKUP_DIR"] == str((tmp_path / "run" / "session-backup").resolve())
+    assert harness.backup_root == (tmp_path / "run" / "session-backup").resolve()
+
+
+def test_scenario1_performance_backup_omits_selection_task_id_and_checks_backup(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    runner = _load_runner()
+    harnesses = []
+
+    class FakeHarness:
+        def __init__(self, args) -> None:
+            self.args = args
+            self.run_dir = tmp_path
+            self.workspace_dir = tmp_path / "workspace"
+            self.workspace_dir.mkdir()
+            self.server_env = {
+                "IAC_CODE_A2A_EXTREME_PERFORMANCE": "true",
+                "IAC_CODE_CONFIG_BACKUP_DIR": str(tmp_path / "backup"),
+            }
+            self.context_id = ""
+            self.pipeline_task_id = ""
+            self.checks = {}
+            self.notes = []
+            self.summaries = {}
+            self.snapshots = {}
+            self.stream_request_task_ids = {}
+
+        def stream(
+            self,
+            *,
+            prompt: str,
+            name: str,
+            context_id: str | None = None,
+            task_id: str | None = None,
+            **_kwargs,
+        ):
+            if context_id == "":
+                self.context_id = "ctx-1"
+            if not self.context_id:
+                self.context_id = "ctx-1"
+            if not self.pipeline_task_id:
+                self.pipeline_task_id = "task-1"
+            request_task_id = self.pipeline_task_id if task_id is None else task_id
+            self.stream_request_task_ids[name] = request_task_id
+            if name == "01-initial":
+                summary = runner.StreamSummary(
+                    name=name,
+                    prompt=prompt,
+                    request_task_id=request_task_id,
+                    context_id=self.context_id,
+                    task_id=self.pipeline_task_id,
+                    status_states=["TASK_STATE_INPUT_REQUIRED"],
+                    pipeline_event_types=["input_required"],
+                    last_input_required_step_id="confirm_and_select",
+                )
+            elif name == "02-select-candidate":
+                summary = runner.StreamSummary(
+                    name=name,
+                    prompt=prompt,
+                    request_task_id=request_task_id,
+                    context_id=self.context_id,
+                    task_id=self.pipeline_task_id,
+                    status_states=["TASK_STATE_COMPLETED"],
+                    pipeline_event_types=["input_received", "step_completed", "pipeline_completed"],
+                    normal_handoff_ready=True,
+                    text="created ALIYUN::ECS::VSwitch",
+                )
+            else:
+                summary = runner.StreamSummary(
+                    name=name,
+                    prompt=prompt,
+                    request_task_id=request_task_id,
+                    context_id=self.context_id,
+                    task_id=f"{name}-task",
+                    status_states=["TASK_STATE_COMPLETED"],
+                    text="created ALIYUN::ECS::VSwitch",
+                )
+            self.summaries[name] = summary
+            return summary
+
+        def fetch_state(self, name: str):
+            return {
+                "snapshot": {
+                    "contextId": self.context_id,
+                    "taskId": self.pipeline_task_id,
+                    "status": "completed",
+                    "normalHandoff": {"action": "switch_to_normal", "targetMode": "normal"},
+                }
+            }
+
+        def kill9_and_restart(self) -> None:
+            pass
+
+    def fake_run_with_harness(args, _scenario, callback):
+        harness = FakeHarness(args)
+        harnesses.append(harness)
+        callback(harness)
+        return 0 if all(harness.checks.values()) else 1
+
+    monkeypatch.setattr(runner, "_run_with_harness", fake_run_with_harness)
+    monkeypatch.setattr(
+        runner,
+        "_waiting_input_backup_snapshots",
+        lambda _h: {"task": {"state": "input-required"}, "context": {"active_task_id": None}},
+    )
+    monkeypatch.setattr(runner, "_a2a_session_contains_user_message", lambda _h, _text: True)
+    monkeypatch.setattr(runner, "_all_evidence", lambda _h: "ALIYUN::ECS::VSwitch")
+    monkeypatch.setattr(runner, "_run_dir_has_cleanup_events", lambda _run_dir: False)
+    monkeypatch.setattr(runner, "_session_has_cleanup_prompt", lambda _h: False)
+    monkeypatch.setattr(runner, "_cleanup_ledger_has_required_resources", lambda _h: False)
+    args = SimpleNamespace(
+        initial_prompt=runner.DEFAULT_INITIAL_PROMPT,
+        selection_prompt=runner.DEFAULT_SELECTION_PROMPT,
+        normal_followup_prompt=runner.DEFAULT_NORMAL_FOLLOWUP_PROMPT,
+        recovery_prompt=runner.DEFAULT_RECOVERY_PROMPT,
+    )
+
+    assert runner.run_scenario1_performance_backup(args, "scenario1-performance-backup") == 0
+    assert harnesses[0].stream_request_task_ids["02-select-candidate"] == ""
+    assert harnesses[0].checks["selection omitted taskId"] is True
+    assert harnesses[0].checks["selection hydrated recovered taskId"] is True
+    assert harnesses[0].checks["step4 backup context has no active task"] is True
 
 
 def test_fault_after_snapshot_requires_real_cloud_opt_in_even_when_deterministic() -> None:


### PR DESCRIPTION
## Summary

Fix A2A pipeline continuation recovery when performance mode and session backup copying capture a step4 waiting-input state.

## Root Cause

In extreme performance mode, pipeline events are published through the outbound queue while backup copies the session directory around publication time. For `input-required` pipeline events, the A2A task snapshot was mirrored as `input-required`, but the context snapshot could still contain the live in-process `active_task_id`.

After restoring from that backup, the task looked like a recoverable waiting-input task, while the context still looked actively owned. A follow-up without `taskId` could then hydrate the old task and hit `Task is already working.`. That failed status could poison the SDK task into terminal `FAILED`, causing later retries to fail earlier with `Task ... is in terminal state: 4`.

## Changes

- Mirror `input-required` backup snapshots with `context.active_task_id = None` without mutating the live context.
- Clear stale recoverable `active_task_id` in the pipeline executor when the same task is recoverable from sidecar and has no live owner.
- Reconcile an already-poisoned terminal SDK task back to `input-required` before the A2A SDK terminal guard when sidecar proves the pipeline is still waiting for input.
- Add regression coverage for backup snapshot shape, stale active-task recovery, and terminal-task reconciliation.
- Add `scripts/a2a/e2e` scenario `scenario1-performance-backup`, which explicitly enables performance mode and backup dir, omits `taskId` for the step4 selection, and verifies the backup mirror plus full scenario1 flow.

## Validation

- `uv run --all-extras pytest tests/a2a -q` -> `1343 passed`
- `uv run --all-extras pytest tests/a2a/test_pipeline_executor.py tests/a2a/test_transport_dispatcher.py tests/a2a_e2e/test_run_recovery_scenarios.py -q` -> `229 passed`
- `uv run --all-extras pytest tests/a2a_e2e/test_run_recovery_scenarios.py -q` -> `48 passed`
- `uv run --all-extras ruff check ...` -> passed
- `uv run --all-extras python -m py_compile scripts/a2a/e2e/run_recovery_scenarios.py scripts/a2a/e2e/common.py` -> passed
- `git diff --check` -> passed
- Real E2E: `scenario1-performance-backup` -> PASS

Real E2E run dir:

`/var/folders/mj/nr6v3rsj3qs6sb6g27lf9zr80000gn/T/iac-code-a2a-e2e-runs/scenario1-performance-backup/20260721T094429Z-39422-bfe816da`
