### PR TITLE
feat(ros): validate association properties locally

### DIFF
--- a/scripts/aliyun/sync_ros_association_property_specs.py
+++ b/scripts/aliyun/sync_ros_association_property_specs.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate and vendor a sanitized AssociationProperty contract into iac-code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from iac_code.tools.cloud.aliyun.ros_validation.association_property_specs import (
+    apply_contract_corrections,
+    parse_contract_text,
+    verify_contract_payload,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT = (
+    PROJECT_ROOT / "src/iac_code/tools/cloud/aliyun/ros_validation/data/ros_association_property_specs.json"
+)
+
+
+def _load_existing(path: Path) -> Mapping[str, Any] | None:
+    if not path.is_file():
+        return None
+    payload = apply_contract_corrections(parse_contract_text(path.read_text(encoding="utf-8")))
+    verify_contract_payload(payload)
+    return payload
+
+
+def _keys(payload: Mapping[str, Any] | None, section: str) -> set[str]:
+    if payload is None:
+        return set()
+    value = payload.get(section)
+    return set(value) if isinstance(value, Mapping) else set()
+
+
+def _metadata_fields(payload: Mapping[str, Any] | None) -> set[str]:
+    if payload is None:
+        return set()
+    result: set[str] = set()
+
+    def collect(schema: Any, prefix: str) -> None:
+        if not isinstance(schema, Mapping):
+            return
+        properties = schema.get("properties")
+        if isinstance(properties, Mapping):
+            for key, child in properties.items():
+                child_prefix = "{}.{}".format(prefix, key)
+                result.add(child_prefix)
+                collect(child, child_prefix)
+        items = schema.get("items")
+        if isinstance(items, Mapping):
+            collect(items, "{}[]".format(prefix))
+        additional = schema.get("additionalProperties")
+        if isinstance(additional, Mapping):
+            wildcard = "{}.*".format(prefix)
+            result.add(wildcard)
+            collect(additional, wildcard)
+        patterns = schema.get("patternProperties")
+        if isinstance(patterns, Mapping):
+            for pattern, child in patterns.items():
+                pattern_prefix = "{}.pattern({})".format(prefix, pattern)
+                result.add(pattern_prefix)
+                collect(child, pattern_prefix)
+        any_of = schema.get("anyOf")
+        if isinstance(any_of, list):
+            for child in any_of:
+                collect(child, prefix)
+
+    common = payload.get("common_metadata")
+    if isinstance(common, Mapping):
+        collect(common.get("schema"), "common")
+    components = payload.get("components")
+    if isinstance(components, Mapping):
+        for component_name, component in components.items():
+            if isinstance(component, Mapping):
+                collect(component.get("metadata"), str(component_name))
+    return result
+
+
+def _describe_changes(old: Mapping[str, Any] | None, new: Mapping[str, Any]) -> str:
+    old_keys = _keys(old, "association_properties")
+    new_keys = _keys(new, "association_properties")
+    old_fields = _metadata_fields(old)
+    new_fields = _metadata_fields(new)
+    deprecated = sorted(
+        key
+        for key, value in new["association_properties"].items()
+        if isinstance(value, Mapping) and value.get("deprecated")
+    )
+    return "\n".join(
+        (
+            "AssociationProperty added: {}".format(", ".join(sorted(new_keys - old_keys)) or "<none>"),
+            "AssociationProperty removed: {}".format(", ".join(sorted(old_keys - new_keys)) or "<none>"),
+            "AssociationProperty deprecated: {}".format(", ".join(deprecated) or "<none>"),
+            "metadata fields added: {}".format(", ".join(sorted(new_fields - old_fields)) or "<none>"),
+            "metadata fields removed: {}".format(", ".join(sorted(old_fields - new_fields)) or "<none>"),
+        )
+    )
+
+
+def sync_contract(input_path: Path, output_path: Path) -> str:
+    payload = apply_contract_corrections(parse_contract_text(input_path.read_text(encoding="utf-8")))
+    verify_contract_payload(payload)
+    old = _load_existing(output_path)
+    serialized = (
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(serialized, encoding="utf-8", newline="\n")
+    return _describe_changes(old, payload)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+    print(sync_contract(args.input.resolve(), args.output.resolve()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -8614,6 +8614,11 @@ msgstr ""
 "verpasste Fehler zu vermeiden."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "{} local-analysis limitations; details condensed."
+msgstr "{} Einschränkungen der lokalen Analyse; Details zusammengefasst."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 msgid "generated JSON "
 msgstr "erzeugt JSON"
 
@@ -8628,6 +8633,21 @@ msgstr "Einzelheiten:"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
+msgid "{} occurrences; showing {} examples."
+msgstr "{} Vorkommen; {} Beispiele werden angezeigt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   example path: {} — {}"
+msgstr "   Beispielpfad: {} — {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   {} additional occurrences are available in structured diagnostics."
+msgstr "   {} weitere Vorkommen sind in den strukturierten Diagnosen verfügbar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
 msgid "{}line {}:{}"
 msgstr "{}Zeile {}:{}"
 
@@ -8638,7 +8658,7 @@ msgstr "kein Quellort"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   path: {}"
-msgstr "Pfad: {}"
+msgstr "   Pfad: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
@@ -8648,17 +8668,17 @@ msgstr "Verwandter Standort ({}): {}, Pfad: {}"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   expected: {}"
-msgstr "erwartet: {}"
+msgstr "   erwartet: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   actual: {}"
-msgstr "aktuell: {}"
+msgstr "   tatsächlich: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   Suggestion: {}"
-msgstr "Vorschlag: {}"
+msgstr "   Vorschlag: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/symbols.py
 msgid "Number argument cannot be converted to a number"
@@ -8683,6 +8703,806 @@ msgid "The known value of Parameter {} cannot be parsed as its declared type."
 msgstr ""
 "Der bekannte Wert von Parameter {} kann nicht als deklarierter Typ "
 "analysiert werden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Embedded Terraform variable metadata is not analyzed locally."
+msgstr "Eingebettete Terraform-Variablenmetadaten werden lokal nicht analysiert."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Top-level Parameters are validated; metadata inside Workspace files "
+"remains outside local analysis."
+msgstr ""
+"Parameters auf oberster Ebene werden validiert; Metadaten in Workspace-"
+"Dateien bleiben außerhalb der lokalen Analyse."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata nesting is too deep."
+msgstr "Die AssociationPropertyMetadata-Verschachtelung ist zu tief."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Nested Parameter/Parameters validation stops after {} levels."
+msgstr ""
+"Die Validierung verschachtelter Parameter/Parameters stoppt nach {} "
+"Ebenen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "at most {} nested levels"
+msgstr "höchstens {} verschachtelte Ebenen"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty must be a non-empty String."
+msgstr "AssociationProperty muss ein nicht leerer String sein."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target parameter form resolves AssociationProperty keys only from "
+"non-empty strings."
+msgstr ""
+"frontend löst AssociationProperty-Schlüssel nur aus nicht leeren "
+"Zeichenketten auf."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "non-empty String"
+msgstr "nicht leerer String"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Use {} instead."
+msgstr "Verwenden Sie stattdessen {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is deprecated: {}."
+msgstr "Der AssociationProperty-Wert ist veraltet: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The stock ROS form still recognizes this value, so this warning does not "
+"block the template."
+msgstr ""
+"Das Standard-ROS-Formular erkennt diesen Wert weiterhin; diese Warnung "
+"blockiert das Template daher nicht."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is absent from the local frontend contract: {}."
+msgstr ""
+"Der lokale Frontend-Vertrag enthält diesen AssociationProperty-Wert "
+"nicht: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A newer target frontend may support this value. Local validation uses the"
+" stock fallback component and does not mark the value invalid."
+msgstr ""
+"Ein neueres Ziel-Frontend kann den Wert unterstützen. Die lokale Prüfung "
+"nutzt die Standard-Ersatzkomponente und erklärt ihn nicht für ungültig."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is bypassed by a later stock form component selection."
+msgstr ""
+"Eine spätere Komponentenauswahl des Standardformulars umgeht "
+"AssociationProperty."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "No resolved form branch selects the unavailable AssociationProperty value."
+msgstr ""
+"Kein aufgelöster Formularzweig wählt den nicht verfügbaren "
+"AssociationProperty-Wert aus."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationProperty availability depends on the stock form read-only "
+"state."
+msgstr ""
+"Die Verfügbarkeit von AssociationProperty hängt vom Schreibschutzstatus "
+"des Standardformulars ab."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The editable form path does not support this value, while the read-only "
+"path may bypass it."
+msgstr ""
+"Der bearbeitbare Formularpfad unterstützt diesen Wert nicht; der "
+"schreibgeschützte Pfad kann diese Einschränkung umgehen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is unavailable in the stock ROS parameter form."
+msgstr "AssociationProperty ist im Standard-ROS-Parameterformular nicht verfügbar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a stock ROS AssociationProperty"
+msgstr "eine Standard-ROS-AssociationProperty"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata must be a Mapping."
+msgstr "AssociationPropertyMetadata muss ein Mapping sein."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The target form reads named metadata fields from an object."
+msgstr "frontend liest benannte Metadatenfelder aus einem Objekt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Mapping"
+msgstr "Zuordnung"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field names must be Strings."
+msgstr "AssociationPropertyMetadata-Feldnamen müssen Strings sein."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form performs named property access and cannot consume this "
+"key."
+msgstr ""
+"frontend führt benannten Eigenschaftszugriff durch und kann diesen "
+"Schlüssel nicht verarbeiten."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "String field name"
+msgstr "String-Feldname"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is shadowed by a higher-precedence "
+"alias."
+msgstr ""
+"Das AssociationPropertyMetadata-Feld wird von einem Alias mit höherer "
+"Priorität überdeckt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form reads {} first, so this value is ignored by that consumer."
+msgstr ""
+"frontend liest zuerst {}, daher wird dieser Wert von diesem Consumer "
+"ignoriert."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is not supported by the effective form "
+"component."
+msgstr ""
+"Das AssociationPropertyMetadata-Feld wird von der effektiven frontend-"
+"Komponente nicht unterstützt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is outside the audited contract "
+"coverage."
+msgstr ""
+"Das AssociationPropertyMetadata-Feld liegt außerhalb der geprüften "
+"Vertragsabdeckung."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The common schema or at least one possible component is partial/runtime-"
+"dependent; the field cannot be rejected deterministically."
+msgstr ""
+"Das gemeinsame Schema oder mindestens eine mögliche Komponente ist "
+"partiell/laufzeitabhängig; das Feld kann nicht deterministisch abgelehnt "
+"werden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The complete common and possible-component schemas all reject this field."
+msgstr ""
+"Die vollständigen gemeinsamen und möglichen Komponentenschemata lehnen "
+"dieses Feld alle ab."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a field consumed by the common or possible component schema"
+msgstr ""
+"ein Feld, das vom gemeinsamen oder möglichen Komponentenschema "
+"verarbeitet wird"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Metadata field {} is used by some possible form components and ignored by"
+" others."
+msgstr ""
+"Einige Formularkomponenten verwenden das Metadatenfeld {}, andere "
+"ignorieren es."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime component cannot be determined locally, so this field is left"
+" unchecked."
+msgstr ""
+"Die Laufzeitkomponente ist lokal nicht bestimmbar; daher wird das Feld "
+"nicht geprüft."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify whether"
+" the field takes effect in the target ROS form if needed."
+msgstr ""
+"Ändern Sie das Template nicht nur wegen dieser Einschränkung; prüfen Sie "
+"das Feld bei Bedarf im Ziel-ROS-Formular."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is nested too deeply."
+msgstr "Der AssociationPropertyMetadata-Wert ist zu tief verschachtelt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Schema traversal stops after {} levels."
+msgstr "Die Schema-Durchquerung stoppt nach {} Ebenen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is not in the local contract enum."
+msgstr "Der AssociationPropertyMetadata-Wert ist nicht im frontend-Enum enthalten."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective component only implements the exported enum values."
+msgstr "Die effektive Komponente implementiert nur die exportierten Enum-Werte."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object is missing a required field."
+msgstr "Dem AssociationPropertyMetadata-Objekt fehlt ein erforderliches Feld."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective form schema requires this nested field."
+msgstr "Das effektive frontend-Schema erfordert dieses verschachtelte Feld."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "required field {}"
+msgstr "erforderliches Feld {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "missing"
+msgstr "fehlt"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field uses the wrong letter case."
+msgstr ""
+"Das AssociationPropertyMetadata-Feld verwendet die falsche "
+"Groß-/Kleinschreibung."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object contains an unsupported nested field."
+msgstr ""
+"Das AssociationPropertyMetadata-Objekt enthält ein nicht unterstütztes "
+"verschachteltes Feld."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Field names are case-sensitive; use {} instead."
+msgstr ""
+"Bei Feldnamen wird zwischen Groß- und Kleinschreibung unterschieden; "
+"verwenden Sie stattdessen {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This nested schema is closed."
+msgstr "Dieses verschachtelte frontend-Schema ist geschlossen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "one of: {}"
+msgstr "eines von: {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Rename {} to {}."
+msgstr "Benennen Sie {} in {} um."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value does not match the local form schema."
+msgstr "Der AssociationPropertyMetadata-Wert entspricht nicht dem frontend-Schema."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The literal value failed the exported {} constraint."
+msgstr "Der Literalwert hat die exportierte {}-Einschränkung nicht erfüllt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference has inconsistent frontend consumers."
+msgstr ""
+"Die AssociationPropertyMetadata-Referenz hat inkonsistente frontend-"
+"Consumer."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"One consumer parses this value, but the template-default initializer may "
+"use the raw text. Host values and effect timing are unavailable locally."
+msgstr ""
+"Ein Consumer verarbeitet den Wert, aber der Standardwert-Initialisierer "
+"kann den Rohtext nutzen. Hostwerte und Zeitpunkt sind lokal unbekannt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Environment metadata reference cannot be resolved locally."
+msgstr "Die Umgebungs-Metadatenreferenz kann lokal nicht aufgelöst werden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The encoding is valid, but the contract does not provide an environment-"
+"data schema."
+msgstr ""
+"Die Kodierung ist gültig, aber der Vertrag stellt kein Schema für "
+"Umgebungsdaten bereit."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Mapping selector segment is interpreted as a literal key by the target "
+"form."
+msgstr ""
+"Das Mapping-Selektorsegment wird von frontend als literaler Schlüssel "
+"interpretiert."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"No Parameter named {} exists; the current mapping hook falls back to the "
+"segment text."
+msgstr ""
+"Es gibt keinen Parameter mit dem Namen {}; der aktuelle Mapping-Hook "
+"verwendet stattdessen den Segmenttext."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Metadata reference {} has more than one possible lookup scope."
+msgstr "Die Metadatenreferenz {} hat mehrere mögliche Suchbereiche."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"It may resolve from template Parameters or component-local data. The "
+"runtime component is unknown, so local validation leaves the reference "
+"unchecked."
+msgstr ""
+"Sie kann aus Parameters oder lokalen Daten aufgelöst werden. Da die "
+"Laufzeitkomponente unbekannt ist, wird die Referenz nicht geprüft."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify the "
+"reference behavior in the target ROS form if needed."
+msgstr ""
+"Ändern Sie das Template nicht nur wegen dieser Einschränkung; prüfen Sie "
+"die Referenz bei Bedarf im Ziel-ROS-Formular."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field-path reference cannot be resolved "
+"completely."
+msgstr ""
+"Die AssociationPropertyMetadata-Feldpfadreferenz kann nicht vollständig "
+"aufgelöst werden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The reference depends on a nested form or MetaList row context."
+msgstr ""
+"Die Referenz hängt von einem verschachtelten Formular oder MetaList-"
+"Zeilenkontext ab."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference cannot be proven valid locally."
+msgstr ""
+"Die AssociationPropertyMetadata-Referenz kann lokal nicht als gültig "
+"nachgewiesen werden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference is invalid."
+msgstr "Die AssociationPropertyMetadata-Referenz ist ungültig."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Consumer reachability is unknown; the possible encoding problem is: {}."
+msgstr ""
+"Die Erreichbarkeit des Consumers ist unbekannt; das mögliche "
+"Kodierungsproblem ist: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target consumer cannot resolve this encoding: {}."
+msgstr "Der frontend-Consumer kann diese Kodierung nicht auflösen: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a valid reference in the declared consumer context"
+msgstr "eine gültige Referenz im deklarierten Consumer-Kontext"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "referenced Parameter declaration"
+msgstr "referenzierte Parameter-Deklaration"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference type is suspicious."
+msgstr "Der AssociationPropertyMetadata-Referenztyp ist verdächtig."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The referenced Parameter resolves as {}, while this consumer expects {}."
+msgstr ""
+"Der referenzierte Parameter wird als {} aufgelöst, während dieser "
+"Consumer {} erwartet."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition contains a function key that the target form ignores."
+msgstr "Die Condition enthält einen Funktionsschlüssel, den frontend ignoriert."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form evaluates only the first object key, {}."
+msgstr "frontend wertet nur den ersten Objektschlüssel aus, {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select contains an argument that the target form ignores."
+msgstr "Fn::Select enthält ein Argument, das frontend ignoriert."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Only the first two arguments are destructured by the current runtime."
+msgstr ""
+"Nur die ersten beiden Argumente werden von der aktuellen Laufzeitumgebung"
+" destrukturiert."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata Condition is invalid."
+msgstr "Die AssociationPropertyMetadata-Condition ist ungültig."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The condition AST is incompatible with the target form: {}."
+msgstr "Der Condition-AST ist mit frontend inkompatibel: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a supported ParameterMetadataCondition"
+msgstr "eine unterstützte ParameterMetadataCondition"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition Definitions path cannot be resolved locally."
+msgstr "Der Condition-Definitions-Pfad kann lokal nicht aufgelöst werden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The template does not provide a statically inspectable ROS Interface "
+"Definitions object."
+msgstr ""
+"Das Template stellt kein statisch inspizierbares ROS-Interface-"
+"Definitions-Objekt bereit."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The ALIYUN and APSARA environment profiles resolve this path differently."
+msgstr ""
+"Die frontend-Umgebungsprofile ALIYUN und APSARA lösen diesen Pfad "
+"unterschiedlich auf."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata nested container has runtime-dependent "
+"reachability."
+msgstr ""
+"Die Erreichbarkeit des verschachtelten AssociationPropertyMetadata-"
+"Containers hängt von der Laufzeit ab."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Only some possible form components consume this Parameter/Parameters "
+"field; its nested declarations are not rejected locally."
+msgstr ""
+"Nur einige mögliche frontend-Komponenten verwenden dieses Parameter"
+"/Parameters-Feld; seine verschachtelten Deklarationen werden lokal nicht "
+"abgelehnt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Pattern syntax is not checked locally."
+msgstr "Die AutoCompleteInput-Pattern-Syntax wird lokal nicht überprüft."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form compiles Pattern as ECMAScript RegExp; Python regular "
+"expressions are not equivalent."
+msgstr ""
+"frontend kompiliert Pattern als ECMAScript RegExp; Python-reguläre "
+"Ausdrücke sind nicht gleichwertig."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "unsliced generated identifier (Length is falsy in JavaScript)"
+msgstr "nicht gekürzte generierte Kennung (Length ist in JavaScript falsy)"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "generated identifier truncated at position {}"
+msgstr "generierte Kennung an Position {} gekürzt"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Length is normalized non-intuitively by JavaScript."
+msgstr "AutoCompleteInput Length wird von JavaScript nicht intuitiv normalisiert."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Effective generated Length is {} after JavaScript array/slice conversion."
+msgstr ""
+"Die effektive generierte Length beträgt {} nach der JavaScript-Array"
+"-/Slice-Konvertierung."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a positive integer for predictable output"
+msgstr "eine positive Ganzzahl für vorhersehbare Ausgabe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores Pattern when CharacterClasses is non-empty."
+msgstr "AutoCompleteInput ignoriert Pattern, wenn CharacterClasses nicht leer ist."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The character-class generation branch does not compile Pattern."
+msgstr "Der Zweig zur Generierung nach Zeichenklassen kompiliert Pattern nicht."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character-only field."
+msgstr "AutoCompleteInput ignoriert ein reines Sonderzeichenfeld."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} is read only when Class is specialCharacter."
+msgstr "{} wird nur gelesen, wenn Class specialCharacter ist."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput CharacterClass does not guarantee a minimum count."
+msgstr "AutoCompleteInput CharacterClass garantiert keine Mindestanzahl."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"With multiple character classes, missing Min does not reserve characters "
+"for this class."
+msgstr ""
+"Bei mehreren Zeichenklassen reserviert ein fehlendes Min keine Zeichen "
+"für diese Klasse."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Min fills every available position."
+msgstr "AutoCompleteInput Min füllt jede verfügbare Position."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A negative or fractional counter never reaches zero; generation stops "
+"only after available positions are exhausted."
+msgstr ""
+"Ein negativer oder gebrochener Zähler erreicht nie null; die Generierung "
+"stoppt erst, wenn die verfügbaren Positionen erschöpft sind."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a non-negative integer for predictable minimum semantics"
+msgstr "eine nicht negative Ganzzahl für vorhersehbare Mindest-Semantik"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AutoCompleteInput minimum cannot be satisfied after earlier "
+"CharacterClasses."
+msgstr ""
+"Das AutoCompleteInput-Minimum kann nach früheren CharacterClasses nicht "
+"erfüllt werden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Earlier fills require at least {} of this entry's {} available positions."
+msgstr ""
+"Frühere Füllungen erfordern mindestens {} der {} verfügbaren Positionen "
+"dieses Eintrags."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a minimum satisfiable after earlier fills"
+msgstr "ein nach früheren Füllungen erfüllbares Minimum"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput minimum character counts exceed Length."
+msgstr "Die AutoCompleteInput-Mindestzeichenanzahlen überschreiten Length."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The sum of CharacterClasses.Min is {}, but the effective Length is {}."
+msgstr ""
+"Die Summe von CharacterClasses.Min beträgt {}, aber die effektive Length "
+"beträgt {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "sum of Min no greater than {}"
+msgstr "Summe von Min nicht größer als {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character boundary flag."
+msgstr "AutoCompleteInput ignoriert ein Sonderzeichen-Grenz-Flag."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime does not retain specialCharacter configuration when "
+"SpecialCharacters is empty."
+msgstr ""
+"Die Laufzeitumgebung behält die specialCharacter-Konfiguration nicht bei,"
+" wenn SpecialCharacters leer ist."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput requires non-empty SpecialCharacters."
+msgstr "AutoCompleteInput erfordert nicht leere SpecialCharacters."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This specialCharacter branch must fill at least one generated position."
+msgstr ""
+"Dieser specialCharacter-Zweig muss mindestens eine generierte Position "
+"füllen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput special-character minimum exceeds available positions."
+msgstr ""
+"Das AutoCompleteInput-Sonderzeichen-Minimum überschreitet die verfügbaren"
+" Positionen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Start/End restrictions leave {} positions for {} required special "
+"characters."
+msgstr ""
+"Start/End-Beschränkungen lassen {} Positionen für {} erforderliche "
+"Sonderzeichen übrig."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Min no greater than {}"
+msgstr "Min nicht größer als {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"join() can produce a string shorter than Length because the remaining-"
+"character pool becomes empty at the restricted boundary and stays empty."
+msgstr ""
+"join() kann eine Zeichenkette erzeugen, die kürzer als Length ist, weil "
+"der Pool verbleibender Zeichen an der beschränkten Grenze leer wird und "
+"leer bleibt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The mutable remaining-character pool narrows to ordinary classes at the "
+"restricted boundary and does not restore special characters later."
+msgstr ""
+"Der veränderliche Pool verbleibender Zeichen verengt sich an der "
+"beschränkten Grenze auf gewöhnliche Klassen und stellt Sonderzeichen "
+"später nicht wieder her."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput boundary restriction persists for later positions."
+msgstr ""
+"Die AutoCompleteInput-Grenzbeschränkung bleibt für spätere Positionen "
+"bestehen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "All statically reachable generation consumers are skipped. {} "
+msgstr "Alle statisch erreichbaren Generierungs-Consumer werden übersprungen. {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Generation consumer reachability is unknown. {} "
+msgstr "Die Erreichbarkeit des Generierungs-Consumers ist unbekannt. {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "any value"
+msgstr "beliebiger Wert"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is available only in the OOS parameter "
+"form."
+msgstr ""
+"Dieser AssociationProperty-Wert ist nur im OOS-Parameterformular "
+"verfügbar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is unavailable in the stock ROS parameter "
+"form."
+msgstr ""
+"Dieser AssociationProperty-Wert ist im Standard-ROS-Parameterformular "
+"nicht verfügbar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is empty"
+msgstr "die Referenz ist leer"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "environment references are not allowed by this consumer"
+msgstr "Umgebungsreferenzen sind für diesen Consumer nicht zulässig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Parameter references are not allowed by this consumer"
+msgstr "Parameter-Referenzen sind für diesen Consumer nicht zulässig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "field-path references are not allowed by this consumer"
+msgstr "Feldpfadreferenzen sind für diesen Consumer nicht zulässig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path is malformed"
+msgstr "der Feldpfad ist fehlerhaft"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"field paths support one top-level array projection followed by a child "
+"path"
+msgstr ""
+"Feldpfade unterstützen eine Array-Projektion auf oberster Ebene mit "
+"anschließendem untergeordnetem Pfad"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Parameter does not exist"
+msgstr "der Parameter existiert nicht"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter does not exist"
+msgstr "der verschachtelte Parameter existiert nicht"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the MetaList row field does not exist"
+msgstr "das MetaList-Zeilenfeld existiert nicht"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced Parameter declaration is invalid"
+msgstr "die referenzierte Parameter-Deklaration ist ungültig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path traverses a scalar Parameter"
+msgstr "der Feldpfad durchläuft einen skalaren Parameter"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter field does not exist"
+msgstr "das verschachtelte Parameter-Feld existiert nicht"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced nested Parameter declaration is invalid"
+msgstr "die referenzierte verschachtelte Parameter-Deklaration ist ungültig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path does not exist"
+msgstr "der Definitions-Pfad existiert nicht"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} references are not allowed by this consumer"
+msgstr "{}-Referenzen sind für diesen Consumer nicht zulässig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is invalid"
+msgstr "die Referenz ist ungültig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "nested And/Or/Not operands must be condition objects"
+msgstr "verschachtelte And/Or/Not-Operanden müssen Bedingungsobjekte sein"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition must be a non-empty String or object"
+msgstr "die Bedingung muss ein nicht leerer String oder ein Objekt sein"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the first function key is unsupported"
+msgstr "der erste Funktionsschlüssel wird nicht unterstützt"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Not requires one condition object containing a single key"
+msgstr "Fn::Not benötigt ein Bedingungsobjekt mit genau einem Schlüssel"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select requires its first two arguments to be Strings"
+msgstr "die ersten beiden Argumente von Fn::Select müssen Strings sein"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path must resolve to a condition object"
+msgstr "der Definitions-Pfad muss in ein Bedingungsobjekt aufgelöst werden"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires exactly two arguments"
+msgstr "{} benötigt genau zwei Argumente"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires an array"
+msgstr "{} benötigt ein Array"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition is invalid"
+msgstr "die Bedingung ist ungültig"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format
@@ -11747,3 +12567,124 @@ msgstr "Bash zulassen?"
 #~ msgid "由外部登录管理"
 #~ msgstr "Durch externe Anmeldung verwaltet"
 
+#~ msgid "The key maps to component {} with scope {}: {}."
+#~ msgstr ""
+#~ "Der Schlüssel wird der Komponente {} "
+#~ "mit dem Geltungsbereich {} zugeordnet: "
+#~ "{}."
+
+#~ msgid "AssociationProperty is deprecated by the local frontend contract."
+#~ msgstr "AssociationProperty ist von frontend als veraltet markiert."
+
+#~ msgid ""
+#~ "The current stock ROS form still "
+#~ "resolves this key, but the contract "
+#~ "marks it as deprecated."
+#~ msgstr ""
+#~ "Das aktuelle Standard-ROS-Formular löst"
+#~ " diesen Schlüssel noch auf, aber "
+#~ "frontend markiert ihn als veraltet."
+
+#~ msgid ""
+#~ "The local validator cannot prove that"
+#~ " a newer target frontend does not "
+#~ "support this key; stock fallback rules"
+#~ " are used."
+#~ msgstr ""
+#~ "Der lokale Validator kann nicht "
+#~ "nachweisen, dass ein neueres frontend-"
+#~ "Frontend diesen Schlüssel nicht unterstützt;"
+#~ " es werden Standard-Fallback-Regeln "
+#~ "verwendet."
+
+#~ msgid ""
+#~ "Only some possible components consume "
+#~ "this field; its component-specific "
+#~ "schema cannot be enforced deterministically."
+#~ msgstr ""
+#~ "Nur einige mögliche Komponenten verwenden "
+#~ "dieses Feld; sein komponentenspezifisches "
+#~ "Schema kann nicht deterministisch erzwungen"
+#~ " werden."
+
+#~ msgid ""
+#~ "AssociationPropertyMetadata Parameter reference has"
+#~ " a runtime-dependent scope."
+#~ msgstr ""
+#~ "Die AssociationPropertyMetadata-Parameter-Referenz"
+#~ " hat einen laufzeitabhängigen Geltungsbereich."
+
+#~ msgid ""
+#~ "The nested consumer does not use "
+#~ "an unambiguous template-root symbol "
+#~ "table."
+#~ msgstr ""
+#~ "Der verschachtelte Consumer verwendet keine"
+#~ " eindeutige Template-Root-Symboltabelle."
+
+#~ msgid ""
+#~ "Metadata field {} may or may not"
+#~ " take effect, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "Ob das Metadatenfeld {} wirkt, hängt "
+#~ "von der zur Laufzeit gewählten "
+#~ "Formularkomponente ab."
+
+#~ msgid ""
+#~ "Possible form components: {}. Only some"
+#~ " read field {}, so local validation"
+#~ " leaves the field unchecked."
+#~ msgstr ""
+#~ "Mögliche Komponenten: {}. Nur einige "
+#~ "lesen Feld {}; daher prüft die "
+#~ "lokale Validierung es nicht."
+
+#~ msgid ""
+#~ "Metadata reference {} may use different"
+#~ " lookup scopes, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "Die Metadatenreferenz {} kann je nach"
+#~ " Laufzeitkomponente unterschiedliche Suchbereiche "
+#~ "verwenden."
+
+#~ msgid "All resolved components bypass the unavailable {} mapping."
+#~ msgstr "Alle aufgelösten Komponenten umgehen die nicht verfügbare Zuordnung {}."
+
+#~ msgid ""
+#~ "The editable path cannot use component"
+#~ " {}, but the earlier read-only "
+#~ "branch can select {}."
+#~ msgstr ""
+#~ "Der bearbeitbare Pfad kann die "
+#~ "Komponente {} nicht verwenden, aber der"
+#~ " frühere schreibgeschützte Zweig kann {}"
+#~ " auswählen."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is available only in the OOS"
+#~ " parameter form."
+#~ msgstr ""
+#~ "Der Schlüssel verweist auf die "
+#~ "Komponente {}, die nur im OOS-"
+#~ "Parameterformular verfügbar ist."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is not registered in the "
+#~ "stock ROS parameter form."
+#~ msgstr ""
+#~ "Der Schlüssel verweist auf die "
+#~ "Komponente {}, die im Standard-ROS-"
+#~ "Parameterformular nicht registriert ist."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is unavailable in the stock "
+#~ "ROS parameter form."
+#~ msgstr ""
+#~ "Der Schlüssel verweist auf die "
+#~ "Komponente {}, die im Standard-ROS-"
+#~ "Parameterformular nicht verfügbar ist."

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -8546,6 +8546,11 @@ msgstr ""
 "errores perdidos."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "{} local-analysis limitations; details condensed."
+msgstr "{} limitaciones del análisis local; detalles condensados."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 msgid "generated JSON "
 msgstr "JSON"
 
@@ -8560,6 +8565,21 @@ msgstr "Detalles:"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
+msgid "{} occurrences; showing {} examples."
+msgstr "{} incidencias; se muestran {} ejemplos."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   example path: {} — {}"
+msgstr "   ruta de ejemplo: {} — {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   {} additional occurrences are available in structured diagnostics."
+msgstr "   Hay {} incidencias adicionales en los diagnósticos estructurados."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
 msgid "{}line {}:{}"
 msgstr "{}línea {}:{}"
 
@@ -8570,7 +8590,7 @@ msgstr "sin ubicación de origen"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   path: {}"
-msgstr "ruta: {}"
+msgstr "   ruta: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
@@ -8580,17 +8600,17 @@ msgstr "Ubicación relacionada ({}): {}, ruta: {}"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   expected: {}"
-msgstr "esperada: {}"
+msgstr "   valor esperado: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   actual: {}"
-msgstr "actual: {}"
+msgstr "   valor real: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   Suggestion: {}"
-msgstr "Sugerencia: {}"
+msgstr "   Sugerencia: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/symbols.py
 msgid "Number argument cannot be converted to a number"
@@ -8615,6 +8635,808 @@ msgid "The known value of Parameter {} cannot be parsed as its declared type."
 msgstr ""
 "El valor conocido de Parameter {} no puede ser analizado como su tipo "
 "declarado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Embedded Terraform variable metadata is not analyzed locally."
+msgstr "Los metadatos de variables Terraform integradas no se analizan localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Top-level Parameters are validated; metadata inside Workspace files "
+"remains outside local analysis."
+msgstr ""
+"Se validan los Parameters de nivel superior; los metadatos dentro de "
+"archivos Workspace quedan fuera del análisis local."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata nesting is too deep."
+msgstr "El anidamiento de AssociationPropertyMetadata es demasiado profundo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Nested Parameter/Parameters validation stops after {} levels."
+msgstr ""
+"La validación anidada de Parameter/Parameters se detiene después de {} "
+"niveles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "at most {} nested levels"
+msgstr "como máximo {} niveles anidados"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty must be a non-empty String."
+msgstr "AssociationProperty debe ser un String no vacío."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target parameter form resolves AssociationProperty keys only from "
+"non-empty strings."
+msgstr ""
+"frontend resuelve las claves de AssociationProperty solo a partir de "
+"cadenas no vacías."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "non-empty String"
+msgstr "String no vacío"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Use {} instead."
+msgstr "Use {} en su lugar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is deprecated: {}."
+msgstr "El valor de AssociationProperty está obsoleto: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The stock ROS form still recognizes this value, so this warning does not "
+"block the template."
+msgstr ""
+"El formulario ROS estándar aún reconoce este valor, por lo que esta "
+"advertencia no bloquea la plantilla."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is absent from the local frontend contract: {}."
+msgstr ""
+"El contrato frontend local no incluye este valor de AssociationProperty: "
+"{}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A newer target frontend may support this value. Local validation uses the"
+" stock fallback component and does not mark the value invalid."
+msgstr ""
+"Un frontend más reciente podría admitirlo. La validación local usa el "
+"componente alternativo estándar y no lo marca como inválido."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is bypassed by a later stock form component selection."
+msgstr ""
+"Una selección posterior de componente del formulario estándar omite "
+"AssociationProperty."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "No resolved form branch selects the unavailable AssociationProperty value."
+msgstr ""
+"Ninguna rama de formulario resuelta selecciona el valor de "
+"AssociationProperty no disponible."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationProperty availability depends on the stock form read-only "
+"state."
+msgstr ""
+"La disponibilidad de AssociationProperty depende del estado de solo "
+"lectura del formulario estándar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The editable form path does not support this value, while the read-only "
+"path may bypass it."
+msgstr ""
+"La ruta editable del formulario no admite este valor, mientras que la "
+"ruta de solo lectura puede omitir esta restricción."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is unavailable in the stock ROS parameter form."
+msgstr ""
+"AssociationProperty no está disponible en el formulario de parámetros ROS"
+" estándar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a stock ROS AssociationProperty"
+msgstr "un AssociationProperty ROS estándar"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata must be a Mapping."
+msgstr "AssociationPropertyMetadata debe ser un Mapping."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The target form reads named metadata fields from an object."
+msgstr "frontend lee los campos de metadatos con nombre de un objeto."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Mapping"
+msgstr "Asignación"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field names must be Strings."
+msgstr "Los nombres de campo de AssociationPropertyMetadata deben ser Strings."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form performs named property access and cannot consume this "
+"key."
+msgstr ""
+"frontend realiza acceso a propiedades con nombre y no puede consumir esta"
+" clave."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "String field name"
+msgstr "nombre de campo String"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is shadowed by a higher-precedence "
+"alias."
+msgstr ""
+"El campo de AssociationPropertyMetadata queda oculto por un alias de "
+"mayor precedencia."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form reads {} first, so this value is ignored by that consumer."
+msgstr "frontend lee {} primero, por lo que ese consumidor ignora este valor."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is not supported by the effective form "
+"component."
+msgstr ""
+"El campo de AssociationPropertyMetadata no es compatible con el "
+"componente frontend efectivo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is outside the audited contract "
+"coverage."
+msgstr ""
+"El campo de AssociationPropertyMetadata está fuera de la cobertura del "
+"contrato auditado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The common schema or at least one possible component is partial/runtime-"
+"dependent; the field cannot be rejected deterministically."
+msgstr ""
+"El esquema común o al menos un componente posible es parcial o depende "
+"del tiempo de ejecución; el campo no puede rechazarse de forma "
+"determinista."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The complete common and possible-component schemas all reject this field."
+msgstr ""
+"Los esquemas completos del componente común y de los posibles componentes"
+" rechazan todos este campo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a field consumed by the common or possible component schema"
+msgstr "un campo consumido por el esquema del componente común o posible"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Metadata field {} is used by some possible form components and ignored by"
+" others."
+msgstr "Algunos componentes usan el campo de metadatos {} y otros lo ignoran."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime component cannot be determined locally, so this field is left"
+" unchecked."
+msgstr ""
+"El componente de ejecución no puede determinarse localmente, por lo que "
+"el campo no se comprueba."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify whether"
+" the field takes effect in the target ROS form if needed."
+msgstr ""
+"No cambie la plantilla solo por esta limitación; si es necesario, "
+"compruebe el campo en el formulario ROS de destino."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is nested too deeply."
+msgstr ""
+"El valor de AssociationPropertyMetadata está anidado demasiado "
+"profundamente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Schema traversal stops after {} levels."
+msgstr "El recorrido del esquema se detiene después de {} niveles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is not in the local contract enum."
+msgstr ""
+"El valor de AssociationPropertyMetadata no está en la enumeración de "
+"frontend."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective component only implements the exported enum values."
+msgstr ""
+"El componente efectivo solo implementa los valores de enumeración "
+"exportados."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object is missing a required field."
+msgstr "Al objeto de AssociationPropertyMetadata le falta un campo obligatorio."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective form schema requires this nested field."
+msgstr "El esquema frontend efectivo requiere este campo anidado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "required field {}"
+msgstr "campo obligatorio {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "missing"
+msgstr "faltante"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field uses the wrong letter case."
+msgstr ""
+"El campo AssociationPropertyMetadata usa mayúsculas o minúsculas "
+"incorrectas."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object contains an unsupported nested field."
+msgstr ""
+"El objeto de AssociationPropertyMetadata contiene un campo anidado no "
+"admitido."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Field names are case-sensitive; use {} instead."
+msgstr ""
+"Los nombres de campos distinguen mayúsculas de minúsculas; use {} en su "
+"lugar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This nested schema is closed."
+msgstr "Este esquema frontend anidado es cerrado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "one of: {}"
+msgstr "uno de: {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Rename {} to {}."
+msgstr "Cambie el nombre de {} a {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value does not match the local form schema."
+msgstr ""
+"El valor de AssociationPropertyMetadata no coincide con el esquema de "
+"frontend."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The literal value failed the exported {} constraint."
+msgstr "El valor literal no cumplió la restricción {} exportada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference has inconsistent frontend consumers."
+msgstr ""
+"La referencia de AssociationPropertyMetadata tiene consumidores de "
+"frontend inconsistentes."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"One consumer parses this value, but the template-default initializer may "
+"use the raw text. Host values and effect timing are unavailable locally."
+msgstr ""
+"Un consumidor analiza el valor, pero el inicializador predeterminado "
+"puede usar el texto original. Los valores del host y el momento no están "
+"disponibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Environment metadata reference cannot be resolved locally."
+msgstr "La referencia de metadatos de entorno no puede resolverse localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The encoding is valid, but the contract does not provide an environment-"
+"data schema."
+msgstr ""
+"La codificación es válida, pero el contrato no proporciona un esquema de "
+"datos de entorno."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Mapping selector segment is interpreted as a literal key by the target "
+"form."
+msgstr ""
+"frontend interpreta el segmento del selector de asignación como una clave"
+" literal."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"No Parameter named {} exists; the current mapping hook falls back to the "
+"segment text."
+msgstr ""
+"No existe ningún parámetro llamado {}; el hook de asignación actual "
+"utiliza el texto del segmento."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Metadata reference {} has more than one possible lookup scope."
+msgstr "La referencia de metadatos {} tiene varios ámbitos de búsqueda posibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"It may resolve from template Parameters or component-local data. The "
+"runtime component is unknown, so local validation leaves the reference "
+"unchecked."
+msgstr ""
+"Puede resolverse desde Parameters o datos locales. Como se desconoce el "
+"componente de ejecución, la referencia no se comprueba."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify the "
+"reference behavior in the target ROS form if needed."
+msgstr ""
+"No cambie la plantilla solo por esta limitación; si es necesario, "
+"compruebe la referencia en el formulario ROS de destino."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field-path reference cannot be resolved "
+"completely."
+msgstr ""
+"La referencia de ruta de campo de AssociationPropertyMetadata no puede "
+"resolverse por completo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The reference depends on a nested form or MetaList row context."
+msgstr ""
+"La referencia depende de un formulario anidado o del contexto de fila de "
+"MetaList."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference cannot be proven valid locally."
+msgstr ""
+"No se puede demostrar localmente que la referencia de "
+"AssociationPropertyMetadata sea válida."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference is invalid."
+msgstr "La referencia de AssociationPropertyMetadata no es válida."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Consumer reachability is unknown; the possible encoding problem is: {}."
+msgstr ""
+"Se desconoce la accesibilidad del consumidor; el posible problema de "
+"codificación es: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target consumer cannot resolve this encoding: {}."
+msgstr "El consumidor de frontend no puede resolver esta codificación: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a valid reference in the declared consumer context"
+msgstr "una referencia válida en el contexto del consumidor declarado"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "referenced Parameter declaration"
+msgstr "declaración de Parameter referenciada"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference type is suspicious."
+msgstr "El tipo de referencia de AssociationPropertyMetadata es sospechoso."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The referenced Parameter resolves as {}, while this consumer expects {}."
+msgstr ""
+"El Parameter referenciado se resuelve como {}, mientras que este "
+"consumidor espera {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition contains a function key that the target form ignores."
+msgstr "Condition contiene una clave de función que frontend ignora."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form evaluates only the first object key, {}."
+msgstr "frontend evalúa solo la primera clave del objeto, {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select contains an argument that the target form ignores."
+msgstr "Fn::Select contiene un argumento que frontend ignora."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Only the first two arguments are destructured by the current runtime."
+msgstr ""
+"El tiempo de ejecución actual solo desestructura los dos primeros "
+"argumentos."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata Condition is invalid."
+msgstr "La Condition de AssociationPropertyMetadata no es válida."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The condition AST is incompatible with the target form: {}."
+msgstr "El AST de la condición es incompatible con frontend: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a supported ParameterMetadataCondition"
+msgstr "una ParameterMetadataCondition admitida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition Definitions path cannot be resolved locally."
+msgstr "La ruta de Definitions de Condition no puede resolverse localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The template does not provide a statically inspectable ROS Interface "
+"Definitions object."
+msgstr ""
+"La plantilla no proporciona un objeto Definitions de la interfaz ROS que "
+"pueda inspeccionarse estáticamente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The ALIYUN and APSARA environment profiles resolve this path differently."
+msgstr ""
+"Los perfiles de entorno de frontend ALIYUN y APSARA resuelven esta ruta "
+"de forma diferente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata nested container has runtime-dependent "
+"reachability."
+msgstr ""
+"La accesibilidad del contenedor anidado de AssociationPropertyMetadata "
+"depende del tiempo de ejecución."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Only some possible form components consume this Parameter/Parameters "
+"field; its nested declarations are not rejected locally."
+msgstr ""
+"Solo algunos componentes frontend posibles consumen este campo "
+"Parameter/Parameters; sus declaraciones anidadas no se rechazan "
+"localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Pattern syntax is not checked locally."
+msgstr "La sintaxis de Pattern de AutoCompleteInput no se verifica localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form compiles Pattern as ECMAScript RegExp; Python regular "
+"expressions are not equivalent."
+msgstr ""
+"frontend compila Pattern como ECMAScript RegExp; las expresiones "
+"regulares de Python no son equivalentes."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "unsliced generated identifier (Length is falsy in JavaScript)"
+msgstr "identificador generado sin recortar (Length es un valor falso en JavaScript)"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "generated identifier truncated at position {}"
+msgstr "identificador generado truncado en la posición {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Length is normalized non-intuitively by JavaScript."
+msgstr "JavaScript normaliza Length de AutoCompleteInput de forma poco intuitiva."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Effective generated Length is {} after JavaScript array/slice conversion."
+msgstr ""
+"El Length generado efectivo es {} después de la conversión de array/slice"
+" de JavaScript."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a positive integer for predictable output"
+msgstr "un entero positivo para una salida predecible"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores Pattern when CharacterClasses is non-empty."
+msgstr "AutoCompleteInput ignora Pattern cuando CharacterClasses no está vacío."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The character-class generation branch does not compile Pattern."
+msgstr "La rama de generación por clases de caracteres no compila Pattern."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character-only field."
+msgstr "AutoCompleteInput ignora un campo exclusivo de caracteres especiales."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} is read only when Class is specialCharacter."
+msgstr "{} solo se lee cuando Class es specialCharacter."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput CharacterClass does not guarantee a minimum count."
+msgstr "El CharacterClass de AutoCompleteInput no garantiza un recuento mínimo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"With multiple character classes, missing Min does not reserve characters "
+"for this class."
+msgstr ""
+"Con varias clases de caracteres, la ausencia de Min no reserva caracteres"
+" para esta clase."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Min fills every available position."
+msgstr "El Min de AutoCompleteInput llena todas las posiciones disponibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A negative or fractional counter never reaches zero; generation stops "
+"only after available positions are exhausted."
+msgstr ""
+"Un contador negativo o fraccionario nunca llega a cero; la generación solo "
+"se detiene cuando se agotan las posiciones disponibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a non-negative integer for predictable minimum semantics"
+msgstr "un entero no negativo para una semántica de mínimo predecible"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AutoCompleteInput minimum cannot be satisfied after earlier "
+"CharacterClasses."
+msgstr ""
+"El mínimo de AutoCompleteInput no puede satisfacerse después de las "
+"CharacterClasses anteriores."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Earlier fills require at least {} of this entry's {} available positions."
+msgstr ""
+"Los llenados anteriores requieren al menos {} de las {} posiciones "
+"disponibles de esta entrada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a minimum satisfiable after earlier fills"
+msgstr "un mínimo que pueda satisfacerse después de los llenados anteriores"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput minimum character counts exceed Length."
+msgstr "Los recuentos mínimos de caracteres de AutoCompleteInput superan Length."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The sum of CharacterClasses.Min is {}, but the effective Length is {}."
+msgstr "La suma de CharacterClasses.Min es {}, pero el Length efectivo es {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "sum of Min no greater than {}"
+msgstr "suma de Min no mayor que {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character boundary flag."
+msgstr "AutoCompleteInput ignora una marca de límite de carácter especial."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime does not retain specialCharacter configuration when "
+"SpecialCharacters is empty."
+msgstr ""
+"El tiempo de ejecución no conserva la configuración specialCharacter "
+"cuando SpecialCharacters está vacío."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput requires non-empty SpecialCharacters."
+msgstr "AutoCompleteInput requiere SpecialCharacters no vacío."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This specialCharacter branch must fill at least one generated position."
+msgstr "Esta rama specialCharacter debe llenar al menos una posición generada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput special-character minimum exceeds available positions."
+msgstr ""
+"El mínimo de caracteres especiales de AutoCompleteInput supera las "
+"posiciones disponibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Start/End restrictions leave {} positions for {} required special "
+"characters."
+msgstr ""
+"Las restricciones de Start/End dejan {} posiciones para {} caracteres "
+"especiales requeridos."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Min no greater than {}"
+msgstr "Min no mayor que {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"join() can produce a string shorter than Length because the remaining-"
+"character pool becomes empty at the restricted boundary and stays empty."
+msgstr ""
+"join() puede producir una cadena más corta que Length porque el grupo de "
+"caracteres restantes queda vacío en el límite restringido y permanece "
+"vacío."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The mutable remaining-character pool narrows to ordinary classes at the "
+"restricted boundary and does not restore special characters later."
+msgstr ""
+"El grupo mutable de caracteres restantes se reduce a clases ordinarias en"
+" el límite restringido y no restaura los caracteres especiales más tarde."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput boundary restriction persists for later positions."
+msgstr ""
+"La restricción de límite de AutoCompleteInput persiste para las "
+"posiciones posteriores."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "All statically reachable generation consumers are skipped. {} "
+msgstr ""
+"Se omiten todos los consumidores de generación alcanzables estáticamente."
+" {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Generation consumer reachability is unknown. {} "
+msgstr "Se desconoce la accesibilidad del consumidor de generación. {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "any value"
+msgstr "cualquier valor"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is available only in the OOS parameter "
+"form."
+msgstr ""
+"Este valor de AssociationProperty solo está disponible en el formulario "
+"de parámetros de OOS."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is unavailable in the stock ROS parameter "
+"form."
+msgstr ""
+"Este valor de AssociationProperty no está disponible en el formulario de "
+"parámetros ROS estándar."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is empty"
+msgstr "la referencia está vacía"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "environment references are not allowed by this consumer"
+msgstr "este consumidor no permite referencias de entorno"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Parameter references are not allowed by this consumer"
+msgstr "este consumidor no permite referencias a Parameter"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "field-path references are not allowed by this consumer"
+msgstr "este consumidor no permite referencias mediante rutas de campos"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path is malformed"
+msgstr "la ruta de campos tiene un formato incorrecto"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"field paths support one top-level array projection followed by a child "
+"path"
+msgstr ""
+"las rutas de campos admiten una proyección de matriz de nivel superior "
+"seguida de una ruta secundaria"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Parameter does not exist"
+msgstr "el Parameter no existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter does not exist"
+msgstr "el Parameter anidado no existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the MetaList row field does not exist"
+msgstr "el campo de la fila de MetaList no existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced Parameter declaration is invalid"
+msgstr "la declaración del Parameter referenciado no es válida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path traverses a scalar Parameter"
+msgstr "la ruta de campos atraviesa un Parameter escalar"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter field does not exist"
+msgstr "el campo del Parameter anidado no existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced nested Parameter declaration is invalid"
+msgstr "la declaración del Parameter anidado referenciado no es válida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path does not exist"
+msgstr "la ruta de Definitions no existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} references are not allowed by this consumer"
+msgstr "este consumidor no permite referencias de tipo {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is invalid"
+msgstr "la referencia no es válida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "nested And/Or/Not operands must be condition objects"
+msgstr "los operandos And/Or/Not anidados deben ser objetos de condición"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition must be a non-empty String or object"
+msgstr "la condición debe ser un String no vacío o un objeto"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the first function key is unsupported"
+msgstr "la primera clave de función no es compatible"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Not requires one condition object containing a single key"
+msgstr "Fn::Not requiere un objeto de condición que contenga una sola clave"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select requires its first two arguments to be Strings"
+msgstr "Fn::Select requiere que sus dos primeros argumentos sean Strings"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path must resolve to a condition object"
+msgstr "la ruta de Definitions debe resolverse como un objeto de condición"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires exactly two arguments"
+msgstr "{} requiere exactamente dos argumentos"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires an array"
+msgstr "{} requiere una matriz"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition is invalid"
+msgstr "la condición no es válida"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format
@@ -11662,3 +12484,123 @@ msgstr "¿Permitir Bash?"
 #~ msgid "由外部登录管理"
 #~ msgstr "Gestionado mediante inicio de sesión externo"
 
+#~ msgid "The key maps to component {} with scope {}: {}."
+#~ msgstr "La clave se asigna al componente {} con ámbito {}: {}."
+
+#~ msgid "AssociationProperty is deprecated by the local frontend contract."
+#~ msgstr "AssociationProperty está obsoleto según frontend."
+
+#~ msgid ""
+#~ "The current stock ROS form still "
+#~ "resolves this key, but the contract "
+#~ "marks it as deprecated."
+#~ msgstr ""
+#~ "El formulario ROS estándar actual aún"
+#~ " resuelve esta clave, pero frontend "
+#~ "la marca como obsoleta."
+
+#~ msgid ""
+#~ "The local validator cannot prove that"
+#~ " a newer target frontend does not "
+#~ "support this key; stock fallback rules"
+#~ " are used."
+#~ msgstr ""
+#~ "El validador local no puede demostrar"
+#~ " que una interfaz de frontend más "
+#~ "reciente no admita esta clave; se "
+#~ "usan las reglas de reserva estándar."
+
+#~ msgid ""
+#~ "Only some possible components consume "
+#~ "this field; its component-specific "
+#~ "schema cannot be enforced deterministically."
+#~ msgstr ""
+#~ "Solo algunos componentes posibles consumen "
+#~ "este campo; su esquema específico de "
+#~ "componente no puede aplicarse de forma"
+#~ " determinista."
+
+#~ msgid ""
+#~ "AssociationPropertyMetadata Parameter reference has"
+#~ " a runtime-dependent scope."
+#~ msgstr ""
+#~ "La referencia de Parameter de "
+#~ "AssociationPropertyMetadata tiene un ámbito "
+#~ "que depende del tiempo de ejecución."
+
+#~ msgid ""
+#~ "The nested consumer does not use "
+#~ "an unambiguous template-root symbol "
+#~ "table."
+#~ msgstr ""
+#~ "El consumidor anidado no usa una "
+#~ "tabla de símbolos de raíz de "
+#~ "plantilla inequívoca."
+
+#~ msgid ""
+#~ "Metadata field {} may or may not"
+#~ " take effect, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "El campo de metadatos {} puede "
+#~ "aplicarse o no según el componente "
+#~ "elegido en tiempo de ejecución."
+
+#~ msgid ""
+#~ "Possible form components: {}. Only some"
+#~ " read field {}, so local validation"
+#~ " leaves the field unchecked."
+#~ msgstr ""
+#~ "Componentes posibles: {}. Solo algunos "
+#~ "leen el campo {}; por eso la "
+#~ "validación local no lo comprueba."
+
+#~ msgid ""
+#~ "Metadata reference {} may use different"
+#~ " lookup scopes, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "La referencia de metadatos {} puede "
+#~ "usar distintos ámbitos según el "
+#~ "componente elegido en tiempo de "
+#~ "ejecución."
+
+#~ msgid "All resolved components bypass the unavailable {} mapping."
+#~ msgstr "Todos los componentes resueltos omiten la asignación no disponible {}."
+
+#~ msgid ""
+#~ "The editable path cannot use component"
+#~ " {}, but the earlier read-only "
+#~ "branch can select {}."
+#~ msgstr ""
+#~ "La ruta editable no puede usar el"
+#~ " componente {}, pero la rama anterior"
+#~ " de solo lectura puede seleccionar "
+#~ "{}."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is available only in the OOS"
+#~ " parameter form."
+#~ msgstr ""
+#~ "La clave se asigna al componente "
+#~ "{}, que solo está disponible en el"
+#~ " formulario de parámetros de OOS."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is not registered in the "
+#~ "stock ROS parameter form."
+#~ msgstr ""
+#~ "La clave se asigna al componente "
+#~ "{}, que no está registrado en el"
+#~ " formulario de parámetros ROS estándar."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is unavailable in the stock "
+#~ "ROS parameter form."
+#~ msgstr ""
+#~ "La clave se asigna al componente "
+#~ "{}, que no está disponible en el"
+#~ " formulario de parámetros ROS estándar."

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -8596,6 +8596,11 @@ msgstr ""
 "erreurs manquées."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "{} local-analysis limitations; details condensed."
+msgstr "{} limitations d’analyse locale ; détails condensés."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 msgid "generated JSON "
 msgstr "généré JSON"
 
@@ -8610,6 +8615,23 @@ msgstr "Détails:"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
+msgid "{} occurrences; showing {} examples."
+msgstr "{} occurrences ; affichage de {} exemples."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   example path: {} — {}"
+msgstr "   chemin d’exemple : {} — {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   {} additional occurrences are available in structured diagnostics."
+msgstr ""
+"   {} occurrences supplémentaires sont disponibles dans les diagnostics "
+"structurés."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
 msgid "{}line {}:{}"
 msgstr "{}ligne {}:{}"
 
@@ -8620,7 +8642,7 @@ msgstr "Aucune source"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   path: {}"
-msgstr "chemin : {}"
+msgstr "   chemin : {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
@@ -8630,17 +8652,17 @@ msgstr "Lieu associé ({}): {}, chemin: {}"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   expected: {}"
-msgstr "attendu : {}"
+msgstr "   valeur attendue : {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   actual: {}"
-msgstr "Nombre réel : {}"
+msgstr "   valeur réelle : {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   Suggestion: {}"
-msgstr "Suggestion : {}"
+msgstr "   Suggestion : {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/symbols.py
 msgid "Number argument cannot be converted to a number"
@@ -8665,6 +8687,810 @@ msgid "The known value of Parameter {} cannot be parsed as its declared type."
 msgstr ""
 "La valeur connue de Parameter {} ne peut pas être analysée comme son type"
 " déclaré."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Embedded Terraform variable metadata is not analyzed locally."
+msgstr ""
+"Les métadonnées des variables Terraform intégrées ne sont pas analysées "
+"localement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Top-level Parameters are validated; metadata inside Workspace files "
+"remains outside local analysis."
+msgstr ""
+"Les Parameters de premier niveau sont validés ; les métadonnées des "
+"fichiers Workspace restent hors de l’analyse locale."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata nesting is too deep."
+msgstr "L'imbrication d'AssociationPropertyMetadata est trop profonde."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Nested Parameter/Parameters validation stops after {} levels."
+msgstr "La validation imbriquée de Parameter/Parameters s'arrête après {} niveaux."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "at most {} nested levels"
+msgstr "au plus {} niveaux imbriqués"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty must be a non-empty String."
+msgstr "AssociationProperty doit être une String non vide."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target parameter form resolves AssociationProperty keys only from "
+"non-empty strings."
+msgstr ""
+"frontend ne résout les clés AssociationProperty qu'à partir de chaînes "
+"non vides."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "non-empty String"
+msgstr "String non vide"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Use {} instead."
+msgstr "Utilisez {} à la place."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is deprecated: {}."
+msgstr "La valeur d'AssociationProperty est obsolète : {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The stock ROS form still recognizes this value, so this warning does not "
+"block the template."
+msgstr ""
+"Le formulaire ROS standard reconnaît encore cette valeur ; cet "
+"avertissement ne bloque donc pas le modèle."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is absent from the local frontend contract: {}."
+msgstr ""
+"Le contrat frontend local ne contient pas cette valeur "
+"d'AssociationProperty : {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A newer target frontend may support this value. Local validation uses the"
+" stock fallback component and does not mark the value invalid."
+msgstr ""
+"Un frontend cible plus récent peut la prendre en charge. La validation "
+"locale utilise le composant standard de repli sans la déclarer invalide."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is bypassed by a later stock form component selection."
+msgstr ""
+"Une sélection ultérieure de composant du formulaire standard contourne "
+"AssociationProperty."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "No resolved form branch selects the unavailable AssociationProperty value."
+msgstr ""
+"Aucune branche de formulaire résolue ne sélectionne la valeur "
+"AssociationProperty indisponible."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationProperty availability depends on the stock form read-only "
+"state."
+msgstr ""
+"La disponibilité d’AssociationProperty dépend de l’état en lecture seule "
+"du formulaire standard."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The editable form path does not support this value, while the read-only "
+"path may bypass it."
+msgstr ""
+"Le chemin de formulaire modifiable ne prend pas en charge cette valeur, "
+"tandis que le chemin en lecture seule peut contourner cette restriction."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is unavailable in the stock ROS parameter form."
+msgstr ""
+"AssociationProperty n'est pas disponible dans le formulaire de paramètres"
+" ROS standard."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a stock ROS AssociationProperty"
+msgstr "un AssociationProperty ROS standard"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata must be a Mapping."
+msgstr "AssociationPropertyMetadata doit être un Mapping."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The target form reads named metadata fields from an object."
+msgstr "frontend lit les champs de métadonnées nommés à partir d'un objet."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Mapping"
+msgstr "Mappage"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field names must be Strings."
+msgstr "Les noms de champs d'AssociationPropertyMetadata doivent être des Strings."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form performs named property access and cannot consume this "
+"key."
+msgstr ""
+"frontend effectue un accès à des propriétés nommées et ne peut pas "
+"consommer cette clé."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "String field name"
+msgstr "nom de champ String"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is shadowed by a higher-precedence "
+"alias."
+msgstr ""
+"Le champ AssociationPropertyMetadata est masqué par un alias de priorité "
+"supérieure."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form reads {} first, so this value is ignored by that consumer."
+msgstr ""
+"frontend lit {} en premier, donc cette valeur est ignorée par ce "
+"consommateur."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is not supported by the effective form "
+"component."
+msgstr ""
+"Le champ AssociationPropertyMetadata n'est pas pris en charge par le "
+"composant frontend effectif."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is outside the audited contract "
+"coverage."
+msgstr ""
+"Le champ AssociationPropertyMetadata est en dehors de la couverture du "
+"contrat audité."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The common schema or at least one possible component is partial/runtime-"
+"dependent; the field cannot be rejected deterministically."
+msgstr ""
+"Le schéma commun ou au moins un composant possible est partiel/dépendant "
+"de l'exécution ; le champ ne peut pas être rejeté de manière "
+"déterministe."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The complete common and possible-component schemas all reject this field."
+msgstr ""
+"Les schémas complets commun et de composant possible rejettent tous ce "
+"champ."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a field consumed by the common or possible component schema"
+msgstr "un champ consommé par le schéma commun ou de composant possible"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Metadata field {} is used by some possible form components and ignored by"
+" others."
+msgstr ""
+"Certains composants utilisent le champ de métadonnées {}, tandis que "
+"d'autres l'ignorent."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime component cannot be determined locally, so this field is left"
+" unchecked."
+msgstr ""
+"Le composant d'exécution ne peut pas être déterminé localement ; le champ"
+" n'est donc pas contrôlé."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify whether"
+" the field takes effect in the target ROS form if needed."
+msgstr ""
+"Ne modifiez pas le modèle pour cette seule limite ; vérifiez au besoin le"
+" champ dans le formulaire ROS cible."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is nested too deeply."
+msgstr "La valeur d'AssociationPropertyMetadata est imbriquée trop profondément."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Schema traversal stops after {} levels."
+msgstr "Le parcours du schéma s'arrête après {} niveaux."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is not in the local contract enum."
+msgstr ""
+"La valeur d'AssociationPropertyMetadata ne figure pas dans l'énumération "
+"frontend."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective component only implements the exported enum values."
+msgstr ""
+"Le composant effectif n'implémente que les valeurs d'énumération "
+"exportées."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object is missing a required field."
+msgstr "Il manque un champ requis à l'objet AssociationPropertyMetadata."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective form schema requires this nested field."
+msgstr "Le schéma frontend effectif requiert ce champ imbriqué."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "required field {}"
+msgstr "champ requis {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "missing"
+msgstr "manquant"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field uses the wrong letter case."
+msgstr "Le champ AssociationPropertyMetadata utilise une casse incorrecte."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object contains an unsupported nested field."
+msgstr ""
+"L'objet AssociationPropertyMetadata contient un champ imbriqué non pris "
+"en charge."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Field names are case-sensitive; use {} instead."
+msgstr "Les noms de champs sont sensibles à la casse ; utilisez plutôt {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This nested schema is closed."
+msgstr "Ce schéma frontend imbriqué est fermé."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "one of: {}"
+msgstr "l'un de : {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Rename {} to {}."
+msgstr "Renommez {} en {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value does not match the local form schema."
+msgstr ""
+"La valeur d'AssociationPropertyMetadata ne correspond pas au schéma "
+"frontend."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The literal value failed the exported {} constraint."
+msgstr "La valeur littérale n'a pas satisfait la contrainte {} exportée."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference has inconsistent frontend consumers."
+msgstr ""
+"La référence AssociationPropertyMetadata a des consommateurs frontend "
+"incohérents."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"One consumer parses this value, but the template-default initializer may "
+"use the raw text. Host values and effect timing are unavailable locally."
+msgstr ""
+"Un consommateur analyse la valeur, mais l'initialiseur par défaut peut "
+"utiliser le texte brut. Les valeurs hôtes et le moment sont inconnus "
+"localement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Environment metadata reference cannot be resolved locally."
+msgstr ""
+"La référence de métadonnées d'environnement ne peut pas être résolue "
+"localement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The encoding is valid, but the contract does not provide an environment-"
+"data schema."
+msgstr "L'encodage est valide, mais le contrat ne fournit pas de schéma de données d'environnement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Mapping selector segment is interpreted as a literal key by the target "
+"form."
+msgstr ""
+"frontend interprète le segment du sélecteur de mappage comme une clé "
+"littérale."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"No Parameter named {} exists; the current mapping hook falls back to the "
+"segment text."
+msgstr ""
+"Aucun paramètre nommé {} n’existe ; le hook de mappage actuel utilise le "
+"texte du segment."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Metadata reference {} has more than one possible lookup scope."
+msgstr ""
+"La référence de métadonnées {} possède plusieurs portées de recherche "
+"possibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"It may resolve from template Parameters or component-local data. The "
+"runtime component is unknown, so local validation leaves the reference "
+"unchecked."
+msgstr ""
+"Elle peut être résolue depuis Parameters ou des données locales. Le "
+"composant d'exécution étant inconnu, la référence n'est pas contrôlée."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify the "
+"reference behavior in the target ROS form if needed."
+msgstr ""
+"Ne modifiez pas le modèle pour cette seule limite ; vérifiez au besoin la"
+" référence dans le formulaire ROS cible."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field-path reference cannot be resolved "
+"completely."
+msgstr ""
+"La référence de chemin de champ AssociationPropertyMetadata ne peut pas "
+"être résolue complètement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The reference depends on a nested form or MetaList row context."
+msgstr ""
+"La référence dépend d'un formulaire imbriqué ou d'un contexte de ligne "
+"MetaList."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference cannot be proven valid locally."
+msgstr ""
+"La référence AssociationPropertyMetadata ne peut pas être prouvée valide "
+"localement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference is invalid."
+msgstr "La référence AssociationPropertyMetadata est invalide."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Consumer reachability is unknown; the possible encoding problem is: {}."
+msgstr ""
+"L'atteignabilité du consommateur est inconnue ; le problème d'encodage "
+"possible est : {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target consumer cannot resolve this encoding: {}."
+msgstr "Le consommateur frontend ne peut pas résoudre cet encodage : {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a valid reference in the declared consumer context"
+msgstr "une référence valide dans le contexte du consommateur déclaré"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "referenced Parameter declaration"
+msgstr "déclaration Parameter référencée"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference type is suspicious."
+msgstr "Le type de référence AssociationPropertyMetadata est suspect."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The referenced Parameter resolves as {}, while this consumer expects {}."
+msgstr ""
+"Le Parameter référencé se résout en {}, alors que ce consommateur attend "
+"{}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition contains a function key that the target form ignores."
+msgstr "La Condition contient une clé de fonction que frontend ignore."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form evaluates only the first object key, {}."
+msgstr "frontend n'évalue que la première clé de l'objet, {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select contains an argument that the target form ignores."
+msgstr "Fn::Select contient un argument que frontend ignore."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Only the first two arguments are destructured by the current runtime."
+msgstr ""
+"Seuls les deux premiers arguments sont déstructurés par l'exécution "
+"actuelle."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata Condition is invalid."
+msgstr "La Condition d'AssociationPropertyMetadata est invalide."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The condition AST is incompatible with the target form: {}."
+msgstr "L'AST de la condition est incompatible avec frontend : {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a supported ParameterMetadataCondition"
+msgstr "une ParameterMetadataCondition prise en charge"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition Definitions path cannot be resolved locally."
+msgstr "Le chemin Definitions de la Condition ne peut pas être résolu localement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The template does not provide a statically inspectable ROS Interface "
+"Definitions object."
+msgstr ""
+"Le modèle ne fournit pas d'objet ROS Interface Definitions inspectable "
+"statiquement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The ALIYUN and APSARA environment profiles resolve this path differently."
+msgstr ""
+"Les profils d’environnement frontend ALIYUN et APSARA résolvent ce chemin"
+" différemment."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata nested container has runtime-dependent "
+"reachability."
+msgstr ""
+"L’accessibilité du conteneur imbriqué AssociationPropertyMetadata dépend "
+"de l’exécution."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Only some possible form components consume this Parameter/Parameters "
+"field; its nested declarations are not rejected locally."
+msgstr ""
+"Seuls certains composants frontend possibles consomment ce champ "
+"Parameter/Parameters ; ses déclarations imbriquées ne sont pas rejetées "
+"localement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Pattern syntax is not checked locally."
+msgstr "La syntaxe Pattern d'AutoCompleteInput n'est pas vérifiée localement."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form compiles Pattern as ECMAScript RegExp; Python regular "
+"expressions are not equivalent."
+msgstr ""
+"frontend compile Pattern en ECMAScript RegExp ; les expressions "
+"régulières Python ne sont pas équivalentes."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "unsliced generated identifier (Length is falsy in JavaScript)"
+msgstr "identifiant généré non tronqué (Length est faux en JavaScript)"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "generated identifier truncated at position {}"
+msgstr "identifiant généré tronqué à la position {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Length is normalized non-intuitively by JavaScript."
+msgstr ""
+"La Length d'AutoCompleteInput est normalisée de manière non intuitive par"
+" JavaScript."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Effective generated Length is {} after JavaScript array/slice conversion."
+msgstr ""
+"La Length générée effective est {} après la conversion de tableau/tranche"
+" JavaScript."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a positive integer for predictable output"
+msgstr "un entier positif pour une sortie prévisible"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores Pattern when CharacterClasses is non-empty."
+msgstr "AutoCompleteInput ignore Pattern lorsque CharacterClasses n'est pas vide."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The character-class generation branch does not compile Pattern."
+msgstr "La branche de génération par classes de caractères ne compile pas Pattern."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character-only field."
+msgstr "AutoCompleteInput ignore un champ réservé aux caractères spéciaux."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} is read only when Class is specialCharacter."
+msgstr "{} n'est lu que lorsque Class est specialCharacter."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput CharacterClass does not guarantee a minimum count."
+msgstr "AutoCompleteInput CharacterClass ne garantit pas un nombre minimum."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"With multiple character classes, missing Min does not reserve characters "
+"for this class."
+msgstr ""
+"Avec plusieurs classes de caractères, l’absence de Min ne réserve aucun "
+"caractère pour cette classe."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Min fills every available position."
+msgstr "Min d'AutoCompleteInput remplit toutes les positions disponibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A negative or fractional counter never reaches zero; generation stops "
+"only after available positions are exhausted."
+msgstr ""
+"Un compteur négatif ou fractionnaire n'atteint jamais zéro ; la génération "
+"ne s'arrête qu'une fois les positions disponibles épuisées."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a non-negative integer for predictable minimum semantics"
+msgstr "un entier non négatif pour une sémantique minimale prévisible"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AutoCompleteInput minimum cannot be satisfied after earlier "
+"CharacterClasses."
+msgstr ""
+"Le minimum d'AutoCompleteInput ne peut pas être satisfait après les "
+"CharacterClasses précédentes."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Earlier fills require at least {} of this entry's {} available positions."
+msgstr ""
+"Les remplissages précédents requièrent au moins {} des {} positions "
+"disponibles de cette entrée."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a minimum satisfiable after earlier fills"
+msgstr "un minimum satisfiable après les remplissages précédents"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput minimum character counts exceed Length."
+msgstr "Les nombres minimaux de caractères d'AutoCompleteInput dépassent Length."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The sum of CharacterClasses.Min is {}, but the effective Length is {}."
+msgstr "La somme de CharacterClasses.Min est {}, mais la Length effective est {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "sum of Min no greater than {}"
+msgstr "somme de Min ne dépassant pas {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character boundary flag."
+msgstr "AutoCompleteInput ignore un indicateur de limite de caractère spécial."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime does not retain specialCharacter configuration when "
+"SpecialCharacters is empty."
+msgstr ""
+"L'exécution ne conserve pas la configuration specialCharacter lorsque "
+"SpecialCharacters est vide."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput requires non-empty SpecialCharacters."
+msgstr "AutoCompleteInput requiert des SpecialCharacters non vides."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This specialCharacter branch must fill at least one generated position."
+msgstr "Cette branche specialCharacter doit remplir au moins une position générée."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput special-character minimum exceeds available positions."
+msgstr ""
+"Le minimum de caractères spéciaux d'AutoCompleteInput dépasse les "
+"positions disponibles."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Start/End restrictions leave {} positions for {} required special "
+"characters."
+msgstr ""
+"Les restrictions Start/End laissent {} positions pour {} caractères "
+"spéciaux requis."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Min no greater than {}"
+msgstr "Min ne dépassant pas {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"join() can produce a string shorter than Length because the remaining-"
+"character pool becomes empty at the restricted boundary and stays empty."
+msgstr ""
+"join() peut produire une chaîne plus courte que Length car le pool de "
+"caractères restants devient vide à la limite restreinte et le reste."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The mutable remaining-character pool narrows to ordinary classes at the "
+"restricted boundary and does not restore special characters later."
+msgstr ""
+"Le pool mutable de caractères restants se réduit aux classes ordinaires à"
+" la limite restreinte et ne restaure pas les caractères spéciaux par la "
+"suite."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput boundary restriction persists for later positions."
+msgstr ""
+"La restriction de limite d'AutoCompleteInput persiste pour les positions "
+"ultérieures."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "All statically reachable generation consumers are skipped. {} "
+msgstr ""
+"Tous les consommateurs de génération atteignables statiquement sont "
+"ignorés. {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Generation consumer reachability is unknown. {} "
+msgstr "L'atteignabilité du consommateur de génération est inconnue. {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "any value"
+msgstr "n'importe quelle valeur"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is available only in the OOS parameter "
+"form."
+msgstr ""
+"Cette valeur d'AssociationProperty est disponible uniquement dans le "
+"formulaire de paramètres OOS."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is unavailable in the stock ROS parameter "
+"form."
+msgstr ""
+"Cette valeur d'AssociationProperty n'est pas disponible dans le "
+"formulaire de paramètres ROS standard."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is empty"
+msgstr "la référence est vide"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "environment references are not allowed by this consumer"
+msgstr "ce consommateur n'autorise pas les références d'environnement"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Parameter references are not allowed by this consumer"
+msgstr "ce consommateur n'autorise pas les références Parameter"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "field-path references are not allowed by this consumer"
+msgstr "ce consommateur n'autorise pas les références de chemin de champ"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path is malformed"
+msgstr "le chemin de champ est mal formé"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"field paths support one top-level array projection followed by a child "
+"path"
+msgstr ""
+"les chemins de champ prennent en charge une projection de tableau de "
+"premier niveau suivie d'un chemin enfant"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Parameter does not exist"
+msgstr "le Parameter n'existe pas"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter does not exist"
+msgstr "le Parameter imbriqué n'existe pas"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the MetaList row field does not exist"
+msgstr "le champ de ligne MetaList n'existe pas"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced Parameter declaration is invalid"
+msgstr "la déclaration Parameter référencée est invalide"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path traverses a scalar Parameter"
+msgstr "le chemin de champ traverse un Parameter scalaire"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter field does not exist"
+msgstr "le champ Parameter imbriqué n'existe pas"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced nested Parameter declaration is invalid"
+msgstr "la déclaration Parameter imbriquée référencée est invalide"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path does not exist"
+msgstr "le chemin Definitions n'existe pas"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} references are not allowed by this consumer"
+msgstr "ce consommateur n'autorise pas les références {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is invalid"
+msgstr "la référence est invalide"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "nested And/Or/Not operands must be condition objects"
+msgstr "les opérandes And/Or/Not imbriqués doivent être des objets de condition"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition must be a non-empty String or object"
+msgstr "la condition doit être une String non vide ou un objet"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the first function key is unsupported"
+msgstr "la première clé de fonction n'est pas prise en charge"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Not requires one condition object containing a single key"
+msgstr "Fn::Not nécessite un objet de condition contenant une seule clé"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select requires its first two arguments to be Strings"
+msgstr "Fn::Select exige que ses deux premiers arguments soient des Strings"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path must resolve to a condition object"
+msgstr "le chemin Definitions doit être résolu en objet de condition"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires exactly two arguments"
+msgstr "{} nécessite exactement deux arguments"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires an array"
+msgstr "{} nécessite un tableau"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition is invalid"
+msgstr "la condition est invalide"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format
@@ -11723,3 +12549,124 @@ msgstr "Autoriser Bash ?"
 #~ msgid "由外部登录管理"
 #~ msgstr "Géré par une connexion externe"
 
+#~ msgid "The key maps to component {} with scope {}: {}."
+#~ msgstr "La clé correspond au composant {} avec la portée {} : {}."
+
+#~ msgid "AssociationProperty is deprecated by the local frontend contract."
+#~ msgstr "AssociationProperty est déprécié par frontend."
+
+#~ msgid ""
+#~ "The current stock ROS form still "
+#~ "resolves this key, but the contract "
+#~ "marks it as deprecated."
+#~ msgstr ""
+#~ "Le formulaire ROS standard actuel résout"
+#~ " encore cette clé, mais frontend la"
+#~ " marque comme dépréciée."
+
+#~ msgid ""
+#~ "The local validator cannot prove that"
+#~ " a newer target frontend does not "
+#~ "support this key; stock fallback rules"
+#~ " are used."
+#~ msgstr ""
+#~ "Le validateur local ne peut pas "
+#~ "prouver qu'un frontend frontend plus "
+#~ "récent ne prend pas en charge "
+#~ "cette clé ; les règles de repli"
+#~ " standard sont utilisées."
+
+#~ msgid ""
+#~ "Only some possible components consume "
+#~ "this field; its component-specific "
+#~ "schema cannot be enforced deterministically."
+#~ msgstr ""
+#~ "Seuls certains composants possibles consomment"
+#~ " ce champ ; son schéma propre "
+#~ "au composant ne peut pas être "
+#~ "appliqué de manière déterministe."
+
+#~ msgid ""
+#~ "AssociationPropertyMetadata Parameter reference has"
+#~ " a runtime-dependent scope."
+#~ msgstr ""
+#~ "La référence Parameter d'AssociationPropertyMetadata"
+#~ " a une portée dépendante de "
+#~ "l'exécution."
+
+#~ msgid ""
+#~ "The nested consumer does not use "
+#~ "an unambiguous template-root symbol "
+#~ "table."
+#~ msgstr ""
+#~ "Le consommateur imbriqué n'utilise pas "
+#~ "de table de symboles de racine de"
+#~ " modèle non ambiguë."
+
+#~ msgid ""
+#~ "Metadata field {} may or may not"
+#~ " take effect, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "Le champ de métadonnées {} peut "
+#~ "s'appliquer ou non selon le composant"
+#~ " de formulaire choisi à l'exécution."
+
+#~ msgid ""
+#~ "Possible form components: {}. Only some"
+#~ " read field {}, so local validation"
+#~ " leaves the field unchecked."
+#~ msgstr ""
+#~ "Composants possibles : {}. Seuls "
+#~ "certains lisent le champ {} ; la"
+#~ " validation locale ne le contrôle "
+#~ "donc pas."
+
+#~ msgid ""
+#~ "Metadata reference {} may use different"
+#~ " lookup scopes, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "La référence de métadonnées {} peut "
+#~ "utiliser différentes portées selon le "
+#~ "composant choisi à l'exécution."
+
+#~ msgid "All resolved components bypass the unavailable {} mapping."
+#~ msgstr "Tous les composants résolus contournent le mappage {} indisponible."
+
+#~ msgid ""
+#~ "The editable path cannot use component"
+#~ " {}, but the earlier read-only "
+#~ "branch can select {}."
+#~ msgstr ""
+#~ "Le chemin modifiable ne peut pas "
+#~ "utiliser le composant {}, mais la "
+#~ "branche en lecture seule antérieure peut"
+#~ " sélectionner {}."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is available only in the OOS"
+#~ " parameter form."
+#~ msgstr ""
+#~ "La clé correspond au composant {}, "
+#~ "disponible uniquement dans le formulaire "
+#~ "de paramètres OOS."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is not registered in the "
+#~ "stock ROS parameter form."
+#~ msgstr ""
+#~ "La clé correspond au composant {}, "
+#~ "qui n'est pas enregistré dans le "
+#~ "formulaire de paramètres ROS standard."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is unavailable in the stock "
+#~ "ROS parameter form."
+#~ msgstr ""
+#~ "La clé correspond au composant {}, "
+#~ "qui n'est pas disponible dans le "
+#~ "formulaire de paramètres ROS standard."

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -7966,6 +7966,11 @@ msgid "Analysis did not complete; this call was blocked to avoid missed errors."
 msgstr "解析は完了しませんでした。この呼び出しは、見逃されたエラーを避けるためにブロックされました。"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "{} local-analysis limitations; details condensed."
+msgstr "ローカル分析の制限は {} 件です。詳細は集約されています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 msgid "generated JSON "
 msgstr "生成 JSON"
 
@@ -7980,6 +7985,21 @@ msgstr "詳細:"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
+msgid "{} occurrences; showing {} examples."
+msgstr "{} 件中 {} 件の例を表示します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   example path: {} — {}"
+msgstr "   例のパス: {} — {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   {} additional occurrences are available in structured diagnostics."
+msgstr "   構造化診断にはさらに {} 件の記録があります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
 msgid "{}line {}:{}"
 msgstr "{}第 {} 行：{}"
 
@@ -7990,7 +8010,7 @@ msgstr "ソースの場所なし"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   path: {}"
-msgstr "パス: {}"
+msgstr "   パス：{}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
@@ -8000,17 +8020,17 @@ msgstr "関連する場所({}):{}、パス:{}"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   expected: {}"
-msgstr "予想:{}"
+msgstr "   期待値：{}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   actual: {}"
-msgstr "実際の: {}"
+msgstr "   実際値：{}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   Suggestion: {}"
-msgstr "提案: {}"
+msgstr "   提案：{}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/symbols.py
 msgid "Number argument cannot be converted to a number"
@@ -8033,6 +8053,688 @@ msgstr "現在の解析結果は、ROSセクションを含まない。"
 #, python-brace-format
 msgid "The known value of Parameter {} cannot be parsed as its declared type."
 msgstr "Parameter {}の既定値は宣言されたタイプとして解析できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Embedded Terraform variable metadata is not analyzed locally."
+msgstr "埋め込まれた Terraform 変数メタデータはローカルでは分析されません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Top-level Parameters are validated; metadata inside Workspace files "
+"remains outside local analysis."
+msgstr "トップレベルの Parameters は検証されますが、Workspace ファイル内のメタデータはローカル分析の対象外です。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata nesting is too deep."
+msgstr "AssociationPropertyMetadata のネストが深すぎます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Nested Parameter/Parameters validation stops after {} levels."
+msgstr "ネストされた Parameter/Parameters の検証は {} レベルで停止します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "at most {} nested levels"
+msgstr "最大 {} レベルのネスト"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty must be a non-empty String."
+msgstr "AssociationProperty は空でない String でなければなりません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target parameter form resolves AssociationProperty keys only from "
+"non-empty strings."
+msgstr "frontend は空でない文字列からのみ AssociationProperty のキーを解決します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "non-empty String"
+msgstr "空でない String"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Use {} instead."
+msgstr "代わりに {} を使用してください。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is deprecated: {}."
+msgstr "AssociationProperty の値は非推奨です：{}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The stock ROS form still recognizes this value, so this warning does not "
+"block the template."
+msgstr "標準 ROS フォームは現在もこの値を認識するため、この警告はテンプレートをブロックしません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is absent from the local frontend contract: {}."
+msgstr "ローカルのフロントエンド契約にない AssociationProperty の値です：{}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A newer target frontend may support this value. Local validation uses the"
+" stock fallback component and does not mark the value invalid."
+msgstr "新しい対象フロントエンドでは対応している可能性があります。ローカル検証は標準の代替コンポーネントを使用し、この値を無効とはしません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is bypassed by a later stock form component selection."
+msgstr "後続の標準フォームコンポーネント選択により AssociationProperty は迂回されます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "No resolved form branch selects the unavailable AssociationProperty value."
+msgstr "解決されたフォーム分岐のいずれも、利用できない AssociationProperty 値を選択しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationProperty availability depends on the stock form read-only "
+"state."
+msgstr "AssociationProperty の可用性は、標準フォームの読み取り専用状態に依存します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The editable form path does not support this value, while the read-only "
+"path may bypass it."
+msgstr "編集可能なフォーム経路はこの値をサポートしませんが、読み取り専用経路ではこの制限が回避される場合があります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is unavailable in the stock ROS parameter form."
+msgstr "AssociationProperty は標準 ROS パラメータフォームでは利用できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a stock ROS AssociationProperty"
+msgstr "標準 ROS の AssociationProperty"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata must be a Mapping."
+msgstr "AssociationPropertyMetadata は Mapping でなければなりません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The target form reads named metadata fields from an object."
+msgstr "frontend はオブジェクトから名前付きメタデータフィールドを読み取ります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Mapping"
+msgstr "マッピング"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field names must be Strings."
+msgstr "AssociationPropertyMetadata のフィールド名は String でなければなりません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form performs named property access and cannot consume this "
+"key."
+msgstr "frontend は名前付きプロパティアクセスを実行するため、このキーを処理できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "String field name"
+msgstr "String のフィールド名"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is shadowed by a higher-precedence "
+"alias."
+msgstr "AssociationPropertyMetadata フィールドは、より優先度の高いエイリアスによってシャドウされています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form reads {} first, so this value is ignored by that consumer."
+msgstr "frontend は {} を最初に読み取るため、この値はそのコンシューマーによって無視されます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is not supported by the effective form "
+"component."
+msgstr "AssociationPropertyMetadata フィールドは、有効な frontend コンポーネントでサポートされていません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is outside the audited contract "
+"coverage."
+msgstr "AssociationPropertyMetadata フィールドは、監査済みの契約カバレッジの範囲外です。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The common schema or at least one possible component is partial/runtime-"
+"dependent; the field cannot be rejected deterministically."
+msgstr "共通スキーマまたは少なくとも1つの可能なコンポーネントが部分的/ランタイム依存であるため、フィールドを確定的に拒否できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The complete common and possible-component schemas all reject this field."
+msgstr "完全な共通スキーマおよび可能なコンポーネントのスキーマはすべてこのフィールドを拒否します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a field consumed by the common or possible component schema"
+msgstr "共通または可能なコンポーネントスキーマによって処理されるフィールド"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Metadata field {} is used by some possible form components and ignored by"
+" others."
+msgstr "メタデータフィールド {} は一部のフォームコンポーネントだけが使用し、他は無視します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime component cannot be determined locally, so this field is left"
+" unchecked."
+msgstr "実行時のコンポーネントをローカルで特定できないため、このフィールドは検証しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify whether"
+" the field takes effect in the target ROS form if needed."
+msgstr "この制限だけを理由にテンプレートを変更せず、必要なら対象 ROS フォームでフィールドを確認してください。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is nested too deeply."
+msgstr "AssociationPropertyMetadata の値のネストが深すぎます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Schema traversal stops after {} levels."
+msgstr "スキーマの走査は {} レベルで停止します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is not in the local contract enum."
+msgstr "AssociationPropertyMetadata の値は frontend の列挙型に含まれていません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective component only implements the exported enum values."
+msgstr "有効なコンポーネントはエクスポートされた列挙値のみを実装します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object is missing a required field."
+msgstr "AssociationPropertyMetadata オブジェクトに必須フィールドがありません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective form schema requires this nested field."
+msgstr "有効な frontend スキーマはこのネストされたフィールドを必要とします。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "required field {}"
+msgstr "必須フィールド {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "missing"
+msgstr "欠落"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field uses the wrong letter case."
+msgstr "AssociationPropertyMetadata フィールドの大文字と小文字が正しくありません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object contains an unsupported nested field."
+msgstr "AssociationPropertyMetadata オブジェクトにサポートされていないネストされたフィールドが含まれています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Field names are case-sensitive; use {} instead."
+msgstr "フィールド名では大文字と小文字が区別されます。代わりに {} を使用してください。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This nested schema is closed."
+msgstr "このネストされた frontend スキーマは閉じています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "one of: {}"
+msgstr "次のいずれか: {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Rename {} to {}."
+msgstr "{} を {} に変更してください。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value does not match the local form schema."
+msgstr "AssociationPropertyMetadata の値が frontend スキーマと一致しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The literal value failed the exported {} constraint."
+msgstr "リテラル値がエクスポートされた {} 制約を満たしませんでした。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference has inconsistent frontend consumers."
+msgstr "AssociationPropertyMetadata の参照に一貫性のない frontend コンシューマーがあります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"One consumer parses this value, but the template-default initializer may "
+"use the raw text. Host values and effect timing are unavailable locally."
+msgstr "一方のコンシューマーは値を解析しますが、既定値の初期化処理は元のテキストを使う場合があります。ホスト値と適用時点はローカルでは不明です。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Environment metadata reference cannot be resolved locally."
+msgstr "環境メタデータ参照はローカルで解決できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The encoding is valid, but the contract does not provide an environment-"
+"data schema."
+msgstr "エンコーディングは有効ですが、契約には環境データのスキーマがありません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Mapping selector segment is interpreted as a literal key by the target "
+"form."
+msgstr "Mapping セレクターのセグメントは frontend によってリテラルキーとして解釈されます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"No Parameter named {} exists; the current mapping hook falls back to the "
+"segment text."
+msgstr "{} という名前の Parameter は存在しません。現在の Mapping hook はセグメントテキストにフォールバックします。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Metadata reference {} has more than one possible lookup scope."
+msgstr "メタデータ参照 {} には複数の検索範囲が考えられます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"It may resolve from template Parameters or component-local data. The "
+"runtime component is unknown, so local validation leaves the reference "
+"unchecked."
+msgstr "Parameters または内部データから解決される場合があります。実行時のコンポーネントが不明なため、参照は検証しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify the "
+"reference behavior in the target ROS form if needed."
+msgstr "この制限だけを理由にテンプレートを変更せず、必要なら対象 ROS フォームで参照の動作を確認してください。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field-path reference cannot be resolved "
+"completely."
+msgstr "AssociationPropertyMetadata のフィールドパス参照を完全に解決できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The reference depends on a nested form or MetaList row context."
+msgstr "参照はネストされたフォームまたは MetaList の行コンテキストに依存します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference cannot be proven valid locally."
+msgstr "AssociationPropertyMetadata の参照はローカルで有効であると証明できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference is invalid."
+msgstr "AssociationPropertyMetadata の参照は無効です。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Consumer reachability is unknown; the possible encoding problem is: {}."
+msgstr "コンシューマーの到達可能性は不明です。考えられるエンコーディングの問題は次のとおりです: {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target consumer cannot resolve this encoding: {}."
+msgstr "frontend コンシューマーはこのエンコーディングを解決できません: {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a valid reference in the declared consumer context"
+msgstr "宣言されたコンシューマーコンテキストにおける有効な参照"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "referenced Parameter declaration"
+msgstr "参照される Parameter 宣言"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference type is suspicious."
+msgstr "AssociationPropertyMetadata の参照型が疑わしいです。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The referenced Parameter resolves as {}, while this consumer expects {}."
+msgstr "参照される Parameter は {} として解決されますが、このコンシューマーは {} を期待しています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition contains a function key that the target form ignores."
+msgstr "Condition に、frontend が無視する関数キーが含まれています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form evaluates only the first object key, {}."
+msgstr "frontend は最初のオブジェクトキー {} のみを評価します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select contains an argument that the target form ignores."
+msgstr "Fn::Select に、frontend が無視する引数が含まれています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Only the first two arguments are destructured by the current runtime."
+msgstr "現在のランタイムでは最初の2つの引数のみが分解されます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata Condition is invalid."
+msgstr "AssociationPropertyMetadata の Condition は無効です。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The condition AST is incompatible with the target form: {}."
+msgstr "条件の AST は frontend と互換性がありません: {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a supported ParameterMetadataCondition"
+msgstr "サポートされている ParameterMetadataCondition"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition Definitions path cannot be resolved locally."
+msgstr "Condition の Definitions パスはローカルで解決できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The template does not provide a statically inspectable ROS Interface "
+"Definitions object."
+msgstr "テンプレートは静的に検査可能な ROS Interface Definitions オブジェクトを提供しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The ALIYUN and APSARA environment profiles resolve this path differently."
+msgstr "ALIYUN と APSARA の frontend 環境プロファイルでは、このパスの解決結果が異なります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata nested container has runtime-dependent "
+"reachability."
+msgstr "AssociationPropertyMetadata のネストされたコンテナの到達可能性はランタイムに依存します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Only some possible form components consume this Parameter/Parameters "
+"field; its nested declarations are not rejected locally."
+msgstr ""
+"この Parameter/Parameters フィールドを使用するのは一部の候補 frontend "
+"コンポーネントだけなので、ネストされた宣言はローカルで拒否されません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Pattern syntax is not checked locally."
+msgstr "AutoCompleteInput の Pattern 構文はローカルでチェックされません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form compiles Pattern as ECMAScript RegExp; Python regular "
+"expressions are not equivalent."
+msgstr "frontend は Pattern を ECMAScript RegExp としてコンパイルします。Python の正規表現は同等ではありません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "unsliced generated identifier (Length is falsy in JavaScript)"
+msgstr "未切り詰めの生成済み識別子（Length は JavaScript では falsy）"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "generated identifier truncated at position {}"
+msgstr "生成済み識別子を位置 {} で切り詰め"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Length is normalized non-intuitively by JavaScript."
+msgstr "AutoCompleteInput の Length は JavaScript によって直感に反する形で正規化されます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Effective generated Length is {} after JavaScript array/slice conversion."
+msgstr "JavaScript の配列/スライス変換後の有効な生成 Length は {} です。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a positive integer for predictable output"
+msgstr "予測可能な出力のための正の整数"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores Pattern when CharacterClasses is non-empty."
+msgstr "CharacterClasses が空でない場合、AutoCompleteInput は Pattern を無視します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The character-class generation branch does not compile Pattern."
+msgstr "文字クラス生成分岐では Pattern をコンパイルしません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character-only field."
+msgstr "AutoCompleteInput は特殊文字専用のフィールドを無視します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} is read only when Class is specialCharacter."
+msgstr "{} は Class が specialCharacter の場合にのみ読み取られます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput CharacterClass does not guarantee a minimum count."
+msgstr "AutoCompleteInput の CharacterClass は最小数を保証しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"With multiple character classes, missing Min does not reserve characters "
+"for this class."
+msgstr "複数の文字クラスがある場合、Min がないクラスには文字数が予約されません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Min fills every available position."
+msgstr "AutoCompleteInput の Min は利用可能なすべての位置を埋めます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A negative or fractional counter never reaches zero; generation stops "
+"only after available positions are exhausted."
+msgstr "負数または小数のカウンターはゼロに到達しません。生成処理は利用可能な位置を使い切った後にのみ停止します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a non-negative integer for predictable minimum semantics"
+msgstr "予測可能な最小セマンティクスのための非負の整数"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AutoCompleteInput minimum cannot be satisfied after earlier "
+"CharacterClasses."
+msgstr "AutoCompleteInput の最小値は、先行する CharacterClasses の後では満たすことができません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Earlier fills require at least {} of this entry's {} available positions."
+msgstr "先行する埋め込みは、このエントリの {} 個の利用可能な位置のうち少なくとも {} 個を必要とします。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a minimum satisfiable after earlier fills"
+msgstr "先行する埋め込みの後で満たすことができる最小値"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput minimum character counts exceed Length."
+msgstr "AutoCompleteInput の最小文字数が Length を超えています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The sum of CharacterClasses.Min is {}, but the effective Length is {}."
+msgstr "CharacterClasses.Min の合計は {} ですが、有効な Length は {} です。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "sum of Min no greater than {}"
+msgstr "{} 以下の Min の合計"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character boundary flag."
+msgstr "AutoCompleteInput は特殊文字の境界フラグを無視します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime does not retain specialCharacter configuration when "
+"SpecialCharacters is empty."
+msgstr "SpecialCharacters が空の場合、ランタイムは specialCharacter の設定を保持しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput requires non-empty SpecialCharacters."
+msgstr "AutoCompleteInput は空でない SpecialCharacters を必要とします。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This specialCharacter branch must fill at least one generated position."
+msgstr "この specialCharacter ブランチは、少なくとも1つの生成位置を埋める必要があります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput special-character minimum exceeds available positions."
+msgstr "AutoCompleteInput の特殊文字の最小値が利用可能な位置を超えています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Start/End restrictions leave {} positions for {} required special "
+"characters."
+msgstr "Start/End の制限により、{} 個の必須特殊文字に対して {} 個の位置が残ります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Min no greater than {}"
+msgstr "{} 以下の Min"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"join() can produce a string shorter than Length because the remaining-"
+"character pool becomes empty at the restricted boundary and stays empty."
+msgstr "制限された境界で残り文字プールが空になり空のままとなるため、join() は Length より短い文字列を生成する可能性があります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The mutable remaining-character pool narrows to ordinary classes at the "
+"restricted boundary and does not restore special characters later."
+msgstr "可変の残り文字プールは、制限された境界で通常のクラスに絞り込まれ、後で特殊文字を復元しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput boundary restriction persists for later positions."
+msgstr "AutoCompleteInput の境界制限は後続の位置にも持続します。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "All statically reachable generation consumers are skipped. {} "
+msgstr "静的に到達可能なすべての生成コンシューマーがスキップされます。{} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Generation consumer reachability is unknown. {} "
+msgstr "生成コンシューマーの到達可能性は不明です。{} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "any value"
+msgstr "任意の値"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is available only in the OOS parameter "
+"form."
+msgstr "この AssociationProperty 値は OOS パラメータフォームでのみ利用できます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is unavailable in the stock ROS parameter "
+"form."
+msgstr "この AssociationProperty 値は標準 ROS パラメータフォームでは利用できません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is empty"
+msgstr "参照が空です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "environment references are not allowed by this consumer"
+msgstr "このコンシューマーでは環境参照を使用できません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Parameter references are not allowed by this consumer"
+msgstr "このコンシューマーでは Parameter 参照を使用できません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "field-path references are not allowed by this consumer"
+msgstr "このコンシューマーではフィールドパス参照を使用できません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path is malformed"
+msgstr "フィールドパスの形式が正しくありません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"field paths support one top-level array projection followed by a child "
+"path"
+msgstr "フィールドパスでは、最上位の配列射影を 1 つ指定し、その後に子パスを続ける形式のみを使用できます"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Parameter does not exist"
+msgstr "Parameter が存在しません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter does not exist"
+msgstr "ネストされた Parameter が存在しません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the MetaList row field does not exist"
+msgstr "MetaList の行フィールドが存在しません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced Parameter declaration is invalid"
+msgstr "参照先の Parameter 宣言が無効です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path traverses a scalar Parameter"
+msgstr "フィールドパスがスカラーの Parameter をたどっています"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter field does not exist"
+msgstr "ネストされた Parameter フィールドが存在しません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced nested Parameter declaration is invalid"
+msgstr "参照先のネストされた Parameter 宣言が無効です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path does not exist"
+msgstr "Definitions パスが存在しません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} references are not allowed by this consumer"
+msgstr "このコンシューマーでは {} 参照を使用できません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is invalid"
+msgstr "参照が無効です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "nested And/Or/Not operands must be condition objects"
+msgstr "ネストされた And/Or/Not のオペランドは条件オブジェクトである必要があります"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition must be a non-empty String or object"
+msgstr "条件は空でない String またはオブジェクトである必要があります"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the first function key is unsupported"
+msgstr "先頭の関数キーはサポートされていません"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Not requires one condition object containing a single key"
+msgstr "Fn::Not にはキーを 1 つだけ含む条件オブジェクトが必要です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select requires its first two arguments to be Strings"
+msgstr "Fn::Select の最初の 2 つの引数は String である必要があります"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path must resolve to a condition object"
+msgstr "Definitions パスは条件オブジェクトに解決される必要があります"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires exactly two arguments"
+msgstr "{} には引数がちょうど 2 つ必要です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires an array"
+msgstr "{} には配列が必要です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition is invalid"
+msgstr "条件が無効です"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format
@@ -10918,3 +11620,85 @@ msgstr "Bash を許可しますか？"
 #~ msgid "由外部登录管理"
 #~ msgstr "外部ログインによって管理"
 
+#~ msgid "The key maps to component {} with scope {}: {}."
+#~ msgstr "このキーはコンポーネント {} にスコープ {} でマッピングされます: {}。"
+
+#~ msgid "AssociationProperty is deprecated by the local frontend contract."
+#~ msgstr "AssociationProperty は frontend によって非推奨とされています。"
+
+#~ msgid ""
+#~ "The current stock ROS form still "
+#~ "resolves this key, but the contract "
+#~ "marks it as deprecated."
+#~ msgstr "現在の標準 ROS フォームはこのキーを解決しますが、frontend はこれを非推奨としてマークしています。"
+
+#~ msgid ""
+#~ "The local validator cannot prove that"
+#~ " a newer target frontend does not "
+#~ "support this key; stock fallback rules"
+#~ " are used."
+#~ msgstr ""
+#~ "ローカルの検証機能は、新しい frontend "
+#~ "フロントエンドがこのキーをサポートしていないことを証明できません。標準のフォールバックルールが使用されます。"
+
+#~ msgid ""
+#~ "Only some possible components consume "
+#~ "this field; its component-specific "
+#~ "schema cannot be enforced deterministically."
+#~ msgstr "このフィールドを使用するのは一部の候補コンポーネントだけなので、コンポーネント固有のスキーマを確定的に適用できません。"
+
+#~ msgid ""
+#~ "AssociationPropertyMetadata Parameter reference has"
+#~ " a runtime-dependent scope."
+#~ msgstr "AssociationPropertyMetadata の Parameter 参照はランタイム依存のスコープを持ちます。"
+
+#~ msgid ""
+#~ "The nested consumer does not use "
+#~ "an unambiguous template-root symbol "
+#~ "table."
+#~ msgstr "ネストされたコンシューマーは明確なテンプレートルートのシンボルテーブルを使用しません。"
+
+#~ msgid ""
+#~ "Metadata field {} may or may not"
+#~ " take effect, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr "メタデータフィールド {} が有効かどうかは、実行時に選択されるフォームコンポーネントに依存します。"
+
+#~ msgid ""
+#~ "Possible form components: {}. Only some"
+#~ " read field {}, so local validation"
+#~ " leaves the field unchecked."
+#~ msgstr "候補コンポーネント：{}。フィールド {} を読むのは一部だけなので、ローカルでは検証しません。"
+
+#~ msgid ""
+#~ "Metadata reference {} may use different"
+#~ " lookup scopes, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr "メタデータ参照 {} の検索範囲は、実行時に選択されるフォームコンポーネントによって異なる場合があります。"
+
+#~ msgid "All resolved components bypass the unavailable {} mapping."
+#~ msgstr "解決されたすべてのコンポーネントが、利用できない {} マッピングを迂回します。"
+
+#~ msgid ""
+#~ "The editable path cannot use component"
+#~ " {}, but the earlier read-only "
+#~ "branch can select {}."
+#~ msgstr "編集可能なパスではコンポーネント {} を使用できませんが、先行する読み取り専用分岐では {} を選択できます。"
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is available only in the OOS"
+#~ " parameter form."
+#~ msgstr "このキーは、OOS パラメータフォームでのみ利用できるコンポーネント {} に対応します。"
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is not registered in the "
+#~ "stock ROS parameter form."
+#~ msgstr "このキーは、標準 ROS パラメータフォームに登録されていないコンポーネント {} に対応します。"
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is unavailable in the stock "
+#~ "ROS parameter form."
+#~ msgstr "このキーは、標準 ROS パラメータフォームでは利用できないコンポーネント {} に対応します。"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -8464,6 +8464,11 @@ msgstr ""
 "perdidos."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "{} local-analysis limitations; details condensed."
+msgstr "{} limitações da análise local; detalhes condensados."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 msgid "generated JSON "
 msgstr "gerado JSON"
 
@@ -8478,6 +8483,21 @@ msgstr "Detalhes:"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
+msgid "{} occurrences; showing {} examples."
+msgstr "{} ocorrências; mostrando {} exemplos."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   example path: {} — {}"
+msgstr "   caminho de exemplo: {} — {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   {} additional occurrences are available in structured diagnostics."
+msgstr "   Mais {} ocorrências estão disponíveis nos diagnósticos estruturados."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
 msgid "{}line {}:{}"
 msgstr "{}linha {}:{}"
 
@@ -8488,7 +8508,7 @@ msgstr "sem localização de origem"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   path: {}"
-msgstr "caminho: {}"
+msgstr "   caminho: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
@@ -8498,17 +8518,17 @@ msgstr "Localização relacionada ({}): {}, caminho: {}"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   expected: {}"
-msgstr "esperado: {}"
+msgstr "   esperado: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   actual: {}"
-msgstr "atual: {}"
+msgstr "   valor real: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
 msgid "   Suggestion: {}"
-msgstr "Sugestão: {}"
+msgstr "   Sugestão: {}"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/symbols.py
 msgid "Number argument cannot be converted to a number"
@@ -8533,6 +8553,802 @@ msgid "The known value of Parameter {} cannot be parsed as its declared type."
 msgstr ""
 "O valor conhecido de Parameter {} não pode ser analisado como seu tipo "
 "declarado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Embedded Terraform variable metadata is not analyzed locally."
+msgstr ""
+"Os metadados de variáveis Terraform incorporadas não são analisados "
+"localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Top-level Parameters are validated; metadata inside Workspace files "
+"remains outside local analysis."
+msgstr ""
+"Os Parameters de nível superior são validados; os metadados nos arquivos "
+"Workspace permanecem fora da análise local."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata nesting is too deep."
+msgstr "O aninhamento de AssociationPropertyMetadata é muito profundo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Nested Parameter/Parameters validation stops after {} levels."
+msgstr "A validação aninhada de Parameter/Parameters para após {} níveis."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "at most {} nested levels"
+msgstr "no máximo {} níveis aninhados"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty must be a non-empty String."
+msgstr "AssociationProperty deve ser uma String não vazia."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target parameter form resolves AssociationProperty keys only from "
+"non-empty strings."
+msgstr ""
+"frontend resolve chaves de AssociationProperty apenas a partir de strings"
+" não vazias."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "non-empty String"
+msgstr "String não vazia"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Use {} instead."
+msgstr "Use {} em vez disso."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is deprecated: {}."
+msgstr "O valor de AssociationProperty foi descontinuado: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The stock ROS form still recognizes this value, so this warning does not "
+"block the template."
+msgstr ""
+"O formulário ROS padrão ainda reconhece esse valor; portanto, este aviso "
+"não bloqueia o template."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is absent from the local frontend contract: {}."
+msgstr ""
+"O contrato frontend local não inclui este valor de AssociationProperty: "
+"{}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A newer target frontend may support this value. Local validation uses the"
+" stock fallback component and does not mark the value invalid."
+msgstr ""
+"Um frontend mais recente pode aceitar o valor. A validação local usa o "
+"componente alternativo padrão e não o marca como inválido."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is bypassed by a later stock form component selection."
+msgstr ""
+"Uma seleção posterior de componente do formulário padrão ignora "
+"AssociationProperty."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "No resolved form branch selects the unavailable AssociationProperty value."
+msgstr ""
+"Nenhum ramo de formulário resolvido seleciona o valor indisponível de "
+"AssociationProperty."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationProperty availability depends on the stock form read-only "
+"state."
+msgstr ""
+"A disponibilidade de AssociationProperty depende do estado somente "
+"leitura do formulário padrão."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The editable form path does not support this value, while the read-only "
+"path may bypass it."
+msgstr ""
+"O caminho editável do formulário não aceita este valor, enquanto o "
+"caminho somente leitura pode contornar essa restrição."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is unavailable in the stock ROS parameter form."
+msgstr ""
+"AssociationProperty não está disponível no formulário de parâmetros ROS "
+"padrão."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a stock ROS AssociationProperty"
+msgstr "um AssociationProperty ROS padrão"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata must be a Mapping."
+msgstr "AssociationPropertyMetadata deve ser um Mapping."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The target form reads named metadata fields from an object."
+msgstr "frontend lê campos de metadados nomeados de um objeto."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Mapping"
+msgstr "Mapeamento"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field names must be Strings."
+msgstr "Os nomes de campo de AssociationPropertyMetadata devem ser Strings."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form performs named property access and cannot consume this "
+"key."
+msgstr ""
+"frontend realiza acesso a propriedade nomeada e não pode consumir esta "
+"chave."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "String field name"
+msgstr "nome de campo String"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is shadowed by a higher-precedence "
+"alias."
+msgstr ""
+"O campo de AssociationPropertyMetadata é ocultado por um alias de maior "
+"precedência."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form reads {} first, so this value is ignored by that consumer."
+msgstr ""
+"frontend lê {} primeiro, portanto este valor é ignorado por esse "
+"consumidor."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is not supported by the effective form "
+"component."
+msgstr ""
+"O campo de AssociationPropertyMetadata não é suportado pelo componente "
+"frontend efetivo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is outside the audited contract "
+"coverage."
+msgstr ""
+"O campo de AssociationPropertyMetadata está fora da cobertura de contrato"
+" auditada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The common schema or at least one possible component is partial/runtime-"
+"dependent; the field cannot be rejected deterministically."
+msgstr ""
+"O schema comum ou pelo menos um componente possível é parcial/dependente "
+"de runtime; o campo não pode ser rejeitado de forma determinística."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The complete common and possible-component schemas all reject this field."
+msgstr ""
+"Os schemas completos comum e de componente possível rejeitam todos este "
+"campo."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a field consumed by the common or possible component schema"
+msgstr "um campo consumido pelo schema de componente comum ou possível"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Metadata field {} is used by some possible form components and ignored by"
+" others."
+msgstr ""
+"Alguns componentes usam o campo de metadados {}, enquanto outros o "
+"ignoram."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime component cannot be determined locally, so this field is left"
+" unchecked."
+msgstr ""
+"O componente de execução não pode ser determinado localmente; portanto, o"
+" campo não é verificado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify whether"
+" the field takes effect in the target ROS form if needed."
+msgstr ""
+"Não altere o template apenas por esta limitação; se necessário, verifique"
+" o campo no formulário ROS de destino."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is nested too deeply."
+msgstr "O valor de AssociationPropertyMetadata está aninhado profundamente demais."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Schema traversal stops after {} levels."
+msgstr "A travessia do schema para após {} níveis."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is not in the local contract enum."
+msgstr "O valor de AssociationPropertyMetadata não está no enum do frontend."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective component only implements the exported enum values."
+msgstr "O componente efetivo implementa apenas os valores de enum exportados."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object is missing a required field."
+msgstr "O objeto de AssociationPropertyMetadata está sem um campo obrigatório."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective form schema requires this nested field."
+msgstr "O schema frontend efetivo requer este campo aninhado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "required field {}"
+msgstr "campo obrigatório {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "missing"
+msgstr "ausente"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field uses the wrong letter case."
+msgstr ""
+"O campo AssociationPropertyMetadata usa letras maiúsculas ou minúsculas "
+"incorretas."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object contains an unsupported nested field."
+msgstr ""
+"O objeto de AssociationPropertyMetadata contém um campo aninhado não "
+"suportado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Field names are case-sensitive; use {} instead."
+msgstr "Os nomes de campos diferenciam maiúsculas de minúsculas; use {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This nested schema is closed."
+msgstr "Este schema frontend aninhado é fechado."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "one of: {}"
+msgstr "um de: {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Rename {} to {}."
+msgstr "Renomeie {} para {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value does not match the local form schema."
+msgstr ""
+"O valor de AssociationPropertyMetadata não corresponde ao schema do "
+"frontend."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The literal value failed the exported {} constraint."
+msgstr "O valor literal falhou na restrição {} exportada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference has inconsistent frontend consumers."
+msgstr ""
+"A referência de AssociationPropertyMetadata tem consumidores frontend "
+"inconsistentes."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"One consumer parses this value, but the template-default initializer may "
+"use the raw text. Host values and effect timing are unavailable locally."
+msgstr ""
+"Um consumidor analisa o valor, mas o inicializador padrão pode usar o "
+"texto original. Valores de host e o momento não estão disponíveis "
+"localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Environment metadata reference cannot be resolved locally."
+msgstr "A referência de metadados de ambiente não pode ser resolvida localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The encoding is valid, but the contract does not provide an environment-"
+"data schema."
+msgstr "A codificação é válida, mas o contrato não fornece um schema de dados de ambiente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Mapping selector segment is interpreted as a literal key by the target "
+"form."
+msgstr ""
+"O frontend interpreta o segmento do seletor de mapeamento como uma chave "
+"literal."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"No Parameter named {} exists; the current mapping hook falls back to the "
+"segment text."
+msgstr ""
+"Não existe um parâmetro chamado {}; o hook de mapeamento atual usa o "
+"texto do segmento."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Metadata reference {} has more than one possible lookup scope."
+msgstr "A referência de metadados {} tem vários escopos de busca possíveis."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"It may resolve from template Parameters or component-local data. The "
+"runtime component is unknown, so local validation leaves the reference "
+"unchecked."
+msgstr ""
+"Ela pode ser resolvida em Parameters ou dados locais. Como o componente "
+"de execução é desconhecido, a referência não é verificada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify the "
+"reference behavior in the target ROS form if needed."
+msgstr ""
+"Não altere o template apenas por esta limitação; se necessário, verifique"
+" a referência no formulário ROS de destino."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field-path reference cannot be resolved "
+"completely."
+msgstr ""
+"A referência de caminho de campo de AssociationPropertyMetadata não pode "
+"ser resolvida completamente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The reference depends on a nested form or MetaList row context."
+msgstr ""
+"A referência depende de um formulário aninhado ou do contexto de linha de"
+" MetaList."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference cannot be proven valid locally."
+msgstr ""
+"A referência de AssociationPropertyMetadata não pode ser comprovada como "
+"válida localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference is invalid."
+msgstr "A referência de AssociationPropertyMetadata é inválida."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Consumer reachability is unknown; the possible encoding problem is: {}."
+msgstr ""
+"A acessibilidade do consumidor é desconhecida; o possível problema de "
+"codificação é: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target consumer cannot resolve this encoding: {}."
+msgstr "O consumidor frontend não pode resolver esta codificação: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a valid reference in the declared consumer context"
+msgstr "uma referência válida no contexto de consumidor declarado"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "referenced Parameter declaration"
+msgstr "declaração de Parameter referenciada"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference type is suspicious."
+msgstr "O tipo de referência de AssociationPropertyMetadata é suspeito."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The referenced Parameter resolves as {}, while this consumer expects {}."
+msgstr ""
+"O Parameter referenciado é resolvido como {}, enquanto este consumidor "
+"espera {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition contains a function key that the target form ignores."
+msgstr "Condition contém uma chave de função que o frontend ignora."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form evaluates only the first object key, {}."
+msgstr "frontend avalia apenas a primeira chave do objeto, {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select contains an argument that the target form ignores."
+msgstr "Fn::Select contém um argumento que o frontend ignora."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Only the first two arguments are destructured by the current runtime."
+msgstr ""
+"Apenas os dois primeiros argumentos são desestruturados pelo runtime "
+"atual."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata Condition is invalid."
+msgstr "A Condition de AssociationPropertyMetadata é inválida."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The condition AST is incompatible with the target form: {}."
+msgstr "A AST da condição é incompatível com o frontend: {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a supported ParameterMetadataCondition"
+msgstr "uma ParameterMetadataCondition suportada"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition Definitions path cannot be resolved locally."
+msgstr "O caminho de Definitions da Condition não pode ser resolvido localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The template does not provide a statically inspectable ROS Interface "
+"Definitions object."
+msgstr ""
+"O template não fornece um objeto Definitions de Interface ROS "
+"inspecionável estaticamente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The ALIYUN and APSARA environment profiles resolve this path differently."
+msgstr ""
+"Os perfis de ambiente do frontend ALIYUN e APSARA resolvem este caminho "
+"de forma diferente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata nested container has runtime-dependent "
+"reachability."
+msgstr ""
+"A alcançabilidade do contêiner aninhado de AssociationPropertyMetadata "
+"depende do tempo de execução."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Only some possible form components consume this Parameter/Parameters "
+"field; its nested declarations are not rejected locally."
+msgstr ""
+"Apenas alguns componentes frontend possíveis consomem este campo "
+"Parameter/Parameters; suas declarações aninhadas não são rejeitadas "
+"localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Pattern syntax is not checked locally."
+msgstr "A sintaxe de Pattern de AutoCompleteInput não é verificada localmente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form compiles Pattern as ECMAScript RegExp; Python regular "
+"expressions are not equivalent."
+msgstr ""
+"frontend compila Pattern como ECMAScript RegExp; expressões regulares de "
+"Python não são equivalentes."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "unsliced generated identifier (Length is falsy in JavaScript)"
+msgstr "identificador gerado sem recorte (Length é um valor falso em JavaScript)"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "generated identifier truncated at position {}"
+msgstr "identificador gerado truncado na posição {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Length is normalized non-intuitively by JavaScript."
+msgstr ""
+"O Length de AutoCompleteInput é normalizado de forma não intuitiva pelo "
+"JavaScript."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Effective generated Length is {} after JavaScript array/slice conversion."
+msgstr ""
+"O Length efetivo gerado é {} após a conversão de array/slice do "
+"JavaScript."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a positive integer for predictable output"
+msgstr "um inteiro positivo para uma saída previsível"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores Pattern when CharacterClasses is non-empty."
+msgstr "AutoCompleteInput ignora Pattern quando CharacterClasses não está vazio."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The character-class generation branch does not compile Pattern."
+msgstr "O ramo de geração por classes de caracteres não compila Pattern."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character-only field."
+msgstr "AutoCompleteInput ignora um campo somente de caracteres especiais."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} is read only when Class is specialCharacter."
+msgstr "{} é lido apenas quando Class é specialCharacter."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput CharacterClass does not guarantee a minimum count."
+msgstr "AutoCompleteInput CharacterClass não garante uma contagem mínima."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"With multiple character classes, missing Min does not reserve characters "
+"for this class."
+msgstr ""
+"Com várias classes de caracteres, a ausência de Min não reserva "
+"caracteres para esta classe."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Min fills every available position."
+msgstr "O Min de AutoCompleteInput preenche todas as posições disponíveis."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A negative or fractional counter never reaches zero; generation stops "
+"only after available positions are exhausted."
+msgstr ""
+"Um contador negativo ou fracionário nunca chega a zero; a geração só para "
+"quando as posições disponíveis se esgotam."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a non-negative integer for predictable minimum semantics"
+msgstr "um inteiro não negativo para uma semântica mínima previsível"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AutoCompleteInput minimum cannot be satisfied after earlier "
+"CharacterClasses."
+msgstr ""
+"O mínimo de AutoCompleteInput não pode ser satisfeito após "
+"CharacterClasses anteriores."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Earlier fills require at least {} of this entry's {} available positions."
+msgstr ""
+"Preenchimentos anteriores requerem pelo menos {} das {} posições "
+"disponíveis desta entrada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a minimum satisfiable after earlier fills"
+msgstr "um mínimo satisfazível após os preenchimentos anteriores"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput minimum character counts exceed Length."
+msgstr "As contagens mínimas de caracteres de AutoCompleteInput excedem Length."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The sum of CharacterClasses.Min is {}, but the effective Length is {}."
+msgstr "A soma de CharacterClasses.Min é {}, mas o Length efetivo é {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "sum of Min no greater than {}"
+msgstr "soma de Min não maior que {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character boundary flag."
+msgstr "AutoCompleteInput ignora um sinalizador de limite de caractere especial."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime does not retain specialCharacter configuration when "
+"SpecialCharacters is empty."
+msgstr ""
+"O runtime não retém a configuração specialCharacter quando "
+"SpecialCharacters está vazio."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput requires non-empty SpecialCharacters."
+msgstr "AutoCompleteInput requer SpecialCharacters não vazio."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This specialCharacter branch must fill at least one generated position."
+msgstr "Este ramo specialCharacter deve preencher pelo menos uma posição gerada."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput special-character minimum exceeds available positions."
+msgstr ""
+"O mínimo de caracteres especiais de AutoCompleteInput excede as posições "
+"disponíveis."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Start/End restrictions leave {} positions for {} required special "
+"characters."
+msgstr ""
+"As restrições de Start/End deixam {} posições para {} caracteres "
+"especiais obrigatórios."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Min no greater than {}"
+msgstr "Min não maior que {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"join() can produce a string shorter than Length because the remaining-"
+"character pool becomes empty at the restricted boundary and stays empty."
+msgstr ""
+"join() pode produzir uma string mais curta que Length porque o pool de "
+"caracteres restantes fica vazio no limite restrito e permanece vazio."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The mutable remaining-character pool narrows to ordinary classes at the "
+"restricted boundary and does not restore special characters later."
+msgstr ""
+"O pool mutável de caracteres restantes é reduzido a classes comuns no "
+"limite restrito e não restaura caracteres especiais posteriormente."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput boundary restriction persists for later positions."
+msgstr ""
+"A restrição de limite de AutoCompleteInput persiste para posições "
+"posteriores."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "All statically reachable generation consumers are skipped. {} "
+msgstr ""
+"Todos os consumidores de geração estaticamente alcançáveis são ignorados."
+" {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Generation consumer reachability is unknown. {} "
+msgstr "A acessibilidade do consumidor de geração é desconhecida. {} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "any value"
+msgstr "qualquer valor"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is available only in the OOS parameter "
+"form."
+msgstr ""
+"Este valor de AssociationProperty está disponível apenas no formulário de"
+" parâmetros do OOS."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is unavailable in the stock ROS parameter "
+"form."
+msgstr ""
+"Este valor de AssociationProperty não está disponível no formulário de "
+"parâmetros ROS padrão."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is empty"
+msgstr "a referência está vazia"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "environment references are not allowed by this consumer"
+msgstr "este consumidor não permite referências de ambiente"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Parameter references are not allowed by this consumer"
+msgstr "este consumidor não permite referências a Parameter"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "field-path references are not allowed by this consumer"
+msgstr "este consumidor não permite referências de caminho de campo"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path is malformed"
+msgstr "o caminho de campo está malformado"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"field paths support one top-level array projection followed by a child "
+"path"
+msgstr ""
+"os caminhos de campo aceitam uma projeção de matriz de nível superior "
+"seguida por um caminho filho"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Parameter does not exist"
+msgstr "o Parameter não existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter does not exist"
+msgstr "o Parameter aninhado não existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the MetaList row field does not exist"
+msgstr "o campo da linha de MetaList não existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced Parameter declaration is invalid"
+msgstr "a declaração do Parameter referenciado é inválida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path traverses a scalar Parameter"
+msgstr "o caminho de campo atravessa um Parameter escalar"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter field does not exist"
+msgstr "o campo do Parameter aninhado não existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced nested Parameter declaration is invalid"
+msgstr "a declaração do Parameter aninhado referenciado é inválida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path does not exist"
+msgstr "o caminho de Definitions não existe"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} references are not allowed by this consumer"
+msgstr "este consumidor não permite referências de tipo {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is invalid"
+msgstr "a referência é inválida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "nested And/Or/Not operands must be condition objects"
+msgstr "os operandos And/Or/Not aninhados devem ser objetos de condição"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition must be a non-empty String or object"
+msgstr "a condição deve ser uma String não vazia ou um objeto"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the first function key is unsupported"
+msgstr "a primeira chave de função não é compatível"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Not requires one condition object containing a single key"
+msgstr "Fn::Not requer um objeto de condição contendo uma única chave"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select requires its first two arguments to be Strings"
+msgstr "Fn::Select requer que seus dois primeiros argumentos sejam Strings"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path must resolve to a condition object"
+msgstr "o caminho de Definitions deve ser resolvido como um objeto de condição"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires exactly two arguments"
+msgstr "{} requer exatamente dois argumentos"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires an array"
+msgstr "{} requer uma matriz"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition is invalid"
+msgstr "a condição é inválida"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format
@@ -11560,3 +12376,125 @@ msgstr "Permitir Bash?"
 #~ msgid "由外部登录管理"
 #~ msgstr "Gerenciado por login externo"
 
+#~ msgid "The key maps to component {} with scope {}: {}."
+#~ msgstr "A chave mapeia para o componente {} com escopo {}: {}."
+
+#~ msgid "AssociationProperty is deprecated by the local frontend contract."
+#~ msgstr "AssociationProperty foi descontinuado pelo frontend."
+
+#~ msgid ""
+#~ "The current stock ROS form still "
+#~ "resolves this key, but the contract "
+#~ "marks it as deprecated."
+#~ msgstr ""
+#~ "O formulário ROS padrão atual ainda "
+#~ "resolve esta chave, mas o frontend "
+#~ "a marca como descontinuada."
+
+#~ msgid ""
+#~ "The local validator cannot prove that"
+#~ " a newer target frontend does not "
+#~ "support this key; stock fallback rules"
+#~ " are used."
+#~ msgstr ""
+#~ "O validador local não pode provar "
+#~ "que um frontend frontend mais recente"
+#~ " não oferece suporte a esta chave;"
+#~ " regras de fallback padrão são "
+#~ "usadas."
+
+#~ msgid ""
+#~ "Only some possible components consume "
+#~ "this field; its component-specific "
+#~ "schema cannot be enforced deterministically."
+#~ msgstr ""
+#~ "Apenas alguns componentes possíveis consomem"
+#~ " este campo; seu esquema específico "
+#~ "de componente não pode ser aplicado "
+#~ "de forma determinística."
+
+#~ msgid ""
+#~ "AssociationPropertyMetadata Parameter reference has"
+#~ " a runtime-dependent scope."
+#~ msgstr ""
+#~ "A referência de Parameter de "
+#~ "AssociationPropertyMetadata tem um escopo "
+#~ "dependente de runtime."
+
+#~ msgid ""
+#~ "The nested consumer does not use "
+#~ "an unambiguous template-root symbol "
+#~ "table."
+#~ msgstr ""
+#~ "O consumidor aninhado não usa uma "
+#~ "tabela de símbolos de raiz de "
+#~ "template inequívoca."
+
+#~ msgid ""
+#~ "Metadata field {} may or may not"
+#~ " take effect, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "O campo de metadados {} pode ou"
+#~ " não ter efeito, conforme o "
+#~ "componente escolhido em tempo de "
+#~ "execução."
+
+#~ msgid ""
+#~ "Possible form components: {}. Only some"
+#~ " read field {}, so local validation"
+#~ " leaves the field unchecked."
+#~ msgstr ""
+#~ "Componentes possíveis: {}. Apenas alguns "
+#~ "leem o campo {}; por isso, a "
+#~ "validação local não o verifica."
+
+#~ msgid ""
+#~ "Metadata reference {} may use different"
+#~ " lookup scopes, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr ""
+#~ "A referência de metadados {} pode "
+#~ "usar escopos diferentes conforme o "
+#~ "componente escolhido em tempo de "
+#~ "execução."
+
+#~ msgid "All resolved components bypass the unavailable {} mapping."
+#~ msgstr "Todos os componentes resolvidos ignoram o mapeamento indisponível {}."
+
+#~ msgid ""
+#~ "The editable path cannot use component"
+#~ " {}, but the earlier read-only "
+#~ "branch can select {}."
+#~ msgstr ""
+#~ "O caminho editável não pode usar o"
+#~ " componente {}, mas a ramificação "
+#~ "somente leitura anterior pode selecionar "
+#~ "{}."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is available only in the OOS"
+#~ " parameter form."
+#~ msgstr ""
+#~ "A chave corresponde ao componente {},"
+#~ " disponível apenas no formulário de "
+#~ "parâmetros do OOS."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is not registered in the "
+#~ "stock ROS parameter form."
+#~ msgstr ""
+#~ "A chave corresponde ao componente {},"
+#~ " que não está registrado no "
+#~ "formulário de parâmetros ROS padrão."
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is unavailable in the stock "
+#~ "ROS parameter form."
+#~ msgstr ""
+#~ "A chave corresponde ao componente {},"
+#~ " que não está disponível no "
+#~ "formulário de parâmetros ROS padrão."

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -7801,6 +7801,11 @@ msgid "Analysis did not complete; this call was blocked to avoid missed errors."
 msgstr "分析未完整完成；为避免漏检，本次调用已阻断。"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "{} local-analysis limitations; details condensed."
+msgstr "{} 项本地分析限制；详情已折叠。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 msgid "generated JSON "
 msgstr "生成 JSON "
 
@@ -7812,6 +7817,21 @@ msgstr "{}第 {} 行："
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 msgid "Details:"
 msgstr "详情："
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "{} occurrences; showing {} examples."
+msgstr "{} 次出现；显示 {} 个示例。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   example path: {} — {}"
+msgstr "   示例路径：{} — {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+#, python-brace-format
+msgid "   {} additional occurrences are available in structured diagnostics."
+msgstr "   结构化诊断中还提供了 {} 条记录。"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
 #, python-brace-format
@@ -7868,6 +7888,686 @@ msgstr "当前解析结果不能包含 ROS sections。"
 #, python-brace-format
 msgid "The known value of Parameter {} cannot be parsed as its declared type."
 msgstr "参数 {} 的已知值无法按声明类型解析。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Embedded Terraform variable metadata is not analyzed locally."
+msgstr "未在本地分析内嵌 Terraform 变量元数据。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Top-level Parameters are validated; metadata inside Workspace files "
+"remains outside local analysis."
+msgstr "已校验顶层 Parameters；Workspace 文件中的元数据不在本地分析范围内。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata nesting is too deep."
+msgstr "AssociationPropertyMetadata 嵌套过深。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Nested Parameter/Parameters validation stops after {} levels."
+msgstr "嵌套 Parameter/Parameters 校验在 {} 层后停止。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "at most {} nested levels"
+msgstr "最多 {} 层嵌套"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty must be a non-empty String."
+msgstr "AssociationProperty 必须是非空 String。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target parameter form resolves AssociationProperty keys only from "
+"non-empty strings."
+msgstr "目标参数表单仅从非空字符串解析 AssociationProperty 键。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "non-empty String"
+msgstr "非空 String"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Use {} instead."
+msgstr "请改用 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is deprecated: {}."
+msgstr "AssociationProperty 的值已弃用：{}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The stock ROS form still recognizes this value, so this warning does not "
+"block the template."
+msgstr "原生 ROS 表单目前仍能识别该值，因此此警告不会阻断模板。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "AssociationProperty value is absent from the local frontend contract: {}."
+msgstr "本地前端契约未收录 AssociationProperty 的值：{}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A newer target frontend may support this value. Local validation uses the"
+" stock fallback component and does not mark the value invalid."
+msgstr "较新的目标前端可能支持该值。本地校验会使用原生回退组件，不会将该值判为无效。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is bypassed by a later stock form component selection."
+msgstr "AssociationProperty 被后续的原生表单组件选择绕过。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "No resolved form branch selects the unavailable AssociationProperty value."
+msgstr "没有任何已解析的表单分支会选择这个不可用的 AssociationProperty 值。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationProperty availability depends on the stock form read-only "
+"state."
+msgstr "AssociationProperty 的可用性取决于原生表单的只读状态。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The editable form path does not support this value, while the read-only "
+"path may bypass it."
+msgstr "可编辑表单路径不支持该值，而只读路径可能会绕过此限制。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationProperty is unavailable in the stock ROS parameter form."
+msgstr "AssociationProperty 在原生 ROS 参数表单中不可用。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a stock ROS AssociationProperty"
+msgstr "原生 ROS 的 AssociationProperty"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata must be a Mapping."
+msgstr "AssociationPropertyMetadata 必须是 Mapping。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The target form reads named metadata fields from an object."
+msgstr "目标表单从对象中读取具名元数据字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Mapping"
+msgstr "映射"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field names must be Strings."
+msgstr "AssociationPropertyMetadata 字段名必须是 String。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form performs named property access and cannot consume this "
+"key."
+msgstr "目标表单通过名称访问属性，无法使用此键。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "String field name"
+msgstr "String 类型的字段名"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is shadowed by a higher-precedence "
+"alias."
+msgstr "AssociationPropertyMetadata 字段被优先级更高的别名遮蔽。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form reads {} first, so this value is ignored by that consumer."
+msgstr "目标表单会先读取 {}，因此该消费方会忽略此值。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is not supported by the effective form "
+"component."
+msgstr "实际生效的表单组件不支持此 AssociationPropertyMetadata 字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field is outside the audited contract "
+"coverage."
+msgstr "AssociationPropertyMetadata 字段超出已审计的契约覆盖范围。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The common schema or at least one possible component is partial/runtime-"
+"dependent; the field cannot be rejected deterministically."
+msgstr "通用 schema 或至少一个候选组件的契约覆盖不完整或依赖运行时，因此无法确定性地拒绝该字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The complete common and possible-component schemas all reject this field."
+msgstr "完整的公共 schema 和可能的组件 schema 都拒绝此字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a field consumed by the common or possible component schema"
+msgstr "通用 schema 或候选组件 schema 会使用的字段"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Metadata field {} is used by some possible form components and ignored by"
+" others."
+msgstr "Metadata 字段 {} 只会被部分候选表单组件使用，其他组件会忽略它。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime component cannot be determined locally, so this field is left"
+" unchecked."
+msgstr "本地无法确定运行时最终选择的组件，因此不会校验该字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify whether"
+" the field takes effect in the target ROS form if needed."
+msgstr "不要仅根据此限制修改模板；如需确认，请在目标 ROS 表单中检查该字段是否生效。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is nested too deeply."
+msgstr "AssociationPropertyMetadata 值嵌套过深。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Schema traversal stops after {} levels."
+msgstr "Schema 遍历在 {} 层后停止。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value is not in the local contract enum."
+msgstr "AssociationPropertyMetadata 值不在本地契约枚举中。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective component only implements the exported enum values."
+msgstr "生效的组件仅实现已导出的枚举值。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object is missing a required field."
+msgstr "AssociationPropertyMetadata 对象缺少必填字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The effective form schema requires this nested field."
+msgstr "实际生效的表单模式要求此嵌套字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "required field {}"
+msgstr "必填字段 {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "missing"
+msgstr "缺失"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata field uses the wrong letter case."
+msgstr "AssociationPropertyMetadata 字段的字母大小写不正确。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata object contains an unsupported nested field."
+msgstr "AssociationPropertyMetadata 对象包含不支持的嵌套字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Field names are case-sensitive; use {} instead."
+msgstr "字段名区分大小写；请改用 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This nested schema is closed."
+msgstr "此嵌套模式不允许额外字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "one of: {}"
+msgstr "以下之一：{}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Rename {} to {}."
+msgstr "将 {} 重命名为 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata value does not match the local form schema."
+msgstr "AssociationPropertyMetadata 值与本地表单模式不匹配。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The literal value failed the exported {} constraint."
+msgstr "该字面量值未通过已导出的 {} 约束。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference has inconsistent frontend consumers."
+msgstr "AssociationPropertyMetadata 引用的前端消费方行为不一致。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"One consumer parses this value, but the template-default initializer may "
+"use the raw text. Host values and effect timing are unavailable locally."
+msgstr "一个消费方会解析该值，但模板默认值初始化器可能直接使用原始文本。本地无法获知宿主值及生效时机。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Environment metadata reference cannot be resolved locally."
+msgstr "环境元数据引用无法在本地解析。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The encoding is valid, but the contract does not provide an environment-"
+"data schema."
+msgstr "编码有效，但契约未提供环境数据 schema。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Mapping selector segment is interpreted as a literal key by the target "
+"form."
+msgstr "目标表单会将 Mapping 选择器片段解释为字面量键。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"No Parameter named {} exists; the current mapping hook falls back to the "
+"segment text."
+msgstr "不存在名为 {} 的参数；当前 Mapping hook 会回退使用片段文本。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Metadata reference {} has more than one possible lookup scope."
+msgstr "Metadata 引用 {} 存在多个可能的查找范围。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"It may resolve from template Parameters or component-local data. The "
+"runtime component is unknown, so local validation leaves the reference "
+"unchecked."
+msgstr "该引用可能从模板 Parameters 或组件内部数据中解析。本地无法确定运行时组件，因此不会校验该引用。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Do not change the template based on this limitation alone; verify the "
+"reference behavior in the target ROS form if needed."
+msgstr "不要仅根据此限制修改模板；如需确认，请在目标 ROS 表单中检查该引用的实际行为。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata field-path reference cannot be resolved "
+"completely."
+msgstr "AssociationPropertyMetadata 字段路径引用无法完整解析。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The reference depends on a nested form or MetaList row context."
+msgstr "该引用依赖嵌套表单或 MetaList 行上下文。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference cannot be proven valid locally."
+msgstr "AssociationPropertyMetadata 引用无法在本地证明有效。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference is invalid."
+msgstr "AssociationPropertyMetadata 引用无效。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Consumer reachability is unknown; the possible encoding problem is: {}."
+msgstr "消费方可达性未知;可能的编码问题为:{}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target consumer cannot resolve this encoding: {}."
+msgstr "目标消费方无法解析此编码：{}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a valid reference in the declared consumer context"
+msgstr "在声明的消费方上下文中有效的引用"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "referenced Parameter declaration"
+msgstr "被引用的 Parameter 声明"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata reference type is suspicious."
+msgstr "AssociationPropertyMetadata 引用类型可疑。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The referenced Parameter resolves as {}, while this consumer expects {}."
+msgstr "被引用的 Parameter 解析为 {}，而此消费方期望 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition contains a function key that the target form ignores."
+msgstr "Condition 包含一个被目标表单忽略的函数键。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The target form evaluates only the first object key, {}."
+msgstr "目标表单仅计算第一个对象键 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select contains an argument that the target form ignores."
+msgstr "Fn::Select 包含一个被目标表单忽略的参数。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Only the first two arguments are destructured by the current runtime."
+msgstr "当前运行时仅解构前两个参数。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AssociationPropertyMetadata Condition is invalid."
+msgstr "AssociationPropertyMetadata 的 Condition 无效。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The condition AST is incompatible with the target form: {}."
+msgstr "该条件 AST 与目标表单不兼容：{}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a supported ParameterMetadataCondition"
+msgstr "受支持的 ParameterMetadataCondition"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Condition Definitions path cannot be resolved locally."
+msgstr "Condition 的 Definitions 路径无法在本地解析。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The template does not provide a statically inspectable ROS Interface "
+"Definitions object."
+msgstr "模板未提供可静态检查的 ROS Interface Definitions 对象。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The ALIYUN and APSARA environment profiles resolve this path differently."
+msgstr "ALIYUN 与 APSARA 环境配置对此路径的解析结果不同。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AssociationPropertyMetadata nested container has runtime-dependent "
+"reachability."
+msgstr "AssociationPropertyMetadata 嵌套容器的可达性取决于运行时。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"Only some possible form components consume this Parameter/Parameters "
+"field; its nested declarations are not rejected locally."
+msgstr "只有部分可能的表单组件会使用此 Parameter/Parameters 字段；本地不会拒绝其嵌套声明。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Pattern syntax is not checked locally."
+msgstr "AutoCompleteInput 的 Pattern 语法未在本地检查。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The target form compiles Pattern as ECMAScript RegExp; Python regular "
+"expressions are not equivalent."
+msgstr "目标表单会将 Pattern 编译为 ECMAScript RegExp；Python 正则表达式与其并不等价。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "unsliced generated identifier (Length is falsy in JavaScript)"
+msgstr "未切片的生成标识符（Length 在 JavaScript 中为假值）"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "generated identifier truncated at position {}"
+msgstr "生成标识符在位置 {} 处截断"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Length is normalized non-intuitively by JavaScript."
+msgstr "AutoCompleteInput 的 Length 会被 JavaScript 以非直观的方式规范化。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Effective generated Length is {} after JavaScript array/slice conversion."
+msgstr "经过 JavaScript 数组/切片转换后,实际生成的 Length 为 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a positive integer for predictable output"
+msgstr "为获得可预测的输出,应为正整数"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores Pattern when CharacterClasses is non-empty."
+msgstr "当 CharacterClasses 非空时,AutoCompleteInput 会忽略 Pattern。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "The character-class generation branch does not compile Pattern."
+msgstr "字符类生成分支不会编译 Pattern。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character-only field."
+msgstr "AutoCompleteInput 会忽略仅用于特殊字符的字段。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} is read only when Class is specialCharacter."
+msgstr "仅当 Class 为 specialCharacter 时才会读取 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput CharacterClass does not guarantee a minimum count."
+msgstr "AutoCompleteInput 的 CharacterClass 不保证最小数量。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"With multiple character classes, missing Min does not reserve characters "
+"for this class."
+msgstr "存在多个字符类时，缺少 Min 不会为此类预留字符。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput Min fills every available position."
+msgstr "AutoCompleteInput 的 Min 会填满每一个可用位置。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"A negative or fractional counter never reaches zero; generation stops "
+"only after available positions are exhausted."
+msgstr "负数或小数计数器永远无法归零；生成过程只有在可用位置耗尽后才会停止。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a non-negative integer for predictable minimum semantics"
+msgstr "为获得可预测的最小值语义,应为非负整数"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"AutoCompleteInput minimum cannot be satisfied after earlier "
+"CharacterClasses."
+msgstr "在先前的 CharacterClasses 之后,AutoCompleteInput 的最小值无法满足。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Earlier fills require at least {} of this entry's {} available positions."
+msgstr "先前的填充至少需要 {} 个位置,而此条目共有 {} 个可用位置。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "a minimum satisfiable after earlier fills"
+msgstr "在先前填充之后可满足的最小值"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput minimum character counts exceed Length."
+msgstr "AutoCompleteInput 的最小字符数超过 Length。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "The sum of CharacterClasses.Min is {}, but the effective Length is {}."
+msgstr "CharacterClasses.Min 之和为 {},但实际 Length 为 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "sum of Min no greater than {}"
+msgstr "Min 之和不大于 {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput ignores a special-character boundary flag."
+msgstr "AutoCompleteInput 会忽略特殊字符边界标志。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The runtime does not retain specialCharacter configuration when "
+"SpecialCharacters is empty."
+msgstr "当 SpecialCharacters 为空时,运行时不会保留 specialCharacter 配置。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput requires non-empty SpecialCharacters."
+msgstr "AutoCompleteInput 要求 SpecialCharacters 非空。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "This specialCharacter branch must fill at least one generated position."
+msgstr "此 specialCharacter 分支必须至少填充一个生成的位置。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput special-character minimum exceeds available positions."
+msgstr "AutoCompleteInput 的特殊字符最小值超过可用位置。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid ""
+"Start/End restrictions leave {} positions for {} required special "
+"characters."
+msgstr "Start/End 限制留下 {} 个位置,而需要 {} 个特殊字符。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Min no greater than {}"
+msgstr "Min 不大于 {}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"join() can produce a string shorter than Length because the remaining-"
+"character pool becomes empty at the restricted boundary and stays empty."
+msgstr "join() 可能生成比 Length 更短的字符串,因为剩余字符池在受限边界处变空并保持为空。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"The mutable remaining-character pool narrows to ordinary classes at the "
+"restricted boundary and does not restore special characters later."
+msgstr "可变的剩余字符池在受限边界处收窄为普通字符类,之后不会恢复特殊字符。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "AutoCompleteInput boundary restriction persists for later positions."
+msgstr "AutoCompleteInput 的边界限制会持续影响后续位置。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "All statically reachable generation consumers are skipped. {} "
+msgstr "所有静态可达的生成消费方都被跳过。{} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "Generation consumer reachability is unknown. {} "
+msgstr "生成消费方的可达性未知。{} "
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "any value"
+msgstr "任意值"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is available only in the OOS parameter "
+"form."
+msgstr "该 AssociationProperty 值仅适用于 OOS 参数表单。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"This AssociationProperty value is unavailable in the stock ROS parameter "
+"form."
+msgstr "该 AssociationProperty 值在原生 ROS 参数表单中不可用。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is empty"
+msgstr "引用为空"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "environment references are not allowed by this consumer"
+msgstr "此消费方不允许环境引用"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Parameter references are not allowed by this consumer"
+msgstr "此消费方不允许 Parameter 引用"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "field-path references are not allowed by this consumer"
+msgstr "此消费方不允许字段路径引用"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path is malformed"
+msgstr "字段路径格式错误"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid ""
+"field paths support one top-level array projection followed by a child "
+"path"
+msgstr "字段路径仅支持一个顶层数组投影，后接一个子路径"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Parameter does not exist"
+msgstr "Parameter 不存在"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter does not exist"
+msgstr "嵌套 Parameter 不存在"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the MetaList row field does not exist"
+msgstr "MetaList 行字段不存在"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced Parameter declaration is invalid"
+msgstr "被引用的 Parameter 声明无效"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the field path traverses a scalar Parameter"
+msgstr "字段路径穿过了标量 Parameter"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the nested Parameter field does not exist"
+msgstr "嵌套 Parameter 字段不存在"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the referenced nested Parameter declaration is invalid"
+msgstr "被引用的嵌套 Parameter 声明无效"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path does not exist"
+msgstr "Definitions 路径不存在"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} references are not allowed by this consumer"
+msgstr "此消费方不允许 {} 引用"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the reference is invalid"
+msgstr "引用无效"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "nested And/Or/Not operands must be condition objects"
+msgstr "嵌套的 And/Or/Not 操作数必须是条件对象"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition must be a non-empty String or object"
+msgstr "条件必须是非空 String 或对象"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the first function key is unsupported"
+msgstr "不支持第一个函数键"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Not requires one condition object containing a single key"
+msgstr "Fn::Not 需要一个仅包含单个键的条件对象"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "Fn::Select requires its first two arguments to be Strings"
+msgstr "Fn::Select 的前两个参数必须是 String"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the Definitions path must resolve to a condition object"
+msgstr "Definitions 路径必须解析为条件对象"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires exactly two arguments"
+msgstr "{} 恰好需要两个参数"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#, python-brace-format
+msgid "{} requires an array"
+msgstr "{} 需要一个数组"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+msgid "the condition is invalid"
+msgstr "条件无效"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format
@@ -10709,3 +11409,83 @@ msgstr "允许 Bash?"
 #~ msgid "由外部登录管理"
 #~ msgstr "由外部登录管理"
 
+#~ msgid "The key maps to component {} with scope {}: {}."
+#~ msgstr "该键映射到组件 {},作用域为 {}:{}。"
+
+#~ msgid "AssociationProperty is deprecated by the local frontend contract."
+#~ msgstr "本地前端契约已将 AssociationProperty 标记为弃用。"
+
+#~ msgid ""
+#~ "The current stock ROS form still "
+#~ "resolves this key, but the contract "
+#~ "marks it as deprecated."
+#~ msgstr "当前原生 ROS 表单仍能解析此键，但本地契约已将其标记为弃用。"
+
+#~ msgid ""
+#~ "The local validator cannot prove that"
+#~ " a newer target frontend does not "
+#~ "support this key; stock fallback rules"
+#~ " are used."
+#~ msgstr "本地校验器无法证明较新的目标前端不支持此键；将使用原生回退规则。"
+
+#~ msgid ""
+#~ "Only some possible components consume "
+#~ "this field; its component-specific "
+#~ "schema cannot be enforced deterministically."
+#~ msgstr "只有部分候选组件会使用此字段，因此无法确定性地执行组件专属 schema 校验。"
+
+#~ msgid ""
+#~ "AssociationPropertyMetadata Parameter reference has"
+#~ " a runtime-dependent scope."
+#~ msgstr "AssociationPropertyMetadata 的 Parameter 引用作用域取决于运行时。"
+
+#~ msgid ""
+#~ "The nested consumer does not use "
+#~ "an unambiguous template-root symbol "
+#~ "table."
+#~ msgstr "嵌套消费方未使用明确的模板根符号表。"
+
+#~ msgid ""
+#~ "Metadata field {} may or may not"
+#~ " take effect, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr "Metadata 字段 {} 是否生效，取决于运行时选择的表单组件。"
+
+#~ msgid ""
+#~ "Possible form components: {}. Only some"
+#~ " read field {}, so local validation"
+#~ " leaves the field unchecked."
+#~ msgstr "可能使用的表单组件：{}。只有部分组件会读取字段 {}，因此本地校验不会判断该字段是否有效。"
+
+#~ msgid ""
+#~ "Metadata reference {} may use different"
+#~ " lookup scopes, depending on the "
+#~ "runtime-selected form component."
+#~ msgstr "Metadata 引用 {} 的查找范围可能不同，具体取决于运行时选择的表单组件。"
+
+#~ msgid "All resolved components bypass the unavailable {} mapping."
+#~ msgstr "所有已解析组件都会绕过不可用的 {} 映射。"
+
+#~ msgid ""
+#~ "The editable path cannot use component"
+#~ " {}, but the earlier read-only "
+#~ "branch can select {}."
+#~ msgstr "可编辑路径无法使用组件 {}，但更早的只读分支可以选择 {}。"
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is available only in the OOS"
+#~ " parameter form."
+#~ msgstr "该键映射到组件 {}，此组件仅在 OOS 参数表单中可用。"
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is not registered in the "
+#~ "stock ROS parameter form."
+#~ msgstr "该键映射到组件 {}，此组件未在原生 ROS 参数表单中注册。"
+
+#~ msgid ""
+#~ "The key maps to component {}, "
+#~ "which is unavailable in the stock "
+#~ "ROS parameter form."
+#~ msgstr "该键映射到组件 {}，此组件在原生 ROS 参数表单中不可用。"

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
@@ -54,6 +54,7 @@ from iac_code.tools.cloud.aliyun.ros_validation.symbols import (
     ResourceSymbol,
     TemplateSymbols,
 )
+from iac_code.tools.cloud.aliyun.ros_validation.template_kind import is_terraform_template
 from iac_code.tools.cloud.aliyun.ros_validation.types import (
     ANY_VALUE,
     BOOLEAN,
@@ -812,7 +813,7 @@ class ExpressionAnalyzer:
         if (
             "ROSTemplateFormatVersion" in data
             and data.get("ROSTemplateFormatVersion") != "2015-09-01"
-            and not self._is_terraform(data)
+            and not is_terraform_template(data)
         ):
             self.diagnostic(
                 "ROS1120",
@@ -906,7 +907,7 @@ class ExpressionAnalyzer:
             )
 
     def _structure(self, data: Mapping[Any, Any]) -> None:
-        if "ROSTemplateFormatVersion" not in data and not self._is_terraform(data):
+        if "ROSTemplateFormatVersion" not in data and not is_terraform_template(data):
             self.diagnostic(
                 "ROS1004",
                 _("The template is missing ROSTemplateFormatVersion."),
@@ -914,7 +915,7 @@ class ExpressionAnalyzer:
                 (),
                 suggestion=_("Add ROSTemplateFormatVersion: '2015-09-01'."),
             )
-        if self._is_terraform(data):
+        if is_terraform_template(data):
             return
         for section in ("Parameters", "Mappings", "Conditions", "Rules", "Outputs"):
             value = data.get(section)
@@ -1055,14 +1056,6 @@ class ExpressionAnalyzer:
             for item in nested:
                 result.update(self._condition_dependencies(item))
         return result
-
-    @staticmethod
-    def _is_terraform(data: Mapping[Any, Any]) -> bool:
-        transform = data.get("Transform")
-        values = transform if isinstance(transform, list) else [transform]
-        return any(
-            isinstance(value, str) and value.startswith(("Aliyun::Terraform-", "Aliyun::OpenTofu-")) for value in values
-        )
 
     def _existing_vpc_rule(
         self,

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/association_property_specs.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/association_property_specs.py
@@ -1,0 +1,697 @@
+"""Load and verify the vendored AssociationProperty contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import struct
+from copy import deepcopy
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib.resources import files
+from types import MappingProxyType
+from typing import Any, Mapping
+
+ASSOCIATION_PROPERTY_SPECS = "association-property-specs"
+CONTRACT_VERSION = 3
+CONTRACT_CORRECTIONS = (
+    {
+        "target": "common_metadata.schema.properties.ValueLabelMapping",
+        "reason": "Value labels support either plain strings or localized string maps.",
+    },
+    {
+        "target": "components.BailianApiKey.metadata.properties.OnlyKey",
+        "reason": "OnlyKey is a boolean form-mode switch.",
+    },
+)
+_VALUE_LABEL_MAPPING_SCHEMA = {
+    "additionalProperties": {
+        "anyOf": [
+            {"type": "string"},
+            {"additionalProperties": {"type": "string"}, "type": "object"},
+        ]
+    },
+    "type": "object",
+}
+SUPPORTED_SCHEMA_TYPES = frozenset({"array", "boolean", "integer", "null", "number", "object", "string"})
+SUPPORTED_SCHEMA_KEYWORDS = frozenset(
+    {
+        "additionalProperties",
+        "anyOf",
+        "const",
+        "enum",
+        "items",
+        "minLength",
+        "minimum",
+        "patternProperties",
+        "properties",
+        "required",
+        "type",
+        "x-ore-aliases",
+        "x-ore-consumer-set",
+        "x-ore-injected-symbols",
+        "x-ore-nested-parameter",
+        "x-ore-parser",
+        "x-ore-precedence",
+        "x-ore-reference-context",
+        "x-ore-reference-kinds",
+        "x-ore-unresolved-reference",
+        "x-ore-value-suggestions",
+    }
+)
+SUPPORTED_PARSERS = frozenset(
+    {
+        "condition-ast",
+        "literal-only",
+        "lodash-template-interpolation",
+        "mapping-selector-segments",
+        "whole-value-reference",
+    }
+)
+SUPPORTED_REFERENCE_CONTEXTS = frozenset(
+    {"meta-list-row", "nested-parameter-map", "runtime-dependent", "template-root"}
+)
+SUPPORTED_REFERENCE_KINDS = frozenset({"env", "field-path", "parameter"})
+SUPPORTED_SEMANTIC_RULES = frozenset({"auto_complete_character_capacity"})
+SUPPORTED_WHEN = frozenset({"current-value-falsy-at-effect", "effective-default-undefined-after-normalization"})
+VALUE_FLOW_SCHEMA = {
+    "base_default": "initial-value-nullish-coalescing-parameter-default",
+    "component_guard": "js-falsy-current-value",
+    "default_gate": "ros-ref-value-skips-normalization",
+    "host_merge": "runtime-dependent",
+    "metadata_effects": ["Value", "DynamicValue"],
+    "normalization": "template-form-default-normalization",
+}
+EXPECTED_AUTO_COMPLETE_CONSUMER_SETS = {
+    "auto_complete_generation": {
+        "consumers": [
+            {
+                "id": "template-default-initializer",
+                "parser": "literal-only",
+                "reference_context": "template-root",
+                "when": "effective-default-undefined-after-normalization",
+            },
+            {
+                "id": "associated-component",
+                "parser": "whole-value-reference",
+                "reference_context": "template-root",
+                "reference_kinds": ["parameter", "field-path", "env"],
+                "when": "current-value-falsy-at-effect",
+            },
+        ],
+        "resolution": "inconsistent",
+        "value_flow": VALUE_FLOW_SCHEMA,
+    }
+}
+
+
+@dataclass(frozen=True)
+class AssociationPropertySpec:
+    key: str
+    component: str
+    deprecated: bool
+    replacement: str | None
+    scope: str
+
+
+@dataclass(frozen=True)
+class ExcludedAssociationPropertySpec:
+    key: str
+    scope: str
+
+
+@dataclass(frozen=True)
+class ComponentSpec:
+    name: str
+    coverage: str
+    metadata: Mapping[str, Any]
+    semantic_rules: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AssociationPropertySpecRegistry:
+    contract_version: int
+    product: str
+    profile: Mapping[str, Any]
+    corrections: tuple[Mapping[str, str], ...]
+    common_coverage: str
+    common_metadata: Mapping[str, Any]
+    common_semantic_rules: tuple[str, ...]
+    consumer_sets: Mapping[str, Any]
+    association_properties: Mapping[str, AssociationPropertySpec]
+    components: Mapping[str, ComponentSpec]
+    excluded_association_properties: Mapping[str, ExcludedAssociationPropertySpec]
+    raw_contract: Mapping[str, Any]
+
+    def association(self, key: str) -> AssociationPropertySpec | None:
+        return self.association_properties.get(key)
+
+    def excluded(self, key: str) -> ExcludedAssociationPropertySpec | None:
+        return self.excluded_association_properties.get(key)
+
+    def component(self, name: str) -> ComponentSpec | None:
+        return self.components.get(name)
+
+
+def _no_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise RuntimeError("AssociationProperty contract contains duplicate key {}".format(key))
+        result[key] = value
+    return result
+
+
+def parse_contract_text(text: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(text, object_pairs_hook=_no_duplicate_object)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError("AssociationProperty contract is not valid JSON") from error
+    if not isinstance(payload, dict):
+        raise RuntimeError("AssociationProperty contract root must be an object")
+    return payload
+
+
+def _canonical_length(value: int) -> bytes:
+    return "{}:".format(value).encode("ascii")
+
+
+def _utf16_sort_key(value: str) -> tuple[int, ...]:
+    encoded = value.encode("utf-16-le", errors="surrogatepass")
+    return tuple(int.from_bytes(encoded[index : index + 2], "little") for index in range(0, len(encoded), 2))
+
+
+def _canonical_value_bytes(value: Any) -> bytes:
+    if value is None:
+        return b"N"
+    if value is False:
+        return b"F"
+    if value is True:
+        return b"T"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        try:
+            number = float(value)
+        except (OverflowError, ValueError) as error:
+            raise RuntimeError("AssociationProperty contract contains an invalid number") from error
+        if not math.isfinite(number):
+            raise RuntimeError("AssociationProperty contract contains a non-finite number")
+        # JSON.stringify serializes negative zero as zero, so normalize it before
+        # framing the IEEE-754 value used by both the exporter and loader.
+        if number == 0:
+            number = 0.0
+        return b"D" + struct.pack(">d", number)
+    if isinstance(value, str):
+        encoded = value.encode("utf-16-le", errors="surrogatepass")
+        return b"S" + _canonical_length(len(encoded)) + encoded
+    if isinstance(value, (list, tuple)):
+        return b"A" + _canonical_length(len(value)) + b"".join(_canonical_value_bytes(item) for item in value)
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise RuntimeError("AssociationProperty contract contains a non-String object key")
+        keys = sorted((key for key in value if isinstance(key, str)), key=_utf16_sort_key)
+        return (
+            b"O"
+            + _canonical_length(len(keys))
+            + b"".join(_canonical_value_bytes(key) + _canonical_value_bytes(value[key]) for key in keys)
+        )
+    raise RuntimeError("AssociationProperty contract contains an unsupported canonical value")
+
+
+def canonical_contract_bytes(payload: Mapping[str, Any]) -> bytes:
+    content = dict(payload)
+    content.pop("content_sha256", None)
+    return _canonical_value_bytes(content)
+
+
+def contract_content_hash(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_contract_bytes(payload)).hexdigest()
+
+
+def _project_entries(value: Any, allowed_fields: frozenset[str]) -> Any:
+    if not isinstance(value, Mapping):
+        return deepcopy(value)
+    return {
+        key: (
+            {field: deepcopy(entry[field]) for field in allowed_fields if field in entry}
+            if isinstance(entry, Mapping)
+            else deepcopy(entry)
+        )
+        for key, entry in value.items()
+    }
+
+
+def apply_contract_corrections(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the local contract projected onto its supported public fields."""
+
+    common = payload.get("common_metadata")
+    corrected: dict[str, Any] = {
+        "association_properties": _project_entries(
+            payload.get("association_properties"),
+            frozenset({"component", "deprecated", "replacement", "scope"}),
+        ),
+        "common_metadata": (
+            {
+                field: deepcopy(common[field])
+                for field in ("coverage", "schema", "semantic_rules")
+                if field in common
+            }
+            if isinstance(common, Mapping)
+            else deepcopy(common)
+        ),
+        "components": _project_entries(
+            payload.get("components"),
+            frozenset({"coverage", "metadata", "semantic_rules"}),
+        ),
+        "consumer_sets": deepcopy(payload.get("consumer_sets")),
+        "contract_version": CONTRACT_VERSION,
+        "corrections": deepcopy(list(CONTRACT_CORRECTIONS)),
+        "excluded_association_properties": _project_entries(
+            payload.get("excluded_association_properties"),
+            frozenset({"scope"}),
+        ),
+        "product": deepcopy(payload.get("product")),
+        "profile": deepcopy(payload.get("profile")),
+    }
+
+    profile = corrected.get("profile")
+    if not isinstance(profile, dict):
+        raise RuntimeError("AssociationProperty contract profile is missing")
+    profile["id"] = "stock-ros-parameter-form"
+    profile["host_read_only_inputs"] = "unknown"
+
+    common = corrected.get("common_metadata")
+    common_schema = common.get("schema") if isinstance(common, Mapping) else None
+    common_properties = common_schema.get("properties") if isinstance(common_schema, Mapping) else None
+    if not isinstance(common_properties, dict) or "ValueLabelMapping" not in common_properties:
+        raise RuntimeError("AssociationProperty contract cannot apply the ValueLabelMapping correction")
+    common_properties["ValueLabelMapping"] = deepcopy(_VALUE_LABEL_MAPPING_SCHEMA)
+
+    components = corrected.get("components")
+    bailian = components.get("BailianApiKey") if isinstance(components, Mapping) else None
+    metadata = bailian.get("metadata") if isinstance(bailian, Mapping) else None
+    properties = metadata.get("properties") if isinstance(metadata, Mapping) else None
+    only_key = properties.get("OnlyKey") if isinstance(properties, Mapping) else None
+    if not isinstance(only_key, dict):
+        raise RuntimeError("AssociationProperty contract cannot apply the OnlyKey correction")
+    only_key["type"] = "boolean"
+
+    corrected["content_sha256"] = contract_content_hash(corrected)
+    return corrected
+
+
+def _require_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise RuntimeError("{} must be an object with String keys".format(label))
+    return value
+
+
+def _verify_schema(schema: Any, label: str = "schema") -> None:
+    schema = _require_mapping(schema, label)
+    unknown_keywords = set(schema) - SUPPORTED_SCHEMA_KEYWORDS
+    if unknown_keywords:
+        raise RuntimeError("{} contains unsupported keywords {}".format(label, sorted(unknown_keywords)))
+    schema_type = schema.get("type")
+    if schema_type is not None and schema_type not in SUPPORTED_SCHEMA_TYPES:
+        raise RuntimeError("{} has unsupported type {}".format(label, schema_type))
+    properties = schema.get("properties")
+    if properties is not None:
+        properties = _require_mapping(properties, "{}.properties".format(label))
+        if schema_type != "object":
+            raise RuntimeError("{}.properties requires object type".format(label))
+        for key, child in properties.items():
+            _verify_schema(child, "{}.properties.{}".format(label, key))
+    pattern_properties = schema.get("patternProperties")
+    if pattern_properties is not None:
+        pattern_properties = _require_mapping(pattern_properties, "{}.patternProperties".format(label))
+        if schema_type != "object":
+            raise RuntimeError("{}.patternProperties requires object type".format(label))
+        for key, child in pattern_properties.items():
+            try:
+                re.compile(key)
+            except re.error as error:
+                raise RuntimeError("{}.patternProperties contains invalid pattern {}".format(label, key)) from error
+            _verify_schema(child, "{}.patternProperties.{}".format(label, key))
+    if "items" in schema:
+        if schema_type != "array":
+            raise RuntimeError("{}.items requires array type".format(label))
+        _verify_schema(schema["items"], "{}.items".format(label))
+    required = schema.get("required")
+    if required is not None:
+        if (
+            schema_type != "object"
+            or not isinstance(required, list)
+            or not all(isinstance(item, str) and item for item in required)
+            or len(set(required)) != len(required)
+        ):
+            raise RuntimeError("{}.required is invalid".format(label))
+    additional = schema.get("additionalProperties")
+    if additional is not None:
+        if schema_type != "object":
+            raise RuntimeError("{}.additionalProperties requires object type".format(label))
+        if not isinstance(additional, bool):
+            _verify_schema(additional, "{}.additionalProperties".format(label))
+    any_of = schema.get("anyOf")
+    if any_of is not None:
+        if not isinstance(any_of, list) or not any_of:
+            raise RuntimeError("{}.anyOf is invalid".format(label))
+        for index, child in enumerate(any_of):
+            _verify_schema(child, "{}.anyOf[{}]".format(label, index))
+    enum = schema.get("enum")
+    if enum is not None:
+        if (
+            not isinstance(enum, list)
+            or not enum
+            or len({json.dumps(item, sort_keys=True) for item in enum}) != len(enum)
+        ):
+            raise RuntimeError("{}.enum is invalid".format(label))
+        if schema_type is not None and any(not _schema_value_matches_type(item, schema_type) for item in enum):
+            raise RuntimeError("{}.enum does not match type".format(label))
+    if "const" in schema and schema_type is not None and not _schema_value_matches_type(schema["const"], schema_type):
+        raise RuntimeError("{}.const does not match type".format(label))
+    minimum = schema.get("minimum")
+    if minimum is not None and (
+        schema_type not in {"integer", "number"}
+        or isinstance(minimum, bool)
+        or not isinstance(minimum, (int, float))
+        or not math.isfinite(minimum)
+    ):
+        raise RuntimeError("{}.minimum is invalid".format(label))
+    min_length = schema.get("minLength")
+    if min_length is not None and (
+        schema_type != "string" or isinstance(min_length, bool) or not isinstance(min_length, int) or min_length < 0
+    ):
+        raise RuntimeError("{}.minLength is invalid".format(label))
+    for keyword in (
+        "x-ore-aliases",
+        "x-ore-injected-symbols",
+        "x-ore-precedence",
+        "x-ore-reference-kinds",
+    ):
+        values = schema.get(keyword)
+        if values is not None and (
+            not isinstance(values, list)
+            or not values
+            or len(set(values)) != len(values)
+            or not all(isinstance(item, str) and item for item in values)
+        ):
+            raise RuntimeError("{}.{} is invalid".format(label, keyword))
+    aliases = schema.get("x-ore-aliases")
+    precedence = schema.get("x-ore-precedence")
+    if aliases is not None and (not isinstance(precedence, list) or not all(alias in precedence for alias in aliases)):
+        raise RuntimeError("{}.x-ore-aliases requires matching precedence".format(label))
+    parser = schema.get("x-ore-parser")
+    if parser is not None and parser not in SUPPORTED_PARSERS:
+        raise RuntimeError("{}.x-ore-parser is invalid".format(label))
+    reference_context = schema.get("x-ore-reference-context")
+    if reference_context is not None and reference_context not in SUPPORTED_REFERENCE_CONTEXTS:
+        raise RuntimeError("{}.x-ore-reference-context is invalid".format(label))
+    reference_kinds = schema.get("x-ore-reference-kinds")
+    if isinstance(reference_kinds, list) and not set(reference_kinds) <= SUPPORTED_REFERENCE_KINDS:
+        raise RuntimeError("{}.x-ore-reference-kinds is invalid".format(label))
+    unresolved_reference = schema.get("x-ore-unresolved-reference")
+    if unresolved_reference is not None and unresolved_reference != "literal-segment":
+        raise RuntimeError("{}.x-ore-unresolved-reference is invalid".format(label))
+    consumer_set = schema.get("x-ore-consumer-set")
+    if consumer_set is not None and (not isinstance(consumer_set, str) or not consumer_set):
+        raise RuntimeError("{}.x-ore-consumer-set is invalid".format(label))
+    nested_parameter = schema.get("x-ore-nested-parameter")
+    if nested_parameter is not None and not isinstance(nested_parameter, bool):
+        raise RuntimeError("{}.x-ore-nested-parameter is invalid".format(label))
+    suggestions = schema.get("x-ore-value-suggestions")
+    if suggestions is not None:
+        suggestions = _require_mapping(suggestions, "{}.x-ore-value-suggestions".format(label))
+        invalid_suggestion = any(
+            not key or not isinstance(value, str) or not value for key, value in suggestions.items()
+        )
+        if (
+            not suggestions
+            or invalid_suggestion
+            or (isinstance(enum, list) and any(value not in enum for value in suggestions.values()))
+        ):
+            raise RuntimeError("{}.x-ore-value-suggestions is invalid".format(label))
+
+
+def _schema_value_matches_type(value: Any, schema_type: str) -> bool:
+    if schema_type == "null":
+        return value is None
+    if schema_type == "boolean":
+        return isinstance(value, bool)
+    if schema_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if schema_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+    if schema_type == "string":
+        return isinstance(value, str)
+    if schema_type == "array":
+        return isinstance(value, list)
+    if schema_type == "object":
+        return isinstance(value, Mapping)
+    return False
+
+
+def _verify_string_list(value: Any, label: str, *, nonempty: bool = True) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or (nonempty and not value)
+        or not all(isinstance(item, str) and item for item in value)
+        or len(set(value)) != len(value)
+    ):
+        raise RuntimeError("{} must be a unique String array".format(label))
+    return value
+
+
+def _verify_consumer_sets(value: Any) -> Mapping[str, Any]:
+    consumer_sets = _require_mapping(value, "consumer_sets")
+    if not consumer_sets:
+        raise RuntimeError("consumer_sets must not be empty")
+    for name, raw in consumer_sets.items():
+        consumer_set = _require_mapping(raw, "consumer_sets.{}".format(name))
+        if set(consumer_set) != {"consumers", "resolution", "value_flow"}:
+            raise RuntimeError("consumer set {} has invalid schema".format(name))
+        if consumer_set.get("resolution") not in {"consistent", "inconsistent"}:
+            raise RuntimeError("consumer set {} has invalid resolution".format(name))
+        consumers = consumer_set.get("consumers")
+        if not isinstance(consumers, list) or not consumers:
+            raise RuntimeError("consumer set {} has no consumers".format(name))
+        ids: set[str] = set()
+        for index, raw_consumer in enumerate(consumers):
+            consumer = _require_mapping(raw_consumer, "consumer_sets.{}.consumers[{}]".format(name, index))
+            expected = {"id", "parser", "reference_context", "when"}
+            if "reference_kinds" in consumer:
+                expected.add("reference_kinds")
+            consumer_id = consumer.get("id")
+            if (
+                set(consumer) != expected
+                or not isinstance(consumer_id, str)
+                or not consumer_id
+                or consumer_id in ids
+                or consumer.get("parser") not in SUPPORTED_PARSERS
+                or consumer.get("reference_context") not in SUPPORTED_REFERENCE_CONTEXTS
+                or consumer.get("when") not in SUPPORTED_WHEN
+            ):
+                raise RuntimeError("consumer set {} contains an invalid consumer".format(name))
+            ids.add(consumer_id)
+            if "reference_kinds" in consumer:
+                kinds = _verify_string_list(
+                    consumer["reference_kinds"], "consumer_sets.{}.reference_kinds".format(name)
+                )
+                if not set(kinds) <= SUPPORTED_REFERENCE_KINDS:
+                    raise RuntimeError("consumer set {} contains an invalid reference kind".format(name))
+        if (
+            dict(_require_mapping(consumer_set.get("value_flow"), "consumer_sets.{}.value_flow".format(name)))
+            != VALUE_FLOW_SCHEMA
+        ):
+            raise RuntimeError("consumer set {} has invalid value_flow".format(name))
+    return consumer_sets
+
+
+def verify_contract_payload(payload: Mapping[str, Any]) -> None:
+    expected_fields = {
+        "association_properties",
+        "common_metadata",
+        "components",
+        "content_sha256",
+        "consumer_sets",
+        "contract_version",
+        "corrections",
+        "excluded_association_properties",
+        "product",
+        "profile",
+    }
+    if set(payload) != expected_fields or payload.get("contract_version") != CONTRACT_VERSION:
+        raise RuntimeError("AssociationProperty contract has an unsupported top-level schema")
+    if payload.get("product") != "ROS":
+        raise RuntimeError("AssociationProperty contract is not for ROS")
+    profile = _require_mapping(payload.get("profile"), "profile")
+    expected_profile = {
+        "component_overrides": False,
+        "default_read_only_prop": False,
+        "form_type": "parameter",
+        "host_read_only_inputs": "unknown",
+        "host_value_inputs": "unknown",
+        "id": "stock-ros-parameter-form",
+        "read_only_selection": {
+            "component": "ReadOnlyItem",
+            "contains": ["InstanceType"],
+            "exact_association_properties": ["TemplateParameter", "Targets"],
+            "precedence": "before-association-property-resolution",
+        },
+    }
+    if dict(profile) != expected_profile:
+        raise RuntimeError("AssociationProperty contract has an unsupported profile")
+    corrections = payload.get("corrections")
+    if corrections != list(CONTRACT_CORRECTIONS):
+        raise RuntimeError("AssociationProperty contract corrections are invalid")
+    expected_hash = payload.get("content_sha256")
+    if (
+        not isinstance(expected_hash, str)
+        or len(expected_hash) != 64
+        or expected_hash != contract_content_hash(payload)
+    ):
+        raise RuntimeError("AssociationProperty contract content_sha256 mismatch")
+    associations = _require_mapping(payload.get("association_properties"), "association_properties")
+    exclusions = _require_mapping(payload.get("excluded_association_properties"), "excluded_association_properties")
+    components = _require_mapping(payload.get("components"), "components")
+    if not associations or not components or set(associations) & set(exclusions):
+        raise RuntimeError("AssociationProperty keys are not explained exactly once")
+    for key, raw in associations.items():
+        entry = _require_mapping(raw, "association_properties.{}".format(key))
+        if set(entry) != {"component", "deprecated", "replacement", "scope"}:
+            raise RuntimeError("AssociationProperty {} has invalid schema".format(key))
+        if entry.get("component") not in components or entry.get("scope") != "ROS":
+            raise RuntimeError("AssociationProperty {} has no stock ROS component".format(key))
+        replacement = entry.get("replacement")
+        if not isinstance(entry.get("deprecated"), bool) or not (
+            replacement is None or isinstance(replacement, str) and replacement
+        ):
+            raise RuntimeError("AssociationProperty {} has invalid metadata".format(key))
+    for key, raw in exclusions.items():
+        entry = _require_mapping(raw, "excluded_association_properties.{}".format(key))
+        if set(entry) != {"scope"}:
+            raise RuntimeError("excluded AssociationProperty {} has invalid schema".format(key))
+        if entry.get("scope") not in {"OOS-only", "unavailable-stock"}:
+            raise RuntimeError("excluded AssociationProperty {} has invalid metadata".format(key))
+    consumer_sets = _verify_consumer_sets(payload.get("consumer_sets"))
+    if dict(consumer_sets) != EXPECTED_AUTO_COMPLETE_CONSUMER_SETS:
+        raise RuntimeError("AutoCompleteInput consumer sets differ from the supported local contract")
+    for name, raw in components.items():
+        entry = _require_mapping(raw, "components.{}".format(name))
+        if set(entry) != {"coverage", "metadata", "semantic_rules"}:
+            raise RuntimeError("component {} has invalid schema".format(name))
+        if entry.get("coverage") not in {"complete", "partial"}:
+            raise RuntimeError("component {} has invalid coverage".format(name))
+        try:
+            semantic_rules = _verify_string_list(
+                entry.get("semantic_rules"), "components.{}.semantic_rules".format(name), nonempty=False
+            )
+        except RuntimeError as error:
+            raise RuntimeError("component {} has invalid audit metadata".format(name)) from error
+        if not set(semantic_rules) <= SUPPORTED_SEMANTIC_RULES:
+            raise RuntimeError("component {} uses an unknown semantic rule".format(name))
+        _verify_schema(entry.get("metadata"), "components.{}.metadata".format(name))
+    auto_complete = _require_mapping(components.get("AutoCompleteInput"), "components.AutoCompleteInput")
+    if (
+        auto_complete.get("coverage") != "complete"
+        or auto_complete.get("semantic_rules") != ["auto_complete_character_capacity"]
+        or any(
+            name != "AutoCompleteInput" and "auto_complete_character_capacity" in raw.get("semantic_rules", [])
+            for name, raw in components.items()
+            if isinstance(raw, Mapping)
+        )
+    ):
+        raise RuntimeError("AutoCompleteInput semantic rule ownership is invalid")
+    common = _require_mapping(payload.get("common_metadata"), "common_metadata")
+    if set(common) != {"coverage", "schema", "semantic_rules"} or common.get("coverage") not in {
+        "complete",
+        "partial",
+    }:
+        raise RuntimeError("common AssociationPropertyMetadata contract is invalid")
+    if common.get("semantic_rules") != ["parameter_metadata_condition"]:
+        raise RuntimeError("common AssociationPropertyMetadata semantic rules are invalid")
+    _verify_schema(common.get("schema"), "common_metadata.schema")
+
+    def walk_schema(schema: Mapping[str, Any]) -> None:
+        consumer_set = schema.get("x-ore-consumer-set")
+        if consumer_set is not None and consumer_set not in consumer_sets:
+            raise RuntimeError("AssociationProperty schema references unknown consumer set {}".format(consumer_set))
+        for child in _require_mapping(schema.get("properties", {}), "properties").values():
+            walk_schema(child)
+        for child in _require_mapping(schema.get("patternProperties", {}), "patternProperties").values():
+            walk_schema(child)
+        if isinstance(schema.get("items"), Mapping):
+            walk_schema(schema["items"])
+        if isinstance(schema.get("additionalProperties"), Mapping):
+            walk_schema(schema["additionalProperties"])
+        for child in schema.get("anyOf", []):
+            walk_schema(child)
+
+    walk_schema(common["schema"])
+    for raw in components.values():
+        walk_schema(raw["metadata"])
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze(child) for key, child in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze(child) for child in value)
+    return value
+
+
+def registry_from_payload(payload: Mapping[str, Any]) -> AssociationPropertySpecRegistry:
+    verify_contract_payload(payload)
+    common = payload["common_metadata"]
+    associations = {
+        key: AssociationPropertySpec(
+            key=key,
+            component=value["component"],
+            deprecated=value["deprecated"],
+            replacement=value["replacement"],
+            scope=value["scope"],
+        )
+        for key, value in payload["association_properties"].items()
+    }
+    exclusions = {
+        key: ExcludedAssociationPropertySpec(
+            key=key,
+            scope=value["scope"],
+        )
+        for key, value in payload["excluded_association_properties"].items()
+    }
+    components = {
+        name: ComponentSpec(
+            name=name,
+            coverage=value["coverage"],
+            metadata=_freeze(value["metadata"]),
+            semantic_rules=tuple(value["semantic_rules"]),
+        )
+        for name, value in payload["components"].items()
+    }
+    return AssociationPropertySpecRegistry(
+        contract_version=payload["contract_version"],
+        product=payload["product"],
+        profile=_freeze(payload["profile"]),
+        corrections=tuple(_freeze(item) for item in payload["corrections"]),
+        common_coverage=common["coverage"],
+        common_metadata=_freeze(common["schema"]),
+        common_semantic_rules=tuple(common["semantic_rules"]),
+        consumer_sets=_freeze(payload["consumer_sets"]),
+        association_properties=MappingProxyType(associations),
+        components=MappingProxyType(components),
+        excluded_association_properties=MappingProxyType(exclusions),
+        raw_contract=_freeze(payload),
+    )
+
+
+def load_contract_text(text: str) -> AssociationPropertySpecRegistry:
+    return registry_from_payload(parse_contract_text(text))
+
+
+@lru_cache(maxsize=1)
+def load_association_property_specs() -> AssociationPropertySpecRegistry:
+    data_path = files("iac_code.tools.cloud.aliyun.ros_validation").joinpath("data/ros_association_property_specs.json")
+    if not data_path.is_file():
+        raise RuntimeError("vendored ROS AssociationProperty contract is missing")
+    return load_contract_text(data_path.read_text(encoding="utf-8"))

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/data/ros_association_property_specs.json
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/data/ros_association_property_specs.json
@@ -1,0 +1,12563 @@
+{
+  "association_properties": {
+    "ACS::OOS::GitBranch::LatestCommitId": {
+      "component": "OOSGitBranchLatestCommitId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ACR::Namespace::Name": {
+      "component": "ACRNamespace",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ACR::Repo::RepoAttribute": {
+      "component": "ACRRepoAttribute",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ACR::Repo::Tag": {
+      "component": "ACRRepoTag",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ALB::ACL::ACLId": {
+      "component": "AlbAccessControlSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ALB::Instance::InstanceId": {
+      "component": "AlbInstanceSelector",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ALB::LoadBalancer::LoadBalancerId": {
+      "component": "AlbInstanceSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ALB::Zone::ZoneId": {
+      "component": "AlbZoneIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::APIG::Gateway::GatewayId": {
+      "component": "APIGatewayId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::APIG::Gateway::ListDomains": {
+      "component": "APIListDomains",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::AppFlow::UserAuthConfig::ConfigId": {
+      "component": "AppFlowUserAuthConfigId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ApplicationManager::Connection": {
+      "component": "ApplicationManagerConnection",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::BSS::PricingModule::ModuleCode": {
+      "component": "PricingModule",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Bailian::ApiKey::ApiKeyInfo": {
+      "component": "BailianApiKey",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Bailian::MCP::MCPInfo": {
+      "component": "BailianMCPInfo",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CAS::Certificate": {
+      "component": "CASCertificate",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CAS::Certificate::CertificateId": {
+      "component": "CASCertificate",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CEN::Instance::CenId": {
+      "component": "CenIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CEN::TransitRouter::TransitRouterId": {
+      "component": "TransitRouterIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Alarm::MetricSelector": {
+      "component": "MetricSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Alarm::Rule": {
+      "component": "RuleDescribe",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Alarm::SilenceTime": {
+      "component": "SilenceTimeSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Alarm::TriggerResources": {
+      "component": "TriggerResources",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Event::EventFilterRule": {
+      "component": "EventFilterRule",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Event::EventLevel": {
+      "component": "EventLevelSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Event::EventName": {
+      "component": "EventNameSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Product::ProductType": {
+      "component": "ProductTypeSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CMS::Workspace": {
+      "component": "CMSWorkspace",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CR::Instance::InstanceId": {
+      "component": "CRInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CR::NameSpace::Name": {
+      "component": "CRNameSpace",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CR::Repository::RepoName": {
+      "component": "CRRepoName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CR::Repository::Tag": {
+      "component": "CRRepoTag",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CS::Cluster::ClusterId": {
+      "component": "CSClusterId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CS::Cluster::ClusterNodePool": {
+      "component": "CSClusterNodePool",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CS::Cluster::KubernetesVersion": {
+      "component": "CSClusterKubernetesVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CS::ManagedKubernetesCluster::ServiceCidr": {
+      "component": "CSCidr",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CloudSSO::AccessConfiguration::AccessConfigurationId": {
+      "component": "CloudSSOAccessConfigurationId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CloudSSO::Directory::DirectoryId": {
+      "component": "CloudSSODirectoryId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CloudSSO::Group::GroupId": {
+      "component": "CloudSSOGroupId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::CloudSSO::User::UserId": {
+      "component": "CloudSSOUserId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ComputeNest::Artifact::ArtifactId": {
+      "component": "ArtifactId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ComputeNest::Artifact::ArtifactIdVersion": {
+      "component": "ArtifactIdVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ComputeNest::Service::ServiceId": {
+      "component": "ComputeNestServiceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ComputeNest::ServiceInstance::ServiceInstanceId": {
+      "component": "ComputeNestServiceInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ComputeNest::SkillHubConfig": {
+      "component": "ComputeNestSkillHubConfig",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ComputeNest::Skills::SkillsInfo": {
+      "component": "ComputeNestSkillsInfo",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ComputeNestSupplier::Service::ServiceVersion": {
+      "component": "NestServiceVersionIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::DNS::Domain::ValidateDomain": {
+      "component": "DNSDomain",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::DashScope::ApiKey": {
+      "component": "DashScopeApiKey",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::DashVector::ApiKey": {
+      "component": "DashVectorApiKey",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::DashVector::Cluster::ClusterName": {
+      "component": "DashVectorClusterName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::DomainName": {
+      "component": "DomainName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EAS::Instance::InstanceType": {
+      "component": "PAIEASInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EAS::Resource::ResourceId": {
+      "component": "EASResource",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECD::Bundle::DesktopType": {
+      "component": "ECDDesktopTypeSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECI::ContainerGroup::ContainerGroupId": {
+      "component": "ECIContainerGroupId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Command::CommandId": {
+      "component": "ECSCommand",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::DeploymentSet::DeploymentSetId": {
+      "component": "DeploymentSetId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Disk::DataDiskCategory": {
+      "component": "DataDiskCategory",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Disk::DiskId": {
+      "component": "ECSDiskId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Disk::SystemDiskCategory": {
+      "component": "SystemDiskCategory",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Image::ImageFamily": {
+      "component": "ImageFamily",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Image::ImageId": {
+      "component": "ImageId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance": {
+      "component": "InstanceId",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::AttributeSelector": {
+      "component": "AttributeSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::ImageId": {
+      "component": "ImageId",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::InstanceId": {
+      "component": "InstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::InstancePropertyEditor": {
+      "component": "InstancePropertyEditor",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::InstanceType": {
+      "component": "ECSInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::MaxBandwidthIn": {
+      "component": "MaxBandwidthIn",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::OSType": {
+      "component": "ECSInstanceOSType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::Password": {
+      "component": "ECSInstancePassword",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::RenewPeriod": {
+      "component": "RenewPeriod",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::StopMode": {
+      "component": "StopMode",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance::ZoneId": {
+      "component": "ZoneId",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Instance:ZoneId": {
+      "component": "ZoneId",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::InstanceType::AvailableInstanceType": {
+      "component": "AvailableInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::KeyPair::KeyPairName": {
+      "component": "KeyPairName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::LaunchTemplate::LaunchTemplateId": {
+      "component": "LaunchTemplateId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::LaunchTemplate::LaunchTemplateVersion": {
+      "component": "LaunchTemplateVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::ManagedInstance::InstanceId": {
+      "component": "ManagedInstance",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::RAM::Role": {
+      "component": "ECSRamRoleName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::RegionId": {
+      "component": "RegionId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::RegionId::RegionDeploy": {
+      "component": "RegionDeploy",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::RegionId::TargetRegionIds": {
+      "component": "TargetRegionIds",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::ResourceGroup::ResourceGroupId": {
+      "component": "ResourceGroupId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::SecurityGroup::PortRange": {
+      "component": "PortRange",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::SecurityGroup::SecurityGroupId": {
+      "component": "SecurityGroupId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Snapshot::AutoSnapshotPolicyId": {
+      "component": "AutoSnapshotPolicyId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::Snapshot::SnapshotId": {
+      "component": "SnapshotId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::TAG": {
+      "component": "Tags",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::VPC::VPCId": {
+      "component": "VPCId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::VSwitch": {
+      "component": "VSwitch",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::VSwitch::VSwitchId": {
+      "component": "VSwitchId",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ECS::ZoneId": {
+      "component": "ZoneId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EDS::Bundle::BundleId": {
+      "component": "CloudDesktopBundle",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EDS::OfficeSite::OfficeSiteId": {
+      "component": "CloudDesktopOfficeSite",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EDS::PolicyGroup::PolicyGroupId": {
+      "component": "CloudDesktopPolicyGroup",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EHPC::Cluster::ClusterId": {
+      "component": "EHPCClusterId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EHPC::FileSystem::FileSystemId": {
+      "component": "FileSystemId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::EHPC::FileSystem::MountTargetDomain": {
+      "component": "MountTargetDomain",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ESS::AutoScalingGroup::AutoScalingGroupId": {
+      "component": "ScalingGroupId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ESS::ECIScalingConfiguration::ContainerName": {
+      "component": "ECIScalingConfigurationContainerName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ESS::ECIScalingConfiguration::ScalingConfigurationId": {
+      "component": "ECIScalingConfigurationId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ESS::ScalingConfiguration::ScalingConfigurationId": {
+      "component": "ScalingConfigurationId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ElasticSearch::Instance::Version": {
+      "component": "ElasticsearchVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Elasticsearch::Instance::InstanceType": {
+      "component": "ElasticsearchInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Elasticsearch::Instance::Spec": {
+      "component": "ElasticsearchSpec",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Emr::ECSCluster::ClusterId": {
+      "component": "EmrClusterId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::FC3::Function::FunctionName": {
+      "component": "FC3FunctionName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::FC::Function::FunctionName": {
+      "component": "FCFunctionName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::FC::Service::ServiceName": {
+      "component": "FCServiceName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Flow::Connection::ConnectionId": {
+      "component": "ServiceConnectionId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Flow::Organization::OrganizationId": {
+      "component": "OrganizationId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::GPDB::DBInstance::InstanceId": {
+      "component": "GPDBInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Hologres::Instance::InstanceId": {
+      "component": "HologresInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::InfluxDB::Instance::InstanceType": {
+      "component": "InfluxDBInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::KMS::Instance::InstanceId": {
+      "component": "KMSInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::KMS::Key::KeyId": {
+      "component": "KMSKeyId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Kafka::Instance::InstanceId": {
+      "component": "KafkaInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Lindorm::Instance::InstanceId": {
+      "component": "LindormInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::MCP::Server::Server": {
+      "component": "McpServerList",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Market::Product::Code": {
+      "component": "MarketProductCode",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Market::Product::Version": {
+      "component": "MarketProductVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::MongoDB::Instance::InstanceType": {
+      "component": "MongoDBInstance",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NAS::FileSystem::FileSystemId": {
+      "component": "NASFileSystemId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NAS::FileSystem::MountTargetDomain": {
+      "component": "NASMountTarget",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NEST::Service::ServiceId": {
+      "component": "NestServiceIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NEST::Service::ServiceVersion": {
+      "component": "NestServiceVersionIdSelector",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NLB::Instance::InstanceId": {
+      "component": "NlbInstanceId",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NLB::LoadBalancer::LoadBalancerId": {
+      "component": "NlbInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NLB::SecurityPolicy::SecurityPolicyId": {
+      "component": "NLBSecurityPolicyId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NLB::ServerGroup::ServerGroupId": {
+      "component": "NLBServerGroupId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::NLB::Zone::ZoneId": {
+      "component": "NlbZoneId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Action::Name": {
+      "component": "OOSActionName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Application::ApplicationName": {
+      "component": "ApplicationName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Application::DeployRevisionId": {
+      "component": "DeployRevisionId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::ApplicationGroup::ApplicationGroupName": {
+      "component": "ApplicationGroupName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::ArtifactSourceType": {
+      "component": "OOSArtifactSourceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::CodeDeploy::Variables": {
+      "component": "OOSEnvVariables",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Command::CommandContent": {
+      "component": "OOSCommandContent",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::BandwidthUpgradeDurationHour": {
+      "component": "OOSBandwidthUpgradeDurationHour",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::CleanUpInfo": {
+      "component": "CleanUpDiskRules",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::DurationExpression": {
+      "component": "DurationExpression",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::InventoryCollectionPlan": {
+      "component": "InventoryCollectionPlan",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::InventoryInfo": {
+      "component": "InventoryInfo",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::OnOffTimeLine": {
+      "component": "OnOffTimeLine",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::OnOffTimes": {
+      "component": "OnOffTimes",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::OperationType": {
+      "component": "OperationType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::PrivateTemplateName": {
+      "component": "PrivateTemplateName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::SectionType": {
+      "component": "SectionGroup",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::TargetImageName": {
+      "component": "TargetImageName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::TaskName": {
+      "component": "OOSTaskName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::TimerTrigger": {
+      "component": "TimerTrigger",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Component::TransitInstance": {
+      "component": "TransitInstance",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::File::FileUrl": {
+      "component": "OOSFileUrl",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitAccount::Name": {
+      "component": "OOSGitAccount",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitBranch::CommitHash": {
+      "component": "OOSGitBranchCommitHash",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitBranch::Name": {
+      "component": "OOSGitBranch",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitContent::Content": {
+      "component": "OOSGitContent",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitOrganization::Name": {
+      "component": "OOSGitOrganization",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitPlatform::Name": {
+      "component": "OOSGitPlatform",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitRepository::Name": {
+      "component": "OOSGitRepository",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::GitRepository::Samples": {
+      "component": "OOSGitRepositorySamples",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Package::PackageName": {
+      "component": "OOSPackageName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Package::PackageVersion": {
+      "component": "OOSPackageVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Parameter::Value": {
+      "component": "OOSParameterValue",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::PatchBaseline::PatchBaselineContent": {
+      "component": "OOSPatchBaselineContent",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::PatchBaseline::PatchBaselineName": {
+      "component": "OOSPatchBaselineName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::SecretParameter::Value": {
+      "component": "OOSSecretParameterValue",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Template::Content": {
+      "component": "OOSTemplateContent",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Template::TemplateName": {
+      "component": "OOSTemplateName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OOS::Template::TemplateVersion": {
+      "component": "OOSTemplateVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OSS::Bucket::BucketName": {
+      "component": "OSSBucketName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OSS::Bucket::Object": {
+      "component": "OSSBucketObject",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OSS::Object::ObjectName": {
+      "component": "OSSObjectName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::OSS::Object::ObjectVersionId": {
+      "component": "OSSObjectVersionId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::POLARDB::DBCluster::DBClusterId": {
+      "component": "DBClusterIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::POLARDB::DBCluster::DBNodeClass": {
+      "component": "DBNodeClassSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::PrivateLink::VpcEndpointService::ServiceId": {
+      "component": "VpcEndpointServiceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Qwen::Model": {
+      "component": "QwenModelSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RAM::Policy::PolicyName": {
+      "component": "RamPolicy",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RAM::Role": {
+      "component": "RamRole",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RAM::Service::Role": {
+      "component": "RamServiceRole",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RAM::User": {
+      "component": "RamUser",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RDS::Engine::EngineId": {
+      "component": "RDSEngineId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RDS::Engine::EngineVersion": {
+      "component": "RDSEngineVersion",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RDS::Instance::AccountPassword": {
+      "component": "RDSAccountPassword",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RDS::Instance::InstanceId": {
+      "component": "RDSInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RDS::Instance::InstanceType": {
+      "component": "RDSInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::RDS::Instance::InstanceTypeV2": {
+      "component": "RDSInstanceTypeV2",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ROS::Command::CommandContent": {
+      "component": "OOSCommandContent",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ROS::Type::MetaList": {
+      "component": "MetaList",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Redis::Instance::ConnectionURL": {
+      "component": "RedisConnectionUrl",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Redis::Instance::InstanceId": {
+      "component": "RedisInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Redis::Instance::InstanceType": {
+      "component": "RedisInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Resource::Data::API": {
+      "component": "ALiYunResourceDataApi",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ResourceManager::Account": {
+      "component": "ResourceAccount",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ResourceManager::Folder": {
+      "component": "ResourceFolder",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ResourceManager::FolderAccount": {
+      "component": "ResourceFolderAccount",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SAE::Namespace::NamespaceId": {
+      "component": "SAENamespaceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SLB::ACL::ACLId": {
+      "component": "SlbAccessControlSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SLB::Certificate::CertificateId": {
+      "component": "SLBCertificateIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SLB::Instance::InstanceId": {
+      "component": "SlbInstanceSelector",
+      "deprecated": true,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SLB::Instance::InstanceType": {
+      "component": "SLBInstanceType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SLB::LoadBalancer::LoadBalancerId": {
+      "component": "SlbInstanceSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SLB::LoadBalancer::ZoneId": {
+      "component": "LoadBalancerZoneId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::SWAS::Instance::InstanceId": {
+      "component": "SWASInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Service::Api": {
+      "component": "ServiceApi",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Service::Code": {
+      "component": "ServiceCode",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Service::PropertySelector": {
+      "component": "ServicePropertySelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ServiceCatalog::LaunchOption::PortfolioId": {
+      "component": "PortfolioId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::ServiceCatalog::ProductVersion::ProductVersionId": {
+      "component": "ProductVersionIdSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Tag::TagKey": {
+      "component": "TagKey",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::Tag::TagValue": {
+      "component": "TagValue",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::UI::Devbox::DevboxURL": {
+      "component": "DevboxURLSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::UI::Runtime::RuntimeCards": {
+      "component": "RuntimeCards",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::User::Account::AccountIds": {
+      "component": "AccountIds",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::User::AccountId": {
+      "component": "MasterAccountId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::User::UserId": {
+      "component": "CurrentAccountId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::VPC::EIP::AllocationId": {
+      "component": "VPCEipAllocationId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::VPC::NatGateway::NatGatewayId": {
+      "component": "NatGatewayId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::VPC::VPC::CidrBlock": {
+      "component": "VPCCidrBlock",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::VPC::VSwitch::CidrBlock": {
+      "component": "VswitchCidrBlock",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::VPC::VSwitch::VSwitchId": {
+      "component": "VSwitchId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::VPC::VirtualBorderRouter::RouteTableId": {
+      "component": "RouteTableId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ALIYUN::VPC::Zone::ZoneId": {
+      "component": "VPCZoneId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "AlbInstanceSelector": {
+      "component": "AlbInstanceSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Alert": {
+      "component": "Alert",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "AlertCheckbox": {
+      "component": "AlertCheckbox",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ArrayCollapse": {
+      "component": "ArrayCollapse",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ArrayItems": {
+      "component": "ArrayItems",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ArrayTable": {
+      "component": "ArrayTable",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "AssociationProperty": {
+      "component": "AssociationProperty",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "AutoCompleteInput": {
+      "component": "AutoCompleteInput",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Boolean": {
+      "component": "Boolean",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Cascader": {
+      "component": "Cascader",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ChargeType": {
+      "component": "ChargeType",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Code": {
+      "component": "Code",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "CommaDelimitedList": {
+      "component": "CommaDelimitedList",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Cron": {
+      "component": "Cron",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "DatePicker": {
+      "component": "DatePicker",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "DateTime": {
+      "component": "DateTime",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Editable": {
+      "component": "Editable",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "EditablePopover": {
+      "component": "EditablePopover",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "FileContent": {
+      "component": "FileContent",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "FormGrid": {
+      "component": "FormGrid",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "FormGroupCollapsePan": {
+      "component": "FormGroupCollapsePan",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "FormItem": {
+      "component": "FormItem",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "FormItemGroup": {
+      "component": "FormItemGroup",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "FormLayout": {
+      "component": "FormLayout",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "GMTZone": {
+      "component": "GMTZone",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "IP": {
+      "component": "IP",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Input": {
+      "component": "Input",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Integer": {
+      "component": "Integer",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Json": {
+      "component": "Json",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "List": {
+      "component": "List",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "List[Parameter]": {
+      "component": "ListParameter",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "List[Parameters]": {
+      "component": "ListParameters",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "LocalIp": {
+      "component": "LocalIp",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Map": {
+      "component": "Map",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "MathematicalResult": {
+      "component": "MathematicalResult",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "NASFileSystemId": {
+      "component": "NASFileSystemId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Number": {
+      "component": "Number",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "NumberPicker": {
+      "component": "NumberPicker",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "OOSServiceRole": {
+      "component": "OOSServiceRole",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "PDSeparationEstimate": {
+      "component": "PDSeparationEstimate",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "PackageOption": {
+      "component": "PackageOptionSelector",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "PackageTable": {
+      "component": "PackageTable",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ParseText": {
+      "component": "ParseText",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Password": {
+      "component": "Password",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "PayPeriod": {
+      "component": "PayPeriod",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "PayPeriodUnit": {
+      "component": "PayPeriodUnit",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Payment": {
+      "component": "Payment",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Radio": {
+      "component": "Radio",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "RateControl": {
+      "component": "RateControl",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ReadOnly": {
+      "component": "ReadOnlyItem",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ReadOnlyItem": {
+      "component": "ReadOnlyItem",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "RecommendInput": {
+      "component": "RecommendInput",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "RedisInstanceId": {
+      "component": "RedisInstanceId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "RegionId": {
+      "component": "RegionId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ResourceItem": {
+      "component": "ResourceItem",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "SectionGroup": {
+      "component": "SectionGroup",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Select": {
+      "component": "Select",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Space": {
+      "component": "Space",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "String": {
+      "component": "String",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Switch": {
+      "component": "Switch",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Tags": {
+      "component": "Tags",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Targets": {
+      "component": "Targets",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "TemplateName": {
+      "component": "OOSTemplateName",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "TextArea": {
+      "component": "TextArea",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "Time": {
+      "component": "Time",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "TimeTriggerWeekly": {
+      "component": "TimeTriggerWeekly",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "TimeZone": {
+      "component": "TimeZone",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "UploadFilesToUserBucket": {
+      "component": "FileUserOSS",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    },
+    "ZoneId": {
+      "component": "ZoneId",
+      "deprecated": false,
+      "replacement": null,
+      "scope": "ROS"
+    }
+  },
+  "common_metadata": {
+    "coverage": "partial",
+    "schema": {
+      "additionalProperties": true,
+      "properties": {
+        "AllowedValues": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "Condition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  }
+                ]
+              },
+              "Value": {}
+            },
+            "required": [
+              "Condition",
+              "Value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "AutoSelectFirst": {
+          "type": "boolean"
+        },
+        "AutoSelectRandom": {
+          "type": "boolean"
+        },
+        "DoRequestAtFirst": {
+          "type": "boolean"
+        },
+        "DynamicValue": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "Condition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": true,
+                        "type": "object"
+                      }
+                    ],
+                    "x-ore-injected-symbols": [
+                      "RegionId"
+                    ]
+                  },
+                  "Value": {
+                    "x-ore-injected-symbols": [
+                      "RegionId"
+                    ],
+                    "x-ore-parser": "lodash-template-interpolation",
+                    "x-ore-reference-context": "template-root",
+                    "x-ore-reference-kinds": [
+                      "parameter"
+                    ]
+                  }
+                },
+                "required": [
+                  "Condition",
+                  "Value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "x-ore-injected-symbols": [
+            "RegionId"
+          ],
+          "x-ore-parser": "lodash-template-interpolation",
+          "x-ore-reference-context": "template-root",
+          "x-ore-reference-kinds": [
+            "parameter"
+          ]
+        },
+        "ExclusiveTo": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ForceEditable": {},
+        "LocaleKey": {
+          "type": "string"
+        },
+        "MappingMetadata": {
+          "additionalProperties": false,
+          "properties": {
+            "FallbackValue": {},
+            "MappedPropsName": {
+              "type": "string"
+            },
+            "MappingName": {
+              "type": "string"
+            },
+            "ValueSelector": {
+              "type": "string",
+              "x-ore-injected-symbols": [
+                "RegionId"
+              ],
+              "x-ore-parser": "mapping-selector-segments",
+              "x-ore-reference-context": "template-root",
+              "x-ore-reference-kinds": [
+                "parameter"
+              ],
+              "x-ore-unresolved-reference": "literal-segment"
+            }
+          },
+          "required": [
+            "MappingName",
+            "MappedPropsName",
+            "ValueSelector"
+          ],
+          "type": "object"
+        },
+        "MaxValue": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "Condition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  }
+                ]
+              },
+              "Value": {}
+            },
+            "required": [
+              "Condition",
+              "Value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "MinValue": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "Condition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  }
+                ]
+              },
+              "Value": {}
+            },
+            "required": [
+              "Condition",
+              "Value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "Multiple": {
+          "type": "boolean"
+        },
+        "ReadOnly": {
+          "additionalProperties": false,
+          "properties": {
+            "Condition": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "Required": {
+          "additionalProperties": false,
+          "properties": {
+            "Condition": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "ShowLabel": {
+          "type": "boolean"
+        },
+        "Value": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "Condition": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  }
+                ]
+              },
+              "Value": {}
+            },
+            "required": [
+              "Condition",
+              "Value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "ValueLabelMapping": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            ]
+          },
+          "type": "object"
+        },
+        "Visible": {
+          "additionalProperties": false,
+          "properties": {
+            "Condition": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "semantic_rules": [
+      "parameter_metadata_condition"
+    ]
+  },
+  "components": {
+    "ACRNamespace": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ACRRepoAttribute": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Attribute": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ACRRepoTag": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoNamespace": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ALiYunResourceDataApi": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "APIAction": {
+            "type": "string"
+          },
+          "AllowedValues": {
+            "type": "array"
+          },
+          "CreateLabel": {
+            "type": "string"
+          },
+          "CreateLink": {
+            "type": "string"
+          },
+          "LabelGetter": {
+            "type": "string"
+          },
+          "OptionsGetter": {
+            "type": "string"
+          },
+          "PageFilterKeys": {
+            "type": "object"
+          },
+          "Pagination": {
+            "enum": [
+              "pageSize",
+              "nextToken",
+              "maxSize"
+            ],
+            "type": "string"
+          },
+          "Parameters.[ParameterName]": {},
+          "Placeholder": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string"
+          },
+          "ResourceGroupId": {
+            "type": "string"
+          },
+          "SearchParameter": {
+            "type": "string"
+          },
+          "SearchParameterValueType": {
+            "enum": [
+              "string",
+              "JSONArray",
+              "RepeatList"
+            ],
+            "type": "string"
+          },
+          "ShowCreate": {
+            "type": "boolean"
+          },
+          "ShowRefresh": {
+            "type": "boolean"
+          },
+          "ValueGetter": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "APIGatewayId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "GatewayType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Keyword": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "APIListDomains": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "GatewayId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "GatewayType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AccountIds": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AlertMsg": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowAlert": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AlbAccessControlSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AlbInstanceSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AddressType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PayType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcIds": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AlbZoneIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AllowedValues": {
+            "type": "array"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowRandom": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Alert": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AlertCheckbox": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Alert": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ConfirmText": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Description": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "MustChecked": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowIcon": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Type": {
+            "enum": [
+              "info",
+              "success",
+              "error",
+              "warning"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AppFlowUserAuthConfigId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AuthType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ConnectorId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ConnectorVersion": {
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ApplicationGroupName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ApplicationName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DeployRegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ApplicationManagerConnection": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ClusterId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ForceShowCredential": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RequiredConnectionTypes": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowConnectionCategories": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcOption": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ApplicationName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ApplicationType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Tags": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ArrayCollapse": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ArrayItems": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ArrayTable": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ArtifactId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ArtifactType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ArtifactIdVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ArtifactId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AssociationProperty": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ValueLabelMapping": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AttributeSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AutoCompleteInput": {
+      "coverage": "complete",
+      "metadata": {
+        "additionalProperties": false,
+        "properties": {
+          "CharacterClasses": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "Class": {
+                  "enum": [
+                    "lowercase",
+                    "uppercase",
+                    "number",
+                    "specialCharacter"
+                  ],
+                  "type": "string",
+                  "x-ore-value-suggestions": {
+                    "digit": "number"
+                  }
+                },
+                "End": {
+                  "type": "boolean"
+                },
+                "Min": {
+                  "type": "number"
+                },
+                "SpecialCharacters": {
+                  "type": "string"
+                },
+                "Start": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "Class"
+              ],
+              "type": "object"
+            },
+            "type": "array",
+            "x-ore-consumer-set": "auto_complete_generation"
+          },
+          "Length": {
+            "type": "number",
+            "x-ore-consumer-set": "auto_complete_generation"
+          },
+          "Pattern": {
+            "type": "string",
+            "x-ore-consumer-set": "auto_complete_generation"
+          },
+          "Prefix": {
+            "type": "string",
+            "x-ore-consumer-set": "auto_complete_generation"
+          },
+          "Suffix": {
+            "type": "string",
+            "x-ore-consumer-set": "auto_complete_generation"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": [
+        "auto_complete_character_capacity"
+      ]
+    },
+    "AutoSnapshotPolicyId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "AvailableInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DefaultValueToText": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceTypes": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceTypesCombineBehavior": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "LocaleKey": {},
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SystemDiskCategory": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TransitInstance": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "UseRadio": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneIds": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneIdsCombineBehavior": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "BailianApiKey": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "OnlyKey": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SupportCodingPlan": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "BailianMCPInfo": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AgentsMarket": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Boolean": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CASCertificate": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "OrderType": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "WithRegion": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CMSWorkspace": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CRInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AcrType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Attribute": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceStatus": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CRNameSpace": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Attribute": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NamespaceStatus": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CRRepoName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AcrType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoNamespaceName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoStatus": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CRRepoTag": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AcrType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoNamespaceName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowImageRepositoryPath": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CSCidr": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Addons": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ClusterType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ContainerCidr": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NodeCidrMask": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CSClusterId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ClusterId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ClusterSpec": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ClusterState": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ClusterType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Name": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Profile": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowExternalLink": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CSClusterKubernetesVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ClusterType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "KubernetesVersionPrefix": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Profile": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "QueryMode": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Runtime": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CSClusterNodePool": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ClusterId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Cascader": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CenIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Multiple": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ChargeType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CleanUpDiskRules": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CloudDesktopBundle": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "BundleType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ProtocolType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SupportMultiSession": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CloudDesktopOfficeSite": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CloudDesktopPolicyGroup": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Scope": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CloudSSOAccessConfigurationId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DirectoryId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "FilterPrefix": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "StatusNotifications": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CloudSSODirectoryId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CloudSSOGroupId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DirectoryId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "FilterPrefix": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ProvisionType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CloudSSOUserId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DirectoryId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "FilterPrefix": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ProvisionType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "UserStatus": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Code": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Language": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ReadOnly": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CommaDelimitedList": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ComputeNestServiceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "IsSupplier": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceType": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ComputeNestServiceInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DeployType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "IsVendor": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceType": {
+            "enum": [
+              "private",
+              "managed",
+              "operation",
+              "poc"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Version": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ComputeNestSkillHubConfig": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ComputeNestSkillsInfo": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Cron": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "CurrentAccountId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DBClusterIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DBNodeClassSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CommodityCode": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DBNodeClass": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DBType": {
+            "enum": [
+              "MySQL",
+              "PostgreSQL",
+              "Oracle"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DBVersion": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "MasterHa": {
+            "enum": [
+              "single",
+              "cluster",
+              "all"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Mode": {
+            "enum": [
+              "Select",
+              "Table"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OrderType": {
+            "enum": [
+              "BUY",
+              "UPGRADE",
+              "RENEW",
+              "CONVERT"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PayType": {
+            "enum": [
+              "Prepaid",
+              "Postpaid"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowOfflinePrice": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DNSDomain": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DomainType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Lang": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "UseInnerResult": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DashScopeApiKey": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ValidApiKey": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DashVectorApiKey": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DashVectorClusterName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ClusterType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DataDiskCategory": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceType": {
+            "type": "string"
+          },
+          "InstanceTypes": {
+            "type": "array"
+          },
+          "InstanceTypesCombineBehavior": {
+            "enum": [
+              "AND",
+              "XOR"
+            ],
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string"
+          },
+          "ZoneId": {
+            "type": "string"
+          },
+          "ZoneIds": {
+            "type": "array"
+          },
+          "ZoneIdsCombineBehavior": {
+            "enum": [
+              "AND",
+              "XOR"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DatePicker": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DateTime": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Format": {
+            "type": "string"
+          },
+          "GMTZone": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TimeZone": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DeployRevisionId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ApplicationName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DeploymentSetId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "NetworkType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Strategy": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DevboxURLSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DomainName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CheckICP": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "MaxLength": {
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowDomainPrefixInput": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "DurationExpression": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "IsSimple": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "EASResource": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECDDesktopTypeSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECIContainerGroupId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ComputeCategory": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SecurityGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VSwitchId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECIScalingConfigurationContainerName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoSelectFirst": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ScalingConfigurationId": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ScalingGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECIScalingConfigurationId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoSelectFirst": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ScalingGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECSCommand": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ImageId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Provider": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECSDiskId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Category": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DiskChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DiskType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SnapshotId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Type": {
+            "enum": [
+              "table",
+              "select"
+            ],
+            "type": "string"
+          },
+          "UseScroll": {},
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECSInstanceOSType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECSInstancePassword": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CanStartWithSlash": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "CheckWeakPassword": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OSType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECSInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AllowedValues": {
+            "type": "array"
+          },
+          "Constraints": {
+            "additionalProperties": true,
+            "properties": {
+              "Architecture": {
+                "type": "string"
+              },
+              "CustomizeFamily": {
+                "type": "string"
+              },
+              "ExcludeArchitecture": {
+                "type": "string"
+              },
+              "ExcludeCustomizeFamily": {
+                "type": "string"
+              },
+              "ExcludeInstanceType": {
+                "type": "string"
+              },
+              "ExcludeInstanceTypeFamily": {
+                "type": "string"
+              },
+              "ExcludeMemory": {
+                "type": "number"
+              },
+              "ExcludeVCPU": {
+                "type": "number"
+              },
+              "InstanceType": {
+                "type": "string"
+              },
+              "InstanceTypeFamily": {
+                "type": "string"
+              },
+              "Memory": {
+                "type": "number"
+              },
+              "vCPU": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "CreateACKClusterParams": {
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DataDiskCategory": {
+            "enum": [
+              "cloud_efficiency",
+              "cloud",
+              "cloud_ssd",
+              "ephemeral_ssd",
+              "cloud_essd"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DefaultValueStrategy": {
+            "enum": [
+              "recent",
+              "first"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DefaultValueToText": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisableAutoSelectArchitecture": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceChargeType": {
+            "enum": [
+              "PrePaid",
+              "PostPaid"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NetworkCategory": {
+            "enum": [
+              "classic",
+              "vpc"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SpotStrategy": {
+            "enum": [
+              "SpotWithPriceLimit",
+              "NoSpot"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SystemDiskCategory": {
+            "enum": [
+              "cloud_efficiency",
+              "cloud",
+              "cloud_ssd",
+              "ephemeral_ssd",
+              "cloud_essd"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneIds": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneIdsCombineBehavior": {
+            "enum": [
+              "AND",
+              "XOR"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "showOfflinePrice": {
+            "type": "boolean",
+            "x-ore-aliases": [
+              "ShowOfflinePrice"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "ShowOfflinePrice",
+              "showOfflinePrice"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ECSRamRoleName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "EHPCClusterId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Editable": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "EditablePopover": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ElasticsearchInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ElasticsearchSpec": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "NodeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ElasticsearchVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceCategory": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "EmrClusterId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ClusterStates": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ClusterTypes": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PaymentTypes": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "EventFilterRule": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "EventName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Product": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "EventLevelSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Product": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "EventNameSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Product": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FC3FunctionName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Prefix": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FCFunctionName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Date": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Prefix": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Qualifier": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "StartKey": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TraceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FCServiceName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AccountId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Date": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Prefix": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "StartKey": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TraceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FileContent": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AcceptFileSuffixes": {
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FileSystemId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "FileSystemType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FileUserOSS": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AcceptFileSuffixes": {
+            "type": "array"
+          },
+          "AddSuffix": {
+            "type": "boolean"
+          },
+          "BucketName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Directory": {
+            "type": "boolean"
+          },
+          "MaxCount": {
+            "type": "number"
+          },
+          "MaxSize": {
+            "type": "number"
+          },
+          "Mode": {
+            "type": "string"
+          },
+          "Multiple": {
+            "type": "boolean"
+          },
+          "ObjectNamePrefix": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SuffixFormat": {
+            "type": "string"
+          },
+          "UploadToApplicationManager": {
+            "type": "boolean"
+          },
+          "ValueType": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FormGrid": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FormGroupCollapsePan": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FormItem": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FormItemGroup": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "FormLayout": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "GMTZone": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "GPDBInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "HologresInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "cmsInstanceType": {
+            "type": "string",
+            "x-ore-aliases": [
+              "CmsInstanceType"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "CmsInstanceType",
+              "cmsInstanceType"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "IP": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string"
+          },
+          "ServiceType": {
+            "type": "string"
+          },
+          "SupportEngine": {
+            "type": "number"
+          },
+          "mask": {
+            "x-ore-aliases": [
+              "Mask"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "Mask",
+              "mask"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "maskRange": {
+            "x-ore-aliases": [
+              "MaskRange"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "MaskRange",
+              "maskRange"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "parent": {
+            "x-ore-aliases": [
+              "Parent"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "Parent",
+              "parent"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ImageFamily": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ImageId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Architecture": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DefaultValueToText": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ImageFamily": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "IsSelfSupportFullImage": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "IsSupportCloudinit": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "IsSupportIoOptimized": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "IsTrial": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OSType": {
+            "enum": [
+              "windows",
+              "linux"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SupportedImageOwnerAlias": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Usage": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "InfluxDBInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AllowedValues": {
+            "type": "array"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Input": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "EnableEmptyString": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "InstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledInternetChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledNetworkType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledOSType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledStatus": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceTypeFamily": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InternetChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NetworkType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OSType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OnlyCloudAssistantExecutable": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OnlyShowSelector": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PackageName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PublicIpRequired": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowInternetChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowNetworkType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowOSType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "InstancePropertyEditor": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "TargetsData": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Integer": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "MaxBandwidthOut": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Precision": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Step": {
+            "type": "string"
+          },
+          "StringMode": {
+            "type": "boolean"
+          },
+          "UseSlider": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "InventoryCollectionPlan": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "InventoryInfo": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Json": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "KVMap": {
+            "type": "boolean"
+          },
+          "Metadata": {
+            "type": "object"
+          },
+          "Parameters": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object",
+              "x-ore-nested-parameter": true,
+              "x-ore-reference-context": "runtime-dependent"
+            },
+            "type": "object",
+            "x-ore-nested-parameter": true,
+            "x-ore-reference-context": "nested-parameter-map"
+          },
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowKVMapType": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "KMSInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "KMSKeyId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "KMSInstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "KafkaInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "OrderId": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "KeyPairName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "LaunchTemplateId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "LaunchTemplateVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "LaunchTemplateId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "LindormInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SupportEngine": {
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "List": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoChangeType": {},
+          "DescriptionMapping": {},
+          "DisabledValues": {},
+          "ForceEditable": {},
+          "ForceRadio": {},
+          "IsMetaList": {},
+          "MaxNum": {},
+          "ShowSearch": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ListParameter": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Parameter": {
+            "additionalProperties": true,
+            "type": "object",
+            "x-ore-nested-parameter": true,
+            "x-ore-reference-context": "meta-list-row"
+          },
+          "Parameters": {},
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ListParameters": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ListMetadata": {
+            "additionalProperties": true,
+            "properties": {
+              "Order": {
+                "type": "array"
+              },
+              "ShowAddition": {
+                "type": "boolean"
+              },
+              "ShowHeader": {
+                "type": "boolean"
+              },
+              "ShowRemove": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "Mode": {
+            "enum": [
+              "Collapse",
+              "Table"
+            ],
+            "type": "string"
+          },
+          "Parameters": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object",
+              "x-ore-nested-parameter": true,
+              "x-ore-reference-context": "runtime-dependent"
+            },
+            "type": "object",
+            "x-ore-nested-parameter": true,
+            "x-ore-reference-context": "meta-list-row"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "LoadBalancerZoneId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "MasterZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneType": {
+            "enum": [
+              "Master",
+              "Slave"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "LocalIp": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ManagedInstance": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "OsType": {
+            "enum": [
+              "windows",
+              "linux"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Map": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ListMetadata": {},
+          "ParameterKey": {
+            "type": "object"
+          },
+          "ParameterValue": {
+            "type": "object"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MarketProductCode": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MarketProductVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ImageCode": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MasterAccountId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MathematicalResult": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DependenciesParameters": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisplayValue": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Expression": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Precision": {
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MaxBandwidthIn": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "MaxBandwidthOut": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "McpServerList": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Mode": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowCounts": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowTagsCounts": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MetaList": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ListMetadata": {
+            "additionalProperties": true,
+            "properties": {
+              "Order": {
+                "type": "array"
+              },
+              "ShowAddition": {
+                "type": "boolean"
+              },
+              "ShowHeader": {
+                "type": "boolean"
+              },
+              "ShowRemove": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "Mode": {
+            "enum": [
+              "Collapse",
+              "Table"
+            ],
+            "type": "string"
+          },
+          "Parameters": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object",
+              "x-ore-nested-parameter": true,
+              "x-ore-reference-context": "runtime-dependent"
+            },
+            "type": "object",
+            "x-ore-nested-parameter": true,
+            "x-ore-reference-context": "meta-list-row"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MetricSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Product": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MongoDBInstance": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "MountTargetDomain": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VSwitchId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VolumeId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NASFileSystemId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "FileSystemType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NASMountTarget": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "FileSystemId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NLBSecurityPolicyId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NLBServerGroupId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NatGatewayId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceChargeType": {
+            "enum": [
+              "PrePaid",
+              "PostPaid"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NatType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NetworkType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NestServiceIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "IsSupplier": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceType": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NestServiceVersionIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ServiceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NlbInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AddressType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcIds": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NlbZoneId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AllowedValues": {
+            "type": "array"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceCode": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowRandom": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Number": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "MaxBandwidthOut": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Precision": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Step": {
+            "type": "string"
+          },
+          "StringMode": {
+            "type": "boolean"
+          },
+          "UseSlider": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "NumberPicker": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "MaxBandwidthOut": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Precision": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Step": {
+            "type": "string"
+          },
+          "StringMode": {
+            "type": "boolean"
+          },
+          "UseSlider": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSActionName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "FilterOutValues": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Mode": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowFavorites": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSArtifactSourceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Branch": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Organization": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Owner": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ReadOnly": {},
+          "RepoFullName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SampleUrl": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ValueLabelMapping": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSBandwidthUpgradeDurationHour": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "StartHourMinute": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TimerTrigger": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TriggerCron": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSCommandContent": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CommandType": {
+            "enum": [
+              "RunBatScript",
+              "RunPowerShellScript",
+              "RunShellScript",
+              "RunPythonScript",
+              "RunPerlScript"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ReadOnly": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowFullScreen": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSEnvVariables": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CustomVariables": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "MaxCustomVariables": {
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Variables": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSFileUrl": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AcceptFileSuffixes": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "FileType": {
+            "enum": [
+              "local",
+              "https",
+              "oss",
+              "github"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitAccount": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RoleName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowUnbindCom": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitBranch": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoSelectFirst": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "GitFullUrl": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Organization": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Owner": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoFullName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitBranchCommitHash": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Branch": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "GitFullUrl": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Organization": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Owner": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ReadOnly": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoFullName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoUrl": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitBranchLatestCommitId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Branch": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Owner": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoFullName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Selectable": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitContent": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Branch": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ContentType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OrgId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Owner": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RepoFullName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitOrganization": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Owner": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitPlatform": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Extra": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RoleName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitRepository": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoSelectFirst": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Organization": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Owner": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSGitRepositorySamples": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSPackageName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShareType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowShareType": {},
+          "Target": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Type": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSPackageVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "PublicDisabled": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TemplateName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSParameterValue": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSPatchBaselineContent": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Name": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSPatchBaselineName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Name": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSSecretParameterValue": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSServiceRole": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowAccountRole": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TemplateName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TimerTrigger": {
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSTaskName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSTemplateContent": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TemplateName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TemplateReadOnly": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TemplateVersion": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSTemplateName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "NoTrigger": {
+            "type": "boolean"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShareType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowShareType": {},
+          "Type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OOSTemplateVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TemplateName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OSSBucketName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowRegionSelector": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OSSBucketObject": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "MaxNumber": {
+            "type": "number"
+          },
+          "Mode": {
+            "type": "string"
+          },
+          "Multiple": {
+            "type": "boolean"
+          },
+          "ObjectType": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowRegionSelector": {
+            "type": "boolean"
+          },
+          "ShowUpload": {
+            "type": "boolean"
+          },
+          "UploadFileMetadata": {
+            "additionalProperties": true,
+            "properties": {
+              "AcceptFileSuffixes": {
+                "type": "array"
+              },
+              "AddSuffix": {
+                "type": "boolean"
+              },
+              "Directory": {
+                "type": "boolean"
+              },
+              "MaxCount": {
+                "type": "number"
+              },
+              "Multiple": {
+                "type": "boolean"
+              },
+              "SuffixFormat": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "ValueType": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OSSObjectName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "BucketName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Delimiter": {
+            "type": "string"
+          },
+          "MaxNumber": {
+            "type": "number"
+          },
+          "Mode": {
+            "type": "string"
+          },
+          "Multiple": {
+            "type": "boolean"
+          },
+          "ObjectType": {
+            "type": "string"
+          },
+          "Prefix": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowUpload": {
+            "type": "boolean"
+          },
+          "UploadFileMetadata": {
+            "additionalProperties": true,
+            "properties": {
+              "AcceptFileSuffixes": {
+                "type": "array"
+              },
+              "AddSuffix": {
+                "type": "boolean"
+              },
+              "Directory": {
+                "type": "boolean"
+              },
+              "MaxCount": {
+                "type": "number"
+              },
+              "Multiple": {
+                "type": "boolean"
+              },
+              "SuffixFormat": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "ValueType": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OSSObjectVersionId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "BucketName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ObjectName": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OnOffTimeLine": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "DailyTime": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "EndTime": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OnOff": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TimeZone": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Weekdays": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OnOffTimes": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "OnOff": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OperationType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "OrganizationId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "setInOOS": {
+            "type": "boolean",
+            "x-ore-aliases": [
+              "SetInOOS"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "SetInOOS",
+              "setInOOS"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PAIEASInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string"
+          },
+          "SubscriptionType": {
+            "enum": [
+              "PayAsYouGo",
+              "Subscription"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PDSeparationEstimate": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PackageOptionSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AllowedValues": {
+            "type": "array"
+          },
+          "DescriptionMapping": {
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ValueLabelMapping": {
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PackageTable": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ParseText": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "EventTriggerType": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Password": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PayPeriod": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "PayPeriodUnit": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PayPeriodUnit": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Payment": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "PaymentDefinition": {
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PortRange": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "IpProtocol": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PortfolioId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ProductId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PricingModule": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ProductCode": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ProductType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SubscriptionType": {
+            "enum": [
+              "PayAsYouGo",
+              "Subscription"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "PrivateTemplateName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ProductTypeSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "EventTriggerType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "MetricRules": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ProductVersionIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Active": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ProductId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "QwenModelSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceId": {
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RDSAccountPassword": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RDSEngineId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Engine": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RDSEngineVersion": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoSelectFirst": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Engine": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RDSInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RDSInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Category": {
+            "enum": [
+              "Basic",
+              "HighAvailability",
+              "AlwaysOn",
+              "Finance"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "CommodityCode": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DBInstanceClass": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DBInstanceStorageType": {
+            "enum": [
+              "local_ssd",
+              "cloud_ssd",
+              "cloud_essd",
+              "cloud_essd2",
+              "cloud_essd3"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DispenseMode": {
+            "enum": [
+              0,
+              1
+            ],
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Engine": {
+            "enum": [
+              "MySQL",
+              "SQLServer",
+              "PostgreSQL",
+              "PPAS",
+              "MariaDB"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "EngineVersion": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceChargeType": {
+            "enum": [
+              "Prepaid",
+              "Postpaid"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OrderType": {
+            "enum": [
+              "BUY",
+              "UPGRADE",
+              "RENEW",
+              "CONVERT"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowOfflinePrice": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SlaveZoneIds": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "UseNewApi": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RDSInstanceTypeV2": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Category": {
+            "enum": [
+              "Basic",
+              "HighAvailability",
+              "AlwaysOn",
+              "Finance"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "CommodityCode": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DBInstanceClass": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DBInstanceStorageType": {
+            "enum": [
+              "local_ssd",
+              "cloud_ssd",
+              "cloud_essd",
+              "cloud_essd2",
+              "cloud_essd3"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DispenseMode": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Engine": {
+            "enum": [
+              "MySQL",
+              "SQLServer",
+              "PostgreSQL",
+              "PPAS",
+              "MariaDB"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "EngineVersion": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceChargeType": {
+            "enum": [
+              "Prepaid",
+              "Postpaid"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OrderType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowOfflinePrice": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SlaveZoneIds": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "UseNewApi": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Radio": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RamPolicy": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "PolicyType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RamRole": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RamServiceRole": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "APIProduct": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "IsServiceLinedRole": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Service": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RamUser": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RateControl": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ExecutionMode": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ReadOnlyItem": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RecommendInput": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RecommendDescription": {
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RecommendValues": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RedisConnectionUrl": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RedisInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "EditionType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceClass": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceStatus": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NetworkType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RedisInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AllowedValues": {
+            "type": "array"
+          },
+          "Engine": {
+            "enum": [
+              "Redis",
+              "Memcache"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceChargeType": {
+            "enum": [
+              "PrePaid",
+              "PostPaid"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Mode": {
+            "enum": [
+              "Table",
+              "Select"
+            ],
+            "type": "string"
+          },
+          "OrderType": {
+            "enum": [
+              "BUY",
+              "UPGRADE",
+              "DOWNGRADE"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ProductType": {
+            "enum": [
+              "Local",
+              "Tair_rdb",
+              "Tair_scm",
+              "Tair_essd",
+              "OnECS"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RegionDeploy": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RegionId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "FilterOutValues": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RenewPeriod": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoRenew": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "HasYear": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ResourceAccount": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ResourceFolder": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "FilterFolderIds": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowAccounts": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ResourceFolderAccount": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CheckServiceAccess": {},
+          "RegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ResourceGroupId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ResourceItem": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RouteTableId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RuleDescribe": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Product": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "RuntimeCards": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "PageSize": {
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RuntimeGroups": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SAENamespaceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SLBCertificateIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CertificationType": {
+            "enum": [
+              "Server",
+              "CA"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SLBInstanceType": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SWASInstanceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ScalingConfigurationId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ScalingGroupId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ScalingGroupId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SectionGroup": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Sections": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SecurityGroupId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "NetworkType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SecurityGroupType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceManaged": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VPCId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "VpcId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VPCId",
+              "VpcId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "VPCId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VPCId",
+              "VpcId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Select": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AutoChangeType": {},
+          "DescriptionMapping": {},
+          "DisabledValues": {},
+          "ForceEditable": {},
+          "ForceRadio": {},
+          "IsMetaList": {},
+          "MaxNum": {},
+          "ShowSearch": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ServiceApi": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "PopCode": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceKey": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ServiceCode": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ServiceConnectionId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "organizationId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "OrganizationId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "OrganizationId",
+              "organizationId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "sericeConnectionType": {
+            "type": "string",
+            "x-ore-aliases": [
+              "SericeConnectionType"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "SericeConnectionType",
+              "sericeConnectionType"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ServicePropertySelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ApiName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PopCode": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ServiceKey": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SilenceTimeSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SlbAccessControlSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AddressIPVersion": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SlbInstanceSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AddressType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InternetChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "MasterZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NetworkType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PayType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SlaveZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VSwitchId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SnapshotId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Category": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DiskId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SnapshotType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Space": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "StopMode": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "String": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "EnableEmptyString": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Switch": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "SystemDiskCategory": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceType": {
+            "type": "string"
+          },
+          "InstanceTypes": {
+            "type": "array"
+          },
+          "InstanceTypesCombineBehavior": {
+            "enum": [
+              "AND",
+              "XOR"
+            ],
+            "type": "string"
+          },
+          "RegionId": {
+            "type": "string"
+          },
+          "ZoneId": {
+            "type": "string"
+          },
+          "ZoneIds": {
+            "type": "array"
+          },
+          "ZoneIdsCombineBehavior": {
+            "enum": [
+              "AND",
+              "XOR"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TagKey": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowSystem": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TagValue": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Key": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Tags": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowSystem": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ValueRequired": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TargetImageName": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TargetRegionIds": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "FilterOutValues": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Targets": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AccountType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Application": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ApplicationGroup": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DeployedRegionId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledInternetChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledNetworkType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledOSType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "DisabledStatus": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "HideTargetsConditionDisplay": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceTypeFamily": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InternetChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "IsVendor": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "NetworkType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "OSType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "PackageName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Platform": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ResourceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ScalingGroupId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowInternetChargeType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowNetworkType": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowOSType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Status": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SupportUpgradeVersion": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TextArea": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "Time": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "GMTZone": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "TimeZone": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TimeTriggerWeekly": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "Mode": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowCron": {},
+          "StartTime": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "StopTime": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VisibleKey": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TimeZone": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TimerTrigger": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "MinuteInterval": {
+            "type": "number",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SupportStartDate": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TransitInstance": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TransitRouterIdSelector": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "CenId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "TriggerResources": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "EventName": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "EventTriggerType": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "MetricRules": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "Product": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VPCCidrBlock": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RecommendDescription": {
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RecommendValues": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VPCEipAllocationId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ChargeType": {
+            "enum": [
+              "PostPaid",
+              "PrePaid"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "EIPStatus": {
+            "enum": [
+              "Associating",
+              "Unassociating",
+              "InUse",
+              "Available",
+              "Releasing"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VPCId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VPCZoneId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneType": {}
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VSwitch": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SAENamespaceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SecurityGroupId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VPCId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "VpcId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VPCId",
+              "VpcId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "VPCId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VPCId",
+              "VpcId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VSwitchId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "InstanceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SAENamespaceId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "SecurityGroupId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VPCId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "VpcId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VPCId",
+              "VpcId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "VPCId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VPCId",
+              "VpcId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VpcEndpointServiceId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "VswitchCidrBlock": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "ExistCidrs": {
+            "type": "array"
+          },
+          "RecommendDescription": {
+            "type": "object",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RecommendValues": {
+            "type": "array",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VPCId": {
+            "x-ore-aliases": [
+              "VpcId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VpcId",
+              "VPCId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcCidrBlock": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "VpcId": {
+            "type": "string",
+            "x-ore-aliases": [
+              "VPCId"
+            ],
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-precedence": [
+              "VpcId",
+              "VPCId"
+            ],
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ZoneId": {
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    },
+    "ZoneId": {
+      "coverage": "partial",
+      "metadata": {
+        "additionalProperties": true,
+        "properties": {
+          "AllowedValues": {
+            "type": "array"
+          },
+          "AutoSelectFirst": {},
+          "DefaultValueStrategy": {
+            "enum": [
+              "first",
+              "random",
+              "diamond"
+            ],
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceChargeType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "InstanceType": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "RegionId": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "ShowRandom": {
+            "type": "boolean"
+          },
+          "SystemDiskCategory": {
+            "type": "string",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          },
+          "WithAvailableResource": {
+            "type": "boolean",
+            "x-ore-parser": "whole-value-reference",
+            "x-ore-reference-context": "runtime-dependent",
+            "x-ore-reference-kinds": [
+              "parameter",
+              "field-path",
+              "env"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "semantic_rules": []
+    }
+  },
+  "consumer_sets": {
+    "auto_complete_generation": {
+      "consumers": [
+        {
+          "id": "template-default-initializer",
+          "parser": "literal-only",
+          "reference_context": "template-root",
+          "when": "effective-default-undefined-after-normalization"
+        },
+        {
+          "id": "associated-component",
+          "parser": "whole-value-reference",
+          "reference_context": "template-root",
+          "reference_kinds": [
+            "parameter",
+            "field-path",
+            "env"
+          ],
+          "when": "current-value-falsy-at-effect"
+        }
+      ],
+      "resolution": "inconsistent",
+      "value_flow": {
+        "base_default": "initial-value-nullish-coalescing-parameter-default",
+        "component_guard": "js-falsy-current-value",
+        "default_gate": "ros-ref-value-skips-normalization",
+        "host_merge": "runtime-dependent",
+        "metadata_effects": [
+          "Value",
+          "DynamicValue"
+        ],
+        "normalization": "template-form-default-normalization"
+      }
+    }
+  },
+  "content_sha256": "db3b7eb9cd9ea5f53a6afa86e2f8dc02761bbddcbf740fdb848cc7270057897f",
+  "contract_version": 3,
+  "corrections": [
+    {
+      "reason": "Value labels support either plain strings or localized string maps.",
+      "target": "common_metadata.schema.properties.ValueLabelMapping"
+    },
+    {
+      "reason": "OnlyKey is a boolean form-mode switch.",
+      "target": "components.BailianApiKey.metadata.properties.OnlyKey"
+    }
+  ],
+  "excluded_association_properties": {
+    "ALIYUN::OOS::Action::LoopTasks": {
+      "scope": "OOS-only"
+    },
+    "ALIYUN::OOS::Action::Properties": {
+      "scope": "OOS-only"
+    },
+    "ALIYUN::OOS::Component::ActionChoice": {
+      "scope": "OOS-only"
+    },
+    "ALIYUN::OOS::Component::CheckForAPI": {
+      "scope": "OOS-only"
+    },
+    "ALIYUN::OOS::Component::WaitForAPI": {
+      "scope": "OOS-only"
+    },
+    "ALIYUN::Service::Parameter": {
+      "scope": "OOS-only"
+    },
+    "ALIYUN::Service::Parameter::ListParameter": {
+      "scope": "OOS-only"
+    },
+    "Default": {
+      "scope": "unavailable-stock"
+    },
+    "TemplateParameter": {
+      "scope": "OOS-only"
+    },
+    "TimeTrigger": {
+      "scope": "unavailable-stock"
+    }
+  },
+  "product": "ROS",
+  "profile": {
+    "component_overrides": false,
+    "default_read_only_prop": false,
+    "form_type": "parameter",
+    "host_read_only_inputs": "unknown",
+    "host_value_inputs": "unknown",
+    "id": "stock-ros-parameter-form",
+    "read_only_selection": {
+      "component": "ReadOnlyItem",
+      "contains": [
+        "InstanceType"
+      ],
+      "exact_association_properties": [
+        "TemplateParameter",
+        "Targets"
+      ],
+      "precedence": "before-association-property-resolution"
+    }
+  }
+}

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/model.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/model.py
@@ -392,6 +392,10 @@ class ValidationReport:
     def has_errors(self) -> bool:
         return self.error_count > 0
 
+    @property
+    def limitation_count(self) -> int:
+        return sum(item.severity == Severity.LIMITATION for item in self.diagnostics)
+
     def to_dict(self) -> dict[str, Any]:
         def span_dict(span: SourceSpan | None) -> dict[str, Any] | None:
             if span is None:
@@ -416,6 +420,7 @@ class ValidationReport:
         return {
             "error_count": self.error_count,
             "warning_count": self.warning_count,
+            "limitation_count": self.limitation_count,
             "analysis_incomplete": self.analysis_incomplete,
             "counts_by_code": dict(self.counts_by_code),
             "diagnostics": [

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/outcome.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/outcome.py
@@ -76,6 +76,7 @@ def _merge_report_payload(existing: dict, current: dict) -> dict:
             "diagnostics": diagnostics,
             "error_count": sum(item.get("severity") == "ERROR" for item in diagnostics),
             "warning_count": sum(item.get("severity") == "WARNING" for item in diagnostics),
+            "limitation_count": sum(item.get("severity") == "LIMITATION" for item in diagnostics),
             "counts_by_code": counts_by_code,
             "analysis_incomplete": bool(existing.get("analysis_incomplete"))
             or bool(current.get("analysis_incomplete")),

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/renderer.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from iac_code.i18n import _
-from iac_code.tools.cloud.aliyun.ros_validation.model import ValidationReport, display_path
+from iac_code.tools.cloud.aliyun.ros_validation.model import Diagnostic, ValidationReport, display_path
+
+_CONDENSED_LIMITATION_CODES = frozenset({"ROS5304", "ROS5305"})
+_CONDENSE_THRESHOLD = 10
+_EXAMPLE_LIMIT = 3
 
 
 def _severity_label(value: str) -> str:
@@ -14,32 +18,76 @@ def _severity_label(value: str) -> str:
     return _("LIMITATION")
 
 
+def _render_items(diagnostics: tuple[Diagnostic, ...]) -> list[tuple[Diagnostic, ...]]:
+    grouped = {code: tuple(item for item in diagnostics if item.code == code) for code in _CONDENSED_LIMITATION_CODES}
+    condensed_codes = {code for code, items in grouped.items() if len(items) > _CONDENSE_THRESHOLD}
+    emitted: set[str] = set()
+    result: list[tuple[Diagnostic, ...]] = []
+    for item in diagnostics:
+        if item.code not in condensed_codes:
+            result.append((item,))
+            continue
+        if item.code not in emitted:
+            result.append(grouped[item.code])
+            emitted.add(item.code)
+    return result
+
+
 def render_validation_report(report: ValidationReport, *, blocking: bool | None = None) -> str:
     if blocking is None:
         blocking = report.has_errors
-    limitations = sum(item.severity.value == "LIMITATION" for item in report.diagnostics)
     title = _("ROS local validation failed") if blocking else _("ROS local validation completed")
     lines = [
         _("{}: {} errors, {} warnings, {} limitations.").format(
             title,
             report.error_count,
             report.warning_count,
-            limitations,
+            report.limitation_count,
         )
     ]
     if report.analysis_incomplete:
         lines.append(_("Analysis did not complete; this call was blocked to avoid missed errors."))
     if not report.diagnostics:
         return "\n".join(lines)
+    rendered_items = _render_items(report.diagnostics)
     lines.extend(("", _("Summary:")))
-    for index, item in enumerate(report.diagnostics, 1):
+    for index, items in enumerate(rendered_items, 1):
+        item = items[0]
+        if len(items) > 1:
+            lines.append(
+                "{}. [{}] {}".format(
+                    index,
+                    item.code,
+                    _("{} local-analysis limitations; details condensed.").format(len(items)),
+                )
+            )
+            continue
         location = ""
         if item.source_span is not None:
             prefix = _("generated JSON ") if item.source_span.synthetic else ""
             location = _("{}line {}:").format(prefix, item.source_span.line)
         lines.append("{}. [{}] {}{}".format(index, item.code, location, item.summary))
     lines.extend(("", _("Details:")))
-    for index, item in enumerate(report.diagnostics, 1):
+    for index, items in enumerate(rendered_items, 1):
+        item = items[0]
+        if len(items) > 1:
+            examples = items[:_EXAMPLE_LIMIT]
+            lines.append(
+                "{}. [{} {}] {}".format(
+                    index,
+                    _severity_label(item.severity.value),
+                    item.code,
+                    _("{} occurrences; showing {} examples.").format(len(items), len(examples)),
+                )
+            )
+            for example in examples:
+                lines.append(_("   example path: {} — {}").format(display_path(example.path), example.summary))
+            lines.append(
+                _("   {} additional occurrences are available in structured diagnostics.").format(
+                    len(items) - len(examples)
+                )
+            )
+            continue
         if item.source_span is not None:
             prefix = _("generated JSON ") if item.source_span.synthetic else ""
             location = _("{}line {}:{}").format(prefix, item.source_span.line, item.source_span.column)

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
@@ -1,0 +1,3252 @@
+"""Contract-driven validation for ROS AssociationProperty metadata."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+from typing import Any, cast
+
+from iac_code.i18n import _
+from iac_code.tools.cloud.aliyun.ros_validation.association_property_specs import (
+    ASSOCIATION_PROPERTY_SPECS,
+    AssociationPropertySpecRegistry,
+    load_association_property_specs,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.facts import FactBuildResult, RulePhase
+from iac_code.tools.cloud.aliyun.ros_validation.model import (
+    Category,
+    Diagnostic,
+    MappingKeySegment,
+    RelatedLocation,
+    RosPath,
+    SequenceIndexSegment,
+    Severity,
+    make_diagnostic,
+    mapping_segment,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.symbols import TemplateSymbols
+from iac_code.tools.cloud.aliyun.ros_validation.template_kind import is_terraform_template
+
+PARSED_TEMPLATE = "parsed-template"
+TEMPLATE_SYMBOLS = "template-symbols"
+MAX_METADATA_DEPTH = 16
+_REFERENCE = re.compile(r"^\s*\$\{([^{}\r\n]+)}\s*$")
+_FRONTEND_REFERENCE = re.compile(r"^\s*\$\{(.*)}\s*$")
+_ESCAPED_LITERAL = re.compile(r"^\s*\$\{!(.*)}\s*$")
+_ENV_REFERENCE = re.compile(r"^\{\{(.*)\}\}$")
+_LODASH_REFERENCE = re.compile(r"\$\{([^{}]+)}")
+_LODASH_PATH_TOKEN = re.compile(
+    r"""[^.[\]]+|\[(?:([^"'][^[]*)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))"""
+)
+_JS_DECIMAL_NUMBER = re.compile(r"^[+-]?(?:(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?|Infinity)$")
+_JS_NON_DECIMAL_NUMBER = re.compile(r"^0(?:[xX][0-9a-fA-F]+|[oO][0-7]+|[bB][01]+)$")
+_LIST_COMPONENT = "List"
+_INPUT_COMPONENT = "Input"
+
+
+def _lodash_path_segments(value: str) -> tuple[str, ...]:
+    """Mirror the target form's field-path tokenizer."""
+
+    result: list[str] = []
+    if value.startswith("."):
+        result.append("")
+    for match in _LODASH_PATH_TOKEN.finditer(value):
+        expression, quote, quoted = match.groups()
+        if quote is not None:
+            result.append(re.sub(r"\\(\\)?", lambda item: item.group(1) or "", quoted))
+        elif expression is not None:
+            result.append(expression.strip())
+        else:
+            result.append(match.group(0))
+    return tuple(result)
+
+
+def _is_lodash_field_path(value: str) -> bool:
+    """Recognize paths routed to ``lodash.get`` that we cannot resolve statically.
+
+    The target form does not validate the lodash suffix. Once a whole metadata reference contains
+    ``.``, ``[`` or ``]``, it extracts the root up to the first ``.``/``[`` and passes
+    the remainder to lodash.  Keeping a stricter hand-written lodash grammar here would
+    therefore turn accepted (albeit unusual) paths into local blocking errors.
+    """
+
+    return re.search(r"[.\[\]]", value) is not None
+
+
+def _js_property_key(value: Any) -> str | None:
+    """Coerce YAML scalar mapping keys the way a JavaScript object does."""
+
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if not isinstance(value, (int, float)):
+        return None
+    try:
+        number = float(value)
+    except OverflowError:
+        number = math.copysign(math.inf, value)
+    if math.isnan(number):
+        return "NaN"
+    if math.isinf(number):
+        return "Infinity" if number > 0 else "-Infinity"
+    if number == 0:
+        return "0"
+    magnitude = abs(number)
+    representation = repr(number)
+    if 1e-6 <= magnitude < 1e21:
+        fixed = format(Decimal(representation), "f")
+        return fixed.rstrip("0").rstrip(".") if "." in fixed else fixed
+    mantissa, exponent = representation.lower().split("e")
+    mantissa = mantissa.rstrip("0").rstrip(".")
+    exponent_value = int(exponent)
+    exponent_sign = "+" if exponent_value >= 0 else ""
+    return f"{mantissa}e{exponent_sign}{exponent_value}"
+
+
+def _js_mapping_property(mapping: Mapping[Any, Any], name: str) -> tuple[bool, Any]:
+    """Read the last YAML key that becomes ``name`` on a JavaScript object."""
+
+    found = False
+    result: Any = None
+    for key, value in mapping.items():
+        if _js_property_key(key) == name:
+            found = True
+            result = value
+    return found, result
+
+
+def _js_array_index_key(name: str) -> int | None:
+    """Return the ECMAScript array-index value used by ``Object.keys`` ordering."""
+
+    if name == "0":
+        return 0
+    if not name or name[0] == "0" or not name.isascii() or not name.isdecimal():
+        return None
+    value = int(name)
+    return value if value < 2**32 - 1 else None
+
+
+def _js_mapping_properties(mapping: Mapping[Any, Any]) -> tuple[dict[str, Any], tuple[str, ...]]:
+    """Build JavaScript-visible properties and their ``Object.keys`` order."""
+
+    properties: dict[str, Any] = {}
+    for raw_key, value in mapping.items():
+        key = _js_property_key(raw_key)
+        if key is not None:
+            # Reassigning an existing JavaScript property changes its value but not
+            # the insertion order used for non-array-index keys.
+            properties[key] = value
+    array_indexes = sorted((index, key) for key in properties if (index := _js_array_index_key(key)) is not None)
+    non_indexes = tuple(key for key in properties if _js_array_index_key(key) is None)
+    order = tuple(key for _, key in array_indexes) + non_indexes
+    return properties, order
+
+
+def _same_definition_value(left: Any, right: Any) -> bool:
+    """Compare parsed values using the target form's JavaScript object behavior."""
+
+    if isinstance(left, Mapping) and isinstance(right, Mapping):
+        left_properties, left_order = _js_mapping_properties(left)
+        right_properties, right_order = _js_mapping_properties(right)
+        return left_order == right_order and all(
+            _same_definition_value(left_properties[key], right_properties[key]) for key in left_order
+        )
+    if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
+        return len(left) == len(right) and all(
+            _same_definition_value(left_item, right_item) for left_item, right_item in zip(left, right, strict=True)
+        )
+    if isinstance(left, bool) or isinstance(right, bool):
+        return isinstance(left, bool) and isinstance(right, bool) and left is right
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return left == right
+    return type(left) is type(right) and left == right
+
+
+def _js_utf16_units(value: str) -> tuple[str, ...]:
+    encoded = value.encode("utf-16-le", errors="surrogatepass")
+    return tuple(
+        encoded[index : index + 2].decode("utf-16-le", errors="surrogatepass") for index in range(0, len(encoded), 2)
+    )
+
+
+class _RuntimeValueSentinel:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+UNKNOWN_RUNTIME_VALUE = _RuntimeValueSentinel("UNKNOWN_RUNTIME_VALUE")
+ABSENT_RUNTIME_VALUE = _RuntimeValueSentinel("ABSENT_RUNTIME_VALUE")
+
+
+class ConsumerReachability(str, Enum):
+    REACHED = "reached"
+    NOT_REACHED = "not-reached"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class AutoCompleteConsumerReachability:
+    base_default: str
+    effective_default: str
+    current_value: str
+    raw_initializer: ConsumerReachability
+    component_effect: ConsumerReachability
+
+
+def js_truthy(value: Any) -> bool:
+    """Apply JavaScript truthiness to parsed JSON/YAML values."""
+
+    if value is None or value is False:
+        return False
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value != 0 and not (isinstance(value, float) and math.isnan(value))
+    if isinstance(value, str):
+        return value != ""
+    return True  # JavaScript arrays and objects are truthy, including empty ones.
+
+
+def frontend_string_to_boolean(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return isinstance(value, str) and value.lower() == "true"
+
+
+def _frontend_boolean_value(value: Any) -> Any:
+    """Return the target form's string-to-boolean value, including JavaScript undefined."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    return ABSENT_RUNTIME_VALUE
+
+
+def _js_number(value: Any) -> float:
+    """Apply the JavaScript Number/unary-plus conversion used by the target ROS form."""
+
+    if value is None:
+        return 0.0
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return math.nan
+    stripped = value.strip()
+    if not stripped:
+        return 0.0
+    try:
+        if _JS_NON_DECIMAL_NUMBER.fullmatch(stripped):
+            return float(int(stripped, 0))
+        if _JS_DECIMAL_NUMBER.fullmatch(stripped):
+            return float(stripped)
+    except (OverflowError, ValueError):
+        return math.nan
+    return math.nan
+
+
+def _strict_json_parse(value: Any) -> Any:
+    """Match JSON.parse, including rejection of NaN/Infinity extensions."""
+
+    raw = str(value).lower() if isinstance(value, bool) else str(value)
+
+    def reject_constant(constant: str) -> Any:
+        raise ValueError("invalid JSON constant {}".format(constant))
+
+    return json.loads(raw, parse_constant=reject_constant)
+
+
+def normalize_association_property(value: str) -> str:
+    return "ALIYUN::{}".format(value[len("APSARA::") :]) if value.startswith("APSARA::") else value
+
+
+def is_frontend_ref_value(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return len(value) == 1 and next(iter(value), None) in {"Ref", "Fn::GetAtt"}
+    return bool(value) and isinstance(value, list) and all(is_frontend_ref_value(item) for item in value)
+
+
+def _runtime_value_state(value: Any) -> str:
+    if value is UNKNOWN_RUNTIME_VALUE:
+        return "unknown"
+    if value is ABSENT_RUNTIME_VALUE:
+        return "undefined"
+    return "truthy" if js_truthy(value) else "falsy"
+
+
+def _normalize_template_default(parameter: Mapping[Any, Any], base_default: Any) -> Any:
+    if base_default is UNKNOWN_RUNTIME_VALUE or is_frontend_ref_value(base_default):
+        return base_default
+    default_value = base_default
+    parameter_type = parameter.get("Type")
+    required = parameter.get("Required")
+    required_boolean_default = required if required is not None else default_value is ABSENT_RUNTIME_VALUE
+    if parameter_type == "Boolean" and required_boolean_default:
+        default_value = False
+    # A loose comparison with undefined is false for both null and undefined.
+    enters_normalization = default_value is not ABSENT_RUNTIME_VALUE and default_value is not None
+    if enters_normalization and not isinstance(default_value, (Mapping, list)):
+        if parameter_type == "Boolean":
+            default_value = _frontend_boolean_value(default_value)
+        elif parameter_type == "Json":
+            try:
+                # JSON.parse coerces primitive inputs to strings before parsing.
+                default_value = _strict_json_parse(default_value)
+            except (TypeError, ValueError):
+                default_value = default_value
+        elif parameter_type in {"Number", "Integer", "NumberPicker"}:
+            default_value = _js_number(default_value)
+        elif parameter_type == "CommaDelimitedList" and isinstance(default_value, str):
+            default_value = default_value.split(",")
+        elif (
+            frontend_string_to_boolean(parameter.get("NoEcho"))
+            or parameter.get("AssociationProperty") == "ALIYUN::ECS::Instance::Password"
+        ):
+            default_value = ABSENT_RUNTIME_VALUE
+    return default_value
+
+
+def _auto_complete_character_class_values(
+    specs: AssociationPropertySpecRegistry | None = None,
+) -> frozenset[str]:
+    registry = specs or load_association_property_specs()
+    component = registry.component("AutoCompleteInput")
+    schema: Any = component.metadata if component is not None else {}
+    for key in ("properties", "CharacterClasses", "items", "properties", "Class", "enum"):
+        schema = schema.get(key) if isinstance(schema, Mapping) else None
+    if not isinstance(schema, (list, tuple)) or not all(isinstance(item, str) for item in schema):
+        raise RuntimeError("AutoCompleteInput CharacterClasses enum is missing from the local contract")
+    return frozenset(schema)
+
+
+def _js_integer(value: Any) -> int:
+    number = _js_number(value)
+    if not math.isfinite(number):
+        return 0
+    return math.trunc(number)
+
+
+def _raw_auto_complete_value(
+    metadata: Mapping[Any, Any],
+    valid_classes: frozenset[str] | None = None,
+) -> Any:
+    prefix = metadata.get("Prefix")
+    suffix = metadata.get("Suffix")
+    if js_truthy(prefix) or js_truthy(suffix):
+        return "generated-with-affix"
+    classes = metadata.get("CharacterClasses")
+    length = metadata.get("Length")
+    if isinstance(classes, list) and classes:
+        effective_length = _ValidationState._js_array_length(length if "Length" in metadata else 8)
+        if effective_length <= 0:
+            return ""
+        class_values = valid_classes or _auto_complete_character_class_values()
+        ordinary_pool = False
+        last_special: Mapping[Any, Any] | None = None
+        for item in classes:
+            if not isinstance(item, Mapping):
+                continue
+            class_name = item.get("Class")
+            if class_name in class_values - {"specialCharacter"}:
+                ordinary_pool = True
+                if _fill_count(item.get("Min", ABSENT_RUNTIME_VALUE), effective_length) > 0:
+                    return "generated"
+            elif class_name == "specialCharacter" and js_truthy(item.get("SpecialCharacters")):
+                last_special = item
+                excluded = set()
+                if item.get("Start") is False:
+                    excluded.add(0)
+                if item.get("End") is False:
+                    excluded.add(effective_length - 1)
+                available = max(effective_length - len(excluded), 0)
+                if _fill_count(item.get("Min", ABSENT_RUNTIME_VALUE), available) > 0:
+                    return "generated"
+        if ordinary_pool:
+            return "generated"
+        if last_special is not None:
+            # The generator narrows its mutable pool at the first position and does
+            # not restore it.  With a pure-special pool, Start=false therefore
+            # empties every remaining position, while End=false only affects the
+            # last position.
+            if last_special.get("Start") is False:
+                return ""
+            if effective_length == 1 and last_special.get("End") is False:
+                return ""
+            return "generated"
+        return ""
+    # The generated identifier is truthy; a truthy Length then slices it using JavaScript numeric conversion.
+    if js_truthy(length):
+        slice_end = _ValidationState._js_slice_end(length)
+        if slice_end == 0:
+            return ""
+        # The generated identifier always contains at least three segments.
+        # More-negative endpoints depend on its runtime-generated length.
+        if slice_end <= -3:
+            return UNKNOWN_RUNTIME_VALUE
+    return "generated"
+
+
+def _fill_count(count: Any, available: int) -> int:
+    """Return how many positions the target generator consumes for a fixed pool size."""
+
+    if count is ABSENT_RUNTIME_VALUE or count is UNKNOWN_RUNTIME_VALUE or available <= 0 or not js_truthy(count):
+        return 0
+    if isinstance(count, str):
+        string_number = _js_number(count)
+        # A truthy non-number String enters once; count-- then becomes NaN.
+        if math.isnan(string_number):
+            return 1
+        if string_number > 0 and float(string_number).is_integer():
+            return min(int(string_number), available)
+        return available
+    if isinstance(count, (int, float)) and not isinstance(count, bool):
+        numeric_count = float(count)
+        if math.isnan(numeric_count):
+            return 0
+        if numeric_count > 0 and math.isfinite(numeric_count) and numeric_count.is_integer():
+            return min(int(numeric_count), available)
+        return available
+    # Truthy booleans/objects enter once and become 0/NaN after count--.
+    return 1
+
+
+def evaluate_auto_complete_reachability(
+    parameter: Mapping[Any, Any],
+    *,
+    host_initial_value: Any = UNKNOWN_RUNTIME_VALUE,
+    existing_form_value: Any = UNKNOWN_RUNTIME_VALUE,
+    static_parameter_value: Any = UNKNOWN_RUNTIME_VALUE,
+    initial_parameter_value: Any = UNKNOWN_RUNTIME_VALUE,
+    value_effect: Any = UNKNOWN_RUNTIME_VALUE,
+    dynamic_value_effect: Any = UNKNOWN_RUNTIME_VALUE,
+) -> AutoCompleteConsumerReachability:
+    """Model the target form's initializer/host-merge/effect order without exposing values."""
+
+    if host_initial_value is UNKNOWN_RUNTIME_VALUE:
+        base_default = UNKNOWN_RUNTIME_VALUE
+    elif host_initial_value is ABSENT_RUNTIME_VALUE or host_initial_value is None:
+        base_default = parameter.get("Default", ABSENT_RUNTIME_VALUE)
+    else:
+        base_default = host_initial_value
+    effective_default = _normalize_template_default(parameter, base_default)
+    if effective_default is UNKNOWN_RUNTIME_VALUE:
+        raw_reachability = ConsumerReachability.UNKNOWN
+        initial_value = UNKNOWN_RUNTIME_VALUE
+    elif is_frontend_ref_value(effective_default):
+        raw_reachability = ConsumerReachability.NOT_REACHED
+        initial_value = effective_default
+    elif effective_default is ABSENT_RUNTIME_VALUE:
+        raw_reachability = ConsumerReachability.REACHED
+        metadata = parameter.get("AssociationPropertyMetadata")
+        initial_value = _raw_auto_complete_value(metadata if isinstance(metadata, Mapping) else {})
+    else:
+        raw_reachability = ConsumerReachability.NOT_REACHED
+        initial_value = effective_default
+
+    # Form state merges the existing, generated, static, then caller-provided initial values.
+    current_value = existing_form_value
+    current_value = initial_value
+    if static_parameter_value is not ABSENT_RUNTIME_VALUE:
+        current_value = static_parameter_value
+    if initial_parameter_value is not ABSENT_RUNTIME_VALUE:
+        current_value = initial_parameter_value
+
+    metadata = parameter.get("AssociationPropertyMetadata")
+    if isinstance(metadata, Mapping):
+        if "DynamicValue" in metadata:
+            if dynamic_value_effect is UNKNOWN_RUNTIME_VALUE:
+                current_value = UNKNOWN_RUNTIME_VALUE
+            elif dynamic_value_effect is not ABSENT_RUNTIME_VALUE:
+                current_value = dynamic_value_effect
+        if "Value" in metadata:
+            if value_effect is UNKNOWN_RUNTIME_VALUE:
+                current_value = UNKNOWN_RUNTIME_VALUE
+            elif value_effect is not ABSENT_RUNTIME_VALUE:
+                current_value = value_effect
+
+    if current_value is UNKNOWN_RUNTIME_VALUE:
+        component_reachability = ConsumerReachability.UNKNOWN
+    elif js_truthy(current_value):
+        component_reachability = ConsumerReachability.NOT_REACHED
+    else:
+        component_reachability = ConsumerReachability.REACHED
+    return AutoCompleteConsumerReachability(
+        base_default=_runtime_value_state(base_default),
+        effective_default=_runtime_value_state(effective_default),
+        current_value=_runtime_value_state(current_value),
+        raw_initializer=raw_reachability,
+        component_effect=component_reachability,
+    )
+
+
+@dataclass(frozen=True)
+class AssociationPropertySpecsProvider:
+    provider_id: str = "builtin.association-property-specs"
+    phase: RulePhase = RulePhase.STRUCTURE
+    requires: frozenset[str] = frozenset()
+    optional_requires: frozenset[str] = frozenset()
+    provides: frozenset[str] = frozenset({ASSOCIATION_PROPERTY_SPECS})
+
+    def build(self, context: Any) -> FactBuildResult:
+        del context
+        return FactBuildResult(provided={ASSOCIATION_PROPERTY_SPECS: load_association_property_specs()})
+
+
+@dataclass(frozen=True)
+class _ComponentResolution:
+    initial_component: str
+    possible_components: tuple[str, ...]
+    deterministic: bool
+    association_supported: bool
+    definite_list_bypass: bool
+
+
+@dataclass(frozen=True)
+class _ResolvedReference:
+    declaration: Mapping[Any, Any] | None = None
+    declaration_path: RosPath | None = None
+    projected_array: bool = False
+    error: str | None = None
+    limitation: bool = False
+
+
+@dataclass(frozen=True)
+class AssociationPropertyRule:
+    rule_id: str = "builtin.association-property"
+    phase: RulePhase = RulePhase.SYMBOLS
+    requires: frozenset[str] = frozenset({PARSED_TEMPLATE, TEMPLATE_SYMBOLS, ASSOCIATION_PROPERTY_SPECS})
+    optional_requires: frozenset[str] = frozenset()
+
+    def check(self, context: Any) -> tuple[Diagnostic, ...]:
+        parsed = context.fact_store.get_required(PARSED_TEMPLATE)
+        symbols = context.fact_store.get_required(TEMPLATE_SYMBOLS)
+        specs = context.fact_store.get_required(ASSOCIATION_PROPERTY_SPECS)
+        if not isinstance(parsed.data, Mapping):
+            return ()
+        state = _ValidationState(parsed.data, parsed.source_map, symbols, specs)
+        if is_terraform_template(parsed.data) and "Workspace" in parsed.data:
+            state._emit(
+                "ROS5305",
+                Severity.LIMITATION,
+                _("Embedded Terraform variable metadata is not analyzed locally."),
+                _(
+                    "Top-level Parameters are validated; metadata inside Workspace files "
+                    "remains outside local analysis."
+                ),
+                (mapping_segment("Workspace"),),
+                stable_args=("terraform-workspace-metadata",),
+            )
+        return state.run()
+
+
+class _ValidationState:
+    def __init__(
+        self,
+        template: Mapping[Any, Any],
+        source_map: Any,
+        symbols: TemplateSymbols,
+        specs: AssociationPropertySpecRegistry,
+    ) -> None:
+        self.template = template
+        self.source_map = source_map
+        self.symbols = symbols
+        self.specs = specs
+        self.diagnostics: list[Diagnostic] = []
+
+    def run(self) -> tuple[Diagnostic, ...]:
+        parameters = self.template.get("Parameters")
+        if not isinstance(parameters, Mapping):
+            return ()
+        root = (mapping_segment("Parameters"),)
+        root_reference_parameters = self._root_reference_parameters()
+        for _parameter_name, parameter, parameter_path in self._source_mapping_items(parameters, root):
+            if not isinstance(parameter, Mapping):
+                continue
+            self._validate_parameter(
+                parameter,
+                parameter_path,
+                depth=0,
+                reference_context="template-root",
+                reference_parameters=root_reference_parameters,
+                reference_declaration_path=root,
+            )
+        return tuple(self.diagnostics)
+
+    def _root_reference_parameters(self) -> Mapping[Any, Any]:
+        parameters = self.template.get("Parameters")
+        if not isinstance(parameters, Mapping):
+            return {}
+        return {name: parameters[name] for name in self.symbols.parameters if name in parameters}
+
+    def _emit(
+        self,
+        code: str,
+        severity: Severity,
+        summary: str,
+        detail: str,
+        path: RosPath,
+        *,
+        subject: str | None = None,
+        stable_args: tuple[str, ...] = (),
+        expected: str | None = None,
+        actual: str | None = None,
+        suggestion: str | None = None,
+        related_locations: tuple[RelatedLocation, ...] = (),
+    ) -> None:
+        if code in {"ROS5304", "ROS5305"} and severity == Severity.WARNING:
+            severity = Severity.LIMITATION
+        category = (
+            Category.COMPATIBILITY
+            if severity == Severity.ERROR
+            else Category.LIMITATION
+            if severity == Severity.LIMITATION
+            else Category.QUALITY
+        )
+        self.diagnostics.append(
+            make_diagnostic(
+                code=code,
+                severity=severity,
+                category=category,
+                summary=summary,
+                detail=detail,
+                path=path,
+                source_map=self.source_map,
+                subject=subject,
+                stable_args=stable_args,
+                expected=expected,
+                actual=actual,
+                suggestion=suggestion,
+                related_locations=related_locations,
+            )
+        )
+
+    def _validate_parameter(
+        self,
+        parameter: Mapping[Any, Any],
+        path: RosPath,
+        *,
+        depth: int,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> None:
+        if depth > MAX_METADATA_DEPTH:
+            self._emit(
+                "ROS1305",
+                Severity.ERROR,
+                _("AssociationPropertyMetadata nesting is too deep."),
+                _("Nested Parameter/Parameters validation stops after {} levels.").format(MAX_METADATA_DEPTH),
+                path,
+                stable_args=("depth", str(MAX_METADATA_DEPTH)),
+                expected=_("at most {} nested levels").format(MAX_METADATA_DEPTH),
+                actual=str(depth),
+            )
+            return
+
+        association_present = "AssociationProperty" in parameter
+        raw_association = parameter.get("AssociationProperty")
+        normalized_association: str | None = None
+        excluded = None
+        association_path = path + (mapping_segment("AssociationProperty"),)
+        if association_present:
+            if not isinstance(raw_association, str) or not raw_association:
+                self._emit(
+                    "ROS1301",
+                    Severity.ERROR,
+                    _("AssociationProperty must be a non-empty String."),
+                    _("The target parameter form resolves AssociationProperty keys only from non-empty strings."),
+                    association_path,
+                    subject=str(raw_association),
+                    stable_args=(type(raw_association).__name__,),
+                    expected=_("non-empty String"),
+                    actual=self._actual(raw_association),
+                )
+            else:
+                normalized_association = normalize_association_property(raw_association)
+                active = self.specs.association(normalized_association)
+                excluded = self.specs.excluded(normalized_association)
+                if active is not None and active.deprecated:
+                    suggestion = _("Use {} instead.").format(active.replacement) if active.replacement else None
+                    self._emit(
+                        "ROS5301",
+                        Severity.WARNING,
+                        _("AssociationProperty value is deprecated: {}.").format(raw_association),
+                        _(
+                            "The stock ROS form still recognizes this value, so this warning does not block the "
+                            "template."
+                        ),
+                        association_path,
+                        subject=normalized_association,
+                        stable_args=(normalized_association,),
+                        actual=raw_association,
+                        suggestion=suggestion,
+                    )
+                elif excluded is None and active is None:
+                    self._emit(
+                        "ROS5303",
+                        Severity.WARNING,
+                        _("AssociationProperty value is absent from the local frontend contract: {}.").format(
+                            raw_association
+                        ),
+                        _(
+                            "A newer target frontend may support this value. Local validation uses the stock fallback "
+                            "component and does not mark the value invalid."
+                        ),
+                        association_path,
+                        subject=normalized_association,
+                        stable_args=(normalized_association,),
+                        actual=raw_association,
+                    )
+
+        resolution = self._resolve_components(parameter, normalized_association)
+        if excluded is not None and normalized_association is not None:
+            read_only_component = self._read_only_component_for(normalized_association)
+            possible = set(resolution.possible_components)
+            if resolution.definite_list_bypass or resolution.initial_component not in possible:
+                self._emit(
+                    "ROS5302",
+                    Severity.WARNING,
+                    _("AssociationProperty is bypassed by a later stock form component selection."),
+                    _("No resolved form branch selects the unavailable AssociationProperty value."),
+                    association_path,
+                    subject=normalized_association,
+                    stable_args=("excluded-bypassed", normalized_association),
+                    actual=str(raw_association),
+                )
+            elif read_only_component is not None and read_only_component in possible:
+                self._emit(
+                    "ROS5305",
+                    Severity.WARNING,
+                    _("AssociationProperty availability depends on the stock form read-only state."),
+                    _(
+                        "The editable form path does not support this value, while the read-only path may bypass it."
+                    ),
+                    association_path,
+                    subject=normalized_association,
+                    stable_args=("excluded-read-only-unknown", normalized_association),
+                    actual=str(raw_association),
+                )
+            else:
+                unavailable_detail = self._unavailable_association_property_detail(excluded.scope)
+                self._emit(
+                    "ROS1302",
+                    Severity.ERROR,
+                    _("AssociationProperty is unavailable in the stock ROS parameter form."),
+                    unavailable_detail,
+                    association_path,
+                    subject=normalized_association,
+                    stable_args=(normalized_association, excluded.scope),
+                    expected=_("a stock ROS AssociationProperty"),
+                    actual=str(raw_association),
+                )
+        semantic_rules = self._shared_semantic_rules(resolution)
+        auto_reachability = (
+            evaluate_auto_complete_reachability(parameter)
+            if "auto_complete_character_capacity" in semantic_rules
+            else None
+        )
+        if "AssociationPropertyMetadata" not in parameter:
+            return
+        metadata = parameter.get("AssociationPropertyMetadata")
+        metadata_path = path + (mapping_segment("AssociationPropertyMetadata"),)
+        if not isinstance(metadata, Mapping):
+            self._emit(
+                "ROS1303",
+                Severity.ERROR,
+                _("AssociationPropertyMetadata must be a Mapping."),
+                _("The target form reads named metadata fields from an object."),
+                metadata_path,
+                stable_args=(type(metadata).__name__,),
+                expected=_("Mapping"),
+                actual=self._actual(metadata),
+            )
+            return
+
+        self._validate_metadata(
+            metadata,
+            metadata_path,
+            resolution,
+            parameter,
+            reference_context=reference_context,
+            reference_parameters=reference_parameters,
+            reference_declaration_path=reference_declaration_path,
+            auto_reachability=auto_reachability,
+        )
+        if "parameter_metadata_condition" in self.specs.common_semantic_rules:
+            self._validate_common_semantics(
+                metadata,
+                metadata_path,
+                reference_context=reference_context,
+                reference_parameters=reference_parameters,
+                reference_declaration_path=reference_declaration_path,
+            )
+        self._validate_nested_parameters(
+            metadata,
+            metadata_path,
+            resolution,
+            depth=depth,
+            reference_context=reference_context,
+            reference_parameters=reference_parameters,
+            reference_declaration_path=reference_declaration_path,
+        )
+        if "auto_complete_character_capacity" in semantic_rules:
+            self._validate_auto_complete(metadata, metadata_path, auto_reachability)
+
+    def _resolve_components(
+        self,
+        parameter: Mapping[Any, Any],
+        association: str | None,
+    ) -> _ComponentResolution:
+        association_spec = self.specs.association(association) if association else None
+        supported = association_spec is not None
+        if supported:
+            normal = association_spec.component
+        elif frontend_string_to_boolean(parameter.get("NoEcho")):
+            normal = "Password"
+        else:
+            parameter_type = parameter.get("Type")
+            allowed_values = parameter.get("AllowedValues")
+            if (
+                js_truthy(parameter_type)
+                and parameter_type not in {"Boolean", "CommaDelimitedList"}
+                and js_truthy(allowed_values)
+            ):
+                normal = _LIST_COMPONENT
+            elif js_truthy(parameter.get("TextArea")):
+                normal = "TextArea"
+            else:
+                type_spec = self.specs.association(parameter_type) if isinstance(parameter_type, str) else None
+                normal = type_spec.component if type_spec is not None else _INPUT_COMPONENT
+        definite_list_bypass = not supported and (
+            isinstance(parameter.get("AllowedValues"), list) or normal == _LIST_COMPONENT
+        )
+
+        possible = [normal]
+        deterministic = True
+        read_only_component = self._read_only_component_for(association) if association else None
+        if read_only_component is not None:
+            if js_truthy(parameter.get("ReadOnly")):
+                possible = [read_only_component]
+            else:
+                possible.append(read_only_component)
+                deterministic = False
+
+        if not supported:
+            if definite_list_bypass:
+                # Static AllowedValues selection replaces the earlier ReadOnly/component choice.
+                possible = [_LIST_COMPONENT]
+            elif _LIST_COMPONENT not in possible:
+                # Dynamic AllowedValues, Mapping props, and external constraints may post-select List.
+                possible.append(_LIST_COMPONENT)
+                deterministic = False
+        possible = list(dict.fromkeys(possible))
+        return _ComponentResolution(normal, tuple(possible), deterministic, supported, definite_list_bypass)
+
+    def _read_only_component_for(self, association: str) -> str | None:
+        selection = self.specs.profile.get("read_only_selection")
+        if not isinstance(selection, Mapping):
+            return None
+        component = selection.get("component")
+        exact = selection.get("exact_association_properties")
+        contains = selection.get("contains")
+        if not isinstance(component, str):
+            return None
+        if isinstance(exact, (list, tuple)) and association in exact:
+            return component
+        if isinstance(contains, (list, tuple)) and any(
+            isinstance(fragment, str) and fragment in association for fragment in contains
+        ):
+            return component
+        return None
+
+    def _shared_semantic_rules(self, resolution: _ComponentResolution) -> frozenset[str]:
+        rule_sets: list[set[str]] = []
+        for component_name in resolution.possible_components:
+            component = self.specs.component(component_name)
+            if component is None:
+                return frozenset()
+            rule_sets.append(set(component.semantic_rules))
+        if not rule_sets:
+            return frozenset()
+        shared = rule_sets[0]
+        for rule_set in rule_sets[1:]:
+            shared &= rule_set
+        return frozenset(shared)
+
+    def _validate_metadata(
+        self,
+        metadata: Mapping[Any, Any],
+        path: RosPath,
+        resolution: _ComponentResolution,
+        parameter: Mapping[Any, Any],
+        *,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        auto_reachability: AutoCompleteConsumerReachability | None,
+    ) -> None:
+        common_properties = self.specs.common_metadata.get("properties", {})
+        components = tuple(
+            component
+            for name in resolution.possible_components
+            if (component := self.specs.component(name)) is not None
+        )
+        for raw_key, value in metadata.items():
+            key_path = path + (mapping_segment(raw_key),)
+            if not isinstance(raw_key, str):
+                self._emit(
+                    "ROS1305",
+                    Severity.ERROR,
+                    _("AssociationPropertyMetadata field names must be Strings."),
+                    _("The target form performs named property access and cannot consume this key."),
+                    key_path,
+                    stable_args=(type(raw_key).__name__,),
+                    expected=_("String field name"),
+                    actual=self._actual(raw_key),
+                )
+                continue
+            schemas: list[Mapping[str, Any]] = []
+            shadowed_by: set[str] = set()
+            common_matched = False
+            component_match_count = 0
+            if isinstance(common_properties, Mapping):
+                matched, shadowed = self._matching_schemas(common_properties, raw_key, metadata)
+                schemas.extend(matched)
+                shadowed_by.update(shadowed)
+                common_matched = bool(matched)
+            for component in components:
+                properties = component.metadata.get("properties", {})
+                if isinstance(properties, Mapping):
+                    matched, shadowed = self._matching_schemas(properties, raw_key, metadata)
+                    schemas.extend(matched)
+                    shadowed_by.update(shadowed)
+                    if matched:
+                        component_match_count += 1
+            if shadowed_by:
+                self._emit(
+                    "ROS5302",
+                    Severity.WARNING,
+                    _("AssociationPropertyMetadata field is shadowed by a higher-precedence alias."),
+                    _("The target form reads {} first, so this value is ignored by that consumer.").format(
+                        ", ".join(sorted(shadowed_by))
+                    ),
+                    key_path,
+                    subject=raw_key,
+                    stable_args=("alias-precedence", raw_key, *sorted(shadowed_by)),
+                )
+            if not schemas:
+                if shadowed_by:
+                    continue
+                closed = (
+                    self.specs.common_coverage == "complete"
+                    and resolution.deterministic
+                    and len(components) == len(resolution.possible_components)
+                    and all(component.coverage == "complete" for component in components)
+                )
+                self._emit(
+                    "ROS1304" if closed else "ROS5304",
+                    Severity.ERROR if closed else Severity.WARNING,
+                    _("AssociationPropertyMetadata field is not supported by the effective form component.")
+                    if closed
+                    else _("AssociationPropertyMetadata field is outside the audited contract coverage."),
+                    _(
+                        "The common schema or at least one possible component is partial/runtime-dependent; "
+                        "the field cannot be rejected deterministically."
+                    )
+                    if not closed
+                    else _("The complete common and possible-component schemas all reject this field."),
+                    key_path,
+                    subject=raw_key,
+                    stable_args=(raw_key, *resolution.possible_components, "closed" if closed else "partial"),
+                    expected=_("a field consumed by the common or possible component schema"),
+                    actual=raw_key,
+                )
+                continue
+            component_only_runtime_dependent = not common_matched and (
+                len(components) != len(resolution.possible_components)
+                or component_match_count != len(resolution.possible_components)
+            )
+            if component_only_runtime_dependent:
+                if not any(schema.get("x-ore-nested-parameter") is True for schema in schemas):
+                    self._emit(
+                        "ROS5305",
+                        Severity.WARNING,
+                        _("Metadata field {} is used by some possible form components and ignored by others.").format(
+                            raw_key
+                        ),
+                        _("The runtime component cannot be determined locally, so this field is left unchecked."),
+                        key_path,
+                        subject=raw_key,
+                        stable_args=("component-field-reachability", raw_key, *resolution.possible_components),
+                        suggestion=_(
+                            "Do not change the template based on this limitation alone; verify whether the field "
+                            "takes effect in the target ROS form if needed."
+                        ),
+                    )
+                continue
+            nested_reachability = self._nested_field_reachability(resolution, raw_key)[0]
+            if nested_reachability == ConsumerReachability.UNKNOWN:
+                # A component-specific nested container is not consumed on
+                # every possible component branch.  Its contents cannot
+                # produce deterministic schema errors on this profile.
+                continue
+            merged_schema: Mapping[str, Any] = schemas[0] if len(schemas) == 1 else {"anyOf": schemas}
+            self._validate_schema(
+                value,
+                merged_schema,
+                key_path,
+                parameter=parameter,
+                reference_context=reference_context,
+                reference_parameters=reference_parameters,
+                reference_declaration_path=reference_declaration_path,
+                auto_reachability=auto_reachability,
+                depth=0,
+            )
+
+    @staticmethod
+    def _matching_schemas(
+        properties: Mapping[str, Any],
+        key: str,
+        metadata: Mapping[Any, Any],
+    ) -> tuple[list[Mapping[str, Any]], set[str]]:
+        matches: list[Mapping[str, Any]] = []
+        shadowed_by: set[str] = set()
+        for canonical, schema in properties.items():
+            if not isinstance(schema, Mapping):
+                continue
+            aliases = schema.get("x-ore-aliases")
+            accepted = {canonical}
+            if isinstance(aliases, (list, tuple)):
+                accepted.update(alias for alias in aliases if isinstance(alias, str))
+            if key not in accepted:
+                continue
+            precedence = schema.get("x-ore-precedence")
+            if isinstance(precedence, (list, tuple)):
+                winner = next((candidate for candidate in precedence if candidate in metadata), None)
+                if winner is not None and winner != key:
+                    shadowed_by.add(winner)
+                    continue
+            matches.append(schema)
+        return matches, shadowed_by
+
+    def _validate_schema(
+        self,
+        value: Any,
+        schema: Mapping[str, Any],
+        path: RosPath,
+        *,
+        parameter: Mapping[Any, Any],
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        auto_reachability: AutoCompleteConsumerReachability | None,
+        depth: int,
+    ) -> None:
+        if depth > MAX_METADATA_DEPTH:
+            self._emit(
+                "ROS1305",
+                Severity.ERROR,
+                _("AssociationPropertyMetadata value is nested too deeply."),
+                _("Schema traversal stops after {} levels.").format(MAX_METADATA_DEPTH),
+                path,
+                stable_args=("schema-depth", str(MAX_METADATA_DEPTH)),
+            )
+            return
+        (
+            effective_reference_context,
+            effective_reference_parameters,
+            effective_reference_declaration_path,
+        ) = self._schema_reference_scope(
+            schema,
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+        )
+        if self._validate_reference_encoding(
+            value,
+            schema,
+            path,
+            parameter=parameter,
+            reference_context=effective_reference_context,
+            reference_parameters=effective_reference_parameters,
+            reference_declaration_path=effective_reference_declaration_path,
+            auto_reachability=auto_reachability,
+        ):
+            self._warn_reference_type(
+                value,
+                schema,
+                path,
+                reference_context=effective_reference_context,
+                reference_parameters=effective_reference_parameters,
+                reference_declaration_path=effective_reference_declaration_path,
+            )
+            return
+        any_of = schema.get("anyOf")
+        if isinstance(any_of, (list, tuple)):
+            # A merged common/component schema deliberately keeps parser
+            # annotations on its candidate branches.  Give every candidate a
+            # chance to consume an encoded reference before literal type-based
+            # branch selection.
+            failed_reference_candidates: list[
+                tuple[
+                    Mapping[str, Any],
+                    str,
+                    Mapping[Any, Any] | None,
+                    RosPath | None,
+                    tuple[Diagnostic, ...],
+                ]
+            ] = []
+            for candidate in any_of:
+                if not isinstance(candidate, Mapping):
+                    continue
+                candidate_context, candidate_parameters, candidate_declaration_path = self._schema_reference_scope(
+                    candidate,
+                    effective_reference_context,
+                    effective_reference_parameters,
+                    effective_reference_declaration_path,
+                )
+                diagnostic_start = len(self.diagnostics)
+                consumed = self._validate_reference_encoding(
+                    value,
+                    candidate,
+                    path,
+                    parameter=parameter,
+                    reference_context=candidate_context,
+                    reference_parameters=candidate_parameters,
+                    reference_declaration_path=candidate_declaration_path,
+                    auto_reachability=auto_reachability,
+                )
+                candidate_diagnostics = tuple(self.diagnostics[diagnostic_start:])
+                del self.diagnostics[diagnostic_start:]
+                if consumed and not any(item.severity == Severity.ERROR for item in candidate_diagnostics):
+                    self.diagnostics.extend(candidate_diagnostics)
+                    self._warn_reference_type(
+                        value,
+                        candidate,
+                        path,
+                        reference_context=candidate_context,
+                        reference_parameters=candidate_parameters,
+                        reference_declaration_path=candidate_declaration_path,
+                    )
+                    return
+                if consumed:
+                    failed_reference_candidates.append(
+                        (
+                            candidate,
+                            candidate_context,
+                            candidate_parameters,
+                            candidate_declaration_path,
+                            candidate_diagnostics,
+                        )
+                    )
+            failed_candidate_ids = {id(candidate) for candidate, *_ in failed_reference_candidates}
+            matches = [
+                candidate
+                for candidate in any_of
+                if id(candidate) not in failed_candidate_ids and self._matches_schema(value, candidate)
+            ]
+            if matches:
+                self._validate_schema(
+                    value,
+                    matches[0],
+                    path,
+                    parameter=parameter,
+                    reference_context=effective_reference_context,
+                    reference_parameters=effective_reference_parameters,
+                    reference_declaration_path=effective_reference_declaration_path,
+                    auto_reachability=auto_reachability,
+                    depth=depth + 1,
+                )
+                return
+            if failed_reference_candidates:
+                candidate, candidate_context, candidate_parameters, candidate_declaration_path, diagnostics = (
+                    failed_reference_candidates[0]
+                )
+                self.diagnostics.extend(diagnostics)
+                self._warn_reference_type(
+                    value,
+                    candidate,
+                    path,
+                    reference_context=candidate_context,
+                    reference_parameters=candidate_parameters,
+                    reference_declaration_path=candidate_declaration_path,
+                )
+                return
+            self._schema_error(value, schema, path, "anyOf")
+            return
+        if not self._matches_type(value, schema.get("type")):
+            self._schema_error(value, schema, path, "type")
+            return
+        if "const" in schema and value != schema["const"]:
+            self._schema_error(value, schema, path, "const")
+            return
+        enum = schema.get("enum")
+        if isinstance(enum, (list, tuple)) and value not in enum:
+            suggestions = schema.get("x-ore-value-suggestions", {})
+            replacement = suggestions.get(str(value)) if isinstance(suggestions, Mapping) else None
+            self._emit(
+                "ROS1305",
+                Severity.ERROR,
+                _("AssociationPropertyMetadata value is not in the local contract enum."),
+                _("The effective component only implements the exported enum values."),
+                path,
+                subject=str(value),
+                stable_args=("enum", str(value), *(str(item) for item in enum)),
+                expected=" | ".join(str(item) for item in enum),
+                actual=self._actual(value),
+                suggestion=_("Use {} instead.").format(replacement) if replacement else None,
+            )
+            return
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and "minimum" in schema:
+            if value < schema["minimum"]:
+                self._schema_error(value, schema, path, "minimum")
+                return
+        if isinstance(value, str) and "minLength" in schema and len(value) < schema["minLength"]:
+            self._schema_error(value, schema, path, "minLength")
+            return
+        if isinstance(value, Mapping):
+            properties = schema.get("properties", {})
+            required = schema.get("required", ())
+            for required_key in required if isinstance(required, (list, tuple)) else ():
+                if required_key not in value:
+                    missing_path = path + (mapping_segment(required_key),)
+                    self._emit(
+                        "ROS1305",
+                        Severity.ERROR,
+                        _("AssociationPropertyMetadata object is missing a required field."),
+                        _("The effective form schema requires this nested field."),
+                        missing_path,
+                        subject=required_key,
+                        stable_args=("required", required_key),
+                        expected=_("required field {}").format(required_key),
+                        actual=_("missing"),
+                    )
+            for key, child in value.items():
+                child_path = path + (mapping_segment(key),)
+                child_schema = properties.get(key) if isinstance(properties, Mapping) else None
+                if not isinstance(child_schema, Mapping):
+                    child_schema = self._pattern_schema(schema, key)
+                if isinstance(child_schema, Mapping):
+                    self._validate_schema(
+                        child,
+                        child_schema,
+                        child_path,
+                        parameter=parameter,
+                        reference_context=effective_reference_context,
+                        reference_parameters=effective_reference_parameters,
+                        reference_declaration_path=effective_reference_declaration_path,
+                        auto_reachability=auto_reachability,
+                        depth=depth + 1,
+                    )
+                else:
+                    additional = schema.get("additionalProperties", True)
+                    if additional is False:
+                        case_match = next(
+                            (
+                                candidate
+                                for candidate in properties
+                                if isinstance(candidate, str)
+                                and isinstance(key, str)
+                                and candidate.casefold() == key.casefold()
+                            ),
+                            None,
+                        )
+                        self._emit(
+                            "ROS1305",
+                            Severity.ERROR,
+                            _("AssociationPropertyMetadata field uses the wrong letter case.")
+                            if case_match
+                            else _("AssociationPropertyMetadata object contains an unsupported nested field."),
+                            _("Field names are case-sensitive; use {} instead.").format(case_match)
+                            if case_match
+                            else _("This nested schema is closed."),
+                            child_path,
+                            subject=str(key),
+                            stable_args=("field-case" if case_match else "additionalProperties", str(key)),
+                            expected=_("one of: {}").format(", ".join(str(item) for item in properties)),
+                            actual=str(key),
+                            suggestion=_("Rename {} to {}.").format(key, case_match) if case_match else None,
+                        )
+                    elif isinstance(additional, Mapping):
+                        self._validate_schema(
+                            child,
+                            additional,
+                            child_path,
+                            parameter=parameter,
+                            reference_context=effective_reference_context,
+                            reference_parameters=effective_reference_parameters,
+                            reference_declaration_path=effective_reference_declaration_path,
+                            auto_reachability=auto_reachability,
+                            depth=depth + 1,
+                        )
+        elif isinstance(value, list) and isinstance(schema.get("items"), Mapping):
+            for index, child in enumerate(value):
+                self._validate_schema(
+                    child,
+                    schema["items"],
+                    path + (SequenceIndexSegment(index),),
+                    parameter=parameter,
+                    reference_context=effective_reference_context,
+                    reference_parameters=effective_reference_parameters,
+                    reference_declaration_path=effective_reference_declaration_path,
+                    auto_reachability=auto_reachability,
+                    depth=depth + 1,
+                )
+
+    def _schema_reference_scope(
+        self,
+        schema: Mapping[str, Any],
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> tuple[str, Mapping[Any, Any] | None, RosPath | None]:
+        schema_reference_context = schema.get("x-ore-reference-context")
+        if schema_reference_context == "runtime-dependent" and reference_context in {
+            "meta-list-row",
+            "nested-parameter-map",
+        }:
+            effective_context = reference_context
+        else:
+            effective_context = (
+                schema_reference_context if isinstance(schema_reference_context, str) else reference_context
+            )
+        if effective_context != "template-root":
+            return effective_context, reference_parameters, reference_declaration_path
+        if reference_context == "nested-parameter-map" and reference_parameters is not None:
+            return effective_context, reference_parameters, reference_declaration_path
+        return effective_context, self._root_reference_parameters(), (mapping_segment("Parameters"),)
+
+    @staticmethod
+    def _pattern_schema(schema: Mapping[str, Any], key: Any) -> Mapping[str, Any] | None:
+        if not isinstance(key, str):
+            return None
+        patterns = schema.get("patternProperties")
+        if not isinstance(patterns, Mapping):
+            return None
+        for pattern, child in patterns.items():
+            try:
+                if re.search(pattern, key) and isinstance(child, Mapping):
+                    return child
+            except re.error:
+                continue
+        return None
+
+    def _schema_error(self, value: Any, schema: Mapping[str, Any], path: RosPath, reason: str) -> None:
+        expected = self._expected(schema)
+        self._emit(
+            "ROS1305",
+            Severity.ERROR,
+            _("AssociationPropertyMetadata value does not match the local form schema."),
+            _("The literal value failed the exported {} constraint.").format(reason),
+            path,
+            subject=reason,
+            stable_args=(reason, self._expected_stable(schema), self._actual(value)),
+            expected=expected,
+            actual=self._actual(value),
+        )
+
+    def _matches_schema(self, value: Any, schema: Any) -> bool:
+        if not isinstance(schema, Mapping):
+            return False
+        any_of = schema.get("anyOf")
+        if isinstance(any_of, (list, tuple)):
+            return any(self._matches_schema(value, candidate) for candidate in any_of)
+        if not self._matches_type(value, schema.get("type")):
+            return False
+        if "const" in schema and value != schema["const"]:
+            return False
+        enum = schema.get("enum")
+        if isinstance(enum, (list, tuple)) and value not in enum:
+            return False
+        minimum = schema.get("minimum")
+        if (
+            isinstance(minimum, (int, float))
+            and not isinstance(minimum, bool)
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value < minimum
+        ):
+            return False
+        min_length = schema.get("minLength")
+        if isinstance(min_length, int) and not isinstance(min_length, bool) and isinstance(value, str):
+            if len(value) < min_length:
+                return False
+        if isinstance(value, Mapping):
+            required = schema.get("required", ())
+            if isinstance(required, (list, tuple)) and any(key not in value for key in required):
+                return False
+            properties = schema.get("properties", {})
+            for key, child in value.items():
+                child_schema = properties.get(key) if isinstance(properties, Mapping) else None
+                if not isinstance(child_schema, Mapping):
+                    child_schema = self._pattern_schema(schema, key)
+                if child_schema is None and isinstance(schema.get("additionalProperties"), Mapping):
+                    child_schema = schema["additionalProperties"]
+                if isinstance(child_schema, Mapping) and not self._matches_schema(child, child_schema):
+                    return False
+                if child_schema is None and schema.get("additionalProperties", True) is False:
+                    return False
+        if isinstance(value, list) and isinstance(schema.get("items"), Mapping):
+            return all(self._matches_schema(child, schema["items"]) for child in value)
+        return True
+
+    @staticmethod
+    def _matches_type(value: Any, expected: Any) -> bool:
+        if expected is None:
+            return True
+        if expected == "null":
+            return value is None
+        if expected == "boolean":
+            return isinstance(value, bool)
+        if expected == "integer":
+            return isinstance(value, int) and not isinstance(value, bool)
+        if expected == "number":
+            return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+        if expected == "string":
+            return isinstance(value, str)
+        if expected == "array":
+            return isinstance(value, list)
+        if expected == "object":
+            return isinstance(value, Mapping)
+        return False
+
+    def _validate_reference_encoding(
+        self,
+        value: Any,
+        schema: Mapping[str, Any],
+        path: RosPath,
+        *,
+        parameter: Mapping[Any, Any],
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        auto_reachability: AutoCompleteConsumerReachability | None,
+    ) -> bool:
+        del parameter
+        if not isinstance(value, str):
+            return False
+        parsers = self._schema_reference_parsers(schema)
+        allowed_kinds: set[str] | None = None
+        injected_symbols: set[str] = set()
+        direct_kinds = schema.get("x-ore-reference-kinds")
+        if isinstance(direct_kinds, (list, tuple)):
+            allowed_kinds = {kind for kind in direct_kinds if isinstance(kind, str)}
+        direct_symbols = schema.get("x-ore-injected-symbols")
+        if isinstance(direct_symbols, (list, tuple)):
+            injected_symbols = {symbol for symbol in direct_symbols if isinstance(symbol, str)}
+        consumer_set_name = schema.get("x-ore-consumer-set")
+        consumer_set = self.specs.consumer_sets.get(consumer_set_name) if isinstance(consumer_set_name, str) else None
+        inconsistent = False
+        if isinstance(consumer_set, Mapping):
+            inconsistent = consumer_set.get("resolution") == "inconsistent"
+            consumers = consumer_set.get("consumers", ())
+            if isinstance(consumers, (list, tuple)):
+                for consumer in consumers:
+                    if not isinstance(consumer, Mapping) or not isinstance(consumer.get("parser"), str):
+                        continue
+                    consumer_kinds = consumer.get("reference_kinds")
+                    if isinstance(consumer_kinds, (list, tuple)):
+                        declared = {kind for kind in consumer_kinds if isinstance(kind, str)}
+                        allowed_kinds = declared if allowed_kinds is None else allowed_kinds & declared
+        parsers.discard("literal-only")
+        if not parsers:
+            return False
+        looks_encoded = (
+            "${" in value
+            or "{{" in value
+            or self._bare_reference_exists(
+                value,
+                reference_context,
+                reference_parameters,
+                reference_declaration_path,
+            )
+        )
+        if not looks_encoded:
+            return False
+        valid_reference = False
+        deterministic_failure = (
+            auto_reachability is not None
+            and auto_reachability.raw_initializer == ConsumerReachability.REACHED
+            and auto_reachability.component_effect == ConsumerReachability.NOT_REACHED
+        )
+        uncertain = inconsistent and not deterministic_failure
+        for parser in parsers:
+            if parser == "whole-value-reference":
+                valid_reference = (
+                    self._validate_whole_reference(
+                        value,
+                        path,
+                        reference_context,
+                        reference_parameters=reference_parameters,
+                        reference_declaration_path=reference_declaration_path,
+                        allowed_kinds=allowed_kinds,
+                        injected_symbols=injected_symbols,
+                        uncertain=uncertain,
+                    )
+                    or valid_reference
+                )
+            elif parser == "lodash-template-interpolation":
+                valid_reference = (
+                    self._validate_interpolations(
+                        value,
+                        path,
+                        reference_context,
+                        reference_parameters=reference_parameters,
+                        reference_declaration_path=reference_declaration_path,
+                        allowed_kinds=allowed_kinds,
+                        injected_symbols=injected_symbols,
+                        uncertain=uncertain,
+                    )
+                    or valid_reference
+                )
+            elif parser == "mapping-selector-segments":
+                valid_reference = (
+                    self._validate_mapping_selector_segments(
+                        value,
+                        path,
+                        reference_context,
+                        reference_parameters=reference_parameters,
+                        reference_declaration_path=reference_declaration_path,
+                        allowed_kinds=allowed_kinds,
+                        injected_symbols=injected_symbols,
+                        uncertain=uncertain,
+                        unresolved_as_literal=schema.get("x-ore-unresolved-reference") == "literal-segment",
+                    )
+                    or valid_reference
+                )
+        if inconsistent and valid_reference:
+            self._emit(
+                "ROS5305",
+                Severity.WARNING,
+                _("AssociationPropertyMetadata reference has inconsistent frontend consumers."),
+                _(
+                    "One consumer parses this value, but the template-default initializer may use the raw text. "
+                    "Host values and effect timing are unavailable locally."
+                ),
+                path,
+                subject=value,
+                stable_args=("inconsistent-consumers", value),
+            )
+        return valid_reference
+
+    def _schema_reference_parsers(self, schema: Mapping[str, Any]) -> set[str]:
+        parsers = {parser for parser in (schema.get("x-ore-parser"),) if isinstance(parser, str)}
+        consumer_set_name = schema.get("x-ore-consumer-set")
+        consumer_set = self.specs.consumer_sets.get(consumer_set_name) if isinstance(consumer_set_name, str) else None
+        consumers = consumer_set.get("consumers", ()) if isinstance(consumer_set, Mapping) else ()
+        if isinstance(consumers, (list, tuple)):
+            parsers.update(
+                parser
+                for consumer in consumers
+                if isinstance(consumer, Mapping) and isinstance((parser := consumer.get("parser")), str)
+            )
+        parsers.discard("literal-only")
+        return parsers
+
+    def _validate_whole_reference(
+        self,
+        value: str,
+        path: RosPath,
+        reference_context: str,
+        *,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        allowed_kinds: set[str] | None,
+        injected_symbols: set[str],
+        uncertain: bool,
+    ) -> bool:
+        classified = self._classify_whole_reference(
+            value,
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+        )
+        if classified is None:
+            return False
+        reference_kind, name = classified
+        if reference_kind == "field-path":
+            self._validate_reference_name(
+                name,
+                value,
+                path,
+                reference_context,
+                reference_parameters=reference_parameters,
+                reference_declaration_path=reference_declaration_path,
+                allowed_kinds=allowed_kinds,
+                injected_symbols=injected_symbols,
+                uncertain=uncertain,
+            )
+            return True
+        if reference_kind == "parameter":
+            self._validate_exact_parameter_reference(
+                name,
+                value,
+                path,
+                reference_context,
+                reference_parameters=reference_parameters,
+                reference_declaration_path=reference_declaration_path,
+                allowed_kinds=allowed_kinds,
+                injected_symbols=injected_symbols,
+                uncertain=uncertain,
+            )
+            return True
+        if reference_kind == "env":
+            if allowed_kinds is not None and "env" not in allowed_kinds:
+                self._reference_error(
+                    value,
+                    path,
+                    "environment references are not allowed by this consumer",
+                    uncertain=uncertain,
+                )
+                return True
+            self._emit(
+                "ROS5305",
+                Severity.WARNING,
+                _("Environment metadata reference cannot be resolved locally."),
+                _("The encoding is valid, but the contract does not provide an environment-data schema."),
+                path,
+                subject=value,
+                stable_args=("env", name),
+            )
+            return True
+        raise AssertionError("unsupported whole-value reference classification")
+
+    def _classify_whole_reference(
+        self,
+        value: str,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> tuple[str, str] | None:
+        """Classify one value in the branch order used by the target form."""
+
+        reference_match = _FRONTEND_REFERENCE.fullmatch(value)
+        name = reference_match.group(1).strip() if reference_match is not None else None
+        # Field-path detection runs on the raw wrapper before ref-key extraction
+        # or ${!...} processing.
+        if name is not None and _is_lodash_field_path(name):
+            return "field-path", name
+        # The parameter-reference pattern is deliberately greedy. Keys such as A{B} are
+        # exact Parameter names, while a leading ! suppresses this branch.
+        if name and not name.startswith("!"):
+            return "parameter", name
+        # The escape branch rewrites the spelling before the legacy exact
+        # Parameter lookup. JavaScript truthiness preserves whitespace-only
+        # captures but treats an empty capture as absent.
+        legacy_key = value
+        escaped_match = _ESCAPED_LITERAL.fullmatch(value)
+        if escaped_match is not None and escaped_match.group(1):
+            legacy_key = "${" + escaped_match.group(1) + "}"
+        if self._bare_reference_exists(
+            legacy_key,
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+        ):
+            return "parameter", legacy_key
+        # A raw legacy Parameter named {{x}} shadows environment data.
+        env_match = _ENV_REFERENCE.fullmatch(value)
+        if env_match is not None and env_match.group(1):
+            return "env", env_match.group(1)
+        return None
+
+    def _validate_exact_parameter_reference(
+        self,
+        name: str,
+        encoded: str,
+        path: RosPath,
+        reference_context: str,
+        *,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        allowed_kinds: set[str] | None = None,
+        injected_symbols: set[str] | None = None,
+        uncertain: bool = False,
+    ) -> None:
+        """Validate a consumer that performs one exact JavaScript property lookup."""
+
+        if not name:
+            self._reference_error(encoded, path, "empty reference", uncertain=uncertain)
+            return
+        if allowed_kinds is not None and "parameter" not in allowed_kinds:
+            self._reference_error(
+                encoded,
+                path,
+                "parameter references are not allowed by this consumer",
+                name=name,
+                uncertain=uncertain,
+            )
+            return
+        if injected_symbols and name in injected_symbols:
+            return
+        resolution = self._resolve_exact_parameter_declaration(
+            name,
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+        )
+        if resolution.limitation:
+            self._emit_reference_limitation(name, path, reference_context)
+            return
+        if resolution.error is not None:
+            self._reference_error(encoded, path, resolution.error, name=name, uncertain=uncertain)
+            return
+
+    def _resolve_exact_parameter_declaration(
+        self,
+        name: str,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> _ResolvedReference:
+        parameters, declaration_path = self._reference_scope(
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+            relative=False,
+        )
+        if parameters is None or declaration_path is None:
+            return _ResolvedReference(limitation=True)
+        found, declaration, resolved_path = self._source_mapping_property(
+            parameters,
+            declaration_path,
+            name,
+        )
+        if not found:
+            reason = (
+                "nested Parameter does not exist"
+                if reference_context == "nested-parameter-map"
+                else "Parameter does not exist"
+            )
+            return _ResolvedReference(error=reason)
+        if not isinstance(declaration, Mapping):
+            return _ResolvedReference(error="referenced Parameter declaration is invalid")
+        return _ResolvedReference(
+            declaration=declaration,
+            declaration_path=resolved_path,
+        )
+
+    def _validate_interpolations(
+        self,
+        value: str,
+        path: RosPath,
+        reference_context: str,
+        *,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        allowed_kinds: set[str] | None,
+        injected_symbols: set[str],
+        uncertain: bool,
+    ) -> bool:
+        matches = list(_LODASH_REFERENCE.finditer(value))
+        if not matches:
+            return False
+        for match in matches:
+            name = match.group(1).strip()
+            if name.startswith("!"):
+                continue
+            if allowed_kinds == {"parameter"}:
+                self._validate_exact_parameter_reference(
+                    name,
+                    match.group(0),
+                    path,
+                    reference_context,
+                    reference_parameters=reference_parameters,
+                    reference_declaration_path=reference_declaration_path,
+                    allowed_kinds=allowed_kinds,
+                    injected_symbols=injected_symbols,
+                    uncertain=uncertain,
+                )
+            else:
+                self._validate_reference_name(
+                    name,
+                    match.group(0),
+                    path,
+                    reference_context,
+                    reference_parameters=reference_parameters,
+                    reference_declaration_path=reference_declaration_path,
+                    allowed_kinds=allowed_kinds,
+                    injected_symbols=injected_symbols,
+                    uncertain=uncertain,
+                )
+        return True
+
+    def _validate_mapping_selector_segments(
+        self,
+        value: str,
+        path: RosPath,
+        reference_context: str,
+        *,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        allowed_kinds: set[str] | None,
+        injected_symbols: set[str],
+        uncertain: bool,
+        unresolved_as_literal: bool,
+    ) -> bool:
+        matched_reference = False
+        for segment in value.split("."):
+            match = _FRONTEND_REFERENCE.fullmatch(segment)
+            if match is None or match.group(1) == "":
+                continue
+            matched_reference = True
+            name = match.group(1)
+            if name in injected_symbols:
+                continue
+            if allowed_kinds is not None and "parameter" not in allowed_kinds:
+                self._reference_error(
+                    segment,
+                    path,
+                    "parameter references are not allowed by this consumer",
+                    name=name,
+                    uncertain=uncertain,
+                )
+                continue
+            parameters, declaration_path = self._reference_scope(
+                reference_context,
+                reference_parameters,
+                reference_declaration_path,
+                relative=False,
+            )
+            if parameters is None or declaration_path is None:
+                self._emit_reference_limitation(name, path, reference_context)
+                continue
+            exists, _resolved, _resolved_path = self._source_mapping_property(
+                parameters,
+                declaration_path,
+                name,
+            )
+            if exists:
+                continue
+            if unresolved_as_literal:
+                self._emit(
+                    "ROS5305",
+                    Severity.WARNING,
+                    _("Mapping selector segment is interpreted as a literal key by the target form."),
+                    _("No Parameter named {} exists; the current mapping hook falls back to the segment text.").format(
+                        name
+                    ),
+                    path,
+                    subject=name,
+                    stable_args=("mapping-literal-segment", name),
+                )
+                continue
+            self._reference_error(
+                segment,
+                path,
+                "Parameter does not exist",
+                name=name,
+                uncertain=uncertain,
+            )
+        return matched_reference
+
+    def _bare_reference_exists(
+        self,
+        value: str,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> bool:
+        parameters, declaration_path = self._reference_scope(
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+            relative=False,
+        )
+        if not isinstance(parameters, Mapping) or declaration_path is None:
+            return False
+        return self._source_mapping_property(parameters, declaration_path, value)[0]
+
+    def _reference_scope(
+        self,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        *,
+        relative: bool,
+    ) -> tuple[Mapping[Any, Any] | None, RosPath | None]:
+        if relative:
+            return (
+                (reference_parameters, reference_declaration_path)
+                if reference_context == "meta-list-row"
+                else (None, None)
+            )
+        if reference_context == "meta-list-row":
+            return self._root_reference_parameters(), (mapping_segment("Parameters"),)
+        if reference_context in {"template-root", "nested-parameter-map"}:
+            return reference_parameters, reference_declaration_path
+        return None, None
+
+    def _source_mapping_items(
+        self,
+        value: Mapping[Any, Any],
+        value_path: RosPath,
+    ) -> tuple[tuple[str, Any, RosPath], ...]:
+        """Rebuild the JavaScript-visible direct properties from YAML source occurrences."""
+
+        visible: dict[str, tuple[Any, RosPath]] = {}
+        for positioned in self.source_map.occurrences:
+            if (
+                len(positioned.path) == len(value_path) + 1
+                and positioned.path[:-1] == value_path
+                and isinstance((segment := positioned.path[-1]), MappingKeySegment)
+            ):
+                key = _js_property_key(segment.value)
+                if key is not None:
+                    visible[key] = (positioned.value, positioned.path)
+        for raw_key, resolved in value.items():
+            key = _js_property_key(raw_key)
+            if key is not None and key not in visible:
+                visible[key] = (resolved, value_path + (mapping_segment(raw_key),))
+        return tuple((key, resolved, path) for key, (resolved, path) in visible.items())
+
+    def _source_mapping_property(
+        self,
+        value: Mapping[Any, Any],
+        value_path: RosPath,
+        key: str,
+    ) -> tuple[bool, Any, RosPath]:
+        for visible_key, resolved, resolved_path in self._source_mapping_items(value, value_path):
+            if visible_key == key:
+                return True, resolved, resolved_path
+        return False, None, value_path + (mapping_segment(key),)
+
+    @staticmethod
+    def _parse_reference_path(name: str) -> tuple[bool, list[tuple[str, bool]]] | None:
+        relative = name.startswith(".")
+        raw = name[1:] if relative else name
+        if not raw:
+            return None
+        result: list[tuple[str, bool]] = []
+        for segment in raw.split("."):
+            match = re.fullmatch(r"([^.[\]]+)(\[\])?", segment)
+            if match is None:
+                return None
+            result.append((match.group(1), match.group(2) is not None))
+        return relative, result
+
+    def _validate_reference_name(
+        self,
+        name: str,
+        encoded: str,
+        path: RosPath,
+        reference_context: str,
+        *,
+        reference_parameters: Mapping[Any, Any] | None = None,
+        reference_declaration_path: RosPath | None = None,
+        allowed_kinds: set[str] | None = None,
+        injected_symbols: set[str] | None = None,
+        uncertain: bool = False,
+    ) -> None:
+        if not name:
+            self._reference_error(encoded, path, "empty reference", uncertain=uncertain)
+            return
+        parsed = self._parse_reference_path(name)
+        if parsed is None:
+            if _is_lodash_field_path(name):
+                if allowed_kinds is not None and "field-path" not in allowed_kinds:
+                    self._reference_error(
+                        encoded,
+                        path,
+                        "field-path references are not allowed by this consumer",
+                        name=name,
+                        uncertain=uncertain,
+                    )
+                else:
+                    self._emit_reference_limitation(name, path, reference_context)
+                return
+            self._reference_error(encoded, path, "malformed field path", name=name, uncertain=uncertain)
+            return
+        relative, segments = parsed
+        reference_kind = "field-path" if relative or len(segments) > 1 or segments[0][1] else "parameter"
+        if allowed_kinds is not None and reference_kind not in allowed_kinds:
+            self._reference_error(
+                encoded,
+                path,
+                "{} references are not allowed by this consumer".format(reference_kind),
+                name=name,
+                uncertain=uncertain,
+            )
+            return
+        if not relative and segments == [(name, False)] and injected_symbols and name in injected_symbols:
+            return
+        array_segments = [index for index, (_, is_array) in enumerate(segments) if is_array]
+        if array_segments and (relative or array_segments != [0] or len(segments) < 2):
+            self._reference_error(
+                encoded,
+                path,
+                "field paths support one top-level array projection followed by a child path",
+                name=name,
+                uncertain=uncertain,
+            )
+            return
+        resolution = self._resolve_reference_declaration(
+            name,
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+        )
+        if resolution.limitation:
+            self._emit_reference_limitation(name, path, reference_context)
+            return
+        if resolution.error is not None:
+            self._reference_error(
+                encoded,
+                path,
+                resolution.error,
+                name=name,
+                uncertain=uncertain,
+            )
+        return
+
+    def _resolve_reference_declaration(
+        self,
+        name: str,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> _ResolvedReference:
+        parsed = self._parse_reference_path(name)
+        if parsed is None:
+            return _ResolvedReference(error="malformed field path")
+        relative, segments = parsed
+        array_segments = [index for index, (_, is_array) in enumerate(segments) if is_array]
+        if array_segments and (relative or array_segments != [0] or len(segments) < 2):
+            return _ResolvedReference(
+                error="field paths support one top-level array projection followed by a child path"
+            )
+        parameters, declaration_path = self._reference_scope(
+            reference_context,
+            reference_parameters,
+            reference_declaration_path,
+            relative=relative,
+        )
+        if parameters is None or declaration_path is None:
+            return _ResolvedReference(limitation=True)
+        first_name, first_array = segments[0]
+        found, current, current_path = self._source_mapping_property(
+            parameters,
+            declaration_path,
+            first_name,
+        )
+        if not found:
+            reason = "MetaList row field does not exist" if relative else "Parameter does not exist"
+            if reference_context == "nested-parameter-map" and not relative:
+                reason = "nested Parameter does not exist"
+            return _ResolvedReference(error=reason)
+        if not isinstance(current, Mapping):
+            return _ResolvedReference(error="referenced Parameter declaration is invalid")
+        nested_parameters_proven = False
+        if first_array:
+            descended = self._descend_array_reference(current, current_path)
+            if descended is None:
+                return _ResolvedReference(limitation=True)
+            current, current_path, nested_parameters_proven = descended
+        for segment_name, segment_array in segments[1:]:
+            if not nested_parameters_proven:
+                if current.get("Type") in {"Boolean", "CommaDelimitedList", "Integer", "Number", "String"}:
+                    return _ResolvedReference(error="field path traverses a scalar Parameter")
+                raw_association = current.get("AssociationProperty")
+                association = (
+                    normalize_association_property(raw_association)
+                    if isinstance(raw_association, str) and raw_association
+                    else None
+                )
+                resolution = self._resolve_components(current, association)
+                reachability, nested_context = self._nested_field_reachability(resolution, "Parameters")
+                if reachability != ConsumerReachability.REACHED or nested_context != "nested-parameter-map":
+                    return _ResolvedReference(limitation=True)
+            metadata = current.get("AssociationPropertyMetadata")
+            nested = metadata.get("Parameters") if isinstance(metadata, Mapping) else None
+            if not isinstance(nested, Mapping):
+                return _ResolvedReference(limitation=True)
+            nested_path = current_path + (
+                mapping_segment("AssociationPropertyMetadata"),
+                mapping_segment("Parameters"),
+            )
+            found, current, current_path = self._source_mapping_property(
+                nested,
+                nested_path,
+                segment_name,
+            )
+            if not found:
+                return _ResolvedReference(error="nested Parameter field does not exist")
+            if not isinstance(current, Mapping):
+                return _ResolvedReference(error="referenced nested Parameter declaration is invalid")
+            nested_parameters_proven = False
+            if segment_array:
+                descended = self._descend_array_reference(current, current_path)
+                if descended is None:
+                    return _ResolvedReference(limitation=True)
+                current, current_path, nested_parameters_proven = descended
+        return _ResolvedReference(
+            declaration=current,
+            declaration_path=current_path,
+            projected_array=first_array,
+        )
+
+    def _descend_array_reference(
+        self,
+        parameter: Mapping[Any, Any],
+        declaration_path: RosPath,
+    ) -> tuple[Mapping[Any, Any], RosPath, bool] | None:
+        metadata = parameter.get("AssociationPropertyMetadata")
+        if not isinstance(metadata, Mapping):
+            return None
+        raw_association = parameter.get("AssociationProperty")
+        association = (
+            normalize_association_property(raw_association)
+            if isinstance(raw_association, str) and raw_association
+            else None
+        )
+        resolution = self._resolve_components(parameter, association)
+        row_fields: set[str] = set()
+        for component_name in resolution.possible_components:
+            component = self.specs.component(component_name)
+            properties = component.metadata.get("properties", {}) if component is not None else {}
+            component_row_fields = {
+                field
+                for field in ("Parameter", "Parameters")
+                if isinstance(properties, Mapping)
+                and isinstance((schema := properties.get(field)), Mapping)
+                and schema.get("x-ore-reference-context") == "meta-list-row"
+            }
+            if len(component_row_fields) != 1:
+                return None
+            row_fields.update(component_row_fields)
+        if len(row_fields) != 1:
+            return None
+        row_field = row_fields.pop()
+        child = metadata.get(row_field)
+        if row_field == "Parameter" and isinstance(child, Mapping):
+            return (
+                child,
+                declaration_path
+                + (
+                    mapping_segment("AssociationPropertyMetadata"),
+                    mapping_segment("Parameter"),
+                ),
+                False,
+            )
+        if row_field == "Parameters" and isinstance(child, Mapping):
+            # MetaList/List[Parameters] represent each array item directly as
+            # this Parameters map.  Keep a virtual row declaration so normal
+            # child traversal yields the real terminal declaration/path.
+            return {"AssociationPropertyMetadata": {"Parameters": child}}, declaration_path, True
+        return None
+
+    def _emit_reference_limitation(self, name: str, path: RosPath, reference_context: str) -> None:
+        if not any(character in name for character in ".[]{}"):
+            self._emit(
+                "ROS5305",
+                Severity.WARNING,
+                _(
+                    "Metadata reference {} has more than one possible lookup scope."
+                ).format(name),
+                _(
+                    "It may resolve from template Parameters or component-local data. The runtime component is "
+                    "unknown, so local validation leaves the reference unchecked."
+                ),
+                path,
+                subject=name,
+                stable_args=("runtime-reference-context", reference_context, name),
+                suggestion=_(
+                    "Do not change the template based on this limitation alone; verify the reference behavior in "
+                    "the target ROS form if needed."
+                ),
+            )
+            return
+        self._emit(
+            "ROS5305",
+            Severity.WARNING,
+            _("AssociationPropertyMetadata field-path reference cannot be resolved completely."),
+            _("The reference depends on a nested form or MetaList row context."),
+            path,
+            subject=name,
+            stable_args=("field-path", reference_context, name),
+        )
+
+    def _reference_error(
+        self,
+        encoded: str,
+        path: RosPath,
+        reason: str,
+        *,
+        name: str | None = None,
+        uncertain: bool = False,
+    ) -> None:
+        localized_reason = self._localized_reference_reason(reason)
+        self._emit(
+            "ROS5305" if uncertain else "ROS1306",
+            Severity.WARNING if uncertain else Severity.ERROR,
+            _("AssociationPropertyMetadata reference cannot be proven valid locally.")
+            if uncertain
+            else _("AssociationPropertyMetadata reference is invalid."),
+            _("Consumer reachability is unknown; the possible encoding problem is: {}.").format(localized_reason)
+            if uncertain
+            else _("The target consumer cannot resolve this encoding: {}.").format(localized_reason),
+            path,
+            subject=name or encoded,
+            stable_args=(reason, name or encoded),
+            expected=_("a valid reference in the declared consumer context"),
+            actual=encoded,
+        )
+
+    def _warn_reference_type(
+        self,
+        value: Any,
+        schema: Mapping[str, Any],
+        path: RosPath,
+        *,
+        explicit_name: str | None = None,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> None:
+        if not isinstance(value, str):
+            return
+        exact_parameter = False
+        if explicit_name is not None:
+            name = explicit_name
+        elif "whole-value-reference" in self._schema_reference_parsers(schema):
+            classified = self._classify_whole_reference(
+                value,
+                reference_context,
+                reference_parameters,
+                reference_declaration_path,
+            )
+            if classified is None or classified[0] == "env":
+                return
+            reference_kind, name = classified
+            exact_parameter = reference_kind == "parameter"
+        else:
+            match = _REFERENCE.fullmatch(value)
+            name = match.group(1).strip() if match else value
+        if not name:
+            return
+        if exact_parameter:
+            resolution = self._resolve_exact_parameter_declaration(
+                name,
+                reference_context,
+                reference_parameters,
+                reference_declaration_path,
+            )
+        else:
+            parsed = self._parse_reference_path(name)
+            if parsed is None or parsed[0]:
+                return
+            resolution = self._resolve_reference_declaration(
+                name,
+                reference_context,
+                reference_parameters,
+                reference_declaration_path,
+            )
+        if resolution.declaration is None or resolution.declaration_path is None:
+            return
+        expected = schema.get("type")
+        if expected not in {"array", "boolean", "integer", "number", "object", "string"}:
+            return
+        parameter_type = resolution.declaration.get("Type")
+        terminal_type = {
+            "Boolean": "boolean",
+            "CommaDelimitedList": "array",
+            "Integer": "integer",
+            "Json": "object",
+            "List": "array",
+            "Number": "number",
+            "NumberPicker": "number",
+            "String": "string",
+        }.get(parameter_type if isinstance(parameter_type, str) else "")
+        expected_display = str(expected)
+        if resolution.projected_array:
+            actual = "array<{}>".format(terminal_type) if terminal_type is not None else "array"
+            if expected == "array":
+                item_schema = schema.get("items")
+                expected_item_types = self._schema_declared_types(item_schema)
+                if (
+                    terminal_type is None
+                    or not expected_item_types
+                    or any(self._reference_types_compatible(terminal_type, item) for item in expected_item_types)
+                ):
+                    return
+                expected_display = "array<{}>".format(" | ".join(sorted(expected_item_types)))
+        else:
+            actual = terminal_type
+        if actual is None or self._reference_types_compatible(actual, expected):
+            return
+        declaration_path = resolution.declaration_path
+        node = self.source_map.node_for(declaration_path)
+        related = (
+            RelatedLocation(_("referenced Parameter declaration"), node.span if node else None, declaration_path),
+        )
+        self._emit(
+            "ROS5302",
+            Severity.WARNING,
+            _("AssociationPropertyMetadata reference type is suspicious."),
+            _("The referenced Parameter resolves as {}, while this consumer expects {}.").format(
+                actual,
+                expected_display,
+            ),
+            path,
+            subject=name,
+            stable_args=("reference-type", name, str(actual), expected_display),
+            expected=expected_display,
+            actual=str(actual if resolution.projected_array else parameter_type),
+            related_locations=related,
+        )
+
+    @classmethod
+    def _schema_declared_types(cls, schema: Any) -> set[str]:
+        if not isinstance(schema, Mapping):
+            return set()
+        result = {schema_type} if isinstance((schema_type := schema.get("type")), str) else set()
+        any_of = schema.get("anyOf")
+        if isinstance(any_of, (list, tuple)):
+            for candidate in any_of:
+                result.update(cls._schema_declared_types(candidate))
+        return result
+
+    @staticmethod
+    def _reference_types_compatible(actual: str, expected: Any) -> bool:
+        return actual == expected or actual == "integer" and expected == "number"
+
+    def _validate_common_semantics(
+        self,
+        metadata: Mapping[Any, Any],
+        path: RosPath,
+        *,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> None:
+        for field in ("Visible", "ReadOnly", "Required"):
+            wrapper = metadata.get(field)
+            if isinstance(wrapper, Mapping) and "Condition" in wrapper:
+                self._validate_condition(
+                    wrapper["Condition"],
+                    path + (mapping_segment(field), mapping_segment("Condition")),
+                    root_string=True,
+                    reference_context=reference_context,
+                    reference_parameters=reference_parameters,
+                    reference_declaration_path=reference_declaration_path,
+                )
+        for field in ("AllowedValues", "Value", "MinValue", "MaxValue"):
+            values = metadata.get(field)
+            if not isinstance(values, list):
+                continue
+            for index, item in enumerate(values):
+                if isinstance(item, Mapping) and "Condition" in item:
+                    condition_item = cast(Mapping[Any, Any], item)
+                    self._validate_condition(
+                        condition_item["Condition"],
+                        path + (mapping_segment(field), SequenceIndexSegment(index), mapping_segment("Condition")),
+                        root_string=True,
+                        reference_context=reference_context,
+                        reference_parameters=reference_parameters,
+                        reference_declaration_path=reference_declaration_path,
+                    )
+        dynamic = metadata.get("DynamicValue")
+        if isinstance(dynamic, list):
+            injected_symbols = self._dynamic_condition_injected_symbols()
+            for index, item in enumerate(dynamic):
+                if isinstance(item, Mapping) and "Condition" in item:
+                    condition_item = cast(Mapping[Any, Any], item)
+                    self._validate_condition(
+                        condition_item["Condition"],
+                        path
+                        + (mapping_segment("DynamicValue"), SequenceIndexSegment(index), mapping_segment("Condition")),
+                        root_string=True,
+                        reference_context=reference_context,
+                        reference_parameters=reference_parameters,
+                        reference_declaration_path=reference_declaration_path,
+                        injected_symbols=injected_symbols,
+                    )
+
+    def _dynamic_condition_injected_symbols(self) -> set[str]:
+        properties = self.specs.common_metadata.get("properties", {})
+        dynamic = properties.get("DynamicValue") if isinstance(properties, Mapping) else None
+        any_of = dynamic.get("anyOf", ()) if isinstance(dynamic, Mapping) else ()
+        for candidate in any_of if isinstance(any_of, (list, tuple)) else ():
+            if not isinstance(candidate, Mapping) or candidate.get("type") != "array":
+                continue
+            items = candidate.get("items")
+            item_properties = items.get("properties", {}) if isinstance(items, Mapping) else {}
+            condition = item_properties.get("Condition") if isinstance(item_properties, Mapping) else None
+            symbols = condition.get("x-ore-injected-symbols") if isinstance(condition, Mapping) else None
+            if isinstance(symbols, (list, tuple)):
+                return {symbol for symbol in symbols if isinstance(symbol, str)}
+        return set()
+
+    def _validate_condition(
+        self,
+        condition: Any,
+        path: RosPath,
+        *,
+        root_string: bool,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        injected_symbols: set[str] | None = None,
+    ) -> None:
+        if isinstance(condition, str):
+            if root_string:
+                self._validate_definition_path(
+                    condition,
+                    path,
+                    reference_context=reference_context,
+                    reference_parameters=reference_parameters,
+                    reference_declaration_path=reference_declaration_path,
+                    injected_symbols=injected_symbols,
+                )
+            else:
+                self._condition_error(condition, path, "nested And/Or/Not operands must be condition objects")
+            return
+        if not isinstance(condition, Mapping) or not condition:
+            self._condition_error(condition, path, "condition must be a non-empty String or object")
+            return
+        properties, key_order = _js_mapping_properties(condition)
+        first_key = key_order[0]
+        supported = {"Fn::And", "Fn::Contains", "Fn::Equals", "Fn::Not", "Fn::Or", "Fn::Select"}
+        if first_key not in supported:
+            self._condition_error(condition, path, "the first function key is unsupported")
+            return
+        for ignored_key in key_order[1:]:
+            self._emit(
+                "ROS5302",
+                Severity.WARNING,
+                _("Condition contains a function key that the target form ignores."),
+                _("The target form evaluates only the first object key, {}.").format(first_key),
+                path + (mapping_segment(ignored_key),),
+                subject=str(ignored_key),
+                stable_args=("ignored-condition-key", str(first_key), str(ignored_key)),
+            )
+        value = properties[first_key]
+        value_path = path + (mapping_segment(first_key),)
+        if first_key in {"Fn::Equals", "Fn::Contains"}:
+            if not isinstance(value, list) or len(value) != 2:
+                self._condition_error(value, value_path, "{} requires exactly two arguments".format(first_key))
+            else:
+                for index, child in enumerate(value):
+                    self._validate_condition_operand(
+                        child,
+                        value_path + (SequenceIndexSegment(index),),
+                        reference_context=reference_context,
+                        reference_parameters=reference_parameters,
+                        reference_declaration_path=reference_declaration_path,
+                        injected_symbols=injected_symbols,
+                    )
+            return
+        if first_key in {"Fn::And", "Fn::Or"}:
+            if not isinstance(value, list):
+                self._condition_error(value, value_path, "{} requires an array".format(first_key))
+                return
+            for index, child in enumerate(value):
+                self._validate_condition(
+                    child,
+                    value_path + (SequenceIndexSegment(index),),
+                    root_string=False,
+                    reference_context=reference_context,
+                    reference_parameters=reference_parameters,
+                    reference_declaration_path=reference_declaration_path,
+                    injected_symbols=injected_symbols,
+                )
+            return
+        if first_key == "Fn::Not":
+            if not isinstance(value, Mapping) or len(value) != 1:
+                self._condition_error(value, value_path, "Fn::Not requires one single-key condition object")
+            else:
+                self._validate_condition(
+                    value,
+                    value_path,
+                    root_string=False,
+                    reference_context=reference_context,
+                    reference_parameters=reference_parameters,
+                    reference_declaration_path=reference_declaration_path,
+                    injected_symbols=injected_symbols,
+                )
+            return
+        self._validate_select_arguments(
+            value,
+            value_path,
+            reference_context=reference_context,
+            reference_parameters=reference_parameters,
+            reference_declaration_path=reference_declaration_path,
+            injected_symbols=injected_symbols,
+        )
+
+    def _validate_condition_operand(
+        self,
+        value: Any,
+        path: RosPath,
+        *,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        injected_symbols: set[str] | None = None,
+    ) -> None:
+        if isinstance(value, str):
+            match = _FRONTEND_REFERENCE.fullmatch(value)
+            if match is not None:
+                self._validate_exact_parameter_reference(
+                    match.group(1),
+                    value,
+                    path,
+                    reference_context,
+                    reference_parameters=reference_parameters,
+                    reference_declaration_path=reference_declaration_path,
+                    injected_symbols=injected_symbols,
+                )
+            return
+        if isinstance(value, Mapping) and "Fn::Select" in value:
+            self._validate_select_arguments(
+                value["Fn::Select"],
+                path + (mapping_segment("Fn::Select"),),
+                reference_context=reference_context,
+                reference_parameters=reference_parameters,
+                reference_declaration_path=reference_declaration_path,
+                injected_symbols=injected_symbols,
+            )
+
+    def _validate_select_arguments(
+        self,
+        value: Any,
+        value_path: RosPath,
+        *,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        injected_symbols: set[str] | None = None,
+    ) -> None:
+        if not isinstance(value, list):
+            self._condition_error(value, value_path, "Fn::Select requires an array")
+            return
+        param_ref = value[0] if value else None
+        key = value[1] if len(value) >= 2 else None
+        if len(value) > 2:
+            for index in range(2, len(value)):
+                self._emit(
+                    "ROS5302",
+                    Severity.WARNING,
+                    _("Fn::Select contains an argument that the target form ignores."),
+                    _("Only the first two arguments are destructured by the current runtime."),
+                    value_path + (SequenceIndexSegment(index),),
+                    subject=str(index),
+                    stable_args=("select-tail", str(index)),
+                )
+        if not js_truthy(param_ref) or not js_truthy(key):
+            # The target form returns a resolved undefined primitive before consulting the
+            # reference when either destructured argument is missing or empty.
+            return
+        if not all(isinstance(item, str) for item in value[:2]):
+            self._condition_error(value, value_path, "Fn::Select uses its first two String arguments")
+        else:
+            raw_reference = value[0]
+            match = _FRONTEND_REFERENCE.fullmatch(raw_reference)
+            reference_name = match.group(1) if match is not None else raw_reference
+            self._validate_exact_parameter_reference(
+                reference_name,
+                raw_reference,
+                value_path + (SequenceIndexSegment(0),),
+                reference_context,
+                reference_parameters=reference_parameters,
+                reference_declaration_path=reference_declaration_path,
+                injected_symbols=injected_symbols,
+            )
+
+    def _condition_error(self, value: Any, path: RosPath, reason: str) -> None:
+        self._emit(
+            "ROS1305",
+            Severity.ERROR,
+            _("AssociationPropertyMetadata Condition is invalid."),
+            _("The condition AST is incompatible with the target form: {}.").format(
+                self._localized_condition_reason(reason)
+            ),
+            path,
+            subject=reason,
+            stable_args=("condition", reason),
+            expected=_("a supported ParameterMetadataCondition"),
+            actual=self._actual(value),
+        )
+
+    def _validate_definition_path(
+        self,
+        value: str,
+        path: RosPath,
+        *,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+        injected_symbols: set[str] | None,
+    ) -> None:
+        metadata = self.template.get("Metadata")
+        profile_results: list[tuple[str, tuple[bool, Any] | None]] = []
+        if isinstance(metadata, Mapping):
+            for key in ("ALIYUN::ROS::Interface", "APSARA::ROS::Interface"):
+                if key not in metadata:
+                    continue
+                interface = metadata.get(key)
+                definitions = interface.get("Definitions") if isinstance(interface, Mapping) else None
+                if isinstance(definitions, Mapping):
+                    profile_results.append(
+                        (
+                            key,
+                            self._definition_path_value(
+                                definitions,
+                                value,
+                                (
+                                    mapping_segment("Metadata"),
+                                    mapping_segment(key),
+                                    mapping_segment("Definitions"),
+                                ),
+                            ),
+                        )
+                    )
+                else:
+                    profile_results.append((key, None))
+        inspectable = [result for _, result in profile_results if result is not None]
+        if not profile_results or not inspectable:
+            self._emit(
+                "ROS5305",
+                Severity.WARNING,
+                _("Condition Definitions path cannot be resolved locally."),
+                _("The template does not provide a statically inspectable ROS Interface Definitions object."),
+                path,
+                subject=value,
+                stable_args=("definitions-unavailable", value),
+            )
+            return
+        found_results = [
+            (profile, result[1]) for profile, result in profile_results if result is not None and result[0]
+        ]
+        has_unavailable = any(result is None for _, result in profile_results)
+        has_missing = any(result is not None and not result[0] for _, result in profile_results)
+        values_differ = bool(found_results) and any(
+            not _same_definition_value(found_results[0][1], resolved) for _, resolved in found_results[1:]
+        )
+        if found_results and not has_unavailable and not has_missing and not values_differ:
+            resolved = found_results[0][1]
+            if not isinstance(resolved, Mapping):
+                self._condition_error(resolved, path, "Definitions path must resolve to a condition object")
+                return
+            self._validate_condition(
+                resolved,
+                path,
+                root_string=False,
+                reference_context=reference_context,
+                reference_parameters=reference_parameters,
+                reference_declaration_path=reference_declaration_path,
+                injected_symbols=injected_symbols,
+            )
+            return
+        if found_results:
+            self._emit(
+                "ROS5305",
+                Severity.WARNING,
+                _("Condition Definitions path cannot be resolved locally."),
+                _("The ALIYUN and APSARA environment profiles resolve this path differently."),
+                path,
+                subject=value,
+                stable_args=(
+                    "definitions-profile-dependent",
+                    value,
+                    *(
+                        "{}={}".format(
+                            profile,
+                            "unavailable" if result is None else "found" if result[0] else "missing",
+                        )
+                        for profile, result in profile_results
+                    ),
+                ),
+            )
+            return
+        self._reference_error(value, path, "Definitions path does not exist", name=value)
+
+    def _definition_path_value(
+        self,
+        definitions: Mapping[Any, Any],
+        value: str,
+        definitions_path: RosPath,
+    ) -> tuple[bool, Any]:
+        # Field-path parsing first treats the complete string as an exact root
+        # key, even when it contains dots or brackets.
+        found, exact, _ = self._definition_mapping_property(definitions, definitions_path, value)
+        if found:
+            return True, exact
+        current: Any = definitions
+        current_path = definitions_path
+        segments = _lodash_path_segments(value)
+        if not segments:
+            return False, None
+        for segment in segments:
+            if isinstance(current, Mapping):
+                found, current, current_path = self._definition_mapping_property(
+                    current,
+                    current_path,
+                    segment,
+                )
+                if not found:
+                    return False, None
+                continue
+            if isinstance(current, (list, tuple)):
+                if segment == "length":
+                    current = len(current)
+                    continue
+                if re.fullmatch(r"(?:0|[1-9][0-9]*)", segment) is None:
+                    return False, None
+                index = int(segment)
+                if index >= len(current):
+                    return False, None
+                current = current[index]
+                current_path = current_path + (SequenceIndexSegment(index),)
+                continue
+            if isinstance(current, str):
+                units = _js_utf16_units(current)
+                if segment == "length":
+                    current = len(units)
+                    continue
+                if re.fullmatch(r"(?:0|[1-9][0-9]*)", segment) is None:
+                    return False, None
+                index = int(segment)
+                if index >= len(units):
+                    return False, None
+                current = units[index]
+                continue
+            return False, None
+        return True, current
+
+    def _definition_mapping_property(
+        self,
+        value: Mapping[Any, Any],
+        value_path: RosPath,
+        key: str,
+    ) -> tuple[bool, Any, RosPath]:
+        """Read one JS-visible key without losing YAML ``true/1`` or ``false/0`` siblings."""
+
+        return self._source_mapping_property(value, value_path, key)
+
+    def _validate_nested_parameters(
+        self,
+        metadata: Mapping[Any, Any],
+        path: RosPath,
+        resolution: _ComponentResolution,
+        *,
+        depth: int,
+        reference_context: str,
+        reference_parameters: Mapping[Any, Any] | None,
+        reference_declaration_path: RosPath | None,
+    ) -> None:
+        for field in ("Parameter", "Parameters"):
+            if field not in metadata:
+                continue
+            reachability, nested_context = self._nested_field_reachability(resolution, field)
+            field_path = path + (mapping_segment(field),)
+            if reachability == ConsumerReachability.NOT_REACHED:
+                continue
+            if reachability == ConsumerReachability.UNKNOWN or nested_context is None:
+                self._emit(
+                    "ROS5305",
+                    Severity.WARNING,
+                    _("AssociationPropertyMetadata nested container has runtime-dependent reachability."),
+                    _(
+                        "Only some possible form components consume this Parameter/Parameters field; "
+                        "its nested declarations are not rejected locally."
+                    ),
+                    field_path,
+                    subject=field,
+                    stable_args=("nested-container-reachability", field, *resolution.possible_components),
+                )
+                continue
+            if field == "Parameter":
+                nested = metadata.get(field)
+                if not isinstance(nested, Mapping):
+                    continue
+                keep_scope = nested_context == reference_context
+                self._validate_parameter(
+                    nested,
+                    field_path,
+                    depth=depth + 1,
+                    reference_context=nested_context,
+                    reference_parameters=reference_parameters if keep_scope else None,
+                    reference_declaration_path=reference_declaration_path if keep_scope else None,
+                )
+                continue
+            nested_map = metadata.get(field)
+            if not isinstance(nested_map, Mapping):
+                continue
+            for _child_name, child, child_path in self._source_mapping_items(nested_map, field_path):
+                if isinstance(child, Mapping):
+                    self._validate_parameter(
+                        child,
+                        child_path,
+                        depth=depth + 1,
+                        reference_context=nested_context,
+                        reference_parameters=nested_map,
+                        reference_declaration_path=field_path,
+                    )
+
+    def _nested_field_reachability(
+        self,
+        resolution: _ComponentResolution,
+        field: str,
+    ) -> tuple[ConsumerReachability, str | None]:
+        contexts: set[str] = set()
+        consumer_count = 0
+        for component_name in resolution.possible_components:
+            component = self.specs.component(component_name)
+            properties = component.metadata.get("properties", {}) if component is not None else {}
+            schema = properties.get(field) if isinstance(properties, Mapping) else None
+            if not isinstance(schema, Mapping) or schema.get("x-ore-nested-parameter") is not True:
+                continue
+            consumer_count += 1
+            context = schema.get("x-ore-reference-context") if isinstance(schema, Mapping) else None
+            if isinstance(context, str):
+                contexts.add(context)
+        if consumer_count == 0:
+            return ConsumerReachability.NOT_REACHED, None
+        if consumer_count == len(resolution.possible_components) and len(contexts) == 1:
+            return ConsumerReachability.REACHED, next(iter(contexts))
+        return ConsumerReachability.UNKNOWN, next(iter(contexts)) if len(contexts) == 1 else None
+
+    def _validate_auto_complete(
+        self,
+        metadata: Mapping[Any, Any],
+        path: RosPath,
+        reachability: AutoCompleteConsumerReachability | None,
+    ) -> None:
+        classes = metadata.get("CharacterClasses")
+        pattern = metadata.get("Pattern")
+        if isinstance(pattern, str) and not (isinstance(classes, list) and classes):
+            self._emit(
+                "ROS5305",
+                Severity.WARNING,
+                _("AutoCompleteInput Pattern syntax is not checked locally."),
+                _(
+                    "The target form compiles Pattern as ECMAScript RegExp; "
+                    "Python regular expressions are not equivalent."
+                ),
+                path + (mapping_segment("Pattern"),),
+                subject="Pattern",
+                stable_args=("ecma262-regex",),
+            )
+        has_character_classes = isinstance(classes, list) and bool(classes)
+        raw_length = metadata.get("Length")
+        if isinstance(raw_length, (int, float)) and not isinstance(raw_length, bool):
+            if not math.isfinite(float(raw_length)) or raw_length <= 0 or float(raw_length).is_integer() is False:
+                if has_character_classes:
+                    normalized_length: int | str = self._js_array_length(raw_length)
+                    normalized_length_stable = str(normalized_length)
+                elif not js_truthy(raw_length):
+                    normalized_length = _("unsliced generated identifier (Length is falsy in JavaScript)")
+                    normalized_length_stable = "unsliced-generated-identifier"
+                else:
+                    slice_end = self._js_slice_end(raw_length)
+                    normalized_length = (
+                        slice_end
+                        if slice_end >= 0
+                        else _("generated identifier truncated at position {}").format(slice_end)
+                    )
+                    normalized_length_stable = str(normalized_length)
+                self._emit(
+                    "ROS5302",
+                    Severity.WARNING,
+                    _("AutoCompleteInput Length is normalized non-intuitively by JavaScript."),
+                    _("Effective generated Length is {} after JavaScript array/slice conversion.").format(
+                        normalized_length
+                    ),
+                    path + (mapping_segment("Length"),),
+                    subject="Length",
+                    stable_args=("length-normalization", str(raw_length), normalized_length_stable),
+                    expected=_("a positive integer for predictable output"),
+                    actual=str(raw_length),
+                )
+        if not isinstance(classes, list) or not classes:
+            return
+        if "Pattern" in metadata:
+            self._emit(
+                "ROS5302",
+                Severity.WARNING,
+                _("AutoCompleteInput ignores Pattern when CharacterClasses is non-empty."),
+                _("The character-class generation branch does not compile Pattern."),
+                path + (mapping_segment("Pattern"),),
+                subject="Pattern",
+                stable_args=("pattern-with-character-classes",),
+            )
+        length = metadata.get("Length", 8)
+        effective_length = self._js_array_length(length)
+
+        valid_minimums = True
+        minimum_sum = 0
+        ordinary_present = False
+        special_entries: list[tuple[int, Mapping[Any, Any]]] = []
+        valid_classes = _auto_complete_character_class_values(self.specs)
+        prior_fills: list[tuple[int, frozenset[int]]] = []
+        remaining_upper_bound = effective_length
+        for index, item in enumerate(classes):
+            if not isinstance(item, Mapping):
+                continue
+            class_item = cast(Mapping[Any, Any], item)
+            if class_item.get("Class") not in valid_classes:
+                continue
+            item_path = path + (mapping_segment("CharacterClasses"), SequenceIndexSegment(index))
+            class_name = class_item["Class"]
+            if class_name != "specialCharacter":
+                ordinary_present = True
+                for ignored in ("SpecialCharacters", "Start", "End"):
+                    if ignored in class_item:
+                        self._emit(
+                            "ROS5302",
+                            Severity.WARNING,
+                            _("AutoCompleteInput ignores a special-character-only field."),
+                            _("{} is read only when Class is specialCharacter.").format(ignored),
+                            item_path + (mapping_segment(ignored),),
+                            subject=ignored,
+                            stable_args=("non-special-ignored", str(class_name), ignored),
+                        )
+            else:
+                special_entries.append((index, class_item))
+
+            if "Min" not in class_item:
+                valid_minimums = False
+                if "min" not in class_item and len(classes) > 1:
+                    self._emit(
+                        "ROS5302",
+                        Severity.WARNING,
+                        _("AutoCompleteInput CharacterClass does not guarantee a minimum count."),
+                        _("With multiple character classes, missing Min does not reserve characters for this class."),
+                        item_path + (mapping_segment("Min"),),
+                        subject="Min",
+                        stable_args=("missing-min", str(index)),
+                    )
+                continue
+            minimum = class_item.get("Min")
+            if not isinstance(minimum, (int, float)) or isinstance(minimum, bool) or not math.isfinite(float(minimum)):
+                valid_minimums = False
+                continue
+            fills_runtime = class_name != "specialCharacter" or js_truthy(class_item.get("SpecialCharacters"))
+            excluded_count = 0
+            if class_name == "specialCharacter" and fills_runtime and effective_length > 0:
+                excluded_positions = set()
+                if class_item.get("Start") is False:
+                    excluded_positions.add(0)
+                if class_item.get("End") is False:
+                    excluded_positions.add(effective_length - 1)
+                excluded_count = len(excluded_positions)
+            if minimum < 0 or float(minimum).is_integer() is False:
+                valid_minimums = False
+                if fills_runtime:
+                    self._emit(
+                        "ROS5302",
+                        Severity.WARNING,
+                        _("AutoCompleteInput Min fills every available position."),
+                        _(
+                            "A negative or fractional counter never reaches zero; generation stops only after "
+                            "available positions are exhausted."
+                        ),
+                        item_path + (mapping_segment("Min"),),
+                        subject="Min",
+                        stable_args=("non-integer-min", str(index), str(minimum)),
+                        expected=_("a non-negative integer for predictable minimum semantics"),
+                        actual=str(minimum),
+                    )
+                    if class_name == "specialCharacter":
+                        remaining_upper_bound = min(remaining_upper_bound, excluded_count)
+                    else:
+                        remaining_upper_bound = 0
+            else:
+                minimum_value = int(minimum)
+                if fills_runtime:
+                    minimum_sum += minimum_value
+                    allowed_positions = set(range(effective_length))
+                    if class_name == "specialCharacter":
+                        if class_item.get("Start") is False:
+                            allowed_positions.discard(0)
+                        if class_item.get("End") is False:
+                            allowed_positions.discard(effective_length - 1)
+                    required_from_prior = sum(
+                        max(0, prior_minimum - len(prior_allowed - allowed_positions))
+                        for prior_minimum, prior_allowed in prior_fills
+                    )
+                    if (
+                        required_from_prior > 0
+                        and len(allowed_positions) < effective_length
+                        and minimum_value + required_from_prior > len(allowed_positions)
+                    ):
+                        self._emit_auto_semantic(
+                            _("AutoCompleteInput minimum cannot be satisfied after earlier CharacterClasses."),
+                            _("Earlier fills require at least {} of this entry's {} available positions.").format(
+                                required_from_prior,
+                                len(allowed_positions),
+                            ),
+                            item_path + (mapping_segment("Min"),),
+                            reachability,
+                            subject="shared-character-capacity",
+                            stable_args=(
+                                "shared-capacity",
+                                str(index),
+                                str(minimum_value),
+                                str(required_from_prior),
+                                str(len(allowed_positions)),
+                            ),
+                            expected=_("a minimum satisfiable after earlier fills"),
+                            actual=str(minimum_value),
+                        )
+                    prior_fills.append((minimum_value, frozenset(allowed_positions)))
+                    if class_name == "specialCharacter":
+                        remaining_upper_bound = min(
+                            remaining_upper_bound,
+                            max(excluded_count, remaining_upper_bound - minimum_value),
+                        )
+                    else:
+                        remaining_upper_bound = max(remaining_upper_bound - minimum_value, 0)
+
+        if valid_minimums and minimum_sum > effective_length:
+            self._emit_auto_semantic(
+                _("AutoCompleteInput minimum character counts exceed Length."),
+                _("The sum of CharacterClasses.Min is {}, but the effective Length is {}.").format(
+                    minimum_sum,
+                    effective_length,
+                ),
+                path + (mapping_segment("CharacterClasses"),),
+                reachability,
+                subject="character-capacity",
+                stable_args=("capacity", str(minimum_sum), str(effective_length)),
+                expected=_("sum of Min no greater than {}").format(effective_length),
+                actual=str(minimum_sum),
+            )
+
+        truthy_special_indices = [
+            index
+            for index, item in special_entries
+            if isinstance(item.get("SpecialCharacters"), str) and item.get("SpecialCharacters")
+        ]
+        last_truthy_special = truthy_special_indices[-1] if truthy_special_indices else None
+        has_usable_pool = ordinary_present or bool(truthy_special_indices)
+        for index, item in special_entries:
+            item_path = path + (mapping_segment("CharacterClasses"), SequenceIndexSegment(index))
+            characters = item.get("SpecialCharacters")
+            minimum = item.get("Min")
+            requires_characters = (
+                isinstance(minimum, (int, float)) and not isinstance(minimum, bool) and minimum > 0
+            ) or (not has_usable_pool and effective_length > 0)
+            if not (isinstance(characters, str) and characters):
+                for ignored in ("Start", "End"):
+                    if ignored in item:
+                        self._emit(
+                            "ROS5302",
+                            Severity.WARNING,
+                            _("AutoCompleteInput ignores a special-character boundary flag."),
+                            _(
+                                "The runtime does not retain specialCharacter configuration when SpecialCharacters "
+                                "is empty."
+                            ),
+                            item_path + (mapping_segment(ignored),),
+                            subject=ignored,
+                            stable_args=("empty-special-ignored", str(index), ignored),
+                        )
+                if requires_characters:
+                    self._emit_auto_semantic(
+                        _("AutoCompleteInput requires non-empty SpecialCharacters."),
+                        _("This specialCharacter branch must fill at least one generated position."),
+                        item_path + (mapping_segment("SpecialCharacters"),),
+                        reachability,
+                        subject="SpecialCharacters",
+                        stable_args=("special-characters-required", str(index)),
+                        expected=_("non-empty String"),
+                        actual=self._actual(characters),
+                    )
+                continue
+            excluded_positions = set()
+            if item.get("Start") is False and effective_length > 0:
+                excluded_positions.add(0)
+            if item.get("End") is False and effective_length > 0:
+                excluded_positions.add(effective_length - 1)
+            available = max(effective_length - len(excluded_positions), 0)
+            if isinstance(minimum, int) and not isinstance(minimum, bool) and minimum >= 0 and minimum > available:
+                self._emit_auto_semantic(
+                    _("AutoCompleteInput special-character minimum exceeds available positions."),
+                    _("Start/End restrictions leave {} positions for {} required special characters.").format(
+                        available,
+                        minimum,
+                    ),
+                    item_path + (mapping_segment("Min"),),
+                    reachability,
+                    subject="special-capacity",
+                    stable_args=("special-capacity", str(index), str(minimum), str(available)),
+                    expected=_("Min no greater than {}").format(available),
+                    actual=str(minimum),
+                )
+            if (
+                index == last_truthy_special
+                and isinstance(characters, str)
+                and characters
+                and (item.get("Start") is False or item.get("End") is False)
+                and remaining_upper_bound > 0
+            ):
+                boundary = "Start" if item.get("Start") is False else "End"
+                detail = (
+                    _(
+                        "join() can produce a string shorter than Length because the remaining-character pool becomes "
+                        "empty at the restricted boundary and stays empty."
+                    )
+                    if not ordinary_present
+                    else _(
+                        "The mutable remaining-character pool narrows to ordinary classes at the restricted boundary "
+                        "and does not restore special characters later."
+                    )
+                )
+                self._emit(
+                    "ROS5302",
+                    Severity.WARNING,
+                    _("AutoCompleteInput boundary restriction persists for later positions."),
+                    detail,
+                    item_path + (mapping_segment(boundary),),
+                    subject=boundary,
+                    stable_args=("persistent-character-pool", str(index), boundary, str(ordinary_present)),
+                )
+
+    def _emit_auto_semantic(
+        self,
+        summary: str,
+        detail: str,
+        path: RosPath,
+        reachability: AutoCompleteConsumerReachability | None,
+        **kwargs: Any,
+    ) -> None:
+        states = (
+            (reachability.raw_initializer, reachability.component_effect)
+            if reachability is not None
+            else (ConsumerReachability.UNKNOWN,)
+        )
+        if ConsumerReachability.REACHED in states:
+            code = "ROS1307"
+            severity = Severity.ERROR
+        elif all(state == ConsumerReachability.NOT_REACHED for state in states):
+            code = "ROS5302"
+            severity = Severity.WARNING
+            detail = _("All statically reachable generation consumers are skipped. {} ").format(detail)
+        else:
+            code = "ROS5305"
+            severity = Severity.WARNING
+            detail = _("Generation consumer reachability is unknown. {} ").format(detail)
+        self._emit(code, severity, summary, detail, path, **kwargs)
+
+    @staticmethod
+    def _js_array_length(value: Any) -> int:
+        return max(_js_integer(value), 0)
+
+    @staticmethod
+    def _js_slice_end(value: Any) -> int:
+        return _js_integer(value)
+
+    @staticmethod
+    def _actual(value: Any) -> str:
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "array"
+        if isinstance(value, Mapping):
+            return "object"
+        return str(value)
+
+    @classmethod
+    def _expected(cls, schema: Mapping[str, Any]) -> str:
+        if "enum" in schema:
+            return " | ".join(str(item) for item in schema["enum"])
+        if "const" in schema:
+            return str(schema["const"])
+        if "anyOf" in schema:
+            return _("one of: {}").format(" | ".join(cls._expected(item) for item in schema["anyOf"]))
+        schema_type = schema.get("type")
+        return str(schema_type) if schema_type is not None else _("any value")
+
+    @classmethod
+    def _expected_stable(cls, schema: Mapping[str, Any]) -> str:
+        if "enum" in schema:
+            return " | ".join(str(item) for item in schema["enum"])
+        if "const" in schema:
+            return str(schema["const"])
+        if "anyOf" in schema:
+            return " or ".join(cls._expected_stable(item) for item in schema["anyOf"])
+        return str(schema.get("type", "any value"))
+
+    @staticmethod
+    def _unavailable_association_property_detail(scope: str) -> str:
+        if scope == "OOS-only":
+            return _("This AssociationProperty value is available only in the OOS parameter form.")
+        return _("This AssociationProperty value is unavailable in the stock ROS parameter form.")
+
+    @staticmethod
+    def _localized_reference_reason(reason: str) -> str:
+        if reason == "empty reference":
+            return _("the reference is empty")
+        if reason == "environment references are not allowed by this consumer":
+            return _("environment references are not allowed by this consumer")
+        if reason == "parameter references are not allowed by this consumer":
+            return _("Parameter references are not allowed by this consumer")
+        if reason == "field-path references are not allowed by this consumer":
+            return _("field-path references are not allowed by this consumer")
+        if reason == "malformed field path":
+            return _("the field path is malformed")
+        if reason == "field paths support one top-level array projection followed by a child path":
+            return _("field paths support one top-level array projection followed by a child path")
+        if reason == "Parameter does not exist":
+            return _("the Parameter does not exist")
+        if reason == "nested Parameter does not exist":
+            return _("the nested Parameter does not exist")
+        if reason == "MetaList row field does not exist":
+            return _("the MetaList row field does not exist")
+        if reason == "referenced Parameter declaration is invalid":
+            return _("the referenced Parameter declaration is invalid")
+        if reason == "field path traverses a scalar Parameter":
+            return _("the field path traverses a scalar Parameter")
+        if reason == "nested Parameter field does not exist":
+            return _("the nested Parameter field does not exist")
+        if reason == "referenced nested Parameter declaration is invalid":
+            return _("the referenced nested Parameter declaration is invalid")
+        if reason == "Definitions path does not exist":
+            return _("the Definitions path does not exist")
+        match = re.fullmatch(r"(.+) references are not allowed by this consumer", reason)
+        if match is not None:
+            return _("{} references are not allowed by this consumer").format(match.group(1))
+        return _("the reference is invalid")
+
+    @staticmethod
+    def _localized_condition_reason(reason: str) -> str:
+        if reason == "nested And/Or/Not operands must be condition objects":
+            return _("nested And/Or/Not operands must be condition objects")
+        if reason == "condition must be a non-empty String or object":
+            return _("the condition must be a non-empty String or object")
+        if reason == "the first function key is unsupported":
+            return _("the first function key is unsupported")
+        if reason == "Fn::Not requires one single-key condition object":
+            return _("Fn::Not requires one condition object containing a single key")
+        if reason == "Fn::Select uses its first two String arguments":
+            return _("Fn::Select requires its first two arguments to be Strings")
+        if reason == "Definitions path must resolve to a condition object":
+            return _("the Definitions path must resolve to a condition object")
+        match = re.fullmatch(r"(.+) requires exactly two arguments", reason)
+        if match is not None:
+            return _("{} requires exactly two arguments").format(match.group(1))
+        match = re.fullmatch(r"(.+) requires an array", reason)
+        if match is not None:
+            return _("{} requires an array").format(match.group(1))
+        return _("the condition is invalid")

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/template_kind.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/template_kind.py
@@ -1,0 +1,16 @@
+"""Shared ROS template-kind predicates."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def is_terraform_template(data: Mapping[Any, Any]) -> bool:
+    """Return whether a parsed template uses a ROS Terraform/OpenTofu transform."""
+
+    transform = data.get("Transform")
+    values = transform if isinstance(transform, list) else [transform]
+    return any(
+        isinstance(value, str) and value.startswith(("Aliyun::Terraform-", "Aliyun::OpenTofu-")) for value in values
+    )

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/validator.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/validator.py
@@ -29,6 +29,10 @@ from iac_code.tools.cloud.aliyun.ros_validation.resource_value_specs import (
     DEFAULT_RESOURCE_SPECS,
     ResourceValueSpecRegistry,
 )
+from iac_code.tools.cloud.aliyun.ros_validation.rules.association_property import (
+    AssociationPropertyRule,
+    AssociationPropertySpecsProvider,
+)
 from iac_code.tools.cloud.aliyun.ros_validation.rules.registry import create_validation_registry
 from iac_code.tools.cloud.aliyun.ros_validation.symbols import collect_symbols
 
@@ -240,12 +244,13 @@ class _ResourceRule:
 _VALIDATION_REGISTRY = create_validation_registry(
     providers=(
         _ParserProvider(),
+        AssociationPropertySpecsProvider(),
         _SymbolsProvider(),
         _AnalyzerProvider(),
         _LocalsPrecompileProvider(),
         _CountPrecompileProvider(),
     ),
-    rules=(_StructureRule(), _ConditionRule(), _ResourceRule()),
+    rules=(AssociationPropertyRule(), _StructureRule(), _ConditionRule(), _ResourceRule()),
 )
 
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -760,6 +760,82 @@ def test_ros_validation_uses_runtime_language(monkeypatch: pytest.MonkeyPatch) -
         setup_i18n()
 
 
+def test_association_property_diagnostics_render_in_all_seven_languages() -> None:
+    from iac_code.i18n import set_language
+    from iac_code.tools.cloud.aliyun.ros_validation.model import (
+        MaterializedTemplateSource,
+        RequestValidationContext,
+    )
+    from iac_code.tools.cloud.aliyun.ros_validation.renderer import render_validation_report
+    from iac_code.tools.cloud.aliyun.ros_validation.validator import validate_ros_template
+
+    template = """ROSTemplateFormatVersion: '2015-09-01'
+Parameters:
+  InvalidEnum:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      CharacterClasses:
+        - Class: digit
+          Min: 1
+  MissingReference:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible:
+        Condition:
+          Fn::Equals:
+            - ${Missing}
+            - expected
+  InvalidCondition:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible:
+        Condition:
+          Fn::Equals:
+            - only-one
+  NormalizedLength:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Length: 0
+  DeprecatedAssociation:
+    Type: String
+    AssociationProperty: ALIYUN::ECS::Instance:ZoneId
+  UnknownAssociation:
+    Type: String
+    AssociationProperty: ALIYUN::Future::Selector
+  UnavailableAssociation:
+    Type: String
+    AssociationProperty: ALIYUN::OOS::Component::ActionChoice
+Resources: {}
+"""
+    rendered_by_language: dict[str, str] = {}
+    diagnostic_ids_by_language: dict[str, tuple[str, ...]] = {}
+    try:
+        for language in SUPPORTED_LANGUAGES:
+            set_language(language)
+            report = validate_ros_template(
+                MaterializedTemplateSource(template, origin="association-i18n.yaml"),
+                RequestValidationContext(action="ValidateTemplate"),
+            )
+            rendered = render_validation_report(report)
+            rendered_by_language[language] = rendered
+            diagnostic_ids_by_language[language] = tuple(item.diagnostic_id for item in report.diagnostics)
+
+            assert "not_registered_in_stock_ros_component_map" not in rendered
+            assert "OOS-only" not in rendered
+            if language != DEFAULT_LANGUAGE:
+                assert "Parameter does not exist" not in rendered
+                assert "Fn::Equals requires exactly two arguments" not in rendered
+                assert "unsliced generated identifier (Length is falsy in JavaScript)" not in rendered
+    finally:
+        set_language(DEFAULT_LANGUAGE)
+
+    assert set(rendered_by_language) == set(SUPPORTED_LANGUAGES)
+    assert len(set(rendered_by_language.values())) == len(SUPPORTED_LANGUAGES)
+    assert len(set(diagnostic_ids_by_language.values())) == 1
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="messages.pot not generated on Windows")
 def test_memory_command_translations_are_complete():
     """Verify /memory-specific strings are translated, not copied as placeholders."""

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -135,6 +135,7 @@ def test_web_static_assets_are_included_in_package_data():
     assert "**/*.html" in package_data
     assert "**/*.css" in package_data
     assert "**/*.js" in package_data
+    assert "**/*.json" in package_data
     assert "**/*.svg" in package_data
     assert "**/*.LICENSE" in package_data
 
@@ -147,6 +148,7 @@ def test_web_static_assets_are_included_in_legacy_setup_package_data(monkeypatch
         assert "**/*.html" in package_data
         assert "**/*.css" in package_data
         assert "**/*.js" in package_data
+        assert "**/*.json" in package_data
         assert "**/*.svg" in package_data
         assert "**/*.LICENSE" in package_data
 

--- a/tests/tools/cloud/aliyun/test_aliyun_api.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api.py
@@ -1960,6 +1960,51 @@ async def test_ros_hook_structure_error_preserves_actionable_detail(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_ros_association_property_error_blocks_before_credentials_endpoint_and_transport(
+    tmp_path: Path,
+) -> None:
+    services, _, endpoint_resolver, transport = _production_services()
+    credential_calls: list[None] = []
+    services.credential_provider = lambda: credential_calls.append(None)
+    tool = AliyunApi(services=services)
+    template = tmp_path / "association-property.yml"
+    template.write_text(
+        "ROSTemplateFormatVersion: '2015-09-01'\n"
+        "Parameters:\n"
+        "  PasswordSuffix:\n"
+        "    Type: String\n"
+        "    AssociationProperty: AutoCompleteInput\n"
+        "    AssociationPropertyMetadata:\n"
+        "      Length: 8\n"
+        "      CharacterClasses:\n"
+        "        - Class: digit\n"
+        "          Min: 1\n"
+        "Resources: {}\n",
+        encoding="utf-8",
+    )
+
+    result = await _production_execute(
+        tool,
+        {
+            "product": "ros",
+            "action": "ValidateTemplate",
+            "params": {"TemplateURL": str(template)},
+            "region_id": "cn-hangzhou",
+        },
+        cwd=str(tmp_path),
+    )
+
+    assert result.is_error is True
+    assert "ROS1305" in result.content
+    assert "CharacterClasses[0].Class" in result.content
+    assert "Use number instead" in result.content
+    assert result.metadata["ros_validation"]["counts_by_code"] == {"ROS1305": 1}
+    assert credential_calls == []
+    assert endpoint_resolver.calls == []
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
 async def test_openmeta_preserves_hook_error_result(monkeypatch) -> None:
     services, _, _, transport = _production_services()
     hook_detail = "actionable hook detail"

--- a/tests/tools/cloud/aliyun/test_ros_association_property_specs.py
+++ b/tests/tools/cloud/aliyun/test_ros_association_property_specs.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from types import MappingProxyType
+
+import pytest
+
+from iac_code.tools.cloud.aliyun.ros_validation.association_property_specs import (
+    CONTRACT_CORRECTIONS,
+    apply_contract_corrections,
+    contract_content_hash,
+    load_association_property_specs,
+    load_contract_text,
+    parse_contract_text,
+    registry_from_payload,
+    verify_contract_payload,
+)
+from scripts.aliyun.sync_ros_association_property_specs import _metadata_fields
+
+
+def _payload() -> dict:
+    path = files("iac_code.tools.cloud.aliyun.ros_validation").joinpath("data/ros_association_property_specs.json")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _rehash(payload: dict) -> None:
+    payload["content_sha256"] = contract_content_hash(payload)
+
+
+def test_canonical_contract_hash_matches_language_neutral_number_and_utf16_vectors() -> None:
+    payload = {
+        "content_sha256": "ignored",
+        "numbers": [1e-7, 1e21, -0.0],
+        "keys": {"\ufffd": "bmp", "\U00010000": "astral"},
+    }
+
+    assert contract_content_hash(payload) == "afa9b95335995e6ccee74aefe3918c4bbb3e6b4d6a192b4754f59c3e88e54ea4"
+
+
+def test_vendored_contract_corrections_and_freezing() -> None:
+    registry = load_association_property_specs()
+
+    assert registry.contract_version == 3
+    assert registry.product == "ROS"
+    assert registry.corrections == tuple(MappingProxyType(item) for item in CONTRACT_CORRECTIONS)
+    assert len(registry.association_properties) == 296
+    assert sum(spec.deprecated for spec in registry.association_properties.values()) == 10
+    assert len(registry.excluded_association_properties) == 10
+    assert len(registry.components) == 276
+    assert registry.component("AutoCompleteInput").coverage == "complete"
+    assert registry.association("AutoCompleteInput").component == "AutoCompleteInput"
+    assert registry.excluded("ALIYUN::OOS::Component::ActionChoice").scope == "OOS-only"
+    assert registry.profile["read_only_selection"]["exact_association_properties"] == (
+        "TemplateParameter",
+        "Targets",
+    )
+    assert isinstance(registry.profile, MappingProxyType)
+    with pytest.raises(TypeError):
+        registry.profile["id"] = "changed"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda item: item.__setitem__("contract_version", 4),
+        lambda item: item.__setitem__("product", "OOS"),
+        lambda item: item["corrections"][0].__setitem__("reason", "changed"),
+        lambda item: item["profile"].__setitem__("id", "changed"),
+        lambda item: item["common_metadata"].__setitem__("coverage", "complete"),
+        lambda item: item["consumer_sets"]["auto_complete_generation"].__setitem__("resolution", "consistent"),
+        lambda item: item["association_properties"]["AutoCompleteInput"].__setitem__("deprecated", True),
+        lambda item: item["components"]["AutoCompleteInput"].__setitem__("coverage", "partial"),
+        lambda item: item["excluded_association_properties"]["Default"].__setitem__("scope", "OOS-only"),
+    ],
+)
+def test_hash_protects_every_contract_region(mutate) -> None:
+    payload = _payload()
+    mutate(payload)
+
+    with pytest.raises(RuntimeError):
+        registry_from_payload(payload)
+
+
+def test_vendored_contract_contains_only_supported_public_fields() -> None:
+    payload = _payload()
+
+    assert set(payload) == {
+        "association_properties",
+        "common_metadata",
+        "components",
+        "consumer_sets",
+        "content_sha256",
+        "contract_version",
+        "corrections",
+        "excluded_association_properties",
+        "product",
+        "profile",
+    }
+    assert all(
+        set(spec) <= {"component", "deprecated", "replacement", "scope"}
+        for spec in payload["association_properties"].values()
+    )
+    assert all(set(spec) <= {"scope"} for spec in payload["excluded_association_properties"].values())
+    assert all(
+        set(spec) <= {"coverage", "metadata", "semantic_rules"} for spec in payload["components"].values()
+    )
+
+
+def test_contract_corrections_are_idempotent_and_sanitizing() -> None:
+    payload = _payload()
+    payload["unsupported_top_level"] = {"detail": "discarded"}
+    payload["association_properties"]["AutoCompleteInput"]["unsupported_detail"] = "discarded"
+    payload["excluded_association_properties"]["Default"].update(
+        {
+            "component": "DiscardedComponent",
+            "unsupported_detail": "discarded",
+        }
+    )
+    payload["components"]["AutoCompleteInput"]["unsupported_detail"] = "discarded"
+
+    corrected = apply_contract_corrections(payload)
+
+    assert "unsupported_top_level" not in corrected
+    assert "unsupported_detail" not in corrected["association_properties"]["AutoCompleteInput"]
+    assert corrected["excluded_association_properties"]["Default"] == {"scope": "unavailable-stock"}
+    assert set(corrected["components"]["AutoCompleteInput"]) == {"coverage", "metadata", "semantic_rules"}
+    assert corrected["corrections"] == list(CONTRACT_CORRECTIONS)
+    assert (
+        corrected["common_metadata"]["schema"]["properties"]["ValueLabelMapping"]["additionalProperties"]["anyOf"][1][
+            "type"
+        ]
+        == "object"
+    )
+    assert corrected["components"]["BailianApiKey"]["metadata"]["properties"]["OnlyKey"]["type"] == "boolean"
+    verify_contract_payload(corrected)
+
+
+def test_loader_rejects_duplicate_json_keys_and_unsupported_schema() -> None:
+    with pytest.raises(RuntimeError, match="duplicate key"):
+        parse_contract_text('{"contract_version": 1, "contract_version": 1}')
+
+    payload = _payload()
+    payload["components"]["AutoCompleteInput"]["metadata"]["properties"]["Length"]["type"] = "float"
+    _rehash(payload)
+    with pytest.raises(RuntimeError, match="unsupported type"):
+        registry_from_payload(payload)
+
+
+def test_loader_rejects_unknown_consumer_set_and_semantic_rule() -> None:
+    payload = _payload()
+    payload["components"]["AutoCompleteInput"]["metadata"]["properties"]["Length"]["x-ore-consumer-set"] = "missing"
+    _rehash(payload)
+    with pytest.raises(RuntimeError, match="unknown consumer set"):
+        registry_from_payload(payload)
+
+    payload = _payload()
+    payload["components"]["AutoCompleteInput"]["semantic_rules"].append("unknown")
+    _rehash(payload)
+    with pytest.raises(RuntimeError, match="unknown semantic rule"):
+        registry_from_payload(payload)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda item: item.__setitem__("unsupported_top_level", {"count": 1}),
+        lambda item: item["association_properties"]["AutoCompleteInput"].__setitem__(
+            "unsupported_detail", "discarded"
+        ),
+        lambda item: item["components"]["AutoCompleteInput"].__setitem__(
+            "unsupported_detail", "discarded"
+        ),
+        lambda item: item["excluded_association_properties"]["Default"].__setitem__(
+            "unsupported_detail", "discarded"
+        ),
+    ],
+)
+def test_loader_rejects_fields_outside_public_contract(mutate) -> None:
+    payload = _payload()
+    mutate(payload)
+    _rehash(payload)
+
+    with pytest.raises(RuntimeError):
+        registry_from_payload(payload)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda item: item["consumer_sets"]["auto_complete_generation"]["consumers"][1].__setitem__(
+                "parser", "arbitrary-code"
+            ),
+            "invalid consumer",
+        ),
+        (
+            lambda item: item["consumer_sets"]["auto_complete_generation"]["consumers"][1].__setitem__(
+                "id", "template-default-initializer"
+            ),
+            "invalid consumer",
+        ),
+        (
+            lambda item: item["consumer_sets"]["auto_complete_generation"]["value_flow"].__setitem__(
+                "host_merge", "guess"
+            ),
+            "invalid value_flow",
+        ),
+        (
+            lambda item: item["components"]["HologresInstanceId"]["metadata"]["properties"][
+                "cmsInstanceType"
+            ].__setitem__("x-ore-precedence", ["cmsInstanceType"]),
+            "requires matching precedence",
+        ),
+    ],
+)
+def test_loader_rejects_invalid_consumers_entries_and_alias_precedence(mutate, message: str) -> None:
+    payload = _payload()
+    mutate(payload)
+    _rehash(payload)
+
+    with pytest.raises(RuntimeError, match=message):
+        registry_from_payload(payload)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda item: item["components"]["AutoCompleteInput"]["metadata"]["properties"]["CharacterClasses"]["items"][
+                "properties"
+            ]["Min"].__setitem__("minimum", "bad"),
+            "minimum is invalid",
+        ),
+        (
+            lambda item: item["components"]["AutoCompleteInput"]["metadata"]["properties"]["Prefix"].__setitem__(
+                "minLength", -1
+            ),
+            "minLength is invalid",
+        ),
+        (
+            lambda item: item["components"]["Json"]["metadata"]["properties"]["Parameters"].__setitem__(
+                "x-ore-nested-parameter", "yes"
+            ),
+            "x-ore-nested-parameter is invalid",
+        ),
+        (
+            lambda item: item["components"]["AutoCompleteInput"]["metadata"]["properties"]["CharacterClasses"]["items"][
+                "properties"
+            ]["Class"].__setitem__("x-ore-value-suggestions", ["bad"]),
+            "x-ore-value-suggestions",
+        ),
+        (
+            lambda item: item["components"]["AutoCompleteInput"]["metadata"]["properties"]["Length"].__setitem__(
+                "x-ore-consumer-set", ""
+            ),
+            "x-ore-consumer-set is invalid",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"]["properties"]["DynamicValue"].__setitem__(
+                "x-ore-injected-symbols", []
+            ),
+            "x-ore-injected-symbols is invalid",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"]["properties"]["MappingMetadata"]["properties"][
+                "ValueSelector"
+            ].__setitem__("x-ore-unresolved-reference", "error"),
+            "x-ore-unresolved-reference is invalid",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"].__setitem__("patternProperties", {"[": {}}),
+            "invalid pattern",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"]["properties"]["MappingMetadata"].__setitem__(
+                "required", [""]
+            ),
+            "required is invalid",
+        ),
+        (
+            lambda item: item["components"]["AutoCompleteInput"]["metadata"]["properties"]["Prefix"].__setitem__(
+                "const", 1
+            ),
+            "const does not match type",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"].__setitem__("additionalProperties", "yes"),
+            "must be an object",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"]["properties"]["AutoSelectFirst"].__setitem__(
+                "enum", ["true"]
+            ),
+            "enum does not match type",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"]["properties"]["LocaleKey"].update({"enum": [False]}),
+            "enum does not match type",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"]["properties"]["ExclusiveTo"].__setitem__("enum", [{}]),
+            "enum does not match type",
+        ),
+        (
+            lambda item: item["common_metadata"]["schema"]["properties"]["ValueLabelMapping"].__setitem__("enum", [[]]),
+            "enum does not match type",
+        ),
+    ],
+)
+def test_loader_rejects_semantically_invalid_supported_schema_keywords(mutate, message: str) -> None:
+    payload = _payload()
+    mutate(payload)
+    _rehash(payload)
+
+    with pytest.raises(RuntimeError, match=message):
+        registry_from_payload(payload)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda item: item["consumer_sets"]["auto_complete_generation"]["consumers"][0].__setitem__(
+            "id", "another-initializer"
+        ),
+        lambda item: item["consumer_sets"]["auto_complete_generation"]["consumers"][1].__setitem__(
+            "parser", "lodash-template-interpolation"
+        ),
+        lambda item: item["components"]["AutoCompleteInput"].__setitem__("semantic_rules", []),
+        lambda item: item["components"]["String"].__setitem__("semantic_rules", ["auto_complete_character_capacity"]),
+    ],
+)
+def test_loader_rejects_supported_but_source_inconsistent_consumers_and_semantic_rules(mutate) -> None:
+    payload = _payload()
+    mutate(payload)
+    _rehash(payload)
+
+    with pytest.raises(RuntimeError, match="AutoCompleteInput"):
+        registry_from_payload(payload)
+
+
+def test_serialized_contract_round_trips_without_mutation() -> None:
+    payload = _payload()
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    loaded = load_contract_text(text)
+
+    assert loaded.raw_contract["content_sha256"] == payload["content_sha256"]
+    assert loaded.profile["id"] == "stock-ros-parameter-form"
+
+
+def test_sync_summary_inventory_includes_common_and_deep_metadata_paths() -> None:
+    fields = _metadata_fields(_payload())
+
+    assert "common.DynamicValue" in fields
+    assert "MetaList.ListMetadata.Order" in fields
+    assert "Json.Parameters.*" in fields
+    assert "AutoCompleteInput.CharacterClasses[].Class" in fields

--- a/tests/tools/cloud/aliyun/test_ros_association_property_validation.py
+++ b/tests/tools/cloud/aliyun/test_ros_association_property_validation.py
@@ -1,0 +1,2887 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from types import MappingProxyType
+
+import pytest
+
+from iac_code.tools.cloud.aliyun.ros_validation.association_property_specs import (
+    load_association_property_specs,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.model import (
+    MaterializedTemplateSource,
+    RequestValidationContext,
+    Severity,
+    SourceMap,
+    display_path,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.rules import association_property as association_property_rule
+from iac_code.tools.cloud.aliyun.ros_validation.rules.association_property import (
+    ABSENT_RUNTIME_VALUE,
+    UNKNOWN_RUNTIME_VALUE,
+    ConsumerReachability,
+    evaluate_auto_complete_reachability,
+    frontend_string_to_boolean,
+    is_frontend_ref_value,
+    js_truthy,
+    normalize_association_property,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.symbols import TemplateSymbols
+from iac_code.tools.cloud.aliyun.ros_validation.validator import validate_ros_template
+
+
+def _validate(parameter: dict, *, extra_parameters: dict | None = None, template_metadata: dict | None = None):
+    parameters = {"Target": parameter, **(extra_parameters or {})}
+    template = {
+        "ROSTemplateFormatVersion": "2015-09-01",
+        "Parameters": parameters,
+        "Resources": {},
+    }
+    if template_metadata is not None:
+        template["Metadata"] = template_metadata
+    return validate_ros_template(
+        MaterializedTemplateSource(json.dumps(template, ensure_ascii=False), origin="test-template"),
+        RequestValidationContext(action="ValidateTemplate"),
+    )
+
+
+def _validate_yaml(template: str):
+    return validate_ros_template(
+        MaterializedTemplateSource(template, origin="test-template"),
+        RequestValidationContext(action="ValidateTemplate"),
+    )
+
+
+def _association_diagnostics(report):
+    return [item for item in report.diagnostics if item.code.startswith(("ROS13", "ROS53"))]
+
+
+def _codes(report):
+    return [item.code for item in _association_diagnostics(report)]
+
+
+def _resolve_components(parameter: dict, association: str | None = None):
+    state = object.__new__(association_property_rule._ValidationState)
+    state.specs = load_association_property_specs()
+    return state._resolve_components(parameter, association)
+
+
+def test_javascript_compatibility_helpers_match_frontend_boundaries() -> None:
+    assert js_truthy([])
+    assert js_truthy({})
+    assert js_truthy("false")
+    assert not js_truthy("")
+    assert not js_truthy(0)
+    assert frontend_string_to_boolean(True)
+    assert frontend_string_to_boolean("TRUE")
+    assert not frontend_string_to_boolean(1)
+    assert not frontend_string_to_boolean("1")
+    assert normalize_association_property("APSARA::ECS::RegionId") == "ALIYUN::ECS::RegionId"
+    assert is_frontend_ref_value({"Ref": "P"})
+    assert is_frontend_ref_value({"Fn::GetAtt": ["R", "A"]})
+    assert is_frontend_ref_value([{"Ref": "P"}])
+    assert not is_frontend_ref_value([])
+    assert not is_frontend_ref_value({"Ref": "P", "Other": True})
+    assert association_property_rule._js_property_key(True) == "true"
+    assert association_property_rule._js_property_key(None) == "null"
+    assert association_property_rule._js_property_key(-0.0) == "0"
+    assert association_property_rule._js_property_key(1.0) == "1"
+    assert association_property_rule._js_property_key(1e20) == "100000000000000000000"
+    assert association_property_rule._js_property_key(1e21) == "1e+21"
+    assert association_property_rule._js_property_key(9007199254740993) == "9007199254740992"
+
+
+def test_any_of_branch_matching_applies_every_supported_value_constraint() -> None:
+    state = object.__new__(association_property_rule._ValidationState)
+
+    assert not state._matches_schema("abc", {"type": "string", "minLength": 5})
+    assert state._matches_schema("abc", {"type": "string", "minLength": 1})
+    assert not state._matches_schema(3, {"type": "number", "minimum": 5})
+    assert state._matches_schema(3, {"type": "number", "minimum": 1})
+    assert not state._matches_schema(
+        {"key": "x"},
+        {"type": "object", "additionalProperties": {"type": "number"}},
+    )
+
+
+def test_any_of_discards_failed_parser_diagnostics_when_a_literal_branch_accepts() -> None:
+    state = association_property_rule._ValidationState(
+        {"Parameters": {}},
+        SourceMap({}, ()),
+        TemplateSymbols({}, {}, {}, frozenset(), {}, {}),
+        load_association_property_specs(),
+    )
+    state._validate_schema(
+        "${Missing}",
+        {
+            "anyOf": [
+                {
+                    "type": "boolean",
+                    "x-ore-parser": "whole-value-reference",
+                    "x-ore-reference-context": "template-root",
+                    "x-ore-reference-kinds": ["parameter"],
+                },
+                {"type": "string"},
+            ]
+        },
+        (),
+        parameter={},
+        reference_context="template-root",
+        reference_parameters={},
+        reference_declaration_path=(),
+        auto_reachability=None,
+        depth=0,
+    )
+
+    assert state.diagnostics == []
+
+
+def test_stock_component_selection_matches_frontend_precedence_and_javascript_truthiness() -> None:
+    supported = _resolve_components(
+        {"Type": "String", "NoEcho": True, "AllowedValues": ["a"]},
+        "AutoCompleteInput",
+    )
+    assert supported.initial_component == "AutoCompleteInput"
+    assert supported.possible_components == ("AutoCompleteInput",)
+    assert supported.deterministic
+
+    assert _resolve_components({"Type": "String", "NoEcho": True}).initial_component == "Password"
+    assert _resolve_components({"Type": "String", "NoEcho": "1"}).initial_component == "String"
+    assert _resolve_components({"Type": "String", "AllowedValues": []}).initial_component == "List"
+    assert _resolve_components({"Type": "String", "AllowedValues": {}}).initial_component == "List"
+    assert _resolve_components({"TextArea": "false"}).initial_component == "TextArea"
+    assert _resolve_components({}).initial_component == "Input"
+
+    boolean_list = _resolve_components({"Type": "Boolean", "AllowedValues": []})
+    assert boolean_list.initial_component == "Boolean"
+    assert boolean_list.possible_components == ("List",)
+
+
+def test_component_semantic_dispatch_is_driven_by_the_vendored_component_rules() -> None:
+    registry = load_association_property_specs()
+    resolution = _resolve_components({"Type": "String"}, "AutoCompleteInput")
+    state = object.__new__(association_property_rule._ValidationState)
+    state.specs = registry
+    assert state._shared_semantic_rules(resolution) == {"auto_complete_character_capacity"}
+
+    auto_complete = registry.component("AutoCompleteInput")
+    assert auto_complete is not None
+    components = dict(registry.components)
+    components["AutoCompleteInput"] = replace(auto_complete, semantic_rules=())
+    state.specs = replace(registry, components=MappingProxyType(components))
+    assert state._shared_semantic_rules(resolution) == set()
+
+
+def test_read_only_and_dynamic_allowed_values_expand_possible_components_without_guessing_host_inputs() -> None:
+    association = "ALIYUN::ECS::Instance::InstanceType"
+    normal = _resolve_components({"Type": "String"}, association)
+    assert normal.initial_component == "ECSInstanceType"
+    assert normal.possible_components == ("ECSInstanceType", "ReadOnlyItem")
+    assert not normal.deterministic
+
+    condition = _resolve_components(
+        {"Type": "String", "AssociationPropertyMetadata": {"ReadOnly": {"Condition": "Conditions.Locked"}}},
+        association,
+    )
+    assert condition.possible_components == ("ECSInstanceType", "ReadOnlyItem")
+    assert not condition.deterministic
+
+    forced = _resolve_components({"Type": "String", "ReadOnly": True}, association)
+    assert forced.possible_components == ("ReadOnlyItem",)
+    assert forced.deterministic
+
+    unknown = _resolve_components({"Type": "String"}, "ALIYUN::Future::InstanceType")
+    assert unknown.initial_component == "String"
+    assert unknown.possible_components == ("String", "ReadOnlyItem", "List")
+    assert not unknown.deterministic
+
+    static_list = _resolve_components(
+        {"Type": "String", "ReadOnly": True, "AllowedValues": ["a"]},
+        "ALIYUN::Future::InstanceType",
+    )
+    assert static_list.initial_component == "List"
+    assert static_list.possible_components == ("List",)
+    assert static_list.deterministic
+
+
+def _reachability(parameter: dict, **overrides):
+    runtime = {
+        "host_initial_value": ABSENT_RUNTIME_VALUE,
+        "existing_form_value": ABSENT_RUNTIME_VALUE,
+        "static_parameter_value": ABSENT_RUNTIME_VALUE,
+        "initial_parameter_value": ABSENT_RUNTIME_VALUE,
+        "value_effect": ABSENT_RUNTIME_VALUE,
+        "dynamic_value_effect": ABSENT_RUNTIME_VALUE,
+    }
+    runtime.update(overrides)
+    return evaluate_auto_complete_reachability(parameter, **runtime)
+
+
+def test_auto_complete_reachability_defaults_to_unknown_without_host_context() -> None:
+    reachability = evaluate_auto_complete_reachability({"Type": "String", "AssociationProperty": "AutoCompleteInput"})
+
+    assert reachability.base_default == "unknown"
+    assert reachability.effective_default == "unknown"
+    assert reachability.raw_initializer == ConsumerReachability.UNKNOWN
+    assert reachability.component_effect == ConsumerReachability.UNKNOWN
+
+
+def test_auto_complete_reachability_uses_nullish_host_default_and_ref_gate() -> None:
+    from_default = _reachability(
+        {"Type": "String", "Default": "template-default"},
+        host_initial_value=None,
+    )
+    assert from_default.base_default == "truthy"
+    assert from_default.raw_initializer == ConsumerReachability.NOT_REACHED
+    assert from_default.component_effect == ConsumerReachability.NOT_REACHED
+
+    host_wins = _reachability(
+        {"Type": "String", "Default": "template-default"},
+        host_initial_value="",
+    )
+    assert host_wins.base_default == "falsy"
+    assert host_wins.raw_initializer == ConsumerReachability.NOT_REACHED
+    assert host_wins.component_effect == ConsumerReachability.REACHED
+
+    for default in ({"Ref": "P"}, {"Fn::GetAtt": ["R", "A"]}, [{"Ref": "P"}]):
+        referenced = _reachability({"Type": "String", "Default": default})
+        assert referenced.raw_initializer == ConsumerReachability.NOT_REACHED
+        assert referenced.component_effect == ConsumerReachability.NOT_REACHED
+
+
+def test_auto_complete_reachability_matches_type_and_password_branch_precedence() -> None:
+    password = _reachability({"Type": "String", "Default": "secret", "NoEcho": True})
+    assert password.effective_default == "undefined"
+    assert password.raw_initializer == ConsumerReachability.REACHED
+    assert password.component_effect == ConsumerReachability.NOT_REACHED
+
+    no_echo_one = _reachability({"Type": "String", "Default": "secret", "NoEcho": "1"})
+    assert no_echo_one.raw_initializer == ConsumerReachability.NOT_REACHED
+
+    number = _reachability({"Type": "Number", "Default": "1", "NoEcho": True})
+    assert number.effective_default == "truthy"
+    assert number.raw_initializer == ConsumerReachability.NOT_REACHED
+
+    invalid_boolean = _reachability({"Type": "Boolean", "Default": "not-a-boolean"})
+    assert invalid_boolean.effective_default == "undefined"
+    assert invalid_boolean.raw_initializer == ConsumerReachability.REACHED
+
+    json_null = _reachability({"Type": "Json", "Default": "null"})
+    assert json_null.effective_default == "falsy"
+    assert json_null.raw_initializer == ConsumerReachability.NOT_REACHED
+    assert json_null.component_effect == ConsumerReachability.REACHED
+
+    hexadecimal_number = _reachability({"Type": "Number", "Default": "0x10"})
+    assert hexadecimal_number.effective_default == "truthy"
+    assert hexadecimal_number.component_effect == ConsumerReachability.NOT_REACHED
+
+    for non_javascript_number in ("1_000", "inf", "infinity", "+0x10"):
+        invalid_number = _reachability({"Type": "Number", "Default": non_javascript_number})
+        assert invalid_number.effective_default == "falsy"
+        assert invalid_number.component_effect == ConsumerReachability.REACHED
+
+    javascript_infinity = _reachability({"Type": "Number", "Default": "Infinity"})
+    assert javascript_infinity.effective_default == "truthy"
+    assert javascript_infinity.component_effect == ConsumerReachability.NOT_REACHED
+
+    strict_json_nan = _reachability({"Type": "Json", "Default": "NaN"})
+    assert strict_json_nan.effective_default == "truthy"
+    assert strict_json_nan.component_effect == ConsumerReachability.NOT_REACHED
+
+
+def test_auto_complete_raw_initializer_truthiness_and_slice_conversion() -> None:
+    unresolved_length = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Length": "${P}"},
+        }
+    )
+    assert unresolved_length.raw_initializer == ConsumerReachability.REACHED
+    assert unresolved_length.current_value == "falsy"
+    assert unresolved_length.component_effect == ConsumerReachability.REACHED
+
+    numeric_string_length = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Length": "3",
+                "CharacterClasses": [{"Class": "number", "Min": 1}],
+            },
+        }
+    )
+    assert numeric_string_length.current_value == "truthy"
+    assert numeric_string_length.component_effect == ConsumerReachability.NOT_REACHED
+
+    for metadata in ({"Prefix": "pre"}, {"Suffix": "post"}):
+        with_affix = _reachability({"Type": "String", "AssociationPropertyMetadata": metadata})
+        assert with_affix.raw_initializer == ConsumerReachability.REACHED
+        assert with_affix.component_effect == ConsumerReachability.NOT_REACHED
+
+    negative_slice = _reachability({"Type": "String", "AssociationPropertyMetadata": {"Length": -1}})
+    assert negative_slice.current_value == "truthy"
+    assert negative_slice.component_effect == ConsumerReachability.NOT_REACHED
+
+    runtime_length_dependent_slice = _reachability({"Type": "String", "AssociationPropertyMetadata": {"Length": -999}})
+    assert runtime_length_dependent_slice.current_value == "unknown"
+    assert runtime_length_dependent_slice.component_effect == ConsumerReachability.UNKNOWN
+
+    exhausted_special_pool = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Length": 1,
+                "CharacterClasses": [{"Class": "specialCharacter", "Min": 1, "SpecialCharacters": "!", "Start": False}],
+            },
+        }
+    )
+    assert exhausted_special_pool.current_value == "falsy"
+    assert exhausted_special_pool.component_effect == ConsumerReachability.REACHED
+
+    end_excludes_single_position = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Length": 1,
+                "CharacterClasses": [{"Class": "specialCharacter", "Min": 0, "SpecialCharacters": "!", "End": False}],
+            },
+        }
+    )
+    assert end_excludes_single_position.current_value == "falsy"
+    assert end_excludes_single_position.component_effect == ConsumerReachability.REACHED
+
+    start_empties_persistent_pure_special_pool = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Length": 2,
+                "CharacterClasses": [{"Class": "specialCharacter", "Min": 0, "SpecialCharacters": "!", "Start": False}],
+            },
+        }
+    )
+    assert start_empties_persistent_pure_special_pool.current_value == "falsy"
+    assert start_empties_persistent_pure_special_pool.component_effect == ConsumerReachability.REACHED
+
+    missing_min_does_not_prefill_pure_special_pool = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Length": 2,
+                "CharacterClasses": [{"Class": "specialCharacter", "SpecialCharacters": "!", "Start": False}],
+            },
+        }
+    )
+    assert missing_min_does_not_prefill_pure_special_pool.current_value == "falsy"
+    assert missing_min_does_not_prefill_pure_special_pool.component_effect == ConsumerReachability.REACHED
+
+    end_only_removes_last_position = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Length": 2,
+                "CharacterClasses": [{"Class": "specialCharacter", "Min": 0, "SpecialCharacters": "!", "End": False}],
+            },
+        }
+    )
+    assert end_only_removes_last_position.current_value == "truthy"
+    assert end_only_removes_last_position.component_effect == ConsumerReachability.NOT_REACHED
+
+
+def test_auto_complete_host_merge_and_metadata_effects_control_component_guard() -> None:
+    parameter = {"Type": "String"}
+    generated_overrides_existing = _reachability(
+        parameter,
+        existing_form_value="existing",
+    )
+    assert generated_overrides_existing.current_value == "truthy"
+
+    static_clears_generated = _reachability(
+        parameter,
+        static_parameter_value="",
+    )
+    assert static_clears_generated.component_effect == ConsumerReachability.REACHED
+
+    initial_wins_last = _reachability(
+        parameter,
+        static_parameter_value="",
+        initial_parameter_value="initial",
+    )
+    assert initial_wins_last.component_effect == ConsumerReachability.NOT_REACHED
+
+    dynamic_clears = _reachability(
+        {"Type": "String", "AssociationPropertyMetadata": {"DynamicValue": "${P}"}},
+        dynamic_value_effect="",
+    )
+    assert dynamic_clears.component_effect == ConsumerReachability.REACHED
+
+    unknown_dynamic = _reachability(
+        {"Type": "String", "AssociationPropertyMetadata": {"DynamicValue": "${P}"}},
+        dynamic_value_effect=UNKNOWN_RUNTIME_VALUE,
+    )
+    assert unknown_dynamic.component_effect == ConsumerReachability.UNKNOWN
+
+    value_wins_after_dynamic = _reachability(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"DynamicValue": "${P}", "Value": []},
+        },
+        dynamic_value_effect="",
+        value_effect="value-effect",
+    )
+    assert value_wins_after_dynamic.component_effect == ConsumerReachability.NOT_REACHED
+
+
+@pytest.mark.parametrize("value", [None, "", 1, [], {}])
+def test_association_property_must_be_a_non_empty_string(value) -> None:
+    report = _validate({"Type": "String", "AssociationProperty": value})
+
+    diagnostic = next(item for item in report.diagnostics if item.code == "ROS1301")
+    assert diagnostic.severity == Severity.ERROR
+    assert display_path(diagnostic.path) == "$.Parameters.Target.AssociationProperty"
+
+
+def test_known_unknown_excluded_apsara_and_deprecated_association_properties() -> None:
+    valid = _validate({"Type": "String", "AssociationProperty": "AutoCompleteInput"})
+    assert not _association_diagnostics(valid)
+
+    apsara = _validate({"Type": "String", "AssociationProperty": "APSARA::ECS::RegionId"})
+    assert "ROS5303" not in _codes(apsara)
+
+    unknown = _validate({"Type": "String", "AssociationProperty": "ALIYUN::Future::Selector"})
+    assert _codes(unknown) == ["ROS5303"]
+    unknown_diagnostic = next(item for item in unknown.diagnostics if item.code == "ROS5303")
+    assert "ALIYUN::Future::Selector" in unknown_diagnostic.summary
+    assert "does not mark the value invalid" in unknown_diagnostic.detail
+
+    excluded = _validate({"Type": "String", "AssociationProperty": "ALIYUN::OOS::Component::ActionChoice"})
+    assert _codes(excluded) == ["ROS1302"]
+    excluded_diagnostic = next(item for item in excluded.diagnostics if item.code == "ROS1302")
+    assert excluded_diagnostic.detail == (
+        "This AssociationProperty value is available only in the OOS parameter form."
+    )
+
+    for allowed_values in ([], ["a"], {}):
+        bypassed = _validate(
+            {
+                "Type": "String",
+                "AssociationProperty": "ALIYUN::OOS::Component::ActionChoice",
+                "AllowedValues": allowed_values,
+            }
+        )
+        assert "ROS1302" not in _codes(bypassed)
+        bypassed_diagnostic = next(
+            item
+            for item in bypassed.diagnostics
+            if item.code == "ROS5302" and item.subject == "ALIYUN::OOS::Component::ActionChoice"
+        )
+        assert bypassed_diagnostic.detail == (
+            "No resolved form branch selects the unavailable AssociationProperty value."
+        )
+
+    read_only_oos = _validate({"Type": "String", "AssociationProperty": "TemplateParameter", "ReadOnly": True})
+    assert "ROS1302" not in _codes(read_only_oos)
+    assert "ROS5302" in _codes(read_only_oos)
+
+    runtime_read_only_oos = _validate({"Type": "String", "AssociationProperty": "TemplateParameter"})
+    assert "ROS1302" not in _codes(runtime_read_only_oos)
+    assert "ROS5305" in _codes(runtime_read_only_oos)
+    runtime_read_only_diagnostic = next(item for item in runtime_read_only_oos.diagnostics if item.code == "ROS5305")
+    assert runtime_read_only_diagnostic.detail == (
+        "The editable form path does not support this value, while the read-only path may bypass it."
+    )
+
+    deprecated = _validate({"Type": "String", "AssociationProperty": "ALIYUN::ECS::Instance"})
+    assert _codes(deprecated) == ["ROS5301"]
+    deprecated_diagnostic = next(item for item in deprecated.diagnostics if item.code == "ROS5301")
+    assert "ALIYUN::ECS::Instance" in deprecated_diagnostic.summary
+    assert "does not block the template" in deprecated_diagnostic.detail
+
+
+def test_runtime_dependent_component_and_reference_limitations_explain_the_uncertainty() -> None:
+    component_dependent = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::ECS::Instance::InstanceType",
+            "AssociationPropertyMetadata": {"ZoneId": "${ZoneId}"},
+        },
+        extra_parameters={"ZoneId": {"Type": "String"}},
+    )
+    field_diagnostic = next(
+        item for item in component_dependent.diagnostics if item.code == "ROS5305" and item.subject == "ZoneId"
+    )
+    assert "field ZoneId" in field_diagnostic.summary
+    assert "used by some possible form components and ignored by others" in field_diagnostic.summary
+    assert "runtime component cannot be determined locally" in field_diagnostic.detail
+    assert field_diagnostic.suggestion and "Do not change the template" in field_diagnostic.suggestion
+
+    reference_scope = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::ECS::VSwitch::VSwitchId",
+            "AssociationPropertyMetadata": {"VpcId": "${VpcId}"},
+        },
+        extra_parameters={"VpcId": {"Type": "String"}},
+    )
+    reference_diagnostic = next(
+        item for item in reference_scope.diagnostics if item.code == "ROS5305" and item.subject == "VpcId"
+    )
+    assert "reference VpcId" in reference_diagnostic.summary
+    assert "template Parameters or component-local data" in reference_diagnostic.detail
+    assert "leaves the reference unchecked" in reference_diagnostic.detail
+    assert reference_diagnostic.suggestion and "Do not change the template" in reference_diagnostic.suggestion
+
+
+def test_metadata_is_valid_without_association_property_and_must_be_a_mapping() -> None:
+    valid = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": {"Fn::Equals": [1, 1]}}},
+        }
+    )
+    assert "ROS1303" not in _codes(valid)
+
+    invalid = _validate({"Type": "String", "AssociationPropertyMetadata": []})
+    diagnostic = next(item for item in invalid.diagnostics if item.code == "ROS1303")
+    assert display_path(diagnostic.path) == "$.Parameters.Target.AssociationPropertyMetadata"
+
+
+def test_fallback_component_metadata_is_validated_without_association_property() -> None:
+    valid = _validate({"Type": "String", "AssociationPropertyMetadata": {"EnableEmptyString": True}})
+    assert "ROS1305" not in _codes(valid)
+
+    invalid = _validate({"Type": "String", "AssociationPropertyMetadata": {"EnableEmptyString": "true"}})
+    assert "ROS1305" not in _codes(invalid)
+    assert any(item.code == "ROS5305" and item.subject == "EnableEmptyString" for item in invalid.diagnostics)
+
+    boolean_post_list = _validate(
+        {
+            "Type": "Boolean",
+            "AllowedValues": [],
+            "AssociationPropertyMetadata": {"ForceRadio": True},
+        }
+    )
+    assert "ROS1305" not in _codes(boolean_post_list)
+
+
+def test_unknown_metadata_key_is_warning_while_common_contract_is_partial() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"FutureField": 1},
+        }
+    )
+
+    diagnostic = next(item for item in report.diagnostics if item.code == "ROS5304")
+    assert diagnostic.severity == Severity.LIMITATION
+    assert display_path(diagnostic.path).endswith("AssociationPropertyMetadata.FutureField")
+
+
+def test_unknown_metadata_key_is_blocking_only_when_common_and_component_contracts_are_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = load_association_property_specs()
+    closed_common = dict(registry.common_metadata)
+    closed_common["additionalProperties"] = False
+    closed_registry = replace(
+        registry,
+        common_coverage="complete",
+        common_metadata=MappingProxyType(closed_common),
+    )
+    monkeypatch.setattr(
+        association_property_rule,
+        "load_association_property_specs",
+        lambda: closed_registry,
+    )
+
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"FutureField": 1},
+        }
+    )
+
+    diagnostic = next(item for item in report.diagnostics if item.code == "ROS1304")
+    assert diagnostic.severity == Severity.ERROR
+
+
+def test_auto_complete_digit_is_one_precise_blocking_enum_error() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 8,
+                "CharacterClasses": [{"Class": "digit", "Min": 1}],
+            },
+        }
+    )
+
+    diagnostics = [item for item in report.diagnostics if item.code == "ROS1305"]
+    assert len(diagnostics) == 1
+    diagnostic = diagnostics[0]
+    assert diagnostic.severity == Severity.ERROR
+    assert diagnostic.expected == "lowercase | uppercase | number | specialCharacter"
+    assert diagnostic.actual == "digit"
+    assert diagnostic.suggestion == "Use number instead."
+    assert display_path(diagnostic.path) == (
+        "$.Parameters.Target.AssociationPropertyMetadata.CharacterClasses[0].Class"
+    )
+
+
+def test_local_contract_corrections_accept_localized_labels_and_boolean_only_key() -> None:
+    localized_labels = _validate(
+        {
+            "Type": "String",
+            "AllowedValues": ["CreateNew"],
+            "AssociationPropertyMetadata": {"ValueLabelMapping": {"CreateNew": {"zh-cn": "新建", "en": "Create new"}}},
+        }
+    )
+    assert not [item for item in localized_labels.diagnostics if item.code == "ROS1305"]
+
+    invalid_label = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"ValueLabelMapping": {"CreateNew": {"en": 1}}},
+        }
+    )
+    assert any(item.code == "ROS1305" for item in invalid_label.diagnostics)
+
+    only_key = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::Bailian::ApiKey::ApiKeyInfo",
+            "AssociationPropertyMetadata": {"OnlyKey": True},
+        }
+    )
+    assert not [item for item in only_key.diagnostics if item.code == "ROS1305"]
+
+    invalid_only_key = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::Bailian::ApiKey::ApiKeyInfo",
+            "AssociationPropertyMetadata": {"OnlyKey": "true"},
+        }
+    )
+    assert any(item.code == "ROS1305" for item in invalid_only_key.diagnostics)
+
+
+def test_auto_complete_number_is_valid() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 8,
+                "CharacterClasses": [{"Class": "number", "Min": 1}],
+            },
+        }
+    )
+
+    assert not [item for item in _association_diagnostics(report) if item.severity == Severity.ERROR]
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected_path"),
+    [
+        ({"CharacterClasses": {"Class": "number"}}, "CharacterClasses"),
+        ({"CharacterClasses": ["number"]}, "CharacterClasses[0]"),
+        ({"CharacterClasses": [{"Min": 1}]}, "CharacterClasses[0].Class"),
+        (
+            {"CharacterClasses": [{"Class": "number", "Min": 1, "Unknown": True}]},
+            "CharacterClasses[0].Unknown",
+        ),
+    ],
+)
+def test_auto_complete_deep_structure_errors(metadata: dict, expected_path: str) -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": metadata,
+        }
+    )
+
+    diagnostic = next(item for item in report.diagnostics if item.code == "ROS1305")
+    assert display_path(diagnostic.path).endswith(expected_path)
+
+
+def test_auto_complete_missing_min_warns_only_for_multiple_character_classes() -> None:
+    missing = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "number"}]},
+        }
+    )
+    assert not [item for item in missing.diagnostics if item.code == "ROS5302" and item.subject == "Min"]
+
+    multiple = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "CharacterClasses": [{"Class": "number"}, {"Class": "lowercase", "Min": 1}]
+            },
+        }
+    )
+    diagnostic = next(item for item in multiple.diagnostics if item.code == "ROS5302" and item.subject == "Min")
+    assert "does not guarantee" in diagnostic.summary
+    assert "multiple character classes" in diagnostic.detail
+
+
+def test_auto_complete_wrong_case_min_is_one_actionable_error() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "number", "min": 1}]},
+        }
+    )
+
+    diagnostics = [item for item in report.diagnostics if item.subject in {"min", "Min"}]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].code == "ROS1305"
+    assert diagnostics[0].suggestion == "Rename min to Min."
+
+
+def test_auto_complete_non_integer_min_is_a_runtime_warning() -> None:
+
+    for minimum in (-1, 1.5):
+        report = _validate(
+            {
+                "Type": "String",
+                "AssociationProperty": "AutoCompleteInput",
+                "AssociationPropertyMetadata": {
+                    "Length": 8,
+                    "CharacterClasses": [{"Class": "number", "Min": minimum}],
+                },
+            }
+        )
+        diagnostic = next(item for item in report.diagnostics if item.code == "ROS5302" and item.subject == "Min")
+        assert "every available position" in diagnostic.summary
+
+    skipped_empty_special = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 4,
+                "CharacterClasses": [
+                    {"Class": "number", "Min": 1},
+                    {"Class": "specialCharacter", "Min": -1, "SpecialCharacters": ""},
+                ],
+            },
+        }
+    )
+    assert not any(
+        item.subject == "Min" and "every available position" in item.summary
+        for item in skipped_empty_special.diagnostics
+    )
+
+
+def test_auto_complete_capacity_and_special_character_requirements() -> None:
+    overflow = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 2,
+                "CharacterClasses": [
+                    {"Class": "number", "Min": 2},
+                    {"Class": "uppercase", "Min": 1},
+                ],
+            },
+        }
+    )
+    assert any(item.code == "ROS5305" and item.subject == "character-capacity" for item in overflow.diagnostics)
+
+    missing_specials = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 4,
+                "CharacterClasses": [{"Class": "specialCharacter", "Min": 1}],
+            },
+        }
+    )
+    assert any(item.code == "ROS5305" and item.subject == "SpecialCharacters" for item in missing_specials.diagnostics)
+
+    optional_specials = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 4,
+                "CharacterClasses": [
+                    {"Class": "number", "Min": 1},
+                    {"Class": "specialCharacter", "Min": 0},
+                ],
+            },
+        }
+    )
+    assert not [item for item in optional_specials.diagnostics if item.code == "ROS1307"]
+
+
+def test_auto_complete_empty_and_multiple_special_character_entries_follow_runtime_state() -> None:
+    empty_special_does_not_add_capacity = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 2,
+                "CharacterClasses": [
+                    {"Class": "number", "Min": 2},
+                    {"Class": "specialCharacter", "Min": 99, "SpecialCharacters": ""},
+                ],
+            },
+        }
+    )
+    assert not any(item.subject == "character-capacity" for item in empty_special_does_not_add_capacity.diagnostics)
+
+    shared_positions = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 4,
+                "CharacterClasses": [
+                    {
+                        "Class": "specialCharacter",
+                        "Min": 2,
+                        "SpecialCharacters": "!",
+                        "Start": False,
+                        "End": False,
+                    },
+                    {
+                        "Class": "specialCharacter",
+                        "Min": 2,
+                        "SpecialCharacters": "@",
+                        "Start": False,
+                        "End": False,
+                    },
+                ],
+            },
+        }
+    )
+    assert any(item.subject == "shared-character-capacity" for item in shared_positions.diagnostics)
+    boundary_warnings = [
+        item for item in shared_positions.diagnostics if item.code == "ROS5302" and item.subject in {"Start", "End"}
+    ]
+    assert len(boundary_warnings) == 1
+    assert display_path(boundary_warnings[0].path).endswith("CharacterClasses[1].Start")
+
+
+def test_auto_complete_ignored_fields_pattern_and_mutable_remaining_pool() -> None:
+    non_special = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Pattern": "[0-9]+",
+                "CharacterClasses": [
+                    {
+                        "Class": "number",
+                        "Min": 1,
+                        "SpecialCharacters": "!",
+                        "Start": False,
+                        "End": False,
+                    }
+                ],
+            },
+        }
+    )
+    ignored_subjects = {item.subject for item in non_special.diagnostics if item.code == "ROS5302"}
+    assert {"Pattern", "SpecialCharacters", "Start", "End"} <= ignored_subjects
+
+    only_special = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 4,
+                "CharacterClasses": [
+                    {
+                        "Class": "specialCharacter",
+                        "Min": 1,
+                        "SpecialCharacters": "!",
+                        "Start": False,
+                    }
+                ],
+            },
+        }
+    )
+    pool = next(item for item in only_special.diagnostics if item.code == "ROS5302" and item.subject == "Start")
+    assert "shorter than Length" in pool.detail
+
+    fully_prefilled = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 4,
+                "CharacterClasses": [
+                    {"Class": "number", "Min": 4},
+                    {
+                        "Class": "specialCharacter",
+                        "Min": 0,
+                        "SpecialCharacters": "!",
+                        "Start": False,
+                    },
+                ],
+            },
+        }
+    )
+    assert not any(
+        item.code == "ROS5302" and item.subject == "Start" and "boundary restriction persists" in item.summary
+        for item in fully_prefilled.diagnostics
+    )
+
+
+def test_auto_complete_length_and_pattern_limitations() -> None:
+    normalized = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 2.5,
+                "CharacterClasses": [{"Class": "number", "Min": 1}],
+            },
+        }
+    )
+    assert any(
+        item.code == "ROS5302" and item.subject == "Length" and "Effective generated Length is 2" in item.detail
+        for item in normalized.diagnostics
+    )
+
+    pattern = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Pattern": "(?<name>a)"},
+        }
+    )
+    assert any(item.code == "ROS5305" and item.subject == "Pattern" for item in pattern.diagnostics)
+
+
+@pytest.mark.parametrize(
+    ("length", "detail"),
+    [
+        (2.5, "Effective generated Length is 2"),
+        (0, "unsliced generated identifier"),
+        (-1, "generated identifier truncated at position -1"),
+    ],
+)
+def test_auto_complete_generated_identifier_branch_reports_actual_length_normalization(length, detail: str) -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Length": length},
+        }
+    )
+
+    warning = next(item for item in report.diagnostics if item.code == "ROS5302" and item.subject == "Length")
+    assert detail in warning.detail
+
+
+def test_empty_special_character_configuration_ignores_boundary_flags_even_when_minimum_is_zero() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "Length": 4,
+                "CharacterClasses": [
+                    {"Class": "number", "Min": 1},
+                    {
+                        "Class": "specialCharacter",
+                        "Min": 0,
+                        "SpecialCharacters": "",
+                        "Start": False,
+                        "End": False,
+                    },
+                ],
+            },
+        }
+    )
+
+    ignored = {
+        item.subject
+        for item in report.diagnostics
+        if item.code == "ROS5302" and "does not retain specialCharacter" in item.detail
+    }
+    assert ignored == {"Start", "End"}
+    assert not any(
+        item.subject == "SpecialCharacters" and item.code in {"ROS1307", "ROS5305"} for item in report.diagnostics
+    )
+
+
+def test_whole_value_parameter_references_validate_scope_type_and_consumer_consistency() -> None:
+    valid = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Length": "${Length}"},
+        },
+        extra_parameters={"Length": {"Type": "Number"}},
+    )
+    assert "ROS1305" not in _codes(valid)
+    assert "ROS5305" in _codes(valid)
+    assert not any(item.code == "ROS5302" and item.subject == "Length" for item in valid.diagnostics)
+
+    wrong_type = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Length": "${Length}"},
+        },
+        extra_parameters={"Length": {"Type": "String"}},
+    )
+    warning = next(item for item in wrong_type.diagnostics if item.code == "ROS5302" and item.subject == "Length")
+    assert warning.related_locations
+
+    missing = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Length": "${Missing}"},
+        }
+    )
+    assert "ROS1306" not in _codes(missing)
+    assert any(item.code == "ROS5305" and item.subject == "Missing" for item in missing.diagnostics)
+
+
+def test_dynamic_and_environment_reference_parsers() -> None:
+    dynamic = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"DynamicValue": "prefix-${Missing}"},
+        }
+    )
+    assert "ROS1306" in _codes(dynamic)
+
+    environment = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "{{env.prefix}}"},
+        }
+    )
+    assert "ROS5305" in _codes(environment)
+
+    malformed = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${Missing"},
+        }
+    )
+    assert "ROS1306" not in _codes(malformed)
+    assert "ROS5305" not in _codes(malformed)
+
+    escaped_literal = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"DynamicValue": "prefix-${!not-a-parameter}"},
+        }
+    )
+    assert not any(
+        item.code == "ROS1306" and item.subject == "!not-a-parameter" for item in escaped_literal.diagnostics
+    )
+
+    whole_escaped_literal = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${!not-a-parameter}"},
+        }
+    )
+    assert not any(
+        item.code == "ROS1306" and item.subject == "!not-a-parameter" for item in whole_escaped_literal.diagnostics
+    )
+
+    escaped_field_path = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${!Object.Name}"},
+        },
+        extra_parameters={
+            "Object": {
+                "Type": "Json",
+                "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+            }
+        },
+    )
+    assert any(item.code == "ROS5305" and item.subject == "!Object.Name" for item in escaped_field_path.diagnostics)
+
+    injected_region = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"DynamicValue": "prefix-${RegionId}"},
+        }
+    )
+    injected_region_array = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "DynamicValue": [{"Condition": {"Fn::Equals": [1, 1]}, "Value": "prefix-${RegionId}"}]
+            },
+        }
+    )
+    for report in (injected_region, injected_region_array):
+        assert not any(item.code == "ROS1306" and item.subject == "RegionId" for item in report.diagnostics)
+
+    injected_region_condition = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "DynamicValue": [
+                    {
+                        "Condition": {"Fn::Equals": ["${RegionId}", "cn-hangzhou"]},
+                        "Value": "test",
+                    }
+                ]
+            },
+        }
+    )
+    assert not any(
+        item.code == "ROS1306" and item.subject == "RegionId" for item in injected_region_condition.diagnostics
+    )
+
+    ordinary_condition = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": {"Fn::Equals": ["${RegionId}", "cn-hangzhou"]}}},
+        }
+    )
+    assert any(item.code == "ROS1306" and item.subject == "RegionId" for item in ordinary_condition.diagnostics)
+
+
+def test_dynamic_value_condition_values_and_mapping_selector_segments_use_their_actual_parsers() -> None:
+    dynamic_array = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "DynamicValue": [
+                    {
+                        "Condition": {"Fn::Equals": [1, 1]},
+                        "Value": "prefix-${Missing}",
+                    }
+                ]
+            },
+        }
+    )
+    assert any(item.code == "ROS1306" and item.subject == "Missing" for item in dynamic_array.diagnostics)
+
+    for literal_fragment in ("${", "prefix-${", "${P}${"):
+        unmatched_fragment = _validate(
+            {
+                "Type": "String",
+                "AssociationPropertyMetadata": {"DynamicValue": literal_fragment},
+            },
+            extra_parameters={"P": {"Type": "String"}},
+        )
+        assert not any(
+            item.code == "ROS1306" and item.subject in {literal_fragment, "P"}
+            for item in unmatched_fragment.diagnostics
+        )
+
+    disallowed_field_paths = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "DynamicValue": [{"Condition": {"Fn::Equals": [1, 1]}, "Value": "${Object.Name}"}]
+            },
+        },
+        extra_parameters={
+            "Object": {
+                "Type": "Json",
+                "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+            }
+        },
+    )
+    assert any(item.code == "ROS1306" and item.subject == "Object.Name" for item in disallowed_field_paths.diagnostics)
+
+    partial_segment = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "By${Missing}.Value",
+                }
+            },
+        }
+    )
+    assert not any(item.code == "ROS1306" and item.subject == "Missing" for item in partial_segment.diagnostics)
+
+    whole_segment = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "${Missing}.Value",
+                }
+            },
+        }
+    )
+    assert not any(item.code == "ROS1306" and item.subject == "Missing" for item in whole_segment.diagnostics)
+    assert any(item.code == "ROS5305" and item.subject == "Missing" for item in whole_segment.diagnostics)
+
+    greedy_mapping_parameter = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "${A{B}}",
+                }
+            },
+        },
+        extra_parameters={"A{B}": {"Type": "String"}},
+    )
+    assert not any(
+        item.code in {"ROS1306", "ROS5305"} and item.subject == "A{B}" for item in greedy_mapping_parameter.diagnostics
+    )
+
+    greedy_mapping_literal = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "${A{B}}",
+                }
+            },
+        }
+    )
+    assert any(item.code == "ROS5305" and item.subject == "A{B}" for item in greedy_mapping_literal.diagnostics)
+
+    empty_mapping_reference_is_literal = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "${}",
+                }
+            },
+        }
+    )
+    assert not any(
+        item.code in {"ROS1306", "ROS5305"} and item.subject == ""
+        for item in empty_mapping_reference_is_literal.diagnostics
+    )
+
+    projected_name_is_literal = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "${Rows[]}",
+                }
+            },
+        },
+        extra_parameters={"Rows": {"Type": "Json"}},
+    )
+    assert not any(
+        item.code == "ROS1306" and item.subject == "Rows[]" for item in projected_name_is_literal.diagnostics
+    )
+    assert any(item.code == "ROS5305" and item.subject == "Rows[]" for item in projected_name_is_literal.diagnostics)
+
+    mapping_region = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "ByRegion.${RegionId}",
+                }
+            },
+        }
+    )
+    assert not any(item.code == "ROS1306" and item.subject == "RegionId" for item in mapping_region.diagnostics)
+
+    spaced_mapping_parameter = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "${ P }",
+                }
+            },
+        },
+        extra_parameters={"P": {"Type": "String"}},
+    )
+    assert any(item.code == "ROS5305" and item.subject == " P " for item in spaced_mapping_parameter.diagnostics)
+
+    spaced_mapping_region = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "MappingMetadata": {
+                    "MappingName": "Example",
+                    "MappedPropsName": "AllowedValues",
+                    "ValueSelector": "${ RegionId }",
+                }
+            },
+        }
+    )
+    assert any(item.code == "ROS5305" and item.subject == " RegionId " for item in spaced_mapping_region.diagnostics)
+
+
+def test_condition_ast_arity_ignored_keys_and_definitions_paths() -> None:
+    assert association_property_rule._same_definition_value(
+        {"1": "one", "0": "zero"},
+        {"0": "zero", "1": "one"},
+    )
+    assert not association_property_rule._same_definition_value(
+        {"Fn::Equals": [1, 1], "Fn::Contains": [[1], 1]},
+        {"Fn::Contains": [[1], 1], "Fn::Equals": [1, 1]},
+    )
+
+    empty_definition_path = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": ""}},
+        },
+        template_metadata={"ALIYUN::ROS::Interface": {"Definitions": {}}},
+    )
+    assert any(item.code == "ROS1306" and item.subject == "" for item in empty_definition_path.diagnostics)
+
+    invalid_arity = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {"Condition": {"Fn::Equals": [1]}},
+            },
+        }
+    )
+    assert "ROS1305" in _codes(invalid_arity)
+
+    ignored = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::Equals": [1, 1],
+                        "Fn::Contains": [[1], 1],
+                    }
+                },
+            },
+        }
+    )
+    assert any(item.code == "ROS5302" and item.subject == "Fn::Contains" for item in ignored.diagnostics)
+
+    js_integer_first_key = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::Equals": [1, 1],
+                        "0": "unsupported",
+                    }
+                },
+            },
+        }
+    )
+    assert "ROS1305" in _codes(js_integer_first_key)
+
+    unresolved = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions.Visible"}},
+        }
+    )
+    assert "ROS5305" in _codes(unresolved)
+
+    resolved = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions.Visible"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {"Definitions": {"Conditions": {"Visible": {"Fn::Equals": [1, 1]}}}}
+        },
+    )
+    assert "ROS1306" not in _codes(resolved)
+    assert "ROS5305" not in _codes(resolved)
+
+    for lodash_path, definitions in (
+        ("Conditions[0]", {"Conditions": [{"Fn::Equals": [1, 1]}]}),
+        ("Groups['A.B']", {"Groups": {"A.B": {"Fn::Equals": [1, 1]}}}),
+        ("A.B", {"A.B": {"Fn::Equals": [1, 1]}, "A": {}}),
+        ("Conditions[ foo ]", {"Conditions": {"foo": {"Fn::Equals": [1, 1]}}}),
+        ("A[.5]", {"A": {".5": {"Fn::Equals": [1, 1]}}}),
+        ("A[[x]]", {"A": {"[x]": {"Fn::Equals": [1, 1]}}}),
+        ("S[0]", {"S": "abc"}),
+        ("S[1]", {"S": "😀"}),
+        ("S.length", {"S": "abc"}),
+        ("A.length", {"A": [1, 2]}),
+    ):
+        lodash_resolved = _validate(
+            {
+                "Type": "String",
+                "AssociationPropertyMetadata": {"Visible": {"Condition": lodash_path}},
+            },
+            template_metadata={"ALIYUN::ROS::Interface": {"Definitions": definitions}},
+        )
+        assert not any(
+            item.code in {"ROS1306", "ROS5305"} and item.subject == lodash_path for item in lodash_resolved.diagnostics
+        )
+
+    whitespace_is_trimmed = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions[ foo ]"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {"Definitions": {"Conditions": {" foo ": {"Fn::Equals": [1, 1]}}}}
+        },
+    )
+    assert any(
+        item.code == "ROS1306" and item.subject == "Conditions[ foo ]" for item in whitespace_is_trimmed.diagnostics
+    )
+
+    string_index_out_of_range = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "S[3]"}},
+        },
+        template_metadata={"ALIYUN::ROS::Interface": {"Definitions": {"S": "abc"}}},
+    )
+    assert any(item.code == "ROS1306" and item.subject == "S[3]" for item in string_index_out_of_range.diagnostics)
+
+    non_bmp_index_out_of_range = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "S[2]"}},
+        },
+        template_metadata={"ALIYUN::ROS::Interface": {"Definitions": {"S": "😀"}}},
+    )
+    assert any(item.code == "ROS1306" and item.subject == "S[2]" for item in non_bmp_index_out_of_range.diagnostics)
+
+    noncanonical_array_index = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions[01]"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {"Definitions": {"Conditions": [{"Fn::Equals": [1, 1]}, {"Fn::Equals": [1, 1]}]}}
+        },
+    )
+    assert any(
+        item.code == "ROS1306" and item.subject == "Conditions[01]" for item in noncanonical_array_index.diagnostics
+    )
+
+    missing = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions.Missing"}},
+        },
+        template_metadata={"ALIYUN::ROS::Interface": {"Definitions": {"Conditions": {}}}},
+    )
+    assert "ROS1306" in _codes(missing)
+
+    invalid_resolved_ast = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Broken"}},
+        },
+        template_metadata={"ALIYUN::ROS::Interface": {"Definitions": {"Broken": {"Fn::Equals": [1]}}}},
+    )
+    assert "ROS1305" in _codes(invalid_resolved_ast)
+
+    invalid_resolved_js_integer_first_key = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "IntegerFirst"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {
+                "Definitions": {
+                    "IntegerFirst": {
+                        "Fn::Equals": [1, 1],
+                        "0": "unsupported",
+                    }
+                }
+            }
+        },
+    )
+    assert "ROS1305" in _codes(invalid_resolved_js_integer_first_key)
+
+    profile_value_dependent = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Shared"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {"Definitions": {"Shared": {"Fn::Equals": [1, 1]}}},
+            "APSARA::ROS::Interface": {"Definitions": {"Shared": {"Fn::Equals": [1]}}},
+        },
+    )
+    assert "ROS1305" not in _codes(profile_value_dependent)
+    assert any(item.code == "ROS5305" and item.subject == "Shared" for item in profile_value_dependent.diagnostics)
+
+    profile_first_key_dependent = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Shared"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {
+                "Definitions": {
+                    "Shared": {
+                        "Fn::Equals": [1, 1],
+                        "Fn::Contains": [[1], 1],
+                    }
+                }
+            },
+            "APSARA::ROS::Interface": {
+                "Definitions": {
+                    "Shared": {
+                        "Fn::Contains": [[1], 1],
+                        "Fn::Equals": [1, 1],
+                    }
+                }
+            },
+        },
+    )
+    assert any(item.code == "ROS5305" and item.subject == "Shared" for item in profile_first_key_dependent.diagnostics)
+
+    environment_dependent = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions.Visible"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {"Definitions": {"Conditions": {}}},
+            "APSARA::ROS::Interface": {"Definitions": {"Conditions": {"Visible": {"Fn::Equals": [1, 1]}}}},
+        },
+    )
+    assert "ROS1306" not in _codes(environment_dependent)
+    assert any(
+        item.code == "ROS5305" and item.subject == "Conditions.Visible" for item in environment_dependent.diagnostics
+    )
+
+    for unavailable_aliyun in ({}, {"Definitions": []}):
+        unavailable_profile = _validate(
+            {
+                "Type": "String",
+                "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions.Visible"}},
+            },
+            template_metadata={
+                "ALIYUN::ROS::Interface": unavailable_aliyun,
+                "APSARA::ROS::Interface": {"Definitions": {"Conditions": {"Visible": {"Fn::Equals": [1, 1]}}}},
+            },
+        )
+        assert not any(
+            item.code == "ROS1306" and item.subject == "Conditions.Visible" for item in unavailable_profile.diagnostics
+        )
+        assert any(
+            item.code == "ROS5305" and item.subject == "Conditions.Visible" for item in unavailable_profile.diagnostics
+        )
+
+    both_unavailable = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions.Visible"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {},
+            "APSARA::ROS::Interface": {"Definitions": []},
+        },
+    )
+    assert any(item.code == "ROS5305" and item.subject == "Conditions.Visible" for item in both_unavailable.diagnostics)
+
+    missing_in_both_profiles = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": "Conditions.Missing"}},
+        },
+        template_metadata={
+            "ALIYUN::ROS::Interface": {"Definitions": {"Conditions": {}}},
+            "APSARA::ROS::Interface": {"Definitions": {"Conditions": {}}},
+        },
+    )
+    assert "ROS1306" in _codes(missing_in_both_profiles)
+
+
+def test_condition_definitions_coerce_yaml_scalar_keys_like_javascript_objects() -> None:
+    report = validate_ros_template(
+        MaterializedTemplateSource(
+            """
+ROSTemplateFormatVersion: '2015-09-01'
+Metadata:
+  ALIYUN::ROS::Interface:
+    Definitions:
+      Numeric:
+        1:
+          Fn::Equals: [1, 1]
+      Nullish:
+        null:
+          Fn::Equals: [1, 1]
+      Boolean:
+        true:
+          Fn::Equals: [1, 1]
+      Float:
+        1.5:
+          Fn::Equals: [1, 1]
+Parameters:
+  NumericTarget:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible:
+        Condition: Numeric.1
+  NullTarget:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible:
+        Condition: Nullish.null
+  BooleanTarget:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible:
+        Condition: Boolean.true
+  FloatTarget:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible:
+        Condition: Float[1.5]
+Resources: {}
+""".strip(),
+            origin="yaml-definitions-test",
+        ),
+        RequestValidationContext(action="ValidateTemplate"),
+    )
+
+    subjects = {"Numeric.1", "Nullish.null", "Boolean.true", "Float[1.5]"}
+    assert not [item for item in report.diagnostics if item.code in {"ROS1306", "ROS5305"} and item.subject in subjects]
+
+
+def test_condition_definitions_preserve_javascript_distinct_boolean_and_numeric_yaml_keys() -> None:
+    report = validate_ros_template(
+        MaterializedTemplateSource(
+            """
+ROSTemplateFormatVersion: '2015-09-01'
+Metadata:
+  ALIYUN::ROS::Interface:
+    Definitions:
+      true:
+        Fn::Equals: [1, 1]
+      1:
+        Unknown: invalid
+      false:
+        Fn::Equals: [1, 1]
+      0:
+        Unknown: invalid
+Parameters:
+  BooleanTrue:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible: {Condition: 'true'}
+  NumericOne:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible: {Condition: '1'}
+  BooleanFalse:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible: {Condition: 'false'}
+  NumericZero:
+    Type: String
+    AssociationPropertyMetadata:
+      Visible: {Condition: '0'}
+Resources: {}
+""".strip(),
+            origin="typed-definition-keys.yaml",
+        ),
+        RequestValidationContext(action="ValidateTemplate"),
+    )
+
+    condition_errors = [item for item in report.diagnostics if item.code == "ROS1305"]
+    assert not any("BooleanTrue" in display_path(item.path) for item in condition_errors)
+    assert not any("BooleanFalse" in display_path(item.path) for item in condition_errors)
+    assert any("NumericOne" in display_path(item.path) for item in condition_errors)
+    assert any("NumericZero" in display_path(item.path) for item in condition_errors)
+
+
+def test_condition_children_select_and_not_shapes() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::And": [
+                            {"Fn::Equals": [1, 1]},
+                            1,
+                            {"Fn::Not": {}},
+                            {"Fn::Select": ["${P}"]},
+                            {"Fn::Select": ["${P}", "key", "ignored"]},
+                        ]
+                    }
+                },
+            },
+        },
+        extra_parameters={"P": {"Type": "Json"}},
+    )
+
+    assert sum(item.code == "ROS1305" for item in report.diagnostics) >= 2
+    assert any(item.code == "ROS5302" and item.subject == "2" for item in report.diagnostics)
+
+    short_select = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::Equals": [
+                            {"Fn::Select": ["${Missing}"]},
+                            "value",
+                        ]
+                    }
+                }
+            },
+        }
+    )
+    assert "ROS1305" not in _codes(short_select)
+    assert not any(item.code == "ROS1306" and item.subject == "Missing" for item in short_select.diagnostics)
+
+    nested_string = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {"Visible": {"Condition": {"Fn::And": ["Conditions.Visible"]}}},
+        }
+    )
+    assert "ROS1305" in _codes(nested_string)
+
+
+def test_condition_operands_validate_parameter_references_and_fn_select_uses_operand_semantics() -> None:
+    missing = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::And": [
+                            {"Fn::Equals": ["${MissingEquals}", 1]},
+                            {"Fn::Contains": [[1], "${MissingContains}"]},
+                            {"Fn::Select": ["${MissingSelect}", "key"]},
+                        ]
+                    }
+                }
+            },
+        }
+    )
+    assert {"MissingEquals", "MissingContains", "MissingSelect"} <= {
+        item.subject for item in missing.diagnostics if item.code == "ROS1306"
+    }
+
+    non_first_select = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::Equals": [
+                            {"Other": 1, "Fn::Select": ["${P}", "key"]},
+                            "value",
+                        ]
+                    }
+                }
+            },
+        },
+        extra_parameters={"P": {"Type": "Json"}},
+    )
+    assert not any(
+        item.code == "ROS1305" and item.subject and "first function key" in item.subject
+        for item in non_first_select.diagnostics
+    )
+    assert not any(item.code == "ROS1306" and item.subject == "P" for item in non_first_select.diagnostics)
+
+    spaced_references = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "DynamicValue": [
+                    {
+                        "Condition": {
+                            "Fn::And": [
+                                {"Fn::Equals": ["${ P }", "value"]},
+                                {"Fn::Equals": ["${ RegionId }", "cn-hangzhou"]},
+                                {"Fn::Select": ["${ P }", "key"]},
+                            ]
+                        },
+                        "Value": "value",
+                    }
+                ]
+            },
+        },
+        extra_parameters={"P": {"Type": "Json"}},
+    )
+    assert {" P ", " RegionId "} <= {item.subject for item in spaced_references.diagnostics if item.code == "ROS1306"}
+
+
+def test_condition_references_use_exact_keys_and_select_short_circuits_empty_arguments() -> None:
+    nested_only = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::And": [
+                            {"Fn::Equals": ["${Object.Name}", "value"]},
+                            {"Fn::Select": ["${Object.Name}", "key"]},
+                        ]
+                    }
+                }
+            },
+        },
+        extra_parameters={
+            "Object": {
+                "Type": "Json",
+                "AssociationProperty": "Json",
+                "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+            }
+        },
+    )
+    assert sum(item.code == "ROS1306" and item.subject == "Object.Name" for item in nested_only.diagnostics) == 2
+
+    exact_dotted_key = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::And": [
+                            {"Fn::Equals": ["${Object.Name}", "value"]},
+                            {"Fn::Select": ["${Object.Name}", "key"]},
+                        ]
+                    }
+                }
+            },
+        },
+        extra_parameters={"Object.Name": {"Type": "Json"}},
+    )
+    assert not any(item.code == "ROS1306" and item.subject == "Object.Name" for item in exact_dotted_key.diagnostics)
+
+    empty_arguments = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::And": [
+                            {"Fn::Select": ["", "key"]},
+                            {"Fn::Select": ["${Missing}", ""]},
+                        ]
+                    }
+                }
+            },
+        }
+    )
+    assert not any(
+        item.code in {"ROS1305", "ROS1306"} and item.subject in {"", "Missing"} for item in empty_arguments.diagnostics
+    )
+
+    empty_arguments_with_tail = _validate(
+        {
+            "Type": "String",
+            "AssociationPropertyMetadata": {
+                "Visible": {
+                    "Condition": {
+                        "Fn::And": [
+                            {"Fn::Select": ["", "key", "ignored"]},
+                            {"Fn::Select": ["${Missing}", "", "ignored"]},
+                        ]
+                    }
+                }
+            },
+        }
+    )
+    assert sum(item.code == "ROS5302" and item.subject == "2" for item in empty_arguments_with_tail.diagnostics) == 2
+    assert not any(
+        item.code in {"ROS1305", "ROS1306"} and item.subject in {"", "Missing"}
+        for item in empty_arguments_with_tail.diagnostics
+    )
+
+
+def test_field_reference_context_overrides_nested_parameter_context() -> None:
+    report = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "List[Parameter]",
+            "AssociationPropertyMetadata": {
+                "Parameter": {
+                    "Type": "String",
+                    "AssociationPropertyMetadata": {"DynamicValue": "prefix-${P}"},
+                }
+            },
+        },
+        extra_parameters={"P": {"Type": "String"}},
+    )
+
+    assert not [item for item in report.diagnostics if item.subject == "P" and item.code in {"ROS1306", "ROS5305"}]
+
+
+def test_nested_parameter_map_and_meta_list_row_reference_contexts() -> None:
+    nested_map = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "Json",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Local": {"Type": "String"},
+                    "Dependent": {
+                        "Type": "String",
+                        "AssociationPropertyMetadata": {"DynamicValue": "${Local}"},
+                    },
+                }
+            },
+        }
+    )
+    assert not [
+        item for item in nested_map.diagnostics if item.subject == "Local" and item.code in {"ROS1306", "ROS5305"}
+    ]
+
+    meta_list = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "ALIYUN::ROS::Type::MetaList",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Sibling": {"Type": "String"},
+                    "Dependent": {
+                        "Type": "String",
+                        "AssociationProperty": "ALIYUN::Hologres::Instance::InstanceId",
+                        "AssociationPropertyMetadata": {"cmsInstanceType": "${.Sibling}"},
+                    },
+                }
+            },
+        }
+    )
+    assert not [
+        item for item in meta_list.diagnostics if item.subject == ".Sibling" and item.code in {"ROS1306", "ROS5305"}
+    ]
+
+    missing_row_field = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "ALIYUN::ROS::Type::MetaList",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Dependent": {
+                        "Type": "String",
+                        "AssociationProperty": "ALIYUN::Hologres::Instance::InstanceId",
+                        "AssociationPropertyMetadata": {"cmsInstanceType": "${.Missing}"},
+                    }
+                }
+            },
+        }
+    )
+    assert any(item.code == "ROS1306" and item.subject == ".Missing" for item in missing_row_field.diagnostics)
+
+
+def test_nested_reference_validation_uses_local_declarations_full_paths_and_related_locations() -> None:
+    local = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "Json",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Flag": {"Type": "Boolean"},
+                    "Dependent": {
+                        "Type": "String",
+                        "AssociationProperty": "AutoCompleteInput",
+                        "AssociationPropertyMetadata": {"Length": "Flag"},
+                    },
+                }
+            },
+        },
+        extra_parameters={"Flag": {"Type": "Number"}},
+    )
+    type_warning = next(item for item in local.diagnostics if item.code == "ROS5302" and item.subject == "Flag")
+    assert type_warning.actual == "Boolean"
+    assert type_warning.related_locations
+    assert "AssociationPropertyMetadata.Parameters.Flag" in display_path(type_warning.related_locations[0].path)
+
+    malformed_and_missing_path = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "Json",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Flag": {"Type": "Boolean"},
+                    "Malformed": {
+                        "Type": "String",
+                        "AssociationPropertyMetadata": {"DynamicValue": "${Flag[}"},
+                    },
+                    "MissingPath": {
+                        "Type": "String",
+                        "AssociationPropertyMetadata": {"DynamicValue": "${Flag.missing}"},
+                    },
+                }
+            },
+        }
+    )
+    assert {"Flag[", "Flag.missing"} <= {
+        item.subject for item in malformed_and_missing_path.diagnostics if item.code == "ROS1306"
+    }
+
+    known_path = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "Json",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Object": {
+                        "Type": "Json",
+                        "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+                    },
+                    "Dependent": {
+                        "Type": "String",
+                        "AssociationPropertyMetadata": {"DynamicValue": "${Object.Name}"},
+                    },
+                }
+            },
+        }
+    )
+    assert any(item.subject == "Object.Name" and item.code == "ROS1306" for item in known_path.diagnostics)
+
+    known_array_path = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "Json",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Rows": {
+                        "Type": "Json",
+                        "AssociationProperty": "List[Parameter]",
+                        "AssociationPropertyMetadata": {
+                            "Parameter": {
+                                "Type": "Json",
+                                "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+                            }
+                        },
+                    },
+                    "Dependent": {
+                        "Type": "String",
+                        "AssociationPropertyMetadata": {"DynamicValue": "${Rows[].Name}"},
+                    },
+                }
+            },
+        }
+    )
+    assert any(item.subject == "Rows[].Name" and item.code == "ROS1306" for item in known_array_path.diagnostics)
+
+
+def test_merged_common_and_component_any_of_preserves_branch_reference_parser() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "Code",
+            "AssociationPropertyMetadata": {"ReadOnly": "${Flag}"},
+        },
+        extra_parameters={"Flag": {"Type": "Boolean"}},
+    )
+
+    assert not any(item.code == "ROS1305" and "ReadOnly" in display_path(item.path) for item in report.diagnostics)
+    assert not any(item.code == "ROS1306" and item.subject == "Flag" for item in report.diagnostics)
+
+
+@pytest.mark.parametrize("literal", ["${", "x${P}", "{{bad"])
+def test_unmatched_whole_value_reference_fragments_remain_literals(literal: str) -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": literal},
+        },
+        extra_parameters={"P": {"Type": "String"}},
+    )
+    assert not any(item.code in {"ROS1306", "ROS5305"} and item.subject == literal for item in report.diagnostics)
+
+
+def test_whole_value_reference_accepts_exact_parameter_keys_without_identifier_grammar() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${1A}"},
+        },
+        extra_parameters={"1A": {"Type": "String"}},
+    )
+
+    assert not any(item.code in {"ROS1306", "ROS5305"} and item.subject == "1A" for item in report.diagnostics)
+
+
+@pytest.mark.parametrize("parameter_key", ["A{B}", "{{env.path}}", "{{}}"])
+def test_whole_value_reference_uses_greedy_and_legacy_exact_parameter_keys(parameter_key: str) -> None:
+    encoded = "${A{B}}" if parameter_key == "A{B}" else parameter_key
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": encoded},
+        },
+        extra_parameters={parameter_key: {"Type": "String"}},
+    )
+
+    assert not any(item.code == "ROS1306" for item in report.diagnostics)
+    assert not any(
+        item.code == "ROS5305" and "Environment metadata reference" in item.summary for item in report.diagnostics
+    )
+
+
+def test_whole_value_escaped_literal_can_resolve_a_transformed_legacy_parameter_key() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${!literal}"},
+        },
+        extra_parameters={"${literal}": {"Type": "String"}},
+    )
+
+    assert not any(item.code == "ROS1306" for item in report.diagnostics)
+
+
+@pytest.mark.parametrize(
+    ("encoded", "parameter_key"),
+    [
+        ("${1A}", "1A"),
+        ("${A{B}}", "A{B}"),
+        ("1A", "1A"),
+        ("${!literal}", "${literal}"),
+    ],
+)
+def test_whole_value_nonstandard_exact_keys_keep_reference_type_warnings(
+    encoded: str,
+    parameter_key: str,
+) -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Length": encoded},
+        },
+        extra_parameters={parameter_key: {"Type": "String"}},
+    )
+
+    warning = next(
+        item for item in report.diagnostics if item.code == "ROS5302" and "reference type is suspicious" in item.summary
+    )
+    assert warning.subject == parameter_key
+    assert warning.related_locations
+    assert warning.related_locations[0].path[-1].value == parameter_key
+
+
+def test_yaml_scalar_parameter_keys_use_javascript_property_lookup_in_every_exact_parser() -> None:
+    report = _validate_yaml(
+        """ROSTemplateFormatVersion: '2015-09-01'
+Parameters:
+  Target:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Prefix: "${true}"
+      Suffix: "${1}"
+      DynamicValue: "value-${false}"
+      MappingMetadata:
+        MappingName: Example
+        MappedPropsName: AllowedValues
+        ValueSelector: "${null}.${0}"
+      Visible:
+        Condition:
+          Fn::Equals: ["${false}", enabled]
+  true:
+    Type: String
+  1:
+    Type: Number
+  false:
+    Type: String
+  0:
+    Type: Number
+  null:
+    Type: String
+Resources: {}
+"""
+    )
+
+    assert not any(
+        item.code in {"ROS1306", "ROS5305"} and item.subject in {"true", "1", "false", "0", "null"}
+        for item in report.diagnostics
+    )
+    type_warnings = [
+        item
+        for item in report.diagnostics
+        if item.code == "ROS5302" and item.subject in {"true", "1"} and "reference type is suspicious" in item.summary
+    ]
+    assert [item.subject for item in type_warnings] == ["1"]
+    assert association_property_rule._js_property_key(type_warnings[0].related_locations[0].path[-1].value) == "1"
+
+
+def test_yaml_boolean_and_numeric_parameter_siblings_are_all_validated() -> None:
+    report = _validate_yaml(
+        """ROSTemplateFormatVersion: '2015-09-01'
+Parameters:
+  true:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Length: 8
+      CharacterClasses:
+        - Class: digit
+          Min: 1
+  1:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Length: 8
+      CharacterClasses:
+        - Class: number
+          Min: 1
+  false:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Length: 8
+      CharacterClasses:
+        - Class: digit
+          Min: 1
+  0:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Length: 8
+      CharacterClasses:
+        - Class: number
+          Min: 1
+Resources: {}
+"""
+    )
+
+    invalid_classes = [item for item in report.diagnostics if item.code == "ROS1305" and item.subject == "digit"]
+    assert len(invalid_classes) == 2
+
+
+def test_yaml_large_integer_parameter_keys_follow_binary64_rounding_and_last_wins() -> None:
+    report = _validate_yaml(
+        """ROSTemplateFormatVersion: '2015-09-01'
+Parameters:
+  Target:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Prefix: "${9007199254740992.Name}"
+      Suffix: "${9007199254740992}"
+      DynamicValue: "value-${9007199254740992}"
+      MappingMetadata:
+        MappingName: Example
+        MappedPropsName: AllowedValues
+        ValueSelector: "${9007199254740992}"
+      Visible:
+        Condition:
+          Fn::Equals: ["${9007199254740992}", enabled]
+  9007199254740992:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Length: 8
+      CharacterClasses:
+        - Class: digit
+          Min: 1
+  9007199254740993:
+    Type: Json
+    AssociationProperty: Json
+    AssociationPropertyMetadata:
+      Parameters:
+        Name:
+          Type: String
+Resources: {}
+"""
+    )
+
+    rounded_key = "9007199254740992"
+    assert not any(item.code in {"ROS1306", "ROS5305"} and item.subject == rounded_key for item in report.diagnostics)
+    assert not any(item.code == "ROS1305" and item.subject == "digit" for item in report.diagnostics)
+    warning = next(
+        item
+        for item in report.diagnostics
+        if item.code == "ROS5302" and item.subject == rounded_key and "reference type is suspicious" in item.summary
+    )
+    assert warning.related_locations[0].path[-1].value == 9007199254740993
+
+
+def test_nested_yaml_scalar_parameter_keys_use_source_mapped_javascript_properties() -> None:
+    report = _validate_yaml(
+        """ROSTemplateFormatVersion: '2015-09-01'
+Parameters:
+  Target:
+    Type: String
+    AssociationProperty: AutoCompleteInput
+    AssociationPropertyMetadata:
+      Prefix: "${Object.true}"
+      Suffix: "${Object.1}"
+      Length: "${Object.0}"
+      Pattern: "${Object.false}"
+      CharacterClasses: "${Object.9007199254740992}"
+      Required: "${Object.null}"
+  Object:
+    Type: Json
+    AssociationProperty: Json
+    AssociationPropertyMetadata:
+      Parameters:
+        true:
+          Type: String
+        1:
+          Type: Number
+        false:
+          Type: String
+        0:
+          Type: Number
+        null:
+          Type: Boolean
+        9007199254740992:
+          Type: String
+          AssociationProperty: AutoCompleteInput
+          AssociationPropertyMetadata:
+            Length: 8
+            CharacterClasses:
+              - Class: digit
+                Min: 1
+        9007199254740993:
+          Type: CommaDelimitedList
+Resources: {}
+"""
+    )
+
+    names = {
+        "Object.true",
+        "Object.1",
+        "Object.false",
+        "Object.0",
+        "Object.null",
+        "Object.9007199254740992",
+    }
+    assert not any(item.code in {"ROS1306", "ROS5305"} and item.subject in names for item in report.diagnostics)
+    assert not any(item.code == "ROS1305" and item.subject == "digit" for item in report.diagnostics)
+    warning = next(
+        item
+        for item in report.diagnostics
+        if item.code == "ROS5302" and item.subject == "Object.1" and "reference type is suspicious" in item.summary
+    )
+    assert warning.related_locations[0].path[-1].value == 1
+
+
+def test_whole_value_field_paths_validate_terminal_type_projection_and_location() -> None:
+    object_parameter = {
+        "Type": "Json",
+        "AssociationProperty": "Json",
+        "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "Number"}}},
+    }
+    mismatch = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${Object.Name}"},
+        },
+        extra_parameters={"Object": object_parameter},
+    )
+    warning = next(item for item in mismatch.diagnostics if item.code == "ROS5302" and item.subject == "Object.Name")
+    assert warning.actual == "Number"
+    assert warning.related_locations
+    assert display_path(warning.related_locations[0].path).endswith(
+        "Object.AssociationPropertyMetadata.Parameters.Name"
+    )
+
+    matching_object = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${Object.Name}"},
+        },
+        extra_parameters={
+            "Object": {
+                "Type": "Json",
+                "AssociationProperty": "Json",
+                "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+            }
+        },
+    )
+    assert not any(item.code == "ROS5302" and item.subject == "Object.Name" for item in matching_object.diagnostics)
+
+    rows_parameter = {
+        "Type": "Json",
+        "AssociationProperty": "List[Parameter]",
+        "AssociationPropertyMetadata": {
+            "Parameter": {
+                "Type": "Json",
+                "AssociationProperty": "Json",
+                "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+            }
+        },
+    }
+    string_projection_to_object_items = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"CharacterClasses": "${Rows[].Name}"},
+        },
+        extra_parameters={"Rows": rows_parameter},
+    )
+    item_warning = next(
+        item
+        for item in string_projection_to_object_items.diagnostics
+        if item.code == "ROS5302" and item.subject == "Rows[].Name"
+    )
+    assert item_warning.actual == "array<string>"
+    assert item_warning.expected == "array<object>"
+    assert item_warning.related_locations
+
+    matching_object_projection = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"CharacterClasses": "${Rows[].Details}"},
+        },
+        extra_parameters={
+            "Rows": {
+                "Type": "Json",
+                "AssociationProperty": "List[Parameter]",
+                "AssociationPropertyMetadata": {
+                    "Parameter": {
+                        "Type": "Json",
+                        "AssociationPropertyMetadata": {"Parameters": {"Details": {"Type": "Json"}}},
+                    }
+                },
+            }
+        },
+    )
+    assert not any(
+        item.code == "ROS5302" and item.subject == "Rows[].Details" for item in matching_object_projection.diagnostics
+    )
+
+    parameters_row_projection = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"CharacterClasses": "${Rows[].Name}"},
+        },
+        extra_parameters={
+            "Rows": {
+                "Type": "Json",
+                "AssociationProperty": "List[Parameters]",
+                "AssociationPropertyMetadata": {"Parameters": {"Name": {"Type": "String"}}},
+            }
+        },
+    )
+    parameters_row_warning = next(
+        item
+        for item in parameters_row_projection.diagnostics
+        if item.code == "ROS5302" and item.subject == "Rows[].Name"
+    )
+    assert parameters_row_warning.actual == "array<string>"
+    assert parameters_row_warning.expected == "array<object>"
+    assert display_path(parameters_row_warning.related_locations[0].path).endswith(
+        "Rows.AssociationPropertyMetadata.Parameters.Name"
+    )
+
+    meta_list_with_both_row_shapes = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"CharacterClasses": "${Rows[].Name}"},
+        },
+        extra_parameters={
+            "Rows": {
+                "Type": "Json",
+                "AssociationProperty": "ALIYUN::ROS::Type::MetaList",
+                "AssociationPropertyMetadata": {
+                    "Parameter": {
+                        "Type": "Json",
+                        "AssociationPropertyMetadata": {"Parameters": {"Wrong": {"Type": "Number"}}},
+                    },
+                    "Parameters": {"Name": {"Type": "String"}},
+                },
+            }
+        },
+    )
+    meta_list_warning = next(
+        item
+        for item in meta_list_with_both_row_shapes.diagnostics
+        if item.code == "ROS5302" and item.subject == "Rows[].Name"
+    )
+    assert meta_list_warning.actual == "array<string>"
+    assert display_path(meta_list_warning.related_locations[0].path).endswith(
+        "Rows.AssociationPropertyMetadata.Parameters.Name"
+    )
+    assert not any(
+        item.code == "ROS5305" and item.subject == "Rows[].Name" for item in meta_list_with_both_row_shapes.diagnostics
+    )
+
+    scalar_consumer_projection = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${Rows[].Name}"},
+        },
+        extra_parameters={"Rows": rows_parameter},
+    )
+    projection_warning = next(
+        item
+        for item in scalar_consumer_projection.diagnostics
+        if item.code == "ROS5302" and item.subject == "Rows[].Name"
+    )
+    assert projection_warning.actual == "array<string>"
+
+    runtime_component_path = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${Object.Name}"},
+        },
+        extra_parameters={
+            "Object": {
+                "Type": "Json",
+                "AssociationPropertyMetadata": {"Parameters": {"Other": {"Type": "String"}}},
+            }
+        },
+    )
+    assert any(item.code == "ROS5305" and item.subject == "Object.Name" for item in runtime_component_path.diagnostics)
+    assert not any(
+        item.code == "ROS1306" and item.subject == "Object.Name" for item in runtime_component_path.diagnostics
+    )
+
+
+@pytest.mark.parametrize(
+    "reference",
+    ["Rows[].Children[].Name", "Object.Children[].Name", "Rows[]"],
+)
+def test_whole_value_field_paths_reject_unsupported_array_shapes(reference: str) -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${" + reference + "}"},
+        },
+        extra_parameters={"Rows": {"Type": "Json"}, "Object": {"Type": "Json"}},
+    )
+    diagnostic = next(
+        item for item in report.diagnostics if item.subject == reference and item.code in {"ROS1306", "ROS5305"}
+    )
+    assert diagnostic.actual == "${" + reference + "}"
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "Object.Children[0].Name",
+        "Rows[].Children[0].Name",
+        "Object['A.B']",
+        "Object['']",
+        "Object[0]Name",
+        "Object.[0].Name",
+        "Object..Name",
+        "Object.",
+        "Object]Name",
+    ],
+)
+def test_lodash_fixed_index_and_quoted_key_field_paths_are_valid_but_static_limitations(reference: str) -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"Prefix": "${" + reference + "}"},
+        },
+        extra_parameters={"Rows": {"Type": "Json"}, "Object": {"Type": "Json"}},
+    )
+    assert any(
+        item.code == "ROS5305"
+        and item.subject == reference
+        and "field-path reference cannot be resolved completely" in item.summary
+        for item in report.diagnostics
+    )
+    assert not any(item.code == "ROS1306" and item.subject == reference for item in report.diagnostics)
+
+
+def test_frontend_greedy_reference_wrapper_defers_non_string_literal_checks() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::DomainName",
+            "AssociationPropertyMetadata": {
+                "MaxLength": "${Object.{Name}}",
+                "CheckICP": "${Object]Name}",
+            },
+        },
+        extra_parameters={"Object": {"Type": "Json"}},
+    )
+
+    for field, subject in (("MaxLength", "Object.{Name}"), ("CheckICP", "Object]Name")):
+        assert any(item.code == "ROS5305" and item.subject == subject for item in report.diagnostics)
+        assert not any(
+            item.code in {"ROS1305", "ROS1306"}
+            and display_path(item.path).endswith(".AssociationPropertyMetadata." + field)
+            for item in report.diagnostics
+        )
+
+
+def test_env_wrapper_matches_frontend_whitespace_greedy_and_truthiness_semantics() -> None:
+    outer_whitespace = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::DomainName",
+            "AssociationPropertyMetadata": {"MaxLength": " {{env.path}} "},
+        }
+    )
+    assert "ROS1305" in _codes(outer_whitespace)
+    assert not any(item.code == "ROS5305" and item.subject == " {{env.path}} " for item in outer_whitespace.diagnostics)
+
+    greedy_inner_brace = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::DomainName",
+            "AssociationPropertyMetadata": {
+                "MaxLength": "{{Object.{Name}}}",
+                "CheckICP": "{{Object]Name}}",
+            },
+        }
+    )
+    for field, subject in (
+        ("MaxLength", "{{Object.{Name}}}"),
+        ("CheckICP", "{{Object]Name}}"),
+    ):
+        assert any(item.code == "ROS5305" and item.subject == subject for item in greedy_inner_brace.diagnostics)
+        assert not any(
+            item.code == "ROS1305" and display_path(item.path).endswith(".AssociationPropertyMetadata." + field)
+            for item in greedy_inner_brace.diagnostics
+        )
+
+    empty_env_wrapper = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::DomainName",
+            "AssociationPropertyMetadata": {"MaxLength": "{{}}"},
+        }
+    )
+    assert "ROS1305" in _codes(empty_env_wrapper)
+
+
+def test_lodash_path_fallback_still_respects_the_consumers_declared_reference_kinds() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::ACR::Namespace::Name",
+            "AssociationPropertyMetadata": {"RegionId": "${Object['']}"},
+        },
+        extra_parameters={"Object": {"Type": "Json"}},
+    )
+
+    assert any(item.code == "ROS5305" and item.subject == "Object['']" for item in report.diagnostics)
+    assert not any(item.code == "ROS1306" and item.subject == "Object['']" for item in report.diagnostics)
+
+
+def test_runtime_dependent_context_does_not_assume_the_root_parameter_scope() -> None:
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::Hologres::Instance::InstanceId",
+            "AssociationPropertyMetadata": {"cmsInstanceType": "${Target}"},
+        }
+    )
+
+    assert any(item.code == "ROS5305" and item.subject == "Target" for item in report.diagnostics)
+
+
+def test_associated_property_alias_precedence_matches_use_associated_property() -> None:
+    alias_only = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::Hologres::Instance::InstanceId",
+            "AssociationPropertyMetadata": {"CmsInstanceType": "Standard"},
+        }
+    )
+    assert not [item for item in alias_only.diagnostics if item.code in {"ROS1305", "ROS5304"}]
+
+    both = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "ALIYUN::Hologres::Instance::InstanceId",
+            "AssociationPropertyMetadata": {
+                "CmsInstanceType": "Standard",
+                "cmsInstanceType": 123,
+            },
+        }
+    )
+    assert not [item for item in both.diagnostics if item.code == "ROS1305"]
+    ignored = next(item for item in both.diagnostics if item.subject == "cmsInstanceType")
+    assert ignored.code == "ROS5302"
+    assert "CmsInstanceType" in ignored.detail
+
+
+def test_nested_parameter_metadata_is_recursively_validated() -> None:
+    report = _validate(
+        {
+            "Type": "Json",
+            "AssociationProperty": "Json",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Inner": {
+                        "Type": "String",
+                        "AssociationProperty": "AutoCompleteInput",
+                        "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "digit", "Min": 1}]},
+                    }
+                }
+            },
+        }
+    )
+
+    diagnostic = next(item for item in report.diagnostics if item.code == "ROS1305")
+    assert display_path(diagnostic.path).endswith(
+        "AssociationPropertyMetadata.Parameters.Inner.AssociationPropertyMetadata.CharacterClasses[0].Class"
+    )
+
+
+def test_component_owned_metadata_is_not_blocked_when_its_consumer_is_unreachable() -> None:
+    auto_complete = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {
+                "DisabledValues": "not-an-array",
+                "ListMetadata": {"ShowHeader": "not-a-boolean"},
+                "Parameter": {
+                    "Type": "String",
+                    "AssociationProperty": "AutoCompleteInput",
+                    "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "digit", "Min": 1}]},
+                },
+            },
+        }
+    )
+    assert not [item for item in auto_complete.diagnostics if item.code == "ROS1305"]
+
+    runtime_dependent_json = _validate(
+        {
+            "Type": "Json",
+            "AssociationPropertyMetadata": {
+                "Parameters": {
+                    "Inner": {
+                        "Type": "String",
+                        "AssociationProperty": "AutoCompleteInput",
+                        "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "digit", "Min": 1}]},
+                    }
+                }
+            },
+        }
+    )
+    assert not [item for item in runtime_dependent_json.diagnostics if item.code == "ROS1305"]
+    assert any(item.code == "ROS5305" and item.subject == "Parameters" for item in runtime_dependent_json.diagnostics)
+
+
+def test_independent_errors_have_stable_ids_and_precise_source_spans() -> None:
+    parameter = {
+        "Type": "String",
+        "AssociationProperty": "AutoCompleteInput",
+        "AssociationPropertyMetadata": {
+            "Length": "bad",
+            "CharacterClasses": [
+                {"Class": "digit", "Min": 1},
+                {"Class": "number", "Min": "bad"},
+            ],
+        },
+    }
+    first = _validate(parameter)
+    second = _validate(parameter)
+    diagnostics = [item for item in first.diagnostics if item.code == "ROS1305"]
+
+    assert len(diagnostics) == 3
+    assert all(item.source_span is not None for item in diagnostics)
+    assert [item.diagnostic_id for item in diagnostics] == [
+        item.diagnostic_id for item in second.diagnostics if item.code == "ROS1305"
+    ]
+
+
+@pytest.mark.parametrize("transform", ["Aliyun::Terraform-v1.6", "Aliyun::OpenTofu-v1.8"])
+def test_terraform_template_validates_top_level_parameters_and_marks_workspace_limit(transform: str) -> None:
+    template = {
+        "Transform": transform,
+        "Workspace": {"main.tf": "variable {}"},
+        "Parameters": {
+            "Target": {
+                "Type": "String",
+                "AssociationProperty": "AutoCompleteInput",
+                "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "digit", "Min": 1}]},
+            }
+        },
+    }
+    report = validate_ros_template(
+        MaterializedTemplateSource(json.dumps(template)),
+        RequestValidationContext(action="ValidateTemplate"),
+    )
+
+    assert any(item.code == "ROS1305" and item.subject == "digit" for item in report.diagnostics)
+    limitation = next(item for item in report.diagnostics if item.code == "ROS5305")
+    assert limitation.severity == Severity.LIMITATION
+    assert "Top-level Parameters are validated" in limitation.detail
+
+
+def test_nested_parameter_depth_limit_is_a_deterministic_error() -> None:
+    child: dict = {
+        "Type": "String",
+        "AssociationProperty": "AutoCompleteInput",
+        "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "number", "Min": 1}]},
+    }
+    for index in range(18):
+        child = {
+            "Type": "Json",
+            "AssociationProperty": "Json",
+            "AssociationPropertyMetadata": {"Parameters": {"Level{}".format(index): child}},
+        }
+
+    report = _validate(child)
+
+    assert any(
+        item.code == "ROS1305"
+        and item.severity == Severity.ERROR
+        and item.subject is None
+        and "nesting is too deep" in item.summary
+        for item in report.diagnostics
+    )
+
+
+def test_contract_provider_failure_is_fail_closed_and_does_not_escape(monkeypatch) -> None:
+    def fail_contract_load():
+        raise RuntimeError("invalid vendored contract")
+
+    monkeypatch.setattr(association_property_rule, "load_association_property_specs", fail_contract_load)
+
+    report = _validate(
+        {
+            "Type": "String",
+            "AssociationProperty": "AutoCompleteInput",
+            "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "digit", "Min": 1}]},
+        }
+    )
+
+    diagnostic = next(item for item in report.diagnostics if item.code == "ROS9999")
+    assert diagnostic.subject == "builtin.association-property-specs"
+    assert report.analysis_incomplete

--- a/tests/tools/cloud/aliyun/test_ros_validate_hook.py
+++ b/tests/tools/cloud/aliyun/test_ros_validate_hook.py
@@ -260,3 +260,91 @@ class TestCheckTemplate:
         assert outcome.report.diagnostics[0].code == "ROS1202"
         assert outcome.blocking_result.metadata is not None
         assert outcome.blocking_result.metadata["ros_validation"]["error_count"] == 1
+
+    def test_association_property_error_blocks_validate_template_with_structured_detail(self) -> None:
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Parameters": {
+                "GeneratedSuffix": {
+                    "Type": "String",
+                    "AssociationProperty": "AutoCompleteInput",
+                    "AssociationPropertyMetadata": {
+                        "Length": 8,
+                        "CharacterClasses": [{"Class": "digit", "Min": 1}],
+                    },
+                }
+            },
+            "Resources": {},
+        }
+
+        result = check_template("ros", "ValidateTemplate", {"TemplateBody": body})
+
+        assert result is not None and result.blocking_result is not None
+        assert result.template_analyzed
+        assert "ROS1305" in result.blocking_result.content
+        assert "Use number instead" in result.blocking_result.content
+        metadata = result.blocking_result.metadata["ros_validation"]
+        assert metadata["error_count"] == 1
+        assert metadata["diagnostics"][0]["path"] == (
+            "$.Parameters.GeneratedSuffix.AssociationPropertyMetadata.CharacterClasses[0].Class"
+        )
+
+    def test_association_property_rule_is_shared_with_create_stack(self) -> None:
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Parameters": {
+                "P": {
+                    "Type": "String",
+                    "AssociationProperty": "AutoCompleteInput",
+                    "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "digit", "Min": 1}]},
+                }
+            },
+            "Resources": {},
+        }
+
+        result = check_template(
+            "ros",
+            "CreateStack",
+            {"StackName": "stack", "TemplateBody": body},
+        )
+
+        assert result is not None and result.blocking_result is not None
+        assert result.report.counts_by_code["ROS1305"] == 1
+
+    def test_association_property_warning_does_not_block_and_is_attached_once(self) -> None:
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Parameters": {
+                "P": {
+                    "Type": "String",
+                    "AssociationProperty": "ALIYUN::Future::Selector",
+                }
+            },
+            "Resources": {},
+        }
+
+        result = check_template("ros", "ValidateTemplate", {"TemplateBody": body})
+
+        assert result is not None and result.blocking_result is None
+        assert result.report.warning_count == 1
+        assert result.report.counts_by_code["ROS5303"] == 1
+        assert len([item for item in result.report.diagnostics if item.code == "ROS5303"]) == 1
+
+    def test_valid_auto_complete_metadata_continues_and_input_is_not_mutated(self) -> None:
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Parameters": {
+                "P": {
+                    "Type": "String",
+                    "AssociationProperty": "AutoCompleteInput",
+                    "AssociationPropertyMetadata": {"CharacterClasses": [{"Class": "number", "Min": 1}]},
+                }
+            },
+            "Resources": {},
+        }
+        params = {"TemplateBody": body}
+
+        result = check_template("ros", "ValidateTemplate", params)
+
+        assert result is not None and result.blocking_result is None
+        assert params == {"TemplateBody": body}

--- a/tests/tools/cloud/aliyun/test_ros_validation_semantics.py
+++ b/tests/tools/cloud/aliyun/test_ros_validation_semantics.py
@@ -740,6 +740,34 @@ Resources:
     assert "generated JSON" not in render_validation_report(report, blocking=True)
 
 
+def test_renderer_condenses_high_volume_association_property_limitations() -> None:
+    from iac_code.tools.cloud.aliyun.ros_validation.renderer import render_validation_report
+
+    report = ValidationReport.build(
+        [
+            make_diagnostic(
+                code="ROS5305",
+                severity=Severity.LIMITATION,
+                category=Category.LIMITATION,
+                summary="Runtime-dependent metadata cannot be checked locally.",
+                detail="The value depends on runtime context.",
+                path=(mapping_segment("Parameters"), mapping_segment("P{}".format(index))),
+                subject="P{}".format(index),
+            )
+            for index in range(11)
+        ]
+    )
+
+    rendered = render_validation_report(report, blocking=False)
+
+    assert report.limitation_count == 11
+    assert report.to_dict()["limitation_count"] == 11
+    assert "11 local-analysis limitations; details condensed." in rendered
+    assert "11 occurrences; showing 3 examples." in rendered
+    assert "8 additional occurrences are available in structured diagnostics." in rendered
+    assert rendered.count("example path:") == 3
+
+
 def test_json_parser_accepts_tab_whitespace_and_retains_positions() -> None:
     result = parse_template_source('{\n\t"ROSTemplateFormatVersion": "2015-09-01",\n\t"Resources": {}\n}')
 


### PR DESCRIPTION
## Summary

- add a vendored and sanitized ROS `AssociationProperty` / `AssociationPropertyMetadata` validation contract with a synchronization tool
- hook local contract, type, reference, and semantic validation into ROS template validation
- report `ERROR`, `WARNING`, and `LIMITATION` diagnostics with aggregation and source locations
- provide complete, genuine translations for all seven supported languages
- cover contract loading, validation rules, API hooks, packaging, rendering, and internationalization

## Why

ROS service-side validation cannot validate frontend-only `AssociationProperty` behavior. This adds local validation for cases such as:

```yaml
AssociationProperty: AutoCompleteInput
AssociationPropertyMetadata:
  CharacterClasses:
    - Class: digit
```

where `Class` must be `number`.

## Validation

- `make lint`
- `uv run --all-extras pytest tests/ -q -n auto` — 13225 passed, 2 skipped
- validated 881 templates from the local ROS template corpus with no result regressions versus the recorded baseline
- deterministic ValidateTemplate contract E2E — 15/15
- real REPL scenario 1 — 16/16, teardown passed
- real REPL selection/waiting/resume — 15/15, teardown passed
- real A2A performance/backup scenario — 41/41, backup restore assertions passed
