### PR TITLE
fix(aliyun): preserve approved local file paths

### DIFF
--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -122,7 +122,7 @@ ros_validate_template(
 3. 修复模板并**写回原文件路径**（后续部署步骤从此路径读取，不写回会导致后续步骤使用错误模板）
 4. 重新校验（最多 7 轮）
 
-> **模板路径支持本地文件**：`template_url` 可传本地路径（如 `/tmp/template.yml`）。避免将大模板内容直接作为参数传递。
+> **模板路径支持本地文件**：`template_url` 可传当前工作目录内的本地路径（如 `./template.yml`）。避免将大模板内容直接作为参数传递。
 
 ## 询价参数推荐与传递
 
@@ -147,7 +147,7 @@ PreviewStack 不是硬门禁。它要求完整部署参数，常比询价工具�
 
 ```python
 ros_estimate_template_cost(
-    template_url="/tmp/ros-template.yml",
+    template_url="./ros-template.yml",
     parameters={
         "ZoneId": "cn-hangzhou-k",
         "InstanceType": "ecs.g7.large",

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -128,7 +128,7 @@ conclusion_schema:
 - `ros_deploy` 的 `wait` 只等待已有 Stack 创建完成，不发起创建、继续创建、删除或更新
 - `ros_deploy` 的创建类动作使用装配后的 `parameters` 字典；不要手动展开为 `Parameters.N.ParameterKey`
 
-> **template_url 支持本地文件路径**：`ros_deploy` 的创建类动作中，`template_url` 可传本地文件路径（如 `/tmp/template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
+> **template_url 支持本地文件路径**：`ros_deploy` 的创建类动作中，`template_url` 可传当前工作目录内的本地文件路径（如 `./template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
 
 ## 错误处理
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -41,11 +41,12 @@ conclusion_schema:
 2. 查阅 [references/cloud-products/](references/cloud-products/) 下对应产品文件，了解选型策略和库存相关属性
 3. **必须**阅读 [references/ros-template.md](references/ros-template.md)，了解 ROS 模板最佳实践，未阅读不得生成模板
 4. 生成 ROS YAML 模板（库存相关属性按 [references/cloud-products/](references/cloud-products/) 与 [references/template-parameters.md](references/template-parameters.md) 定义为 Parameters，所有 Parameters 必须添加 AssociationProperty）并写入文件
+   - 生成的模板默认放在当前工作目录；仅当用户指定其他路径时才写入该路径，不要默认使用 `/tmp` 等工作目录外路径
 5. 调用 `ros_validate_template` 校验；`template_url` 使用刚写入的模板文件路径，已有具体地域时传 `region_id`，否则使用工具默认地域
 6. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
 7. 校验通过 → 完成
 
-> **模板路径支持本地文件**：`ros_validate_template` 的 `template_url` 可传本地文件路径（如 `/tmp/template.yml`）。避免将大模板内容直接作为参数传递。
+> **模板路径支持本地文件**：`ros_validate_template` 的 `template_url` 可传当前工作目录内的本地文件路径（如 `./template.yml`）。避免将大模板内容直接作为参数传递。
 
 ## 资源生命周期约束
 

--- a/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
@@ -85,12 +85,13 @@ auto_trigger:
 2. 查阅 [references/cloud-products/](references/cloud-products/) 下对应产品文件，了解选型策略和库存相关属性
 3. **必须**阅读 [references/ros-template.md](references/ros-template.md)，了解 ROS 模板最佳实践（RunCommand、嵌套栈、条件部署、常用函数等），未阅读不得生成模板
 4. 生成模板（库存相关属性按「参数化规则」定义为 Parameters，所有 Parameters 必须添加 AssociationProperty）并写入文件
+   - 生成的模板默认放在当前工作目录；仅当用户指定其他路径时才写入该路径，不要默认使用 `/tmp` 等工作目录外路径
    - **Terraform**：生成 `.tf` 等文件后，必须先用 `tf2ros.py` 打包为 ROS Terraform 类型模板（用法见 [references/terraform-template.md](references/terraform-template.md) 的「与 ROS 集成」节），后续步骤校验/部署的都是这份打包后的 `.yml`
 5. 调用 aliyun_api(product="ros", action="ValidateTemplate", params={"TemplateURL": <模板文件路径>}) 校验
 6. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
 7. 校验通过 → 展示模板 → 询问是否部署（**ROS 与 Terraform 一致**，禁止用 `terraform init/apply` 等本地 CLI 步骤替代部署确认）
 
-> **TemplateURL 支持本地文件路径**：aliyun_api（product=ros）和 ros_stack 中，TemplateURL 可传本地文件路径（如 `/tmp/template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
+> **TemplateURL 支持本地文件路径**：aliyun_api（product=ros）和 ros_stack 中，TemplateURL 可传当前工作目录内的本地文件路径（如 `./template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
 
 ## 部署流程
 
@@ -122,7 +123,7 @@ auto_trigger:
        product="ros",
        action="GetTemplateEstimateCost",
        params={
-           "TemplateURL": "/tmp/ros-ecs-nginx-template.yml",
+           "TemplateURL": "./ros-ecs-nginx-template.yml",
            "Parameters": {
                "zone_id": "cn-hangzhou-k",
                "instance_type": "ecs.g7.large",

--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -13,7 +13,7 @@ import os
 import re
 import time
 from collections.abc import Mapping
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Literal
@@ -42,6 +42,7 @@ from iac_code.tools.cloud.aliyun.api_contract import (
 )
 from iac_code.tools.cloud.aliyun.api_identifiers import SAFE_API_VERSION
 from iac_code.tools.cloud.aliyun.contract_store import (
+    AuthorizedReadPath,
     ResolvedContractError,
     ResolvedContractRecovery,
     ResolvedContractStore,
@@ -65,6 +66,7 @@ from iac_code.tools.cloud.aliyun.template_source import (
 )
 from iac_code.tools.cloud.aliyun.user_agent import build_user_agent
 from iac_code.tools.cloud.base_api import BaseCloudApi
+from iac_code.tools.path_safety import check_read_path_with_resolution
 from iac_code.types.permissions import (
     MAX_PERMISSION_AUDIT_ITEMS,
     ExecutionClass,
@@ -78,6 +80,14 @@ from iac_code.types.permissions import (
 from iac_code.types.stream_events import ResourceObservedEvent
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _RuntimeFileAuthorization:
+    source: Literal["template", "body_file"]
+    resolved_path: str
+    permission: PermissionResult | None
+
 
 VERSION_MAP = {
     "ros": "2019-09-10",
@@ -571,6 +581,17 @@ def _runtime_materialization_path(path: str, context: ToolContext) -> Path:
         return _absolute_materialization_path(expanded, roots)
     candidates = _relative_materialization_candidates(expanded, roots)
     return next((candidate for candidate in candidates if os.path.lexists(candidate)), candidates[0])
+
+
+def _authorized_materialization_path(
+    source: Literal["template", "body_file"],
+    authorized_read_paths: tuple[AuthorizedReadPath, ...],
+) -> Path:
+    """Return the physical path bound to the one-shot authorization snapshot."""
+    matches = [entry.path for entry in authorized_read_paths if entry.source == source]
+    if len(matches) != 1 or not os.path.isabs(matches[0]):
+        raise ApiContractError("snapshot_read_path_mismatch")
+    return Path(matches[0])
 
 
 def _runtime_contract_error_stage(error: ApiContractError) -> str | None:
@@ -1148,7 +1169,11 @@ class AliyunApi(BaseCloudApi):
 
         pending_reasons: list[PermissionDecisionReason] = []
         observe("file_permission")
-        for path_result in self._runtime_file_permission_results(normalized, context):
+        file_authorizations = self._runtime_file_authorizations(normalized, context)
+        for authorization in file_authorizations:
+            path_result = authorization.permission
+            if path_result is None:
+                continue
             if path_result.behavior == "deny":
                 return path_result
             if path_result.behavior == "ask" and path_result.reason is not None:
@@ -1225,7 +1250,11 @@ class AliyunApi(BaseCloudApi):
                 )
             if error := _runtime_pipeline_guard(canonical_normalized, pipeline_mode=context.pipeline_mode):
                 return PermissionResult(behavior="deny", message=error)
-            for path_result in self._runtime_file_permission_results(canonical_normalized, context):
+            file_authorizations = self._runtime_file_authorizations(canonical_normalized, context)
+            for authorization in file_authorizations:
+                path_result = authorization.permission
+                if path_result is None:
+                    continue
                 if path_result.behavior == "deny":
                     return path_result
                 if path_result.behavior == "ask" and path_result.reason is not None:
@@ -1320,6 +1349,10 @@ class AliyunApi(BaseCloudApi):
                 contract=contract,
                 security_digest=digest,
                 execution_class=execution_class,
+                authorized_read_paths=tuple(
+                    AuthorizedReadPath(authorization.source, authorization.resolved_path)
+                    for authorization in file_authorizations
+                ),
             )
         except (ResolvedContractError, RuntimeError) as error:
             return PermissionResult(
@@ -1384,20 +1417,46 @@ class AliyunApi(BaseCloudApi):
         input: dict[str, Any],
         context: ToolPermissionContext | ToolContext,
     ) -> list[PermissionResult]:
-        results: list[PermissionResult] = []
-        if path_result := self._check_local_template_url_read_permission(input, context):
-            results.append(path_result)
-        body_file = input.get("body_file")
-        if isinstance(body_file, str) and body_file:
-            if path_result := check_local_template_url_read_permission(body_file, context):
-                results.append(path_result)
-        return results
+        return [
+            authorization.permission
+            for authorization in self._runtime_file_authorizations(input, context)
+            if authorization.permission is not None
+        ]
 
-    def _check_local_template_url_read_permission(
+    def _runtime_file_authorizations(
         self,
         input: dict[str, Any],
         context: ToolPermissionContext | ToolContext,
-    ) -> PermissionResult | None:
+    ) -> list[_RuntimeFileAuthorization]:
+        authorizations: list[_RuntimeFileAuthorization] = []
+        template_url = self._local_template_url(input)
+        if template_url is not None:
+            authorizations.append(self._authorize_runtime_file("template", template_url, context))
+        body_file = input.get("body_file")
+        if isinstance(body_file, str) and body_file:
+            authorizations.append(self._authorize_runtime_file("body_file", body_file, context))
+        return authorizations
+
+    @staticmethod
+    def _authorize_runtime_file(
+        source: Literal["template", "body_file"],
+        path: str,
+        context: ToolPermissionContext | ToolContext,
+    ) -> _RuntimeFileAuthorization:
+        decision, resolution = check_read_path_with_resolution(
+            path,
+            cwd=context.cwd or ".",
+            additional_directories=list(context.additional_directories),
+            trusted_read_directories=list(context.trusted_read_directories),
+            relative_read_directories=list(context.relative_read_directories),
+            strict_read_directories=list(context.strict_read_directories),
+            read_path_violation_behavior=context.read_path_violation_behavior,
+        )
+        permission = None if decision.behavior == "allow" else decision.to_permission_result()
+        return _RuntimeFileAuthorization(source, resolution.path, permission)
+
+    @staticmethod
+    def _local_template_url(input: dict[str, Any]) -> str | None:
         product = input.get("product", "")
         product = _PRODUCT_CANONICAL.get(str(product).lower(), product)
         if product != "ros":
@@ -1406,7 +1465,17 @@ class AliyunApi(BaseCloudApi):
         if not isinstance(params, dict):
             return None
         template_url = input.get(LOCAL_TEMPLATE_PATH_FIELD, params.get("TemplateURL", ""))
-        if not isinstance(template_url, str) or not is_local_template_url(template_url):
+        if not isinstance(template_url, str) or not template_url or not is_local_template_url(template_url):
+            return None
+        return template_url
+
+    def _check_local_template_url_read_permission(
+        self,
+        input: dict[str, Any],
+        context: ToolPermissionContext | ToolContext,
+    ) -> PermissionResult | None:
+        template_url = self._local_template_url(input)
+        if template_url is None:
             return None
         return check_local_template_url_read_permission(template_url, context)
 
@@ -1784,6 +1853,7 @@ class AliyunApi(BaseCloudApi):
 
         recovery_claim: ResolvedContractRecovery | None = None
         contract: CanonicalWireContract | None = None
+        authorized_read_paths: tuple[AuthorizedReadPath, ...] = ()
         try:
             observe("normalize_trust")
             if trust_path == "internal":
@@ -1824,9 +1894,10 @@ class AliyunApi(BaseCloudApi):
             observe("local_authorization")
             if error := _runtime_pipeline_guard(normalized, pipeline_mode=context.pipeline_mode):
                 raise ApiContractError(error)
-            for result in self._runtime_file_permission_results(normalized, context):
-                if result.behavior == "deny" or (trust_path == "internal" and result.behavior == "ask"):
-                    raise ApiContractError(result.message or "aliyun_file_permission_required")
+            if trust_path == "internal":
+                for result in self._runtime_file_permission_results(normalized, context):
+                    if result.behavior in {"ask", "deny"}:
+                        raise ApiContractError(result.message or "aliyun_file_permission_required")
 
             observe("contract")
             recovery_metadata_contract: CanonicalWireContract | None = None
@@ -1841,6 +1912,7 @@ class AliyunApi(BaseCloudApi):
                     binding=context.invocation_binding,
                     security_digest=context.security_digest,
                 )
+                authorized_read_paths = handoff.authorized_read_paths
                 if isinstance(handoff, ResolvedContractRecovery):
                     recovery_claim = handoff
                     contract = await runtime.contract_resolver.resolve(
@@ -1861,9 +1933,10 @@ class AliyunApi(BaseCloudApi):
                 canonical_normalized = _with_canonical_runtime_product(normalized, contract.product)
                 if error := _runtime_pipeline_guard(canonical_normalized, pipeline_mode=context.pipeline_mode):
                     raise ApiContractError(error)
-                for result in self._runtime_file_permission_results(canonical_normalized, context):
-                    if result.behavior == "deny" or (trust_path == "internal" and result.behavior == "ask"):
-                        raise ApiContractError(result.message or "aliyun_file_permission_required")
+                if trust_path == "internal":
+                    for result in self._runtime_file_permission_results(canonical_normalized, context):
+                        if result.behavior in {"ask", "deny"}:
+                            raise ApiContractError(result.message or "aliyun_file_permission_required")
                 normalized = canonical_normalized
             final_shape = _runtime_call_shape(normalized, contract=contract)
             digest = contract.security_digest(final_shape)
@@ -1905,7 +1978,11 @@ class AliyunApi(BaseCloudApi):
             if params.get("TemplateBody") is LOCAL_TEMPLATE_BODY_SENTINEL:
                 if not isinstance(template_path, str) or not template_path:
                     raise ApiContractError("invalid_template_file")
-                resolved_template = _runtime_materialization_path(template_path, context)
+                resolved_template = (
+                    _runtime_materialization_path(template_path, context)
+                    if trust_path == "internal"
+                    else _authorized_materialization_path("template", authorized_read_paths)
+                )
                 template_bytes = await asyncio.to_thread(_read_body_file, resolved_template)
                 try:
                     params["TemplateBody"] = template_bytes.decode("utf-8")
@@ -1913,7 +1990,11 @@ class AliyunApi(BaseCloudApi):
                     raise ApiContractError("invalid_template_file") from error
             body_file = materialized.get("body_file")
             if isinstance(body_file, str):
-                resolved_body_file = _runtime_materialization_path(body_file, context)
+                resolved_body_file = (
+                    _runtime_materialization_path(body_file, context)
+                    if trust_path == "internal"
+                    else _authorized_materialization_path("body_file", authorized_read_paths)
+                )
                 materialized["body_file"] = await asyncio.to_thread(_read_body_file, resolved_body_file)
             region_id = materialized.get("region_id")
             if isinstance(region_id, str) and region_id:

--- a/src/iac_code/tools/cloud/aliyun/contract_store.py
+++ b/src/iac_code/tools/cloud/aliyun/contract_store.py
@@ -28,11 +28,20 @@ class ResolvedContractError(ValueError):
 
 
 @dataclass(frozen=True)
+class AuthorizedReadPath:
+    """Physical file path approved together with an API contract."""
+
+    source: Literal["template", "body_file"]
+    path: str
+
+
+@dataclass(frozen=True)
 class ResolvedContractSnapshot:
     binding: InvocationBinding
     contract: CanonicalWireContract
     security_digest: str
     execution_class: ExecutionClass
+    authorized_read_paths: tuple[AuthorizedReadPath, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -42,6 +51,7 @@ class ResolvedContractRecovery:
     binding: InvocationBinding
     security_digest: str
     execution_class: ExecutionClass
+    authorized_read_paths: tuple[AuthorizedReadPath, ...]
     claim_id: str
 
 
@@ -56,6 +66,7 @@ class _RecoverableSnapshot:
     binding: InvocationBinding
     security_digest: str
     execution_class: ExecutionClass
+    authorized_read_paths: tuple[AuthorizedReadPath, ...]
     state: Literal["evicted", "expired", "recovering"]
     claim_id: str | None = None
 
@@ -112,12 +123,14 @@ class ResolvedContractStore:
         contract: CanonicalWireContract,
         security_digest: str,
         execution_class: ExecutionClass,
+        authorized_read_paths: tuple[AuthorizedReadPath, ...] = (),
     ) -> str:
         snapshot = ResolvedContractSnapshot(
             binding=binding,
             contract=contract,
             security_digest=security_digest,
             execution_class=execution_class,
+            authorized_read_paths=authorized_read_paths,
         )
         with self._lock:
             now = self._clock()
@@ -274,6 +287,7 @@ class ResolvedContractStore:
             binding=recoverable.binding,
             security_digest=recoverable.security_digest,
             execution_class=recoverable.execution_class,
+            authorized_read_paths=recoverable.authorized_read_paths,
             state="recovering",
             claim_id=claim_id,
         )
@@ -283,6 +297,7 @@ class ResolvedContractStore:
             binding=claimed.binding,
             security_digest=claimed.security_digest,
             execution_class=claimed.execution_class,
+            authorized_read_paths=claimed.authorized_read_paths,
             claim_id=claim_id,
         )
 
@@ -308,6 +323,7 @@ class ResolvedContractStore:
             binding=snapshot.binding,
             security_digest=snapshot.security_digest,
             execution_class=snapshot.execution_class,
+            authorized_read_paths=snapshot.authorized_read_paths,
             state=state,
         )
         return True

--- a/src/iac_code/tools/path_safety.py
+++ b/src/iac_code/tools/path_safety.py
@@ -278,26 +278,56 @@ def check_read_path(
     read_path_violation_behavior: Literal["ask", "deny"] = "ask",
 ) -> ReadPathDecision:
     """Decide whether a read path is safe or should ask for confirmation."""
-    resolved = resolve_read_path(
+    decision, _resolution = check_read_path_with_resolution(
+        path,
+        cwd=cwd,
+        additional_directories=additional_directories,
+        trusted_read_directories=trusted_read_directories,
+        relative_read_directories=relative_read_directories,
+        strict_read_directories=strict_read_directories,
+        read_path_violation_behavior=read_path_violation_behavior,
+    )
+    return decision
+
+
+def check_read_path_with_resolution(
+    path: str,
+    *,
+    cwd: str,
+    additional_directories: list[str],
+    trusted_read_directories: list[str],
+    relative_read_directories: list[str] | None = None,
+    strict_read_directories: list[str] | None = None,
+    read_path_violation_behavior: Literal["ask", "deny"] = "ask",
+) -> tuple[ReadPathDecision, ReadPathResolution]:
+    """Resolve a read path once and return both its decision and physical path."""
+    resolution = resolve_read_path_with_source(
         path,
         cwd,
         relative_read_directories=relative_read_directories,
     )
+    resolved = resolution.path
 
     if strict_read_directories:
         if _is_in_allowed_roots(resolved, strict_read_directories):
-            return ReadPathDecision("allow")
-        return ReadPathDecision(
-            read_path_violation_behavior,
-            reason_type="path_constraint",
-            detail=_("path outside allowed read directories"),
+            return ReadPathDecision("allow"), resolution
+        return (
+            ReadPathDecision(
+                read_path_violation_behavior,
+                reason_type="path_constraint",
+                detail=_("path outside allowed read directories"),
+            ),
+            resolution,
         )
 
     if _is_in_allowed_roots(resolved, trusted_read_directories):
-        return ReadPathDecision("allow")
+        return ReadPathDecision("allow"), resolution
 
     if _path_hits_sensitive(resolved):
-        return ReadPathDecision("ask", reason_type="safety_check", detail=_("read touches a sensitive path"))
+        return (
+            ReadPathDecision("ask", reason_type="safety_check", detail=_("read touches a sensitive path")),
+            resolution,
+        )
 
     allowed_roots = [
         cwd,
@@ -305,9 +335,12 @@ def check_read_path(
         str(get_iac_code_application_root()),
     ]
     if _is_in_allowed_roots(resolved, allowed_roots):
-        return ReadPathDecision("allow")
+        return ReadPathDecision("allow"), resolution
 
-    return ReadPathDecision("ask", reason_type="path_constraint", detail=_("path outside allowed directories"))
+    return (
+        ReadPathDecision("ask", reason_type="path_constraint", detail=_("path outside allowed directories")),
+        resolution,
+    )
 
 
 def check_write_path(

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -170,6 +170,11 @@ class TestSkillContentRosOnly:
     def test_contains_validate_template(self, body):
         assert "ros_validate_template" in body
 
+    def test_template_path_examples_use_the_working_directory(self, body):
+        assert "`./template.yml`" in body
+        assert 'template_url="./ros-template.yml"' in body
+        assert "/tmp/" not in body
+
     def test_skips_validate_template_when_template_unchanged(self, body):
         assert "避免在成本预估前重复校验" in body
 

--- a/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
@@ -143,6 +143,10 @@ class TestSkillContentRosOnly:
         assert "ros_validate_template" in body
         assert "模板校验" in body
 
+    def test_template_path_example_uses_the_working_directory(self, body):
+        assert "`./template.yml`" in body
+        assert "/tmp/" not in body
+
     def test_dedicated_tool_boundary_covers_validation_and_deploy_lifecycle(self, body):
         assert "不要通过 `aliyun_api` 调用 ROS 模板校验或部署生命周期接口" in body
         assert "ROS `ValidateTemplate` 接口" not in body

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -122,6 +122,9 @@ class TestSkillContentRosOnly:
 
     def test_file_write_details_stay_in_step_prompt(self, body):
         assert "并写入文件" in body
+        assert "生成的模板默认放在当前工作目录" in body
+        assert "`./template.yml`" in body
+        assert "/tmp/" not in body
         assert "write_file" not in body
         assert "无需提前创建目录" not in body
         assert "bash" not in body.lower()

--- a/tests/skills/bundled/test_iac_skill.py
+++ b/tests/skills/bundled/test_iac_skill.py
@@ -58,6 +58,15 @@ class TestIacSkill:
         assert "ros_validate_template" not in iac_skill.content
         assert "ros_estimate_template_cost" not in iac_skill.content
 
+    def test_iac_skill_keeps_generated_templates_in_working_directory(self):
+        init_bundled_skills()
+        skills = get_bundled_skills()
+        iac_skill = next(s for s in skills if s.name == "iac-aliyun")
+
+        assert "生成的模板默认放在当前工作目录" in iac_skill.content
+        assert '"TemplateURL": "./ros-ecs-nginx-template.yml"' in iac_skill.content
+        assert "/tmp/" not in iac_skill.content
+
     def test_iac_skill_delegates_infraguard_work_to_pac_skill(self):
         init_bundled_skills()
         skills = get_bundled_skills()

--- a/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
@@ -1761,11 +1761,54 @@ async def test_delegated_local_template_materializes_from_symlinked_logical_cwd(
 
 
 @pytest.mark.asyncio
-async def test_delegated_local_template_symlink_fails_before_hooks_and_request_builder(tmp_path) -> None:
+async def test_delegated_local_template_materializes_from_authorized_path_alias(tmp_path: Path) -> None:
     from iac_code.tools.cloud.aliyun.runtime import AliyunDelegatedExecutor
 
+    project = tmp_path / "project"
+    project.mkdir()
+    physical_temp = tmp_path / "private" / "tmp"
+    physical_temp.mkdir(parents=True)
+    logical_temp = tmp_path / "tmp"
+    try:
+        logical_temp.symlink_to(physical_temp, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlinks are unavailable: {error}")
+    template_body = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
+    physical_template = physical_temp / "template.yml"
+    physical_template.write_text(template_body, encoding="utf-8")
+    logical_template = logical_temp / physical_template.name
+    contract = _canonical_contract(
+        product="ROS",
+        version="2019-09-10",
+        action="ValidateTemplate",
+    )
+    tool, runtime = _execution_runtime(contract)
+    delegated = AliyunDelegatedExecutor(tool, action="ValidateTemplate")
+    outer_input = {"template_url": str(logical_template), "region_id": "cn-hangzhou"}
+    permission_context = _bound_context(
+        outer_input,
+        tool_name="ros_validate_template",
+        cwd=str(project),
+        pipeline_mode=True,
+    )
+
+    permission = await delegated.check_permissions(outer_input, permission_context)
+    assert permission.behavior == "ask"
+    result = await delegated.execute(outer_input, _execution_context(permission_context, permission))
+
+    assert result.is_error is False
+    assert runtime.request_builder.inputs[0]["params"]["TemplateBody"] == template_body
+
+
+@pytest.mark.asyncio
+async def test_delegated_local_template_uses_symlink_target_approved_in_snapshot(tmp_path) -> None:
+    from iac_code.tools.cloud.aliyun.runtime import AliyunDelegatedExecutor
+
+    approved_body = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
     template = tmp_path / "template.yml"
-    template.write_text("Resources: {}\n", encoding="utf-8")
+    template.write_text(approved_body, encoding="utf-8")
+    replacement = tmp_path / "replacement.yml"
+    replacement.write_text("ROSTemplateFormatVersion: '2015-09-01'\nDescription: replacement\n", encoding="utf-8")
     symlink = tmp_path / "template-link.yml"
     symlink.symlink_to(template)
     contract = _canonical_contract(
@@ -1785,14 +1828,14 @@ async def test_delegated_local_template_symlink_fails_before_hooks_and_request_b
     )
     permission = await delegated.check_permissions(outer_input, permission_context)
     assert permission.behavior == "allow"
+    symlink.unlink()
+    symlink.symlink_to(replacement)
 
     result = await delegated.execute(outer_input, _execution_context(permission_context, permission))
 
-    assert result == ToolResult.error(
-        _expected_public_error("invalid_body_file", {"region_id": "cn-hangzhou"}, contract=contract)
-    )
-    assert stages[-1] == "materialize"
-    assert runtime.request_builder.inputs == []
+    assert result.is_error is False
+    assert runtime.request_builder.inputs[0]["params"]["TemplateBody"] == approved_body
+    assert stages.index("contract") < stages.index("materialize") < stages.index("request_builder")
 
 
 @pytest.mark.asyncio
@@ -1842,7 +1885,7 @@ async def test_delegated_local_template_rejects_parent_symlink_swap_at_materiali
 
 
 @pytest.mark.asyncio
-async def test_body_file_is_materialized_no_follow_before_request_builder(tmp_path) -> None:
+async def test_body_file_symlink_is_materialized_from_approved_physical_path(tmp_path) -> None:
     target = tmp_path / "payload.bin"
     target.write_bytes(b"approved-payload")
     symlink = tmp_path / "payload-link.bin"
@@ -1863,9 +1906,9 @@ async def test_body_file_is_materialized_no_follow_before_request_builder(tmp_pa
 
     result = await tool.execute(tool_input=tool_input, context=_execution_context(permission_context, permission))
 
-    assert result == ToolResult.error(_expected_public_error("invalid_body_file", tool_input, contract=contract))
-    assert "request_builder_call" not in calls
-    assert runtime.transport_router.requests == []
+    assert result.is_error is False
+    assert "request_builder_call" in calls
+    assert runtime.transport_router.requests[0].body == b"approved-payload"
 
 
 @pytest.mark.asyncio
@@ -2044,6 +2087,39 @@ async def test_expired_snapshot_re_resolves_and_requires_the_same_digest() -> No
     result = await tool.execute(tool_input=tool_input, context=context)
 
     assert result.is_error is False
+    assert len(runtime.contract_resolver.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_expired_snapshot_preserves_the_authorized_body_file_target(tmp_path) -> None:
+    now = [100.0]
+    store = ResolvedContractStore(ttl_seconds=1.0, clock=lambda: now[0])
+    approved = tmp_path / "approved.bin"
+    approved.write_bytes(b"approved-payload")
+    replacement = tmp_path / "replacement.bin"
+    replacement.write_bytes(b"replacement-payload")
+    body_file = tmp_path / "payload-link.bin"
+    body_file.symlink_to(approved)
+    contract = _canonical_contract(request_body_type="byte")
+    tool, runtime = _execution_runtime(contract, contract_store=store)
+    tool_input = {
+        "product": "ecs",
+        "version": contract.version,
+        "action": contract.action,
+        "region_id": "cn-hangzhou",
+        "body_file": str(body_file),
+    }
+    permission_context = _bound_context(tool_input, cwd=str(tmp_path))
+    permission = await tool.check_permissions(tool_input, permission_context)
+    assert permission.behavior == "allow"
+    now[0] += 2.0
+    body_file.unlink()
+    body_file.symlink_to(replacement)
+
+    result = await tool.execute(tool_input=tool_input, context=_execution_context(permission_context, permission))
+
+    assert result.is_error is False
+    assert runtime.transport_router.requests[0].body == b"approved-payload"
     assert len(runtime.contract_resolver.calls) == 2
 
 

--- a/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
@@ -1775,7 +1775,7 @@ async def test_delegated_local_template_materializes_from_authorized_path_alias(
         pytest.skip(f"directory symlinks are unavailable: {error}")
     template_body = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
     physical_template = physical_temp / "template.yml"
-    physical_template.write_text(template_body, encoding="utf-8")
+    physical_template.write_bytes(template_body.encode("utf-8"))
     logical_template = logical_temp / physical_template.name
     contract = _canonical_contract(
         product="ROS",
@@ -1806,9 +1806,9 @@ async def test_delegated_local_template_uses_symlink_target_approved_in_snapshot
 
     approved_body = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
     template = tmp_path / "template.yml"
-    template.write_text(approved_body, encoding="utf-8")
+    template.write_bytes(approved_body.encode("utf-8"))
     replacement = tmp_path / "replacement.yml"
-    replacement.write_text("ROSTemplateFormatVersion: '2015-09-01'\nDescription: replacement\n", encoding="utf-8")
+    replacement.write_bytes(b"ROSTemplateFormatVersion: '2015-09-01'\nDescription: replacement\n")
     symlink = tmp_path / "template-link.yml"
     symlink.symlink_to(template)
     contract = _canonical_contract(

--- a/tests/tools/test_path_safety.py
+++ b/tests/tools/test_path_safety.py
@@ -4,6 +4,7 @@ from iac_code.tools.path_safety import (
     _path_hits_sensitive,
     _path_is_under,
     check_read_path,
+    check_read_path_with_resolution,
     get_iac_code_application_root,
     is_sensitive_path,
 )
@@ -18,6 +19,23 @@ def test_project_file_is_allowed(tmp_path):
     result = check_read_path(str(target), cwd=str(tmp_path), additional_directories=[], trusted_read_directories=[])
 
     assert result == ReadPathDecision("allow")
+
+
+def test_read_path_decision_returns_the_same_resolved_symlink_target(tmp_path):
+    target = tmp_path / "target.txt"
+    target.write_text("approved", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    link.symlink_to(target)
+
+    decision, resolution = check_read_path_with_resolution(
+        str(link),
+        cwd=str(tmp_path),
+        additional_directories=[],
+        trusted_read_directories=[],
+    )
+
+    assert decision == ReadPathDecision("allow")
+    assert resolution.path == str(target)
 
 
 def test_additional_directory_file_is_allowed(tmp_path):


### PR DESCRIPTION
## Summary

- bind the physical path resolved during local-file permission checks to the one-shot Aliyun API contract snapshot
- consume the approved path during template/body materialization, including snapshot recovery, instead of resolving the original logical path again
- keep O_NOFOLLOW protections against parent-directory symlink swaps
- update the bundled iac-aliyun and selling pipeline skills to create templates in the current working directory rather than suggesting /tmp

## Root cause

Permission checks resolved paths such as macOS /tmp/... to /private/tmp/..., but execution later reopened the original logical path. The secure no-follow reader correctly rejected the /tmp symlink, producing invalid_body_file even after the user had approved the read.

## Impact

Approved local ROS templates and body_file inputs now use exactly the physical path that was checked. Normal generated templates stay inside the workspace, avoiding unnecessary out-of-workspace permission prompts.

## Validation

- make lint
- Python 3.10: 558 path and Aliyun permission tests passed
- 184 bundled and selling-pipeline skill tests passed
- full suite: 11,025 passed, 3 skipped; 8 local failures were limited to the worktree missing generated src/iac_code/i18n/messages.pot