### PR TITLE
fix(diagram): use minimum required reasoning

### DIFF
--- a/src/iac_code/pipeline/engine/architecture_semantic_planning.py
+++ b/src/iac_code/pipeline/engine/architecture_semantic_planning.py
@@ -30,7 +30,7 @@ from typing import Any, NamedTuple
 from rich.console import Console
 
 from iac_code.agent.system_prompt import DYNAMIC_BOUNDARY, split_by_dynamic_boundary
-from iac_code.config import DEFAULT_MODEL, load_credentials, load_saved_model
+from iac_code.config import DEFAULT_MODEL, get_active_provider_key, load_credentials, load_saved_model
 from iac_code.i18n import setup_i18n
 from iac_code.pipeline.engine.architecture_graph import (
     ArchitectureMultiViewRenderResult,
@@ -39,6 +39,7 @@ from iac_code.pipeline.engine.architecture_graph import (
 )
 from iac_code.providers.base import Message
 from iac_code.providers.manager import ProviderManager
+from iac_code.providers.thinking import get_thinking_spec
 from iac_code.ui.diagram_rendering import style_attachment_lines
 
 MAX_SEMANTIC_PLAN_ATTEMPTS = 3
@@ -2153,6 +2154,18 @@ async def create_semantic_plan_with_llm(
     return response.text, semantic_plan, response.usage, parse_error
 
 
+def _resolve_semantic_plan_effort(model: str, effort_override: str | None) -> str | None:
+    if effort_override != "none":
+        return effort_override
+    provider_key = get_active_provider_key()
+    if not provider_key:
+        return effort_override
+    spec = get_thinking_spec(provider_key, model)
+    if spec.supports_disable or not spec.allowed_efforts:
+        return effort_override
+    return spec.allowed_efforts[0].value
+
+
 async def create_semantic_plan_for_architecture_with_llm(
     architecture_context: dict[str, Any],
     template_content: str,
@@ -2165,6 +2178,7 @@ async def create_semantic_plan_for_architecture_with_llm(
     """Create a repaired semantic plan using the same LLM loop as the preview script."""
     llm_architecture_context = build_llm_architecture_context(architecture_context)
     selected_model = model or load_saved_model() or DEFAULT_MODEL
+    effective_effort = _resolve_semantic_plan_effort(selected_model, effort_override)
     max_attempts = max(1, max_attempts)
 
     validation_issues: list[str] = []
@@ -2187,7 +2201,7 @@ async def create_semantic_plan_for_architecture_with_llm(
             llm_architecture_context,
             model=selected_model,
             max_tokens=max_tokens,
-            effort_override=effort_override,
+            effort_override=effective_effort,
             user_prompt=user_prompt,
             messages=request_messages,
             attempt=attempt,

--- a/tests/scripts/test_preview_template_architecture_llm.py
+++ b/tests/scripts/test_preview_template_architecture_llm.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from iac_code.pipeline.engine import architecture_semantic_planning
+
 
 def _load_script_module():
     script_path = Path("scripts/rendering/preview_template_architecture_llm.py")
@@ -16,6 +18,22 @@ def _load_script_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_semantic_plan_uses_lowest_effort_when_thinking_cannot_be_disabled(monkeypatch):
+    monkeypatch.setattr(architecture_semantic_planning, "get_active_provider_key", lambda: "dashscope_token_plan")
+
+    effort = architecture_semantic_planning._resolve_semantic_plan_effort("qwen3.8-max-preview", "none")
+
+    assert effort == "low"
+
+
+def test_semantic_plan_keeps_none_when_thinking_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(architecture_semantic_planning, "get_active_provider_key", lambda: "dashscope_token_plan")
+
+    effort = architecture_semantic_planning._resolve_semantic_plan_effort("qwen3.7-plus", "none")
+
+    assert effort == "none"
 
 
 def test_extract_semantic_plan_json_accepts_fenced_json():


### PR DESCRIPTION
## Summary

- Use the lowest supported reasoning effort when architecture semantic planning requests `none` but the selected model cannot disable thinking.
- Keep existing behavior for models that support disabling thinking and for explicit non-`none` effort overrides.

## Root cause

`qwen3.8-max-preview` is an always-thinking model. The architecture optimizer requested `none`, which could not be sent to the model and therefore fell back to the service default reasoning level, causing long blocking waits before candidate selection became available.

## Impact

Architecture diagram optimization now sends `reasoning_effort=low` for `qwen3.8-max-preview`, reducing latency without changing timeout, retry, rendering, or selection behavior.

## Validation

- 121 architecture semantic planning tests passed.
- 90 DashScope provider and model protocol tests passed.
- Ruff checks passed.