### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __release_date__ = ""

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.10.0\n"
+"Project-Id-Version: iac-code 0.11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.10.0\n"
+"Project-Id-Version: iac-code 0.11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.10.0\n"
+"Project-Id-Version: iac-code 0.11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.10.0\n"
+"Project-Id-Version: iac-code 0.11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.10.0\n"
+"Project-Id-Version: iac-code 0.11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.10.0\n"
+"Project-Id-Version: iac-code 0.11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"

--- a/src/iac_code/pipeline/engine/prerequisites.py
+++ b/src/iac_code/pipeline/engine/prerequisites.py
@@ -162,9 +162,7 @@ def inspect_prerequisites(
         # installer's install_dir (e.g. ~/bin) and version-check it. This is read-only
         # (no download/mkdir) and keeps detection consistent with prepare_prerequisites,
         # so a binary present in install_dir is reported available without touching PATH.
-        available_installers = _available_installers(
-            raw_prerequisite, current_platform, current_architecture, checker
-        )
+        available_installers = _available_installers(raw_prerequisite, current_platform, current_architecture, checker)
         resolved_path, resolved_installer_id, _hint_version_message = _resolve_path_hint_from_installers(
             raw_prerequisite,
             name,

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -913,6 +913,7 @@ class StepExecutor:
                 tool_cls = engine_tools.get(name)
             if tool_cls is not None:
                 if name == "ask_user_question":
+
                     def observe_question_answered(
                         tool_call_id: str | None, option_count: int, answer_type: str
                     ) -> None:

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
@@ -188,9 +188,7 @@ def _preview_source_cardinality(
             _request_error(
                 policy.action,
                 _("PreviewStack must provide Parameters when reusing the existing template."),
-                _(
-                    "A source-less update preview reuses the template only when Parameters is provided."
-                ),
+                _("A source-less update preview reuses the template only when Parameters is provided."),
                 "update-reuse-without-parameters",
             )
         )

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/function_specs.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/function_specs.py
@@ -183,9 +183,7 @@ _RETURN_TYPES: dict[str, RosType] = {
 
 def _context_contract(name: str, context: ExpressionContext) -> FunctionContextContract:
     implementation = (
-        "ParamRef"
-        if name == "Ref" and context not in {ExpressionContext.NORMAL, ExpressionContext.MODULE}
-        else name
+        "ParamRef" if name == "Ref" and context not in {ExpressionContext.NORMAL, ExpressionContext.MODULE} else name
     )
     if name == "Ref" and context in {ExpressionContext.NORMAL, ExpressionContext.MODULE}:
         implementation = "RefFactory"

--- a/src/iac_code/web/diagram_optimizer.py
+++ b/src/iac_code/web/diagram_optimizer.py
@@ -92,9 +92,7 @@ class DiagramOptimizationCoordinator:
         idx = cand.index
         name = cand.name
         try:
-            await session.events.publish(
-                "diagram.optimizing", {"candidateIndex": idx, "candidateName": name}
-            )
+            await session.events.publish("diagram.optimizing", {"candidateIndex": idx, "candidateName": name})
             selection = model_selection_for_session(session)
             base = await asyncio.to_thread(render_ros_template_architecture, cand.template_content)
             if base.mermaid_source.startswith(_ERROR_MERMAID_PREFIX):

--- a/src/iac_code/web/diagrams.py
+++ b/src/iac_code/web/diagrams.py
@@ -92,9 +92,7 @@ def iter_candidate_templates(manager: Any, session: Any) -> list[CandidateTempla
     return list(latest.values())
 
 
-def diagram_items(
-    manager: Any, session: Any, optimizing_indices: frozenset[int] = frozenset()
-) -> list[dict[str, Any]]:
+def diagram_items(manager: Any, session: Any, optimizing_indices: frozenset[int] = frozenset()) -> list[dict[str, Any]]:
     """扫描 pipeline A2A envelope 里各候选生成的模板,产出架构图列表(按候选去重,保留最新)。
 
     optimizing_indices:当前仍在后台优化的候选 index(来自协调器 _inflight)。优化进度态本只活在前端

--- a/src/iac_code/web/mcp_settings.py
+++ b/src/iac_code/web/mcp_settings.py
@@ -156,10 +156,7 @@ def _offline_diagnostics(
 ) -> list[MCPHealthDiagnostic]:
     """Build per-server diagnostics without connecting (mirrors CLI listing)."""
 
-    loaded = {
-        _scoped_server_listing_identity(server): server
-        for server in [*result.servers, *result.pending]
-    }
+    loaded = {_scoped_server_listing_identity(server): server for server in [*result.servers, *result.pending]}
     diagnostics: list[MCPHealthDiagnostic] = []
     represented: set[Any] = set()
     for entry in raw_entries:
@@ -369,9 +366,7 @@ def server_capabilities(
 
     workspace_root = resolve_mcp_workspace_root(cwd)
     snapshot = _run_cli(_connect_and_fetch, scoped_config, workspace_root)
-    diagnostic = (
-        snapshot.diagnostic if snapshot is not None else health_diagnostic_for_config(scoped_config)
-    )
+    diagnostic = snapshot.diagnostic if snapshot is not None else health_diagnostic_for_config(scoped_config)
     tools = snapshot.tools if snapshot is not None else []
     resources = snapshot.resources if snapshot is not None else []
     prompts = snapshot.prompts if snapshot is not None else []
@@ -476,9 +471,9 @@ def _build_config_from_fields(fields: dict[str, Any]) -> dict[str, Any]:
         config["type"] = transport
         config["url"] = url
     else:
-        raise MCPWebError(_("Invalid transport {transport!r}. Valid values: stdio, http, sse, ws.").format(
-            transport=transport
-        ))
+        raise MCPWebError(
+            _("Invalid transport {transport!r}. Valid values: stdio, http, sse, ws.").format(transport=transport)
+        )
 
     oauth = _build_oauth(fields.get("oauth"))
     if oauth:
@@ -514,9 +509,7 @@ def _build_oauth(value: Any) -> dict[str, Any]:
             oauth["callbackPort"] = int(callback_port)
         except (TypeError, ValueError) as exc:
             raise MCPWebError(_("OAuth callback port must be an integer.")) from exc
-    metadata_url = (
-        value.get("authServerMetadataUrl") or value.get("auth_server_metadata_url") or ""
-    ).strip()
+    metadata_url = (value.get("authServerMetadataUrl") or value.get("auth_server_metadata_url") or "").strip()
     if metadata_url:
         oauth["authServerMetadataUrl"] = metadata_url
     return oauth
@@ -586,9 +579,7 @@ def update_mcp_server(
     existing = load_exact_mcp_config(server_name, scope=resolved_scope, cwd=cwd)
     if not existing.servers:
         raise MCPWebError(
-            "MCP server {name!r} not found in {scope} config.".format(
-                name=server_name, scope=resolved_scope.value
-            ),
+            "MCP server {name!r} not found in {scope} config.".format(name=server_name, scope=resolved_scope.value),
             status_code=404,
         )
     if config is not None:

--- a/src/iac_code/web/outputs.py
+++ b/src/iac_code/web/outputs.py
@@ -41,6 +41,7 @@ def _is_pending_stack_status(status: Any) -> bool:
     s = str(status or "").upper()
     return bool(s) and (s.endswith("_IN_PROGRESS") or s.endswith("_REQUESTED"))
 
+
 _ROS_MARKERS = ("ROSTemplateFormatVersion", "Resources", "Transform")
 _TF_PATTERN = re.compile(r'(^|\n)\s*(resource|provider|module|terraform)\s*["{]')
 
@@ -184,11 +185,15 @@ def pipeline_candidate_costs(manager: Any, session: Any) -> dict[int, dict[str, 
             if not isinstance(cost, dict):
                 continue
             resources = cost.get("resources")
-            items = [
-                {"name": res.get("type") or "", "monthly_cost": res.get("cost") or ""}
-                for res in resources
-                if isinstance(res, dict)
-            ] if isinstance(resources, list) else []
+            items = (
+                [
+                    {"name": res.get("type") or "", "monthly_cost": res.get("cost") or ""}
+                    for res in resources
+                    if isinstance(res, dict)
+                ]
+                if isinstance(resources, list)
+                else []
+            )
             total = cost.get("monthly_estimate")
             costs[index] = {
                 "costItems": items,
@@ -211,9 +216,7 @@ def pipeline_candidate_costs(manager: Any, session: Any) -> dict[int, dict[str, 
     return costs
 
 
-def outputs_payload(
-    manager: Any, session: Any, optimizing_indices: frozenset[int] = frozenset()
-) -> dict[str, Any]:
+def outputs_payload(manager: Any, session: Any, optimizing_indices: frozenset[int] = frozenset()) -> dict[str, Any]:
     """扫描会话已存储消息 + pipeline A2A 日志,派生资源栈与模板文件列表。
 
     optimizing_indices 透传给 diagram_items,把协调器在途优化态挂到架构图的后端权威 optimizing 标志上。

--- a/src/iac_code/web/pipeline_actions.py
+++ b/src/iac_code/web/pipeline_actions.py
@@ -102,9 +102,7 @@ class A2APipelineActionRunner:
                 # for the local Web sink so pipeline mode shows 正在思考/思考完成 like normal mode.
                 # Only touches this fallback owner (standalone Web); a shared dispatcher owner
                 # keeps its own exposure config and remote clients are unaffected.
-                thinking_exposure_types=frozenset(
-                    {A2AExposureType.RAW_THINKING, A2AExposureType.TOOL_TRACE}
-                ),
+                thinking_exposure_types=frozenset({A2AExposureType.RAW_THINKING, A2AExposureType.TOOL_TRACE}),
             )
         self._owner = owner
         self._task_store = owner.task_store

--- a/src/iac_code/web/pipeline_transcript.py
+++ b/src/iac_code/web/pipeline_transcript.py
@@ -734,7 +734,7 @@ class PipelineTranscriptTranslator:
                 parent_group_id=str(base_step.get("parentGroupId") or ""),
                 parent_step_id=str(base_step.get("parentStepId") or ""),
                 candidate_name=str(base_step.get("candidateName") or ""),
-            )
+            ),
         ]
 
     def _on_text_delta(self, env: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/src/iac_code/web/settings.py
+++ b/src/iac_code/web/settings.py
@@ -140,9 +140,7 @@ def ui_language_payload() -> dict[str, Any]:
     """Return the saved UI language plus the available-languages list."""
     return {
         "uiLanguage": get_ui_language(),
-        "availableLanguages": [
-            {"code": code, "name": LANGUAGE_DISPLAY_NAMES[code]} for code in SUPPORTED_LANGUAGES
-        ],
+        "availableLanguages": [{"code": code, "name": LANGUAGE_DISPLAY_NAMES[code]} for code in SUPPORTED_LANGUAGES],
     }
 
 

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -571,9 +571,7 @@ class QueueLifecyclePublisher:
             )
         return persisted
 
-    async def enqueue_persisted_batch(
-        self, events, *, wait_for_transport: bool = False, local_envelopes=None
-    ) -> None:
+    async def enqueue_persisted_batch(self, events, *, wait_for_transport: bool = False, local_envelopes=None) -> None:
         await self.publish_batch(events)
 
     async def publish(self, event, **kwargs) -> str | None:

--- a/tests/a2a_e2e/test_run_a2a_contract_scenarios.py
+++ b/tests/a2a_e2e/test_run_a2a_contract_scenarios.py
@@ -70,6 +70,5 @@ def test_pipeline_provider_attribution_ignores_control_spans_but_checks_pipeline
 
     assert _audit_pipeline_provider_attribution([control_span, pipeline_span], context_id="ctx-1")["passed"] is True
     assert (
-        _audit_pipeline_provider_attribution([control_span, pipeline_span], context_id="ctx-other")["passed"]
-        is False
+        _audit_pipeline_provider_attribution([control_span, pipeline_span], context_id="ctx-other")["passed"] is False
     )

--- a/tests/i18n/test_webui_extraction.py
+++ b/tests/i18n/test_webui_extraction.py
@@ -23,9 +23,7 @@ import iac_code.i18n as i18n
 
 # babel_webui.cfg registers the ``t`` keyword for the webui JS domain.
 _WEBUI_KEYWORD = "t"
-_COMPOSER_JS = (
-    Path(i18n.__file__).parent.parent / "web" / "static" / "js" / "components" / "composer.js"
-)
+_COMPOSER_JS = Path(i18n.__file__).parent.parent / "web" / "static" / "js" / "components" / "composer.js"
 
 # Representative msgids from inside the historical dead zone. "Minimal"/"None"
 # are the two lowest effort tiers B4 added; the rest bracket the affected range.

--- a/tests/pipeline/engine/test_architecture_semantic_planning.py
+++ b/tests/pipeline/engine/test_architecture_semantic_planning.py
@@ -56,9 +56,7 @@ async def test_create_semantic_plan_with_llm_defaults_unchanged(monkeypatch):
     monkeypatch.setattr(asp, "ProviderManager", _FakeManager)
     monkeypatch.setattr(asp, "load_credentials", lambda *, model: {"default": "dk"})
 
-    await asp.create_semantic_plan_with_llm(
-        {"visible_nodes": []}, model="m", max_tokens=100, user_prompt="x"
-    )
+    await asp.create_semantic_plan_with_llm({"visible_nodes": []}, model="m", max_tokens=100, user_prompt="x")
 
     assert captured["credentials"] == {"default": "dk"}
     assert captured["provider_key_override"] is None

--- a/tests/providers/test_manager_stream_lifecycle.py
+++ b/tests/providers/test_manager_stream_lifecycle.py
@@ -427,10 +427,7 @@ async def test_refusal_commits_closes_and_discards_buffer_before_fallback(
         assert all(getattr(event, "text", None) != "discard me" for event in output)
     else:
         assert any(getattr(event, "text", None) == "discard me" for event in output)
-    assert all(
-        not isinstance(event, MessageEndEvent) or event.stop_reason != "refusal"
-        for event in output
-    )
+    assert all(not isinstance(event, MessageEndEvent) or event.stop_reason != "refusal" for event in output)
     assert iterator.close_calls == 1
     assert iterator.close_completed is True
     assert span.end_calls == 1

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -118,7 +118,7 @@ def test_legacy_setup_declares_package_metadata(monkeypatch):
     kwargs = setup_module._TEST_SETUP_KWARGS
 
     assert kwargs["name"] == "iac_code"
-    assert kwargs["version"] == "0.10.0"
+    assert kwargs["version"] == "0.11.0"
     assert kwargs["package_dir"] == {"": "src"}
     assert "iac_code.pipeline.selling.tools" in kwargs["packages"]
     assert "iac_code.pipeline.selling.hooks" in kwargs["packages"]

--- a/tests/tools/cloud/aliyun/test_ros_validation_facts.py
+++ b/tests/tools/cloud/aliyun/test_ros_validation_facts.py
@@ -101,9 +101,7 @@ def test_registry_rejects_missing_duplicate_and_future_dependencies() -> None:
         raise AssertionError("duplicate fact provider was accepted")
 
     self_cycle = ValidationRegistry()
-    self_cycle.register_provider(
-        Provider("self", RulePhase.PARSE, frozenset({"x"}), requires=frozenset({"x"}))
-    )
+    self_cycle.register_provider(Provider("self", RulePhase.PARSE, frozenset({"x"}), requires=frozenset({"x"})))
     try:
         self_cycle.freeze()
     except ValueError as error:
@@ -142,9 +140,7 @@ def test_optional_fact_preserves_unavailable_available_and_poisoned_states() -> 
 def test_registry_rejects_future_optional_dependency_and_provider_cycle() -> None:
     future_optional = ValidationRegistry()
     future_optional.register_provider(Provider("future", RulePhase.QUALITY, frozenset({"future"})))
-    future_optional.register_rule(
-        Rule("early", RulePhase.PARSE, "X", optional_requires=frozenset({"future"}))
-    )
+    future_optional.register_rule(Rule("early", RulePhase.PARSE, "X", optional_requires=frozenset({"future"})))
     try:
         future_optional.freeze()
     except ValueError as error:
@@ -153,12 +149,8 @@ def test_registry_rejects_future_optional_dependency_and_provider_cycle() -> Non
         raise AssertionError("future optional fact dependency was accepted")
 
     cycle = ValidationRegistry()
-    cycle.register_provider(
-        Provider("a", RulePhase.PARSE, frozenset({"a"}), requires=frozenset({"b"}))
-    )
-    cycle.register_provider(
-        Provider("b", RulePhase.PARSE, frozenset({"b"}), requires=frozenset({"a"}))
-    )
+    cycle.register_provider(Provider("a", RulePhase.PARSE, frozenset({"a"}), requires=frozenset({"b"})))
+    cycle.register_provider(Provider("b", RulePhase.PARSE, frozenset({"b"}), requires=frozenset({"a"})))
     try:
         cycle.freeze()
     except ValueError as error:

--- a/tests/tools/cloud/aliyun/test_ros_validation_registry.py
+++ b/tests/tools/cloud/aliyun/test_ros_validation_registry.py
@@ -382,12 +382,15 @@ def test_committed_resource_catalog_and_ref_types() -> None:
     assert random_string["official_evidence"]
     assert random_string["official_evidence"][0]["status"] == "NOT_FOUND"
     raw_ref_types = {item["resource_type"]: item["ref_type"] for item in records}
-    assert {name: raw_ref_types[name] for name in {
-        "ALIYUN::RandomString",
-        "ALIYUN::ROS::Stack",
-        "ALIYUN::ECS::PrepayInstance",
-        "ALIYUN::RDS::PrepayDBInstance",
-    }} == {
+    assert {
+        name: raw_ref_types[name]
+        for name in {
+            "ALIYUN::RandomString",
+            "ALIYUN::ROS::Stack",
+            "ALIYUN::ECS::PrepayInstance",
+            "ALIYUN::RDS::PrepayDBInstance",
+        }
+    } == {
         "ALIYUN::RandomString": "String | Null",
         "ALIYUN::ROS::Stack": "String | Null",
         "ALIYUN::ECS::PrepayInstance": "List[String] | Null",

--- a/tests/tools/test_glob.py
+++ b/tests/tools/test_glob.py
@@ -294,9 +294,7 @@ class TestGlobDoesNotBlockEventLoop:
         monkeypatch.setattr(glob_module, "_glob_matches", blocking_glob_matches)
 
         context = ToolPermissionContext(cwd=str(tmp_path))
-        task = asyncio.create_task(
-            tool.check_permissions({"pattern": "**/*.py", "path": str(tmp_path)}, context)
-        )
+        task = asyncio.create_task(tool.check_permissions({"pattern": "**/*.py", "path": str(tmp_path)}, context))
 
         await asyncio.wait_for(asyncio.to_thread(entered.wait, 1), timeout=2)
         assert not task.done()

--- a/tests/web/test_diagram_optimizer.py
+++ b/tests/web/test_diagram_optimizer.py
@@ -152,14 +152,13 @@ async def test_maybe_trigger_skips_when_cached(monkeypatch, tmp_path):
     _patch_engine(monkeypatch, plan_spy)
     monkeypatch.setattr(dc, "get_config_dir", lambda: tmp_path)
     monkeypatch.setattr(
-        opt, "model_selection_for_session",
+        opt,
+        "model_selection_for_session",
         lambda session: WebModelSelection(provider=None, model="m", effort=None),
     )
     session = _make_session(tmp_path)
     manager = _FakeManager([_tool_result("a.yaml", _TPL0, 0, "c0")])
-    dc.write_cached(
-        "ctx-1", 0, _TPL0, [{"id": "overview", "title": "", "mermaidSource": "graph TD\n  CACHED"}], "m"
-    )
+    dc.write_cached("ctx-1", 0, _TPL0, [{"id": "overview", "title": "", "mermaidSource": "graph TD\n  CACHED"}], "m")
 
     coord = opt.DiagramOptimizationCoordinator()
     coord.maybe_trigger(session, manager, _confirm_and_select_envelope())
@@ -175,7 +174,8 @@ async def test_non_candidate_input_required_ignored(monkeypatch, tmp_path):
     _patch_engine(monkeypatch, plan_spy)
     monkeypatch.setattr(dc, "get_config_dir", lambda: tmp_path)
     monkeypatch.setattr(
-        opt, "model_selection_for_session",
+        opt,
+        "model_selection_for_session",
         lambda session: WebModelSelection(provider=None, model="m", effort=None),
     )
     session = _make_session(tmp_path)
@@ -194,7 +194,8 @@ async def test_optimize_failure_publishes_failed_and_skips_cache(monkeypatch, tm
     _patch_engine(monkeypatch)
     monkeypatch.setattr(dc, "get_config_dir", lambda: tmp_path)
     monkeypatch.setattr(
-        opt, "model_selection_for_session",
+        opt,
+        "model_selection_for_session",
         lambda session: WebModelSelection(provider=None, model="m", effort=None),
     )
 
@@ -220,7 +221,8 @@ async def test_views_render_raises_publishes_failed_and_skips_cache(monkeypatch,
     _patch_engine(monkeypatch)
     monkeypatch.setattr(dc, "get_config_dir", lambda: tmp_path)
     monkeypatch.setattr(
-        opt, "model_selection_for_session",
+        opt,
+        "model_selection_for_session",
         lambda session: WebModelSelection(provider=None, model="m", effort=None),
     )
 
@@ -246,15 +248,14 @@ async def test_all_views_filtered_publishes_failed_and_skips_cache(monkeypatch, 
     _patch_engine(monkeypatch)
     monkeypatch.setattr(dc, "get_config_dir", lambda: tmp_path)
     monkeypatch.setattr(
-        opt, "model_selection_for_session",
+        opt,
+        "model_selection_for_session",
         lambda session: WebModelSelection(provider=None, model="m", effort=None),
     )
     monkeypatch.setattr(
         opt,
         "render_ros_template_architecture_views",
-        lambda tpl, *, semantic_plan=None: _Multi(
-            (_V("overview", "总览", "graph TD"), _V("detail", "细节", ""))
-        ),
+        lambda tpl, *, semantic_plan=None: _Multi((_V("overview", "总览", "graph TD"), _V("detail", "细节", ""))),
     )
     session = _make_session(tmp_path)
     manager = _FakeManager([_tool_result("a.yaml", _TPL0, 0, "c0")])

--- a/tests/web/test_diagrams.py
+++ b/tests/web/test_diagrams.py
@@ -351,9 +351,7 @@ def test_diagram_items_prefers_cached_and_flags_optimized(monkeypatch, tmp_path)
     monkeypatch.setattr(dc, "get_config_dir", lambda: tmp_path)
     monkeypatch.setattr("iac_code.web.diagrams.pipeline_candidate_costs", lambda m, s: {})
     session = SimpleNamespace(cwd=str(tmp_path), context_id="ctx-1")
-    manager = _FakeManager(
-        [_tool_result("a.yaml", _TPL0, 0, "c0"), _tool_result("b.yaml", _TPL1, 1, "c1")]
-    )
+    manager = _FakeManager([_tool_result("a.yaml", _TPL0, 0, "c0"), _tool_result("b.yaml", _TPL1, 1, "c1")])
     views = [{"id": "overview", "title": "总览", "mermaidSource": "graph TD\n  OPTIMIZED"}]
     dc.write_cached("ctx-1", 1, _TPL1, views, "m")
 
@@ -370,9 +368,7 @@ def test_diagram_items_uses_cached_views(monkeypatch, tmp_path):
     monkeypatch.setattr(dc, "get_config_dir", lambda: tmp_path)
     monkeypatch.setattr("iac_code.web.diagrams.pipeline_candidate_costs", lambda m, s: {})
     session = SimpleNamespace(cwd=str(tmp_path), context_id="ctx-1")
-    manager = _FakeManager(
-        [_tool_result("a.yaml", _TPL0, 0, "c0"), _tool_result("b.yaml", _TPL1, 1, "c1")]
-    )
+    manager = _FakeManager([_tool_result("a.yaml", _TPL0, 0, "c0"), _tool_result("b.yaml", _TPL1, 1, "c1")])
     views = [
         {"id": "overview", "title": "总览", "mermaidSource": "graph TD\n  OVERVIEW"},
         {"id": "network", "title": "网络", "mermaidSource": "graph TD\n  NETWORK"},

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -1460,7 +1460,7 @@ def test_mcp_tools_render_server_dot_tool_label_and_icon() -> None:
 
     # 卡片挂 data-tool-kind="mcp",供 CSS 换用 MCP 图标。
     card_body = tool_cards.split("function renderToolCard", 1)[1]
-    assert 'toolKind = "mcp"' in card_body or 'dataset.toolKind' in card_body
+    assert 'toolKind = "mcp"' in card_body or "dataset.toolKind" in card_body
 
     # 样式:MCP 卡的图标字形区别于通用 >_。
     styles = _source(Path(__file__).parents[2] / "src/iac_code/web/static/styles.css")
@@ -1838,9 +1838,9 @@ def test_in_progress_tool_labels_use_present_tense() -> None:
     assert 'toolPhrase(tool, "progress")' in command_body
 
     # The grouped summary also flips to present tense when any tool is still in progress.
-    group_body = tool_cards.split("export function toolGroupSummary", 1)[1].split(
-        "function toolGroupSummaryParts", 1
-    )[0]
+    group_body = tool_cards.split("export function toolGroupSummary", 1)[1].split("function toolGroupSummaryParts", 1)[
+        0
+    ]
     assert "tools.some(isToolInProgress)" in group_body
     assert 'toolGroupSummaryParts(tools, "progress")' in group_body
 
@@ -5701,10 +5701,7 @@ def test_pipeline_thinking_indicator_is_injected_per_working_step(tmp_path) -> N
     # 流式助手消息打 is-streaming,供上面的判据识别。
     assert 'article.classList.add("is-streaming");' in app_source
     # handleStreamEvent 收到 text/thinking delta 时打点 lastStreamDeltaAt,喂给上面的时效判据。
-    assert (
-        'if (event.type === "assistant.text.delta" || event.type === "assistant.thinking.delta") {'
-        in app_source
-    )
+    assert 'if (event.type === "assistant.text.delta" || event.type === "assistant.thinking.delta") {' in app_source
     assert "lastStreamDeltaAt = Date.now();" in app_source
     # renderMessages 末尾及心跳按模式分派:流水线→逐叶子;普通→底部单枚。分派内仍调 syncPipelineThinking。
     assert "syncPipelineThinking(stack);" in app_source
@@ -6551,7 +6548,7 @@ def test_plugins_panel_hosts_skills_and_mcp_subtabs() -> None:
     assert 'child.panel.removeAttribute?.("data-workspace-panel")' in source
 
     # 横向子标签栏:技能 / MCP,默认选中技能;切换时激活对应子面板。
-    assert 'const PLUGINS_SUBTABS = [' in source
+    assert "const PLUGINS_SUBTABS = [" in source
     assert '{ id: "skills", label: t("Skills") }' in source
     assert '{ id: "mcp", label: "MCP" }' in source
     assert "workspace-plugins-subtabs" in source
@@ -6973,7 +6970,7 @@ def test_workspace_model_panel_has_provider_subnav() -> None:
     # 唯一非重复的「状态」收成标题旁的徽章(当前模型/已配置/未配置),active 态绿色。
     assert "workspace-provider-status-badge" in source
     assert "workspace-provider-title-row" in source
-    assert 'statusBadge.dataset.state' in source
+    assert "statusBadge.dataset.state" in source
     assert "Current model" in source
     assert ".workspace-provider-title-row" in styles
     assert '.workspace-provider-status-badge[data-state="active"]' in styles
@@ -10191,6 +10188,7 @@ def test_composer_wires_thinking_toggle():
     assert "export function saveThinkingEnabled" in api
     assert '"/thinking-enabled"' in api
 
+
 def test_app_reads_injected_session_defaults():
     app = _source(APP_JS)
     # 后端把新会话默认注入 <body> data 属性,app.js 读一次做模块级常量,避免异步拉取闪烁。
@@ -10271,7 +10269,7 @@ def test_restart_server_wired_across_frontend():
     # api.js 暴露重启调用。
     api_src = _source(API_JS)
     assert "export function restartServer()" in api_src
-    assert '/api/server/restart' in api_src
+    assert "/api/server/restart" in api_src
 
     # workspace.js 常规面板渲染「重启服务」按钮 + 全屏确认遮罩 + 健康轮询后自动刷新。
     ws = _source(WORKSPACE_JS)

--- a/tests/web/test_mcp_settings.py
+++ b/tests/web/test_mcp_settings.py
@@ -512,17 +512,11 @@ def test_connect_and_fetch_snapshots_before_disconnect(monkeypatch) -> None:
     """
 
     scope_sentinel = object()  # identity is compared with ``is``
-    scoped_config = SimpleNamespace(
-        name="probe", scope=scope_sentinel, disabled=False, approved=True
-    )
+    scoped_config = SimpleNamespace(name="probe", scope=scope_sentinel, disabled=False, approved=True)
     record = SimpleNamespace(
         name="probe",
         scoped_config=SimpleNamespace(scope=scope_sentinel),
-        tools=[
-            SimpleNamespace(
-                tool_name="echo", description="Echo back", input_schema={}, annotations={}
-            )
-        ],
+        tools=[SimpleNamespace(tool_name="echo", description="Echo back", input_schema={}, annotations={})],
         resources=[],
         prompts=[
             SimpleNamespace(
@@ -554,9 +548,7 @@ def test_connect_and_fetch_snapshots_before_disconnect(monkeypatch) -> None:
     monkeypatch.setattr(
         mcp_settings,
         "health_diagnostic_for_record",
-        lambda rec: SimpleNamespace(
-            connection_state="connected", auth_state="not-configured", failure_reason=None
-        ),
+        lambda rec: SimpleNamespace(connection_state="connected", auth_state="not-configured", failure_reason=None),
     )
 
     snapshot = mcp_settings._connect_and_fetch(scoped_config, Path("/tmp/workspace"))
@@ -564,16 +556,12 @@ def test_connect_and_fetch_snapshots_before_disconnect(monkeypatch) -> None:
     assert snapshot is not None
     assert [tool["name"] for tool in snapshot.tools] == ["echo"]
     assert [prompt["name"] for prompt in snapshot.prompts] == ["greeting"]
-    assert snapshot.prompts[0]["arguments"] == [
-        {"name": "name", "description": "who", "required": True}
-    ]
+    assert snapshot.prompts[0]["arguments"] == [{"name": "name", "description": "who", "required": True}]
     assert snapshot.diagnostic.connection_state == "connected"
     # The live record really was wiped by disconnect_all — proving we snapshotted first.
     assert record.tools == []
     # And the whole snapshot survives JSON serialisation.
-    json.dumps(
-        {"tools": snapshot.tools, "resources": snapshot.resources, "prompts": snapshot.prompts}
-    )
+    json.dumps({"tools": snapshot.tools, "resources": snapshot.resources, "prompts": snapshot.prompts})
 
 
 def test_connect_and_fetch_skips_disabled_server(monkeypatch) -> None:
@@ -583,7 +571,5 @@ def test_connect_and_fetch_skips_disabled_server(monkeypatch) -> None:
         raise AssertionError("MCPManager must not be constructed for a disabled server")
 
     monkeypatch.setattr(mcp_settings, "MCPManager", _boom)
-    scoped_config = SimpleNamespace(
-        name="probe", scope=object(), disabled=True, approved=True
-    )
+    scoped_config = SimpleNamespace(name="probe", scope=object(), disabled=True, approved=True)
     assert mcp_settings._connect_and_fetch(scoped_config, Path("/tmp/workspace")) is None

--- a/tests/web/test_outputs.py
+++ b/tests/web/test_outputs.py
@@ -361,9 +361,7 @@ def test_payload_pipeline_stack_appears_in_progress(tmp_path):
     # 部署开始:仅有进行中态 stack_current_changed(尚无终态 tool_result)时,资源栈就应出现,
     # 状态为 CREATE_IN_PROGRESS、isSuccess=False、带 console URL——让面板在创建开始即显示,而非完成后。
     envelopes = [
-        _env_stack_current_changed(
-            stack_id="stk-inprog", stack_name="webapp", stack_status="CREATE_IN_PROGRESS"
-        ),
+        _env_stack_current_changed(stack_id="stk-inprog", stack_name="webapp", stack_status="CREATE_IN_PROGRESS"),
     ]
     session = _FakeSession(tmp_path, context_id="ctx-1")
     payload = outputs.outputs_payload(_FakeManager([], envelopes), session)
@@ -380,9 +378,7 @@ def test_payload_pipeline_terminal_result_overwrites_in_progress(tmp_path):
     # 进行中态先落面板,终态 tool_result 到来后应以相同 region::栈名 键覆盖:单个栈、终态权威
     # (status_reason/is_success 来自 tool_result),不残留「创建中」行。
     envelopes = [
-        _env_stack_current_changed(
-            stack_id="stk-1", stack_name="webapp", stack_status="CREATE_IN_PROGRESS"
-        ),
+        _env_stack_current_changed(stack_id="stk-1", stack_name="webapp", stack_status="CREATE_IN_PROGRESS"),
         _env_tool_result(
             "ros_deploy",
             tool_input={"action": "create", "region_id": "cn-hangzhou"},
@@ -405,9 +401,7 @@ def test_payload_pipeline_terminal_stack_current_changed_ignored(tmp_path):
     # 终态 stack_current_changed(CREATE_COMPLETE,非进行中)不应单独入栈:终态一律走 tool_result
     # 权威路径。仅有一条终态 stack_current_changed、无 tool_result 时,面板为空(避免用非权威结果建栈)。
     envelopes = [
-        _env_stack_current_changed(
-            stack_id="stk-done", stack_name="webapp", stack_status="CREATE_COMPLETE"
-        ),
+        _env_stack_current_changed(stack_id="stk-done", stack_name="webapp", stack_status="CREATE_COMPLETE"),
     ]
     session = _FakeSession(tmp_path, context_id="ctx-1")
     payload = outputs.outputs_payload(_FakeManager([], envelopes), session)

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -781,9 +781,7 @@ def test_save_provider_config_round_trips_output_and_budget_knobs(_isolate_confi
 
 def test_save_provider_config_knobs_are_per_model(_isolate_config):
     # 同一 provider 下不同模型互不干扰:给 glm-5.2 设值不应波及 kimi-k2.7-code。
-    web_settings.save_provider_config(
-        {"provider": "dashscope", "model": "glm-5.2", "maxCompletionTokens": 40000}
-    )
+    web_settings.save_provider_config({"provider": "dashscope", "model": "glm-5.2", "maxCompletionTokens": 40000})
     web_settings.save_provider_config(
         {"provider": "dashscope", "model": "kimi-k2.7-code", "maxCompletionTokens": 12000}
     )
@@ -843,13 +841,9 @@ def test_save_provider_config_absent_fields_preserve_existing_knobs(_isolate_con
 @pytest.mark.parametrize("bad", [0, -5, "big", True])
 def test_save_provider_config_rejects_non_positive_or_non_int_knobs(_isolate_config, bad):
     with pytest.raises(ValueError):
-        web_settings.save_provider_config(
-            {"provider": "dashscope", "model": "glm-5.2", "maxCompletionTokens": bad}
-        )
+        web_settings.save_provider_config({"provider": "dashscope", "model": "glm-5.2", "maxCompletionTokens": bad})
     with pytest.raises(ValueError):
-        web_settings.save_provider_config(
-            {"provider": "dashscope", "model": "glm-5.2", "thinkingBudget": bad}
-        )
+        web_settings.save_provider_config({"provider": "dashscope", "model": "glm-5.2", "thinkingBudget": bad})
 
 
 def test_save_active_provider_persists_output_and_budget_knobs(_isolate_config):


### PR DESCRIPTION
## Summary

- bump the project minor version from `0.10.0` to `0.11.0`
- synchronize packaging expectations and translation catalog metadata
- apply the repository formatter across `src/` and `tests/`

## Why

Prepare the next minor release and ensure the branch conforms to the current repository formatting rules.

## Impact

The published package and runtime now report version `0.11.0`. The remaining Python changes are formatter-only and do not alter behavior.

## Validation

- `make format`
- `make lint`
- `make translate`
- `make test` (`13072 passed, 2 skipped`)
- `git diff --check`
