### PR TITLE
fix(repl): recover pending pipeline questions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ src/iac_code/pipeline/engine/architecture_rules.json.backup-*
 .superpowers/
 .worktrees/
 .agents/
+spec/

--- a/scripts/repl/e2e/run_pipeline_scenarios.py
+++ b/scripts/repl/e2e/run_pipeline_scenarios.py
@@ -71,6 +71,9 @@ CANDIDATE_SELECTION_PATTERNS = (
 CANDIDATE_EVALUATION_PATTERNS = (r"(?i)Evaluate candidates\s*\(\d+/\d+\)", r"evaluate_candidates")
 ARCHITECTURE_PLANNING_PATTERNS = (r"(?i)Architecture planning\s*\(\d+/\d+\)", r"architecture_planning")
 ASK_PATTERNS = (r"Ask user question", r"请.*输入", r"请.*补充", r"请描述", r"需要.*信息", r"澄清", r"问题")
+ASK_INPUT_READY_PATTERNS = (
+    r"(?m)^[ \t]*>[ \t]*\r?$",
+)
 PIPELINE_COMPLETED_PATTERNS = (
     r"(?i)Pipeline completed",
     r"CREATE_COMPLETE",
@@ -201,6 +204,46 @@ class CleanupNetworkTarget:
     zone_id: str
     vswitch_cidr: str
     rollback_vswitch_cidr: str
+
+
+@dataclass(frozen=True)
+class ScenarioRuntimePaths:
+    """Per-scenario state roots that remain stable across child restarts."""
+
+    config_dir: Path
+    backup_dir: Path
+
+    @classmethod
+    def for_run(
+        cls,
+        run_dir: Path,
+        *,
+        environment: dict[str, str],
+    ) -> "ScenarioRuntimePaths":
+        fallback_root = run_dir.parent / ".iac-code-state"
+        config_root = Path(
+            environment.get(
+                "IAC_CODE_CONFIG_DIR",
+                str(fallback_root / "config"),
+            )
+        ).expanduser()
+        backup_root = Path(
+            environment.get(
+                "IAC_CODE_CONFIG_BACKUP_DIR",
+                str(fallback_root / "backup"),
+            )
+        ).expanduser()
+        isolated_name = run_dir.name
+        return cls(
+            config_dir=config_root / ".e2e-runs" / isolated_name,
+            backup_dir=backup_root / ".e2e-runs" / isolated_name,
+        )
+
+    def apply(self, environment: dict[str, str]) -> dict[str, str]:
+        isolated = dict(environment)
+        isolated["IAC_CODE_CONFIG_DIR"] = str(self.config_dir)
+        isolated["IAC_CODE_CONFIG_BACKUP_DIR"] = str(self.backup_dir)
+        return isolated
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -674,7 +717,11 @@ def _run_with_pty(
     run_dir = _scenario_run_dir(args, scenario)
     workspace_dir = Path(args.cwd).expanduser().resolve() if args.cwd else run_dir / "workspace"
     workspace_dir.mkdir(parents=True, exist_ok=True)
-    env = _build_child_env(args)
+    shared_env = _build_child_env(args)
+    env = ScenarioRuntimePaths.for_run(
+        run_dir,
+        environment=shared_env,
+    ).apply(shared_env)
     pty = ReplPty(args=args, run_dir=run_dir, cwd=workspace_dir, env=env)
     checks: dict[str, bool] = {}
     notes: list[str] = []
@@ -986,7 +1033,7 @@ def _cleanup_rollback_prompt(args: argparse.Namespace, run_dir: Path) -> str:
 async def _call_aliyun_api_async(product: str, action: str, params: dict[str, Any]) -> dict[str, Any]:
     from iac_code.config import get_config_dir
     from iac_code.services.cloud_credentials import CloudCredentials
-    from iac_code.services.providers.aliyun import AliyunCredentials, DEFAULT_REGION
+    from iac_code.services.providers.aliyun import DEFAULT_REGION, AliyunCredentials
     from iac_code.tools.base import ToolContext
     from iac_code.tools.cloud.aliyun.aliyun_api import AliyunApi
     from iac_code.tools.cloud.aliyun.contract_store import canonical_input_sha256
@@ -1171,7 +1218,11 @@ def _cleanup_ledger_path(pty: Any) -> Path | None:
     try:
         from iac_code.services.session_storage import SessionStorage
 
-        storage = SessionStorage()
+        environment = getattr(pty, "env", {})
+        config_dir = environment.get("IAC_CODE_CONFIG_DIR") if isinstance(environment, dict) else None
+        storage = SessionStorage(
+            projects_dir=Path(config_dir) / "projects" if isinstance(config_dir, str) and config_dir else None
+        )
         session_path: Path | None = None
         if session_id:
             session_path = Path(storage.session_dir(cwd, session_id)) / "pipeline" / "cleanup.yaml"
@@ -2151,16 +2202,36 @@ def _expect_initial_prompt(pty: ReplPty, args: argparse.Namespace) -> None:
 
 def _expect_candidate_selection(pty: ReplPty, args: argparse.Namespace, *, description: str) -> None:
     pty.expect_any(CANDIDATE_SELECTION_PATTERNS, description=description, timeout=args.stream_timeout)
-    pty.expect_optional(
+    controls_ready = pty.expect_optional(
         CANDIDATE_SELECTION_READY_PATTERNS,
         description="candidate selection controls ready",
         timeout=args.candidate_selection_ready_timeout,
     )
-    _expect_raw_input_ready(pty, args, description="candidate selection input ready")
+    if not controls_ready:
+        _expect_raw_input_ready(pty, args, description="candidate selection input ready")
 
 
 def _expect_raw_input_ready(pty: ReplPty, args: argparse.Namespace, *, description: str) -> None:
     pty.expect_any(REPL_INPUT_READY_PATTERNS, description=description, timeout=args.timeout)
+
+
+def _expect_ask_input_ready(pty: ReplPty, args: argparse.Namespace, *, description: str) -> None:
+    pty.expect_any(ASK_INPUT_READY_PATTERNS, description=description, timeout=args.timeout)
+
+
+def _expect_interrupt_input_ready(
+    pty: ReplPty,
+    args: argparse.Namespace,
+    *,
+    visible_description: str,
+    ready_description: str,
+) -> None:
+    pty.expect_any(
+        INTERRUPT_INPUT_PATTERNS,
+        description=visible_description,
+        timeout=args.timeout,
+    )
+    _expect_raw_input_ready(pty, args, description=ready_description)
 
 
 def _expect_parallel_interrupt_ready(pty: ReplPty, args: argparse.Namespace) -> None:
@@ -2203,12 +2274,13 @@ def _finish_vswitch_pipeline_after_possible_selection(
     completion_description: str,
 ) -> None:
     if matched_pattern in CANDIDATE_SELECTION_PATTERNS:
-        pty.expect_optional(
+        controls_ready = pty.expect_optional(
             CANDIDATE_SELECTION_READY_PATTERNS,
             description="candidate selection controls ready after ask",
             timeout=args.candidate_selection_ready_timeout,
         )
-        _expect_raw_input_ready(pty, args, description="candidate selection input ready after ask")
+        if not controls_ready:
+            _expect_raw_input_ready(pty, args, description="candidate selection input ready after ask")
         _select_default_candidate(pty, args)
         checks[selection_check] = True
         pty.expect_any(PIPELINE_COMPLETED_PATTERNS, description=completion_description, timeout=args.stream_timeout)
@@ -2264,6 +2336,8 @@ def run_ask_waiting(args: argparse.Namespace, scenario: str) -> int:
         pty.sendline(args.ask_prompt)
         pty.expect_any(ASK_PATTERNS, description="ask question visible", timeout=args.stream_timeout)
         checks["ask question became visible"] = True
+        _expect_ask_input_ready(pty, args, description="ask answer input ready")
+        checks["ask answer input ready"] = True
         pty.sendline(_stack_creating_prompt(args.ask_answer, pty.run_dir, scenario))
         checks["ask answer sent"] = True
         matched = pty.expect_any(
@@ -2314,12 +2388,14 @@ def run_image_ask_waiting_resume(args: argparse.Namespace, scenario: str) -> int
         pty.sendline(args.ask_prompt)
         pty.expect_any(ASK_PATTERNS, description="ask question visible before kill", timeout=args.stream_timeout)
         checks["ask question became visible before kill"] = True
+        _expect_ask_input_ready(pty, args, description="ask answer input ready before kill")
+        checks["ask answer input ready before kill"] = True
         pty.terminate(force=True)
         checks["first process killed"] = True
         pty.spawn(extra_args=["--continue"])
         pty.expect_any(ASK_PATTERNS, description="ask question replayed", timeout=args.stream_timeout)
         checks["ask question replayed"] = True
-        _expect_raw_input_ready(pty, args, description="ask image answer input ready after resume")
+        _expect_ask_input_ready(pty, args, description="ask image answer input ready after resume")
         checks["ask image answer input ready after resume"] = True
         _submit_image_fixture(pty, "ask-first-answer", caption=_stack_name_constraint(pty.run_dir, scenario))
         checks["ask first answer image fixture pasted after resume"] = True
@@ -2328,7 +2404,7 @@ def run_image_ask_waiting_resume(args: argparse.Namespace, scenario: str) -> int
             description="second ask question after image answer",
             timeout=min(args.timeout, 30.0),
         ):
-            _expect_raw_input_ready(pty, args, description="second ask image answer input ready")
+            _expect_ask_input_ready(pty, args, description="second ask image answer input ready")
             _submit_image_fixture(pty, "ask-second-answer", caption=_stack_name_constraint(pty.run_dir, scenario))
             checks["ask second answer image fixture pasted"] = True
         matched = pty.expect_any(
@@ -2467,12 +2543,14 @@ def run_ask_waiting_resume(args: argparse.Namespace, scenario: str) -> int:
         pty.sendline(args.ask_prompt)
         pty.expect_any(ASK_PATTERNS, description="ask question visible before kill", timeout=args.stream_timeout)
         checks["ask question became visible before kill"] = True
+        _expect_ask_input_ready(pty, args, description="ask answer input ready before kill")
+        checks["ask answer input ready before kill"] = True
         pty.terminate(force=True)
         checks["first process killed"] = True
         pty.spawn(extra_args=["--continue"])
         pty.expect_any(ASK_PATTERNS, description="ask question replayed", timeout=args.stream_timeout)
         checks["ask question replayed"] = True
-        _expect_raw_input_ready(pty, args, description="ask answer input ready after resume")
+        _expect_ask_input_ready(pty, args, description="ask answer input ready after resume")
         checks["ask answer input ready after resume"] = True
         pty.sendline(_stack_creating_prompt(args.ask_answer, pty.run_dir, scenario))
         checks["ask answer sent after resume"] = True
@@ -2622,7 +2700,12 @@ def run_rollback_step4_selection(args: argparse.Namespace, scenario: str) -> int
         checks["candidate selection input ready"] = True
         pty.send("\x1b", label="send-esc")
         checks["esc sent"] = True
-        _expect_raw_input_ready(pty, args, description="candidate selection interrupt text input ready")
+        _expect_interrupt_input_ready(
+            pty,
+            args,
+            visible_description="candidate selection interrupt input visible",
+            ready_description="candidate selection interrupt text input ready",
+        )
         checks["candidate selection interrupt text input ready"] = True
         pty.sendline(args.rollback_prompt)
         checks["rollback prompt sent"] = True
@@ -2669,7 +2752,12 @@ def _run_rollback_step5_cleanup(
         )
         pty.send("\x1b", label="send-esc")
         checks["esc sent during deploying"] = True
-        _expect_raw_input_ready(pty, args, description="deploying interrupt input ready")
+        _expect_interrupt_input_ready(
+            pty,
+            args,
+            visible_description="deploying interrupt input visible",
+            ready_description="deploying interrupt input ready",
+        )
         checks["deploying interrupt input ready"] = True
 
         first_stack_id = _wait_for_latest_observed_stack_id(pty, exclude=set(), timeout=args.stream_timeout)
@@ -2711,6 +2799,7 @@ def _run_rollback_step5_cleanup(
             bool(second_stack_id) and _cleanup_resource_for_stack(pty, second_stack_id) is None
         )
 
+        _expect_raw_input_ready(pty, args, description="normal follow-up prompt input ready")
         pty.sendline(args.normal_followup_prompt)
         if kill_during_cleanup:
             pty.expect_any(

--- a/src/iac_code/cli/process_mode.py
+++ b/src/iac_code/cli/process_mode.py
@@ -962,12 +962,15 @@ class ProcessQuery:
             )
             return
         request_id = frame.request_id or self._next_turn_request_id()
-        task = asyncio.create_task(self._run_turn(frame, request_id))
+        turn_started = asyncio.Event()
+        task = asyncio.create_task(self._run_turn(frame, request_id, turn_started))
         self._active_turn = ProcessTurnHandle(request_id=request_id, session_id=frame.session_id, task=task)
+        await turn_started.wait()
 
-    async def _run_turn(self, frame: SDKUserMessage, request_id: str) -> None:
+    async def _run_turn(self, frame: SDKUserMessage, request_id: str, turn_started: asyncio.Event) -> None:
         started = time.monotonic()
         result = ProcessTurnResult()
+        turn_started.set()
         try:
             async for event in self._runtime_controller.run_turn(frame):
                 result.observe(event, self._error_mapper)

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -67,7 +67,9 @@ _CURRENT_STEP_USER_INPUT_CONTENT_KEY = "current_step_user_input_content"
 _CURRENT_STEP_RESUME_MESSAGES_KEY = "current_step_resume_messages"
 _CURRENT_STEP_PRECOMPLETED_TOOLS_KEY = "current_step_precompleted_tools"
 _PENDING_ASK_USER_QUESTION_RESUME_KEY = "pending_ask_user_question_resume"
+_PENDING_ASK_USER_QUESTION_INPUT_KEY = "pending_ask_user_question_input"
 _PENDING_INPUT_KIND_KEY = "pending_input_kind"
+_ASK_USER_QUESTION_KIND = "ask_user_question"
 _PIPELINE_PAUSE_CONFIRMATION_KIND = "pipeline_pause_confirmation"
 _CANDIDATE_SELECTION_PAYLOAD_FIELDS = frozenset(
     {
@@ -183,6 +185,79 @@ class PipelineStatePersistenceError(RuntimeError):
     def __init__(self, message: str, *, step_id: str | None = None) -> None:
         super().__init__(message)
         self.step_id = step_id
+
+
+@dataclass(frozen=True)
+class PendingAskUserQuestion:
+    """Recovery-critical representation of an unanswered pipeline question."""
+
+    tool_use_id: str
+    question: str
+    options: list[dict[str, Any]]
+    allow_free_text: bool = True
+    free_text_prompt: str = ""
+    answer: dict[str, str] | None = None
+
+    @classmethod
+    def from_event(cls, event: AskUserQuestionEvent) -> PendingAskUserQuestion:
+        return cls(
+            tool_use_id=str(event.tool_use_id),
+            question=str(event.question),
+            options=[dict(option) for option in event.options if isinstance(option, dict)],
+            allow_free_text=bool(event.allow_free_text),
+            free_text_prompt=str(event.free_text_prompt or ""),
+        )
+
+    @classmethod
+    def from_dict(cls, value: Any) -> PendingAskUserQuestion | None:
+        if not isinstance(value, dict):
+            return None
+        tool_use_id = value.get("toolUseId") or value.get("tool_use_id")
+        question = value.get("question")
+        options = value.get("options")
+        if not isinstance(tool_use_id, str) or not tool_use_id:
+            return None
+        if not isinstance(question, str) or not isinstance(options, list):
+            return None
+        raw_answer = value.get("answer")
+        answer = None
+        if isinstance(raw_answer, dict):
+            answer = {
+                "selected_id": _string_answer_value(raw_answer.get("selected_id")),
+                "selected_label": _string_answer_value(raw_answer.get("selected_label")),
+                "free_text": _string_answer_value(raw_answer.get("free_text")),
+            }
+        return cls(
+            tool_use_id=tool_use_id,
+            question=question,
+            options=[dict(option) for option in options if isinstance(option, dict)],
+            allow_free_text=bool(value.get("allowFreeText", value.get("allow_free_text", True))),
+            free_text_prompt=str(value.get("freeTextPrompt") or value.get("free_text_prompt") or ""),
+            answer=answer,
+        )
+
+    def with_answer(self, answer: dict[str, str]) -> PendingAskUserQuestion:
+        return replace(
+            self,
+            answer={
+                "selected_id": _string_answer_value(answer.get("selected_id")),
+                "selected_label": _string_answer_value(answer.get("selected_label")),
+                "free_text": _string_answer_value(answer.get("free_text")),
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        value: dict[str, Any] = {
+            "kind": _ASK_USER_QUESTION_KIND,
+            "toolUseId": self.tool_use_id,
+            "question": self.question,
+            "options": [dict(option) for option in self.options],
+            "allowFreeText": self.allow_free_text,
+            "freeTextPrompt": self.free_text_prompt,
+        }
+        if self.answer is not None:
+            value["answer"] = dict(self.answer)
+        return value
 
 
 def _string_answer_value(value: Any) -> str:
@@ -1011,6 +1086,52 @@ class PipelineRunner:
     def pending_input_kind(self) -> str | None:
         kind = self._execution.get(_PENDING_INPUT_KIND_KEY) if isinstance(self._execution, dict) else None
         return kind if isinstance(kind, str) else None
+
+    def pending_ask_user_question(self) -> dict[str, Any] | None:
+        pending = PendingAskUserQuestion.from_dict(self._execution.get(_PENDING_ASK_USER_QUESTION_INPUT_KEY))
+        return pending.to_dict() if pending is not None else None
+
+    async def persist_pending_ask_user_question(self, event: AskUserQuestionEvent) -> None:
+        pending = PendingAskUserQuestion.from_event(event)
+        previous_pending = self._execution.get(_PENDING_ASK_USER_QUESTION_INPUT_KEY)
+        previous_kind = self.pending_input_kind()
+        self._execution[_PENDING_ASK_USER_QUESTION_INPUT_KEY] = pending.to_dict()
+        self._set_pending_input_kind(_ASK_USER_QUESTION_KIND)
+        try:
+            await self._save_waiting_input(self._terminal_current_step_id())
+        except BaseException:
+            if previous_pending is None:
+                self._execution.pop(_PENDING_ASK_USER_QUESTION_INPUT_KEY, None)
+            else:
+                self._execution[_PENDING_ASK_USER_QUESTION_INPUT_KEY] = previous_pending
+            self._set_pending_input_kind(previous_kind)
+            raise
+
+    async def persist_pending_ask_user_question_answer(
+        self,
+        tool_use_id: str,
+        answer: dict[str, str],
+    ) -> None:
+        pending = PendingAskUserQuestion.from_dict(self._execution.get(_PENDING_ASK_USER_QUESTION_INPUT_KEY))
+        if pending is None or pending.tool_use_id != tool_use_id:
+            raise ValueError("pending ask_user_question tool_use_id mismatch")
+        previous = pending.to_dict()
+        self._execution[_PENDING_ASK_USER_QUESTION_INPUT_KEY] = pending.with_answer(answer).to_dict()
+        try:
+            await self._save_waiting_input(self._terminal_current_step_id())
+        except BaseException:
+            self._execution[_PENDING_ASK_USER_QUESTION_INPUT_KEY] = previous
+            raise
+
+    def acknowledge_pending_ask_user_question(self, tool_use_id: str) -> None:
+        pending = PendingAskUserQuestion.from_dict(self._execution.get(_PENDING_ASK_USER_QUESTION_INPUT_KEY))
+        if pending is None:
+            return
+        if pending.tool_use_id != tool_use_id:
+            raise ValueError("pending ask_user_question tool_use_id mismatch")
+        self._execution.pop(_PENDING_ASK_USER_QUESTION_INPUT_KEY, None)
+        if self.pending_input_kind() == _ASK_USER_QUESTION_KIND:
+            self._set_pending_input_kind(None)
 
     def has_pending_pipeline_pause_confirmation(self) -> bool:
         return self.pending_input_kind() == _PIPELINE_PAUSE_CONFIRMATION_KIND
@@ -2601,6 +2722,7 @@ class PipelineRunner:
             raise ValueError(
                 f"ask_user_question tool_use_id mismatch: expected {expected_tool_use_id!r}, got {tool_use_id!r}"
             )
+        self.acknowledge_pending_ask_user_question(tool_use_id)
         answer_text = payload["free_text"] or payload["selected_label"] or payload["selected_id"]
         if payload["selected_id"] and payload["free_text"]:
             answer_type = "option_and_free_text"

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -913,6 +913,7 @@ class StepExecutor:
                 tool_cls = engine_tools.get(name)
             if tool_cls is not None:
                 if name == "ask_user_question":
+
                     def observe_question_answered(
                         tool_call_id: str | None, option_count: int, answer_type: str
                     ) -> None:

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
@@ -188,9 +188,7 @@ def _preview_source_cardinality(
             _request_error(
                 policy.action,
                 _("PreviewStack must provide Parameters when reusing the existing template."),
-                _(
-                    "A source-less update preview reuses the template only when Parameters is provided."
-                ),
+                _("A source-less update preview reuses the template only when Parameters is provided."),
                 "update-reuse-without-parameters",
             )
         )

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/function_specs.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/function_specs.py
@@ -183,9 +183,7 @@ _RETURN_TYPES: dict[str, RosType] = {
 
 def _context_contract(name: str, context: ExpressionContext) -> FunctionContextContract:
     implementation = (
-        "ParamRef"
-        if name == "Ref" and context not in {ExpressionContext.NORMAL, ExpressionContext.MODULE}
-        else name
+        "ParamRef" if name == "Ref" and context not in {ExpressionContext.NORMAL, ExpressionContext.MODULE} else name
     )
     if name == "Ref" and context in {ExpressionContext.NORMAL, ExpressionContext.MODULE}:
         implementation = "RefFactory"

--- a/src/iac_code/ui/repl.py
+++ b/src/iac_code/ui/repl.py
@@ -13,6 +13,7 @@ InlineREPL wires together:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import re
 import signal
@@ -3721,16 +3722,22 @@ class InlineREPL:
         if not restored:
             return False
         self._render_pipeline_display_replay_on_startup()
-        if (
-            self._pipeline_restored_status != "waiting_input"
-            or self._pipeline_current_step_is_candidate_selection() is not True
-        ):
+        pending_ask = self._pending_ask_user_question_from_pipeline()
+        resume_candidate_selection = (
+            pending_ask is None
+            and self._pipeline_restored_status == "waiting_input"
+            and self._pipeline_current_step_is_candidate_selection() is True
+        )
+        if pending_ask is None and not resume_candidate_selection:
             return False
 
         terminal_event = None
         try:
             self.store.set_state(is_busy=True)
-            terminal_event = await self._resume_waiting_candidate_selection_from_sidecar()
+            if pending_ask is not None:
+                terminal_event = await self._resume_pending_ask_user_question_from_sidecar(pending_ask)
+            else:
+                terminal_event = await self._resume_waiting_candidate_selection_from_sidecar()
             if terminal_event is None:
                 self._pipeline_waiting_input = True
         finally:
@@ -3741,6 +3748,91 @@ class InlineREPL:
                 await self._flush_pipeline_telemetry()
                 await self._maybe_start_pipeline_cleanup(pipeline_for_flush)
         return True
+
+    def _pending_ask_user_question_from_pipeline(self) -> dict[str, Any] | None:
+        pipeline = getattr(self, "_pipeline", None)
+        getter = getattr(pipeline, "pending_ask_user_question", None)
+        if not callable(getter):
+            return None
+        pending = getter()
+        if not isinstance(pending, dict) or pending.get("kind") != "ask_user_question":
+            return None
+        tool_use_id = pending.get("toolUseId") or pending.get("tool_use_id")
+        question = pending.get("question")
+        options = pending.get("options")
+        if not isinstance(tool_use_id, str) or not tool_use_id:
+            return None
+        if not isinstance(question, str) or not isinstance(options, list):
+            return None
+        return dict(pending)
+
+    async def _resume_pending_ask_user_question_from_sidecar(
+        self,
+        pending: dict[str, Any],
+    ) -> PipelineEvent | None:
+        pipeline = getattr(self, "_pipeline", None)
+        resume = getattr(pipeline, "resume_ask_user_question", None)
+        if pipeline is None or not callable(resume):
+            return None
+
+        tool_use_id = str(pending.get("toolUseId") or pending.get("tool_use_id") or "")
+        raw_answer = pending.get("answer")
+        answer = (
+            {
+                "selected_id": str(raw_answer.get("selected_id") or ""),
+                "selected_label": str(raw_answer.get("selected_label") or ""),
+                "free_text": str(raw_answer.get("free_text") or ""),
+            }
+            if isinstance(raw_answer, dict)
+            else None
+        )
+        if answer is None:
+            event = AskUserQuestionEvent(
+                tool_use_id=tool_use_id,
+                question=str(pending.get("question") or ""),
+                options=[dict(option) for option in pending.get("options", []) if isinstance(option, dict)],
+                allow_free_text=bool(pending.get("allowFreeText", pending.get("allow_free_text", True))),
+                free_text_prompt=str(pending.get("freeTextPrompt") or pending.get("free_text_prompt") or ""),
+            )
+            answer = await self.renderer.prompt_user_question(event)
+            if answer is None:
+                return None
+            await self._persist_pending_ask_user_question_answer(tool_use_id, answer)
+
+        event_stream = resume(
+            answer,
+            tool_use_id=tool_use_id,
+            pending_input=pending,
+        )
+        return await self._render_pipeline_stream(event_stream)
+
+    async def _persist_pending_ask_user_question(self, event: AskUserQuestionEvent) -> None:
+        pipeline = getattr(self, "_pipeline", None)
+        persist = getattr(pipeline, "persist_pending_ask_user_question", None)
+        if not callable(persist):
+            return
+        result = persist(event)
+        if inspect.isawaitable(result):
+            await result
+
+    async def _persist_pending_ask_user_question_answer(
+        self,
+        tool_use_id: str,
+        answer: dict[str, str],
+    ) -> None:
+        pipeline = getattr(self, "_pipeline", None)
+        persist = getattr(pipeline, "persist_pending_ask_user_question_answer", None)
+        if not callable(persist):
+            return
+        result = persist(tool_use_id, answer)
+        if inspect.isawaitable(result):
+            await result
+
+    def _acknowledge_pending_ask_user_question(self, tool_use_id: str) -> None:
+        pipeline = getattr(self, "_pipeline", None)
+        acknowledge = getattr(pipeline, "acknowledge_pending_ask_user_question", None)
+        if callable(acknowledge):
+            acknowledge(tool_use_id)
 
     def _render_pipeline_display_replay_on_startup(self) -> None:
         model = self._load_pipeline_display_replay_model(include_nonterminal=True)
@@ -4499,17 +4591,37 @@ class InlineREPL:
                     elif isinstance(event, AskUserQuestionEvent):
                         had_renderer = await _stop_renderer()
                         try:
+                            await self._persist_pending_ask_user_question(event)
+                        except Exception as exc:
+                            if event.response_future is not None and not event.response_future.done():
+                                event.response_future.set_result(None)
+                            self._handle_pipeline_state_persistence_failure(exc)
+                            return None
+                        try:
                             answer = await self.renderer.prompt_user_question(event)
                         except (asyncio.CancelledError, KeyboardInterrupt):
+                            self._acknowledge_pending_ask_user_question(event.tool_use_id)
                             if event.response_future is not None and not event.response_future.done():
                                 event.response_future.set_result(None)
                             raise
                         except Exception as exc:
+                            self._acknowledge_pending_ask_user_question(event.tool_use_id)
                             if event.response_future is not None and not event.response_future.done():
                                 event.response_future.set_result(None)
                             msg = _("Error: {error}").format(error=str(exc))
                             self.renderer.print_system_message(msg, style="red")
                         else:
+                            if answer is not None:
+                                try:
+                                    await self._persist_pending_ask_user_question_answer(event.tool_use_id, answer)
+                                    self._acknowledge_pending_ask_user_question(event.tool_use_id)
+                                except Exception as exc:
+                                    if event.response_future is not None and not event.response_future.done():
+                                        event.response_future.set_result(None)
+                                    self._handle_pipeline_state_persistence_failure(exc)
+                                    return None
+                            else:
+                                self._acknowledge_pending_ask_user_question(event.tool_use_id)
                             if event.response_future is not None and not event.response_future.done():
                                 event.response_future.set_result(answer)
 

--- a/tests/cli/test_process_mode.py
+++ b/tests/cli/test_process_mode.py
@@ -593,14 +593,23 @@ async def test_process_runner_reports_turn_active_and_close_cancels_turn(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_process_runner_interrupt_cancels_active_turn(tmp_path) -> None:
+async def test_process_runner_interrupt_cancels_active_turn_before_first_task_step(monkeypatch, tmp_path) -> None:
+    async def run_inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", run_inline)
     controller = FakeRuntimeController(block_turn=True)
     stdin = io.StringIO(
         "\n".join(
             [
                 json.dumps({"type": "control_request", "request_id": "req-init", "request": {"subtype": "initialize"}}),
                 json.dumps(
-                    {"type": "user", "session_id": "session-1", "message": {"role": "user", "content": "first"}}
+                    {
+                        "type": "user",
+                        "request_id": "req-turn",
+                        "session_id": "session-1",
+                        "message": {"role": "user", "content": "first"},
+                    }
                 ),
                 json.dumps(
                     {
@@ -624,13 +633,24 @@ async def test_process_runner_interrupt_cancels_active_turn(tmp_path) -> None:
 
     assert exit_code == 0
     lines = _load_output(stdout)
-    assert any(
-        line["type"] == "control_response"
+    interrupt_index = next(
+        index
+        for index, line in enumerate(lines)
+        if line["type"] == "control_response"
         and line["response"]["request_id"] == "req-interrupt"
         and line["response"]["subtype"] == "success"
-        for line in lines
     )
-    assert any(line["type"] == "result" and line["subtype"] == "error_during_execution" for line in lines)
+    cancelled_results = [
+        (index, line)
+        for index, line in enumerate(lines)
+        if line["type"] == "result" and line["request_id"] == "req-turn"
+    ]
+    assert len(cancelled_results) == 1
+    result_index, cancelled_result = cancelled_results[0]
+    assert cancelled_result["subtype"] == "error_during_execution"
+    assert cancelled_result["is_error"] is True
+    assert cancelled_result["stop_reason"] == "cancelled"
+    assert interrupt_index < result_index
 
 
 @pytest.mark.asyncio

--- a/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
+++ b/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
@@ -14,6 +14,7 @@ from iac_code.pipeline.engine.session import PipelineSession
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.services.session_metadata import SESSION_LAYOUT_VERSION_V2, SessionMetadata, write_session_metadata
 from iac_code.services.session_storage import SessionStorage
+from iac_code.types.stream_events import AskUserQuestionEvent
 from iac_code.utils import project_paths
 
 
@@ -1500,6 +1501,50 @@ async def test_resume_ask_user_question_rejects_transcript_tool_use_id_mismatch(
             pass
 
     runner._step_executor.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pending_ask_user_question_survives_sidecar_restore(tmp_path):
+    runner = _build_two_step_runner(tmp_path)
+    pending = AskUserQuestionEvent(
+        tool_use_id="ask-1",
+        question="请选择部署目标",
+        options=[{"id": "nginx", "label": "Nginx 网站"}],
+        allow_free_text=True,
+        free_text_prompt="也可以直接描述你的目标",
+    )
+
+    await runner.persist_pending_ask_user_question(pending)
+
+    restored = _build_two_step_runner(tmp_path, resume_from_sidecar=True)
+
+    assert restored.sidecar_status == "waiting_input"
+    assert restored.pending_ask_user_question() == {
+        "kind": "ask_user_question",
+        "toolUseId": "ask-1",
+        "question": "请选择部署目标",
+        "options": [{"id": "nginx", "label": "Nginx 网站"}],
+        "allowFreeText": True,
+        "freeTextPrompt": "也可以直接描述你的目标",
+    }
+
+
+@pytest.mark.asyncio
+async def test_pending_ask_user_question_answer_is_durable_until_resume_stream_starts(tmp_path):
+    runner = _build_two_step_runner(tmp_path)
+    pending = AskUserQuestionEvent(
+        tool_use_id="ask-1",
+        question="请选择部署目标",
+        options=[{"id": "nginx", "label": "Nginx 网站"}],
+    )
+    answer = {"selected_id": "nginx", "selected_label": "Nginx 网站", "free_text": ""}
+
+    await runner.persist_pending_ask_user_question(pending)
+    await runner.persist_pending_ask_user_question_answer("ask-1", answer)
+
+    restored = _build_two_step_runner(tmp_path, resume_from_sidecar=True)
+
+    assert restored.pending_ask_user_question()["answer"] == answer
 
 
 def test_resume_from_sidecar_accepts_list_valued_context_fields(tmp_path):

--- a/tests/repl_e2e/test_run_pipeline_scenarios.py
+++ b/tests/repl_e2e/test_run_pipeline_scenarios.py
@@ -536,7 +536,40 @@ def test_ask_patterns_match_real_repl_question_prompt() -> None:
     assert any(re.search(pattern, real_prompt) for pattern in runner.ASK_PATTERNS)
 
 
-def test_candidate_selection_waits_for_input_ready_sequence() -> None:
+def test_ask_input_ready_patterns_match_answer_prompt_only() -> None:
+    runner = _load_runner()
+    colored_normal_prompt = "\x1b[1m\x1b[36m❯ \x1b[0m\r\x1b[2C\x1b[>4;2m"
+
+    assert any(re.search(pattern, "\r\n  > ") for pattern in runner.ASK_INPUT_READY_PATTERNS)
+    assert not any(re.search(pattern, colored_normal_prompt) for pattern in runner.ASK_INPUT_READY_PATTERNS)
+    assert not any(re.search(pattern, "● Ask user question") for pattern in runner.ASK_INPUT_READY_PATTERNS)
+    assert not any(re.search(pattern, "  → candidate 1") for pattern in runner.ASK_INPUT_READY_PATTERNS)
+
+
+def test_candidate_selection_uses_semantic_controls_without_waiting_for_stale_raw_marker() -> None:
+    runner = _load_runner()
+    descriptions: list[str] = []
+
+    class FakePty:
+        def expect_any(self, patterns, *, description, timeout):
+            descriptions.append(description)
+            return patterns[0]
+
+        def expect_optional(self, patterns, *, description, timeout):
+            descriptions.append(description)
+            return True
+
+    args = runner.parse_args(["--allow-real-cloud"])
+
+    runner._expect_candidate_selection(FakePty(), args, description="candidate selection visible")
+
+    assert descriptions == [
+        "candidate selection visible",
+        "candidate selection controls ready",
+    ]
+
+
+def test_candidate_selection_falls_back_to_raw_marker_when_semantic_controls_are_missing() -> None:
     runner = _load_runner()
     descriptions: list[str] = []
 
@@ -2139,12 +2172,46 @@ def test_image_initial_pastes_static_prompt_image(monkeypatch, tmp_path: Path) -
         ("sendline", runner._stack_name_constraint(tmp_path, "image-initial")),
         ("expect", "pipeline started"),
         ("expect", "candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed after image initial"),
         ("sendline", "/exit"),
     ]
     assert ("sendline", args.initial_prompt) not in actions
+
+
+def test_ask_waiting_waits_for_answer_prompt_before_sending(monkeypatch, tmp_path: Path) -> None:
+    runner = _load_runner()
+    args = runner.parse_args(["--allow-real-cloud", "--run-dir", str(tmp_path)])
+    actions: list[tuple[str, str]] = []
+    stack_owned_answer = runner._stack_creating_prompt(args.ask_answer, tmp_path, "ask-waiting")
+    transcript = (
+        "● Ask user question\n" + stack_owned_answer + "\n● Confirm and select (4/5)\n"
+        "✔ Pipeline completed\n"
+        "交换机 ID   vsw-bp1234567890\n"
+    )
+    _install_flow_fake_pty(monkeypatch, runner, transcript, actions, scenario="ask-waiting")
+
+    assert runner.run_ask_waiting(args, "ask-waiting") == 0
+
+    ordered_actions = [
+        (kind, value)
+        for kind, value in actions
+        if kind in {"expect", "spawn", "terminate", "sendline", "select-default-candidate"}
+    ]
+    assert ordered_actions == [
+        ("spawn", ""),
+        ("expect", "initial prompt"),
+        ("expect", "prompt input ready"),
+        ("sendline", args.ask_prompt),
+        ("expect", "ask question visible"),
+        ("expect", "ask answer input ready"),
+        ("sendline", stack_owned_answer),
+        ("expect", "pipeline continued after ask"),
+        ("select-default-candidate", f"{args.selection_prompt}\r"),
+        ("expect", "pipeline completed after ask"),
+        ("sendline", "/exit"),
+        ("terminate", "False"),
+    ]
 
 
 def test_image_ask_waiting_resume_pastes_static_answer_image(monkeypatch, tmp_path: Path) -> None:
@@ -2173,6 +2240,7 @@ def test_image_ask_waiting_resume_pastes_static_answer_image(monkeypatch, tmp_pa
         ("expect", "prompt input ready"),
         ("sendline", args.ask_prompt),
         ("expect", "ask question visible before kill"),
+        ("expect", "ask answer input ready before kill"),
         ("terminate", "True"),
         ("spawn", "--continue"),
         ("expect", "ask question replayed"),
@@ -2180,7 +2248,6 @@ def test_image_ask_waiting_resume_pastes_static_answer_image(monkeypatch, tmp_pa
         ("paste-image-fixture", "ask-first-answer"),
         ("sendline", runner._stack_name_constraint(tmp_path, "image-ask-waiting-resume")),
         ("expect", "pipeline continued after ask image resume"),
-        ("expect", "candidate selection input ready after ask"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed after ask image resume"),
         ("sendline", "/exit"),
@@ -2212,11 +2279,9 @@ def test_image_selection_waiting_resume_starts_with_image_and_recovers_selection
         ("paste-image-fixture", "initial"),
         ("sendline", runner._stack_name_constraint(tmp_path, "image-selection-waiting-resume")),
         ("expect", "candidate selection visible before image resume kill"),
-        ("expect", "candidate selection input ready"),
         ("terminate", "True"),
         ("spawn", "--continue"),
         ("expect", "candidate selection replayed after image resume"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed after image selection resume"),
         ("sendline", "/exit"),
@@ -2252,7 +2317,6 @@ def test_image_normal_handoff_pastes_static_followup_image(monkeypatch, tmp_path
         ("sendline", stack_owned_initial),
         ("expect", "pipeline started"),
         ("expect", "candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline fully completed"),
         ("expect", "normal prompt input ready"),
@@ -2456,8 +2520,8 @@ def test_rollback_step4_selection_runs_expected_terminal_flow(monkeypatch, tmp_p
         ("expect", "prompt input ready"),
         ("sendline", args.initial_prompt),
         ("expect", "candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("send-esc", "\x1b"),
+        ("expect", "candidate selection interrupt input visible"),
         ("expect", "candidate selection interrupt text input ready"),
         ("sendline", args.rollback_prompt),
         ("expect", "post-rollback pipeline progress visible"),
@@ -2500,7 +2564,6 @@ def test_evaluate_resume_runs_expected_terminal_flow(monkeypatch, tmp_path: Path
         ("expect", "evaluate resume prompt input ready"),
         ("sendline", args.evaluate_resume_continue_prompt),
         ("expect", "candidate selection visible after resume continue"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed after evaluate resume"),
         ("sendline", "/exit"),
@@ -2534,13 +2597,13 @@ def test_ask_waiting_resume_runs_expected_terminal_flow(monkeypatch, tmp_path: P
         ("expect", "prompt input ready"),
         ("sendline", args.ask_prompt),
         ("expect", "ask question visible before kill"),
+        ("expect", "ask answer input ready before kill"),
         ("terminate", "True"),
         ("spawn", "--continue"),
         ("expect", "ask question replayed"),
         ("expect", "ask answer input ready after resume"),
         ("sendline", stack_owned_answer),
         ("expect", "pipeline continued after ask resume"),
-        ("expect", "candidate selection input ready after ask"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed after ask resume"),
         ("sendline", "/exit"),
@@ -2572,7 +2635,6 @@ def test_selection_invalid_then_valid_runs_expected_terminal_flow(monkeypatch, t
         ("expect", "prompt input ready"),
         ("sendline", stack_owned_initial),
         ("expect", "candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("select-invalid-candidate", "9"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed"),
@@ -2693,22 +2755,73 @@ def test_rollback_step5_cleanup_runs_expected_terminal_flow(monkeypatch, tmp_pat
         ("expect", "prompt input ready"),
         ("sendline", runner._cleanup_pipeline_prompt(args, tmp_path)),
         ("expect", "initial candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "first stack create started"),
         ("send-esc", "\x1b"),
+        ("expect", "deploying interrupt input visible"),
         ("expect", "deploying interrupt input ready"),
         ("sendline", runner._cleanup_rollback_prompt(args, tmp_path)),
         ("expect", "post-rollback candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed after second deployment"),
+        ("expect", "normal follow-up prompt input ready"),
         ("sendline", args.normal_followup_prompt),
         ("expect", "cleanup started"),
         ("expect_optional", "cleanup completed"),
         ("expect", "post-cleanup prompt input ready"),
         ("sendline", "/exit"),
     ]
+
+
+def test_scenario_runtime_paths_override_shared_sandbox_state(tmp_path: Path) -> None:
+    runner = _load_runner()
+    run_dir = tmp_path / "runs" / "case-run-1"
+    shared_environment = {
+        "IAC_CODE_CONFIG_DIR": "/home/iac_code_config",
+        "IAC_CODE_CONFIG_BACKUP_DIR": "/home/iac_code_config_backup",
+    }
+    paths = runner.ScenarioRuntimePaths.for_run(
+        run_dir,
+        environment=shared_environment,
+    )
+    environment = paths.apply(shared_environment)
+
+    assert paths.config_dir == Path("/home/iac_code_config/.e2e-runs/case-run-1")
+    assert paths.backup_dir == Path("/home/iac_code_config_backup/.e2e-runs/case-run-1")
+    assert environment["IAC_CODE_CONFIG_DIR"] == str(paths.config_dir)
+    assert environment["IAC_CODE_CONFIG_BACKUP_DIR"] == str(paths.backup_dir)
+
+
+def test_cleanup_ledger_lookup_uses_case_isolated_config_dir(monkeypatch, tmp_path: Path) -> None:
+    runner = _load_runner()
+    from iac_code.services.session_storage import SessionStorage
+
+    cwd = str(tmp_path / "workspace")
+    session_id = "session-current"
+    isolated_config = tmp_path / "isolated-config"
+    shared_config = tmp_path / "shared-config"
+    isolated_storage = SessionStorage(projects_dir=isolated_config / "projects")
+    shared_storage = SessionStorage(projects_dir=shared_config / "projects")
+    isolated_path = isolated_storage.session_dir(cwd, session_id) / "pipeline" / "cleanup.yaml"
+    shared_path = shared_storage.session_dir(cwd, "session-stale") / "pipeline" / "cleanup.yaml"
+    isolated_path.parent.mkdir(parents=True)
+    shared_path.parent.mkdir(parents=True)
+    isolated_path.write_text("observed_resources: []\n", encoding="utf-8")
+    shared_path.write_text("observed_resources:\n  - resource_id: stale\n", encoding="utf-8")
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(shared_config))
+
+    pty = type(
+        "FakePty",
+        (),
+        {
+            "cwd": cwd,
+            "session_id": session_id,
+            "transcript": "",
+            "env": {"IAC_CODE_CONFIG_DIR": str(isolated_config)},
+        },
+    )()
+
+    assert runner._cleanup_ledger_path(pty) == isolated_path
 
 
 def test_rollback_step5_cleanup_recovery_runs_expected_terminal_flow(monkeypatch, tmp_path: Path) -> None:
@@ -2760,16 +2873,16 @@ def test_rollback_step5_cleanup_recovery_runs_expected_terminal_flow(monkeypatch
         ("expect", "prompt input ready"),
         ("sendline", runner._cleanup_pipeline_prompt(args, tmp_path)),
         ("expect", "initial candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "first stack create started"),
         ("send-esc", "\x1b"),
+        ("expect", "deploying interrupt input visible"),
         ("expect", "deploying interrupt input ready"),
         ("sendline", runner._cleanup_rollback_prompt(args, tmp_path)),
         ("expect", "post-rollback candidate selection visible"),
-        ("expect", "candidate selection input ready"),
         ("select-default-candidate", f"{args.selection_prompt}\r"),
         ("expect", "pipeline completed after second deployment"),
+        ("expect", "normal follow-up prompt input ready"),
         ("sendline", args.normal_followup_prompt),
         ("expect", "cleanup started before kill"),
         ("terminate", "True"),

--- a/tests/tools/cloud/aliyun/test_ros_validation_facts.py
+++ b/tests/tools/cloud/aliyun/test_ros_validation_facts.py
@@ -101,9 +101,7 @@ def test_registry_rejects_missing_duplicate_and_future_dependencies() -> None:
         raise AssertionError("duplicate fact provider was accepted")
 
     self_cycle = ValidationRegistry()
-    self_cycle.register_provider(
-        Provider("self", RulePhase.PARSE, frozenset({"x"}), requires=frozenset({"x"}))
-    )
+    self_cycle.register_provider(Provider("self", RulePhase.PARSE, frozenset({"x"}), requires=frozenset({"x"})))
     try:
         self_cycle.freeze()
     except ValueError as error:
@@ -142,9 +140,7 @@ def test_optional_fact_preserves_unavailable_available_and_poisoned_states() -> 
 def test_registry_rejects_future_optional_dependency_and_provider_cycle() -> None:
     future_optional = ValidationRegistry()
     future_optional.register_provider(Provider("future", RulePhase.QUALITY, frozenset({"future"})))
-    future_optional.register_rule(
-        Rule("early", RulePhase.PARSE, "X", optional_requires=frozenset({"future"}))
-    )
+    future_optional.register_rule(Rule("early", RulePhase.PARSE, "X", optional_requires=frozenset({"future"})))
     try:
         future_optional.freeze()
     except ValueError as error:
@@ -153,12 +149,8 @@ def test_registry_rejects_future_optional_dependency_and_provider_cycle() -> Non
         raise AssertionError("future optional fact dependency was accepted")
 
     cycle = ValidationRegistry()
-    cycle.register_provider(
-        Provider("a", RulePhase.PARSE, frozenset({"a"}), requires=frozenset({"b"}))
-    )
-    cycle.register_provider(
-        Provider("b", RulePhase.PARSE, frozenset({"b"}), requires=frozenset({"a"}))
-    )
+    cycle.register_provider(Provider("a", RulePhase.PARSE, frozenset({"a"}), requires=frozenset({"b"})))
+    cycle.register_provider(Provider("b", RulePhase.PARSE, frozenset({"b"}), requires=frozenset({"a"})))
     try:
         cycle.freeze()
     except ValueError as error:

--- a/tests/tools/cloud/aliyun/test_ros_validation_registry.py
+++ b/tests/tools/cloud/aliyun/test_ros_validation_registry.py
@@ -382,12 +382,15 @@ def test_committed_resource_catalog_and_ref_types() -> None:
     assert random_string["official_evidence"]
     assert random_string["official_evidence"][0]["status"] == "NOT_FOUND"
     raw_ref_types = {item["resource_type"]: item["ref_type"] for item in records}
-    assert {name: raw_ref_types[name] for name in {
-        "ALIYUN::RandomString",
-        "ALIYUN::ROS::Stack",
-        "ALIYUN::ECS::PrepayInstance",
-        "ALIYUN::RDS::PrepayDBInstance",
-    }} == {
+    assert {
+        name: raw_ref_types[name]
+        for name in {
+            "ALIYUN::RandomString",
+            "ALIYUN::ROS::Stack",
+            "ALIYUN::ECS::PrepayInstance",
+            "ALIYUN::RDS::PrepayDBInstance",
+        }
+    } == {
         "ALIYUN::RandomString": "String | Null",
         "ALIYUN::ROS::Stack": "String | Null",
         "ALIYUN::ECS::PrepayInstance": "List[String] | Null",

--- a/tests/ui/test_pipeline_interrupt_ui.py
+++ b/tests/ui/test_pipeline_interrupt_ui.py
@@ -506,6 +506,9 @@ class TestPipelineAskUserQuestion:
         mock_repl._pipeline_completed_indices = set()
         mock_repl._pipeline.pause_agent_loops = MagicMock()
         mock_repl._pipeline.resume_agent_loops = MagicMock()
+        mock_repl._pipeline.persist_pending_ask_user_question = AsyncMock()
+        mock_repl._pipeline.persist_pending_ask_user_question_answer = AsyncMock()
+        mock_repl._pipeline.acknowledge_pending_ask_user_question = MagicMock()
 
         fut: asyncio.Future[dict[str, str] | None] = asyncio.get_running_loop().create_future()
         question = AskUserQuestionEvent(
@@ -543,6 +546,9 @@ class TestPipelineAskUserQuestion:
         assert fut.result() == answer
         assert result is terminal_event
         mock_repl.renderer.prompt_user_question.assert_awaited_once_with(question)
+        mock_repl._pipeline.persist_pending_ask_user_question.assert_awaited_once_with(question)
+        mock_repl._pipeline.persist_pending_ask_user_question_answer.assert_awaited_once_with("tu_1", answer)
+        mock_repl._pipeline.acknowledge_pending_ask_user_question.assert_called_once_with("tu_1")
 
     @pytest.mark.asyncio
     async def test_resumed_pipeline_stream_without_pipeline_started_initializes_progress_state(self, mock_repl):

--- a/tests/ui/test_repl_pipeline_sidecar_restore.py
+++ b/tests/ui/test_repl_pipeline_sidecar_restore.py
@@ -501,6 +501,68 @@ async def test_startup_waiting_candidate_selection_reenters_selection_ui(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_startup_pending_ask_user_question_replays_prompt_and_resumes_pipeline(
+    monkeypatch,
+    repl_for_sidecar_restore,
+):
+    monkeypatch.setenv("IAC_CODE_MODE", "pipeline")
+    from iac_code.pipeline.config import RunMode
+    from iac_code.ui.repl import InlineREPL
+
+    repl_for_sidecar_restore._runtime_mode = RunMode.PIPELINE
+    answer = {"selected_id": "nginx", "selected_label": "Nginx 网站", "free_text": ""}
+    pending = {
+        "kind": "ask_user_question",
+        "toolUseId": "ask-1",
+        "question": "请选择部署目标",
+        "options": [{"id": "nginx", "label": "Nginx 网站"}],
+        "allowFreeText": True,
+        "freeTextPrompt": "也可以直接描述你的目标",
+    }
+    terminal_event = PipelineEvent(
+        type=PipelineEventType.PIPELINE_COMPLETED,
+        step_id=None,
+        timestamp=1.0,
+        data={"total_steps": 1},
+    )
+
+    async def resumed_stream():
+        yield terminal_event
+
+    pipeline = MagicMock()
+    pipeline.sidecar_restore_result = MagicMock(ok=True, status="waiting_input", reason=None)
+    pipeline.pending_ask_user_question.return_value = pending
+    pipeline.persist_pending_ask_user_question_answer = AsyncMock()
+    pipeline.resume_ask_user_question = MagicMock(return_value=resumed_stream())
+    pipeline.state_machine.current_step.step_id = "intent"
+    pipeline.state_machine.current_step.ui_mode = ""
+    pipeline.state_machine.is_complete = False
+    pipeline.sidecar_status = "waiting_input"
+    pipeline.display_transcript_path = None
+    repl_for_sidecar_restore.renderer.prompt_user_question = AsyncMock(return_value=answer)
+    repl_for_sidecar_restore._render_pipeline_display_replay_on_startup = MagicMock()
+    repl_for_sidecar_restore._render_pipeline_stream = AsyncMock(return_value=terminal_event)
+    repl_for_sidecar_restore._maybe_start_pipeline_cleanup = AsyncMock(return_value=False)
+    _seed_sidecar(repl_for_sidecar_restore, "waiting_input")
+
+    with patch("iac_code.pipeline.create_pipeline", return_value=pipeline):
+        handled = await InlineREPL._resume_pipeline_sidecar_on_startup(repl_for_sidecar_restore)
+
+    assert handled is True
+    question = repl_for_sidecar_restore.renderer.prompt_user_question.await_args.args[0]
+    assert question.tool_use_id == "ask-1"
+    assert question.question == "请选择部署目标"
+    assert question.options == [{"id": "nginx", "label": "Nginx 网站"}]
+    pipeline.persist_pending_ask_user_question_answer.assert_awaited_once_with("ask-1", answer)
+    pipeline.resume_ask_user_question.assert_called_once_with(
+        answer,
+        tool_use_id="ask-1",
+        pending_input=pending,
+    )
+    repl_for_sidecar_restore._render_pipeline_stream.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_startup_waiting_candidate_selection_starts_cleanup_after_terminal_handoff(
     monkeypatch,
     repl_for_sidecar_restore,


### PR DESCRIPTION
Persist pending REPL questions and submitted answers in the pipeline sidecar so interrupted sessions can resume safely. Synchronize PTY input readiness and isolate scenario state across E2E runs.