### PR TITLE
feat: apply purpose-aware data redaction

### DIFF
--- a/scripts/a2a/e2e/README.md
+++ b/scripts/a2a/e2e/README.md
@@ -1,10 +1,10 @@
-# A2A E2E Session Recovery
+# A2A E2E Session Recovery and Redaction
 
 This directory contains headless end-to-end checks for A2A pipeline session
-recovery. The runner drives the public A2A JSON-RPC streaming endpoint, records
-SSE events and pipeline snapshots, kills the A2A server with `SIGKILL`, restarts
-it with the same persistence directory, and verifies that the session can
-continue with the expected `contextId` / `taskId` behavior.
+recovery and redaction regressions. The runner drives the public A2A JSON-RPC
+streaming endpoint and records SSE events and pipeline snapshots. Recovery
+scenarios kill and restart the A2A server. `redaction-step4` instead stops at
+candidate selection without restarting, submitting a selection, or deploying.
 
 The script is intentionally close to the manual web debugger flow in
 `scripts/a2a/debugger.py`: `contextId` identifies the conversation, and `taskId`
@@ -46,6 +46,31 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1
 ```
 
+Run the real step 4 redaction regression when checking that stack parameters
+are not replaced with `***` or `[REDACTED]`:
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
+  --allow-real-cloud \
+  --provider dashscope \
+  --model qwen3.6-plus \
+  --stream-timeout 2400 \
+  --preflight-timeout 60 \
+  --scenario redaction-step4
+```
+
+This scenario uses the real mini-app backend/database regression prompt and
+explicitly requires both ROS candidates to create a database account with a
+generated NoEcho password parameter, making the original failure deterministic. It forces
+`IAC_CODE_A2A_SAFE_MODE=true`, and stops when two candidates are shown at
+`confirm_and_select`. It compares the canonical snapshot with the public A2A
+recovery response in memory: generated password parameters must retain the same
+real value, token counters must remain numeric when present, and only known server paths may
+become `[PATH]`. `redaction-audit.json` contains paths, counts, and booleans but
+never credential values. `--redaction-step4-prompt` can override the task, but a
+different task may not generate a password parameter.
+
 Run the scenario1 variant that matches the production performance/backup
 configuration and sends the step4 selection without `taskId`:
 
@@ -60,7 +85,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1-performance-backup
 ```
 
-Run the full real recovery matrix:
+Run the full real E2E matrix:
 
 ```bash
 PATH="$HOME/.local/bin:$PATH" \
@@ -73,6 +98,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --preflight-timeout 60 \
   --scenario scenario1 \
   --scenario scenario1-performance-backup \
+  --scenario redaction-step4 \
   --scenario selection-waiting \
   --scenario ask-waiting \
   --scenario image-initial \
@@ -113,8 +139,9 @@ after you finish inspecting the run.
 not a separate runner or a special mode; it lives in the same scenario matrix as
 the rest of the tests.
 
-| Scenario | Cut point / special condition | Recovery input | Main assertion |
+| Scenario | Cut point / special condition | Follow-up / recovery input | Main assertion |
 | --- | --- | --- | --- |
+| `redaction-step4` | Force A2A safe mode and stop when the real mini-app backend/database task reaches step 4 candidate selection | None; no candidate selection is submitted | Canonical password parameters are not placeholders; public A2A passwords equal canonical values; token counters stay numeric when present; known server paths become `[PATH]` only in the public copy; deployment never starts. |
 | `scenario1` | After pipeline completion and one normal-chat follow-up | Ask what the previous normal-chat question was | Normal-chat history survives restart; VSwitch evidence exists. |
 | `scenario1-performance-backup` | Full `scenario1` with `IAC_CODE_A2A_EXTREME_PERFORMANCE=true` and `IAC_CODE_CONFIG_BACKUP_DIR=<run-dir>/session-backup` | After the Step4 backup is durable, stop the server, remove the matching primary session under `projects`, restart, and select without `taskId`; later normal-chat recovery also omits `taskId` | Only the backup session exists before restart; restart alone does not recreate the primary session; selection without `taskId` restores the primary session from backup and hydrates the recovered task; full scenario1 passes. |
 | `selection-waiting` | Step 4 waits for candidate selection | `你随便选一个方案。` without `taskId` | Waiting step4 task is recovered and selected; VSwitch evidence exists. |
@@ -142,6 +169,12 @@ Most scenarios use the same baseline task:
 
 ```text
 选择一个已有vpc，创建一个vswitch
+```
+
+`redaction-step4` uses the real regression task:
+
+```text
+帮我在阿里云上搭个小程序后端环境，要数据库，平时访问不多，每月最好别超过 200 块。2个方案。两个方案的 ROS 模板都要创建数据库主账号，并为主账号定义 NoEcho 密码参数；密码由你生成满足约束的随机值，带入预览并完整保留到方案选择，不要让我提供。
 ```
 
 Candidate selection uses:
@@ -179,18 +212,19 @@ Only ad-hoc or CLI-overridden text falls back to runtime image rendering.
 
 When stabilizing changes, run the smaller or more diagnostic cases first:
 
-1. `fault-after-snapshot`
-2. `scenario1`
-3. `scenario1-performance-backup`
-4. `selection-waiting`
-5. `ask-waiting`
-6. `image-initial`, `image-ask-waiting`, and `image-selection-waiting`
-7. `image-normal-handoff` and `image-interrupt`
-8. `step1-running` through `step5-running`
-9. `normal-running`
-10. `cancel-step1` through `cancel-step5`
-11. `rollback-step1` through `rollback-step5`
-12. `rollback-step5-cleanup`, then `rollback-step5-cleanup-recovery`
+1. `redaction-step4`
+2. `fault-after-snapshot`
+3. `scenario1`
+4. `scenario1-performance-backup`
+5. `selection-waiting`
+6. `ask-waiting`
+7. `image-initial`, `image-ask-waiting`, and `image-selection-waiting`
+8. `image-normal-handoff` and `image-interrupt`
+9. `step1-running` through `step5-running`
+10. `normal-running`
+11. `cancel-step1` through `cancel-step5`
+12. `rollback-step1` through `rollback-step5`
+13. `rollback-step5-cleanup`, then `rollback-step5-cleanup-recovery`
 
 ## Preflight
 
@@ -262,7 +296,8 @@ Important files:
 
 - `summary.json`: scenario result, check results, `contextId`, `taskId`, and stream summaries.
 - `requests.jsonl`: JSON-RPC requests sent by the runner.
-- `*.events.jsonl`: raw SSE payloads for each stream.
+- `*.events.jsonl`: SSE payloads after the runner's basic artifact redaction.
+- `redaction-audit.json`: non-sensitive canonical/A2A comparison evidence from `redaction-step4`; it contains no password values.
 - `before-kill.pipeline-state.json`, `after-restart.pipeline-state.json`, and similar files: pipeline recovery snapshots.
 - `*.task-get.json` and `*.task-list.json`: redacted `GetTask` / `ListTasks` artifacts when captured by the scenario.
 - `server-1.*.log` and `server-2.*.log`: server logs before and after restart.

--- a/scripts/a2a/e2e/README.zh-CN.md
+++ b/scripts/a2a/e2e/README.zh-CN.md
@@ -1,9 +1,9 @@
-# A2A 会话恢复 E2E
+# A2A 会话恢复与脱敏 E2E
 
-本目录包含用于 A2A pipeline 会话恢复的 headless 端到端检查。Runner 会驱动公开的
-A2A JSON-RPC streaming endpoint，记录 SSE 事件和 pipeline snapshot，用 `SIGKILL`
-杀掉 A2A server，再用相同持久化目录重启，并验证会话能按预期的 `contextId` /
-`taskId` 继续。
+本目录包含用于 A2A pipeline 会话恢复和脱敏回归的 headless 端到端检查。Runner 会驱动公开的
+A2A JSON-RPC streaming endpoint 并记录 SSE 事件和 pipeline snapshot。恢复场景会用 `SIGKILL`
+杀掉 A2A server，再用相同持久化目录重启；`redaction-step4` 则在候选方案选择处停止，不重启、
+不提交选择，也不进入部署。
 
 脚本流程刻意贴近 `scripts/a2a/debugger.py` 的手工 Web debugger：`contextId` 表示
 一次会话，`taskId` 表示这个会话里的一个 A2A task。
@@ -60,6 +60,27 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1
 ```
 
+如果要复现资源栈参数被错误替换为 `***` / `[REDACTED]` 的问题，运行真实的 step 4
+脱敏回归场景：
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
+  --allow-real-cloud \
+  --provider dashscope \
+  --model qwen3.6-plus \
+  --stream-timeout 2400 \
+  --preflight-timeout 60 \
+  --scenario redaction-step4
+```
+
+该场景使用真实的小程序后端 + 数据库 + 月预算 200 元 + 2 个方案需求，并明确要求两个 ROS 方案
+都创建数据库主账号、生成 NoEcho 密码参数，以稳定命中原始问题；server 强制使用
+`IAC_CODE_A2A_SAFE_MODE=true`。它只运行到 `confirm_and_select` 的两个候选方案展示，然后在内存中比较
+canonical snapshot 与 A2A recovery response：生成的密码参数必须保持同一真实值，snapshot 中存在的
+token 统计必须仍为数字，只有已知服务器路径可以变成 `[PATH]`。`redaction-audit.json` 只记录字段路径、计数和布尔结果，
+不会写入密码值。可以用 `--redaction-step4-prompt` 临时覆盖需求，但这样可能无法再保证生成密码参数。
+
 如果要验证和生产性能/backup 配置一致的 scenario1 变体，并在 step4 选择时不带
 `taskId`，运行：
 
@@ -74,7 +95,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1-performance-backup
 ```
 
-如果要跑完整真实恢复矩阵：
+如果要跑完整真实 E2E 矩阵：
 
 ```bash
 PATH="$HOME/.local/bin:$PATH" \
@@ -87,6 +108,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --preflight-timeout 60 \
   --scenario scenario1 \
   --scenario scenario1-performance-backup \
+  --scenario redaction-step4 \
   --scenario selection-waiting \
   --scenario ask-waiting \
   --scenario image-initial \
@@ -124,8 +146,9 @@ provider、tool、真实云调用场景默认会被保护住。只有确认要�
 `scenario1` 是历史遗留名称，表示“pipeline 完成后恢复 normal chat”的基线场景。它不是
 单独 runner，也不是特殊模式，而是完整场景矩阵中的一个场景。
 
-| 场景 | 切点 / 特殊条件 | 恢复时输入 | 主要验收 |
+| 场景 | 切点 / 特殊条件 | 后续输入 / 恢复输入 | 主要验收 |
 | --- | --- | --- | --- |
+| `redaction-step4` | 强制 A2A safe mode，真实小程序后端/数据库需求到达 step4 候选方案选择即停止 | 无；不提交方案选择 | canonical 密码参数不是脱敏占位符；A2A 密码值与 canonical 一致；存在的 token 统计仍为数字；已知服务器路径只在 A2A 副本中变成 `[PATH]`；不进入部署。 |
 | `scenario1` | pipeline 完成并完成一轮 normal-chat follow-up 后 | 询问上一条 normal-chat 问题是什么 | normal-chat 历史重启后仍可用；存在 VSwitch 证据。 |
 | `scenario1-performance-backup` | 完整 `scenario1`，并强制 `IAC_CODE_A2A_EXTREME_PERFORMANCE=true`、`IAC_CODE_CONFIG_BACKUP_DIR=<run-dir>/session-backup` | step4 backup 落盘后停服并删除主 `projects` 下对应 session，重启后不带 `taskId` 选择；后续 normal-chat 恢复也不带 `taskId` | 重启前只有 backup session；重启本身不会重建主 session；省略 `taskId` 的选择会从 backup restore 主 session 并 hydrate 到恢复 task；完整 scenario1 通过。 |
 | `selection-waiting` | step4 等待候选方案选择时 | 不带 `taskId` 发送 `你随便选一个方案。` | 能恢复等待中的 step4 task 并完成选择；存在 VSwitch 证据。 |
@@ -153,6 +176,12 @@ provider、tool、真实云调用场景默认会被保护住。只有确认要�
 
 ```text
 选择一个已有vpc，创建一个vswitch
+```
+
+`redaction-step4` 使用原始问题对应的真实回归需求：
+
+```text
+帮我在阿里云上搭个小程序后端环境，要数据库，平时访问不多，每月最好别超过 200 块。2个方案。两个方案的 ROS 模板都要创建数据库主账号，并为主账号定义 NoEcho 密码参数；密码由你生成满足约束的随机值，带入预览并完整保留到方案选择，不要让我提供。
 ```
 
 候选方案选择使用：
@@ -189,18 +218,19 @@ CLI 覆盖后的文本，才会回退到运行时渲染图片。
 
 稳定或回归时，建议从更小、更容易定位问题的场景开始：
 
-1. `fault-after-snapshot`
-2. `scenario1`
-3. `scenario1-performance-backup`
-4. `selection-waiting`
-5. `ask-waiting`
-6. `image-initial`、`image-ask-waiting` 和 `image-selection-waiting`
-7. `image-normal-handoff` 和 `image-interrupt`
-8. `step1-running` 到 `step5-running`
-9. `normal-running`
-10. `cancel-step1` 到 `cancel-step5`
-11. `rollback-step1` 到 `rollback-step5`
-12. `rollback-step5-cleanup`，再跑 `rollback-step5-cleanup-recovery`
+1. `redaction-step4`
+2. `fault-after-snapshot`
+3. `scenario1`
+4. `scenario1-performance-backup`
+5. `selection-waiting`
+6. `ask-waiting`
+7. `image-initial`、`image-ask-waiting` 和 `image-selection-waiting`
+8. `image-normal-handoff` 和 `image-interrupt`
+9. `step1-running` 到 `step5-running`
+10. `normal-running`
+11. `cancel-step1` 到 `cancel-step5`
+12. `rollback-step1` 到 `rollback-step5`
+13. `rollback-step5-cleanup`，再跑 `rollback-step5-cleanup-recovery`
 
 ## Preflight
 
@@ -270,7 +300,8 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
 
 - `summary.json`：场景结果、检查结果、`contextId`、`taskId` 和 stream 摘要。
 - `requests.jsonl`：runner 发送的 JSON-RPC 请求。
-- `*.events.jsonl`：每个 stream 的原始 SSE payload。
+- `*.events.jsonl`：每个 stream 经过 runner 基础脱敏后落盘的 SSE payload。
+- `redaction-audit.json`：仅 `redaction-step4` 生成；记录 canonical/A2A 对比的非敏感证据，不含密码值。
 - `before-kill.pipeline-state.json`、`after-restart.pipeline-state.json` 等文件：pipeline 恢复 snapshot。
 - `*.task-get.json` 和 `*.task-list.json`：场景捕获到的、经过脱敏的 `GetTask` / `ListTasks` artifact。
 - `server-1.*.log` 和 `server-2.*.log`：重启前后的 server 日志。

--- a/scripts/a2a/e2e/run_recovery_scenarios.py
+++ b/scripts/a2a/e2e/run_recovery_scenarios.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Run A2A pipeline session-recovery E2E scenarios.
+"""Run A2A pipeline recovery and redaction E2E scenarios.
 
 The scenarios in this file intentionally drive the public A2A JSON-RPC HTTP
-endpoint. They do not call pipeline internals directly. Each run starts a local
-A2A server, records raw requests/SSE/pipeline snapshots, kills the server with
-SIGKILL at a scenario-specific point, restarts it with the same persistence
-directory, then validates recovery behavior.
+endpoint. They do not call pipeline internals directly. Recovery scenarios kill
+and restart a local A2A server at scenario-specific points. The redaction
+regression scenario stops at step 4 before deployment and compares the
+canonical snapshot with the public A2A projection without persisting secrets.
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 import yaml
@@ -77,13 +78,21 @@ from debugger import (  # noqa: E402
     build_task_get_payload,
 )
 
+from iac_code.a2a.pipeline_paths import existing_a2a_pipeline_dir_for_session  # noqa: E402
 from iac_code.services.session_storage import SessionStorage  # noqa: E402
 from iac_code.utils.project_paths import get_projects_dir  # noqa: E402
+from iac_code.utils.public_paths import redact_known_public_paths  # noqa: E402
 
 ASK_TRIGGER_PROMPT = "我有个产品要上线"
 ASK_FIRST_ANSWER = "我要创建云网络资源；本次只选择已有 VPC 创建一个 VSwitch，不部署 ECS、EIP、SLB 或 Nginx。"
 ASK_SECOND_ANSWER = "选择一个已有 VPC，创建一个 VSwitch；地域、可用区和网段你按低成本默认值推荐。"
 INTERVENING_ASK_ANSWER = "使用默认配置（可用区和网段自动规划），继续。"
+REDACTION_STEP4_PROMPT = (
+    "帮我在阿里云上搭个小程序后端环境，要数据库，平时访问不多，每月最好别超过 200 块。2个方案。"
+    "两个方案的 ROS 模板都要创建数据库主账号，并为主账号定义 NoEcho 密码参数；"
+    "密码由你生成满足约束的随机值，带入预览并完整保留到方案选择，不要让我提供。"
+)
+REDACTION_STEP4_ASK_ANSWER = "使用默认地域和低成本配置；数据库密码由你生成合规随机值，继续准备 2 个方案，不要部署。"
 ROLLBACK_PROMPT = "我改需求了：使用已有 VPC 创建一个安全组，不创建 VSwitch。请基于这个新需求重新规划。"
 CONTINUE_PROMPT = "继续"
 CLEANUP_RECOVERY_PROMPT = (
@@ -208,6 +217,8 @@ MAX_EVIDENCE_FILE_BYTES = 256 * 1024
 SECURITY_GROUP_MARKERS = ("ALIYUN::ECS::SecurityGroup", "SecurityGroupId", "sg-", "安全组")
 TERMINAL_STATES = {"TASK_STATE_COMPLETED", "TASK_STATE_FAILED", "TASK_STATE_CANCELED", "TASK_STATE_INPUT_REQUIRED"}
 ROS_STACK_DELETED_STATUSES = {"DELETE_COMPLETE"}
+REDACTION_PLACEHOLDERS = frozenset({"***", "[REDACTED]", "<redacted>"})
+REDACTION_STEP4_SCENARIO = "redaction-step4"
 
 
 @dataclass
@@ -502,6 +513,9 @@ class ScenarioHarness:
             model=args.model,
             api_base=args.api_base,
         )
+        if scenario == REDACTION_STEP4_SCENARIO:
+            self.server_env["IAC_CODE_A2A_SAFE_MODE"] = "true"
+            self.notes.append("forced IAC_CODE_A2A_SAFE_MODE=true for the step4 redaction regression")
         if scenario in PERFORMANCE_BACKUP_SCENARIOS:
             self.backup_root = (self.run_dir / "session-backup").resolve()
             self.backup_root.mkdir(parents=True, exist_ok=True)
@@ -823,6 +837,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--leave-server-running", action="store_true")
     parser.add_argument("--no-auto-approve-permissions", action="store_true")
     parser.add_argument("--initial-prompt", default=DEFAULT_INITIAL_PROMPT)
+    parser.add_argument(
+        "--redaction-step4-prompt",
+        default=REDACTION_STEP4_PROMPT,
+        help="Real backend/database prompt used only by the redaction-step4 scenario.",
+    )
     parser.add_argument("--selection-prompt", default=DEFAULT_SELECTION_PROMPT)
     parser.add_argument("--normal-followup-prompt", default=DEFAULT_NORMAL_FOLLOWUP_PROMPT)
     parser.add_argument("--recovery-prompt", default=DEFAULT_RECOVERY_PROMPT)
@@ -1085,6 +1104,49 @@ def run_selection_waiting(args: argparse.Namespace, scenario: str) -> int:
         _add_hydrated_task_checks(h, selection, "selection answer")
         h.checks["selection accepted and advanced past waiting step"] = _selection_advanced_past_waiting_step(selection)
         h.checks["VSwitch evidence found"] = _has_any_marker(_all_evidence(h), VSWITCH_MARKERS)
+
+    return _run_with_harness(args, scenario, callback)
+
+
+def run_redaction_step4(args: argparse.Namespace, scenario: str) -> int:
+    """Reach candidate selection and audit canonical versus safe-mode A2A data."""
+
+    def callback(h: ScenarioHarness) -> None:
+        initial = h.stream(prompt=args.redaction_step4_prompt, name="01-redaction-step4", context_id="", task_id="")
+        initial = _answer_intervening_ask_inputs(
+            h,
+            initial,
+            name_prefix="01-redaction-step4",
+            answer_prompt=REDACTION_STEP4_ASK_ANSWER,
+        )
+        h.checks["initial reached step4 candidate selection"] = (
+            initial.last_input_required_step_id == "confirm_and_select"
+        )
+
+        canonical_snapshot = _load_canonical_pipeline_snapshot(h)
+        public_state = _fetch_pipeline_state_for_redaction_audit(h)
+        public_snapshot = _snapshot(public_state)
+        if public_snapshot is None:
+            raise RuntimeError("public pipeline state did not contain a snapshot")
+
+        audit = _build_step4_redaction_audit(
+            canonical_snapshot,
+            public_snapshot,
+            known_server_paths=(h.cwd, h.server_cwd, str(h.run_dir.resolve())),
+            safe_mode=h.server_env.get("IAC_CODE_A2A_SAFE_MODE", ""),
+        )
+        h.snapshots["redaction_audit"] = audit
+        _write_json(h.run_dir / "redaction-audit.json", audit)
+        h.checks.update(_step4_redaction_checks(audit))
+        h.checks["public snapshot is waiting at step4"] = (
+            public_snapshot.get("status") == "waiting_input" and _pending_step_id(public_state) == "confirm_and_select"
+        )
+        pending_input = public_snapshot.get("pendingInput")
+        options = pending_input.get("options") if isinstance(pending_input, dict) else None
+        h.checks["step4 exposes two candidate options"] = isinstance(options, list) and len(options) == 2
+        h.notes.append(
+            "stopped at step4 candidate selection; no selection input was sent and deployment was not started"
+        )
 
     return _run_with_harness(args, scenario, callback)
 
@@ -1888,6 +1950,7 @@ def _answer_intervening_ask_inputs(
     summary: StreamSummary,
     *,
     name_prefix: str,
+    answer_prompt: str = INTERVENING_ASK_ANSWER,
 ) -> StreamSummary:
     current = summary
     for idx in range(1, 5):
@@ -1899,7 +1962,7 @@ def _answer_intervening_ask_inputs(
         if kind != "ask_user_question":
             return current
         h.notes.append(f"answered intervening ask_user_question before step4 selection: {current.name}")
-        current = h.stream(prompt=INTERVENING_ASK_ANSWER, name=f"{name_prefix}-answer-ask-{idx}")
+        current = h.stream(prompt=answer_prompt, name=f"{name_prefix}-answer-ask-{idx}")
     return current
 
 
@@ -2135,6 +2198,207 @@ def fetch_tasks(
         suffix="task-list",
         redaction_env=redaction_env,
     )
+
+
+def _fetch_pipeline_state_for_redaction_audit(h: ScenarioHarness) -> dict[str, Any]:
+    """Read the public state in memory; never persist its credential values."""
+
+    query = urlencode({"contextId": h.context_id, "taskId": h.pipeline_task_id})
+    request = Request(h.server_url.rstrip("/") + f"/iac-code/pipeline/state?{query}", method="GET")
+    with urlopen(request, timeout=30) as response:
+        raw = response.read().decode("utf-8", errors="strict")
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise RuntimeError("public pipeline state was not a JSON object")
+    return value
+
+
+def _load_canonical_pipeline_snapshot(h: ScenarioHarness) -> dict[str, Any]:
+    """Load the functional snapshot in memory without copying secrets to run artifacts."""
+
+    cwd, session_id = _pipeline_session_identity(h)
+    if not cwd or not session_id:
+        raise RuntimeError("cannot locate canonical pipeline snapshot: missing cwd/session id")
+    pipeline_dir = existing_a2a_pipeline_dir_for_session(cwd=cwd, session_id=session_id)
+    snapshot_path = pipeline_dir / "a2a-snapshot.json"
+    try:
+        value = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"cannot read canonical pipeline snapshot: {type(exc).__name__}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError("canonical pipeline snapshot was not a JSON object")
+    return value
+
+
+def _build_step4_redaction_audit(
+    canonical_snapshot: dict[str, Any],
+    public_snapshot: dict[str, Any],
+    *,
+    known_server_paths: Iterable[str],
+    safe_mode: str,
+) -> dict[str, Any]:
+    """Compare step4 data while returning only non-secret evidence."""
+
+    canonical_credentials = _credential_scalar_values(canonical_snapshot)
+    public_credentials = _credential_scalar_values(public_snapshot)
+    canonical_tokens = _token_counter_values(canonical_snapshot)
+    public_tokens = _token_counter_values(public_snapshot)
+    canonical_parameter_placeholders = _functional_parameter_placeholder_paths(canonical_snapshot)
+    public_parameter_placeholders = _functional_parameter_placeholder_paths(public_snapshot)
+    known_paths = tuple(dict.fromkeys(path for path in known_server_paths if isinstance(path, str) and path))
+    public_text = json.dumps(public_snapshot, ensure_ascii=False, default=str)
+
+    credential_paths = set(canonical_credentials)
+    public_credential_paths = set(public_credentials)
+    token_paths = set(canonical_tokens)
+    public_token_paths = set(public_tokens)
+    return {
+        "safeModeValue": safe_mode,
+        "canonicalCredentialFieldCount": len(canonical_credentials),
+        "publicCredentialFieldCount": len(public_credentials),
+        "credentialFieldPaths": sorted(credential_paths),
+        "credentialFieldsMissingFromPublic": sorted(credential_paths - public_credential_paths),
+        "unexpectedPublicCredentialFields": sorted(public_credential_paths - credential_paths),
+        "credentialFieldsChangedInPublic": sorted(
+            path
+            for path in credential_paths & public_credential_paths
+            if canonical_credentials[path] != public_credentials[path]
+        ),
+        "canonicalFunctionalParameterPlaceholderPaths": canonical_parameter_placeholders,
+        "publicFunctionalParameterPlaceholderPaths": public_parameter_placeholders,
+        "canonicalTokenCounterCount": len(canonical_tokens),
+        "publicTokenCounterCount": len(public_tokens),
+        "canonicalNonNumericTokenCounterPaths": sorted(
+            path for path, value in canonical_tokens.items() if not _is_number(value)
+        ),
+        "publicNonNumericTokenCounterPaths": sorted(
+            path for path, value in public_tokens.items() if not _is_number(value)
+        ),
+        "tokenCounterPathsMissingFromPublic": sorted(token_paths - public_token_paths),
+        "unexpectedPublicTokenCounterPaths": sorted(public_token_paths - token_paths),
+        "tokenCountersChangedInPublic": sorted(
+            path for path in token_paths & public_token_paths if canonical_tokens[path] != public_tokens[path]
+        ),
+        "canonicalKnownServerPathOccurrences": _known_server_path_occurrences(canonical_snapshot, known_paths),
+        "publicKnownServerPathOccurrences": _known_server_path_occurrences(public_snapshot, known_paths),
+        "publicPathPlaceholderOccurrences": public_text.count("[PATH]"),
+    }
+
+
+def _step4_redaction_checks(audit: dict[str, Any]) -> dict[str, bool]:
+    return {
+        "A2A safe mode is enabled": str(audit.get("safeModeValue") or "").strip().lower() in {"1", "true", "yes", "on"},
+        "canonical snapshot contains generated credential parameters": bool(audit.get("canonicalCredentialFieldCount")),
+        "canonical functional parameters contain no redaction placeholders": not bool(
+            audit.get("canonicalFunctionalParameterPlaceholderPaths")
+        ),
+        "public functional parameters contain no redaction placeholders": not bool(
+            audit.get("publicFunctionalParameterPlaceholderPaths")
+        ),
+        "public credential fields match canonical values": not any(
+            audit.get(key)
+            for key in (
+                "credentialFieldsMissingFromPublic",
+                "unexpectedPublicCredentialFields",
+                "credentialFieldsChangedInPublic",
+            )
+        ),
+        "canonical token counters are numeric when present": not bool(
+            audit.get("canonicalNonNumericTokenCounterPaths")
+        ),
+        "public token counters remain numeric and unchanged when present": not any(
+            audit.get(key)
+            for key in (
+                "publicNonNumericTokenCounterPaths",
+                "tokenCounterPathsMissingFromPublic",
+                "unexpectedPublicTokenCounterPaths",
+                "tokenCountersChangedInPublic",
+            )
+        ),
+        "canonical snapshot contains a known server path": bool(audit.get("canonicalKnownServerPathOccurrences")),
+        "safe mode hides known server paths from public state": audit.get("publicKnownServerPathOccurrences") == 0,
+        "safe mode public state contains a path placeholder": bool(audit.get("publicPathPlaceholderOccurrences")),
+    }
+
+
+def _credential_scalar_values(value: Any) -> dict[str, Any]:
+    return {path: item for path, key, item in _iter_scalar_values(value) if "password" in key.casefold()}
+
+
+def _token_counter_values(value: Any) -> dict[str, Any]:
+    return {path: item for path, key, item in _iter_scalar_values(value) if key.casefold().endswith("tokens")}
+
+
+def _functional_parameter_placeholder_paths(value: Any) -> list[str]:
+    paths: list[str] = []
+    for path, key, item in _iter_scalar_values(value):
+        if not isinstance(item, str) or item.strip().casefold() not in {
+            placeholder.casefold() for placeholder in REDACTION_PLACEHOLDERS
+        }:
+            continue
+        segments = tuple(segment.casefold() for segment in _json_path_segments(path))
+        if (
+            "password" in key.casefold()
+            or "deployment_parameters" in segments
+            or ("preview_validation" in segments and "parameters" in segments)
+        ):
+            paths.append(path)
+    return sorted(paths)
+
+
+def _known_server_path_occurrences(value: Any, known_server_paths: Iterable[str]) -> int:
+    """Count path tokens under known roots without matching sibling path prefixes."""
+
+    roots = tuple({"path": path, "label": "[PATH]"} for path in known_server_paths if path)
+    if not roots:
+        return 0
+
+    def count_text(text: str) -> int:
+        redacted = redact_known_public_paths(text, roots)
+        return max(0, redacted.count("[PATH]") - text.count("[PATH]"))
+
+    def visit(item: Any) -> int:
+        if isinstance(item, dict):
+            return sum(
+                (count_text(key) if isinstance(key, str) else 0) + visit(child) for key, child in item.items()
+            )
+        if isinstance(item, (list, tuple)):
+            return sum(visit(child) for child in item)
+        if isinstance(item, str):
+            return count_text(item)
+        return 0
+
+    return visit(value)
+
+
+def _iter_scalar_values(value: Any, path: tuple[str, ...] = ()) -> Iterable[tuple[str, str, Any]]:
+    if isinstance(value, dict):
+        for raw_key, item in value.items():
+            key = str(raw_key)
+            next_path = (*path, key)
+            if isinstance(item, (dict, list, tuple)):
+                yield from _iter_scalar_values(item, next_path)
+            else:
+                yield _json_path(next_path), key, item
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            next_path = (*path, str(index))
+            if isinstance(item, (dict, list, tuple)):
+                yield from _iter_scalar_values(item, next_path)
+            else:
+                yield _json_path(next_path), str(index), item
+
+
+def _json_path(path: tuple[str, ...]) -> str:
+    return ".".join(path)
+
+
+def _json_path_segments(path: str) -> tuple[str, ...]:
+    return tuple(path.split(".")) if path else ()
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 def _snapshot(response: Any) -> dict[str, Any] | None:
@@ -3206,6 +3470,7 @@ _REAL_CLOUD_SCENARIOS = {
     "scenario1-performance-backup",
     "normal-running",
     "ask-waiting",
+    REDACTION_STEP4_SCENARIO,
     "selection-waiting",
     "rollback-step5-cleanup",
     "rollback-step5-cleanup-recovery",
@@ -3225,6 +3490,7 @@ _SCENARIOS: dict[str, Callable[[argparse.Namespace, str], int]] = {
     "scenario1-performance-backup": run_scenario1_performance_backup,
     "normal-running": run_normal_running,
     "ask-waiting": run_ask_waiting,
+    REDACTION_STEP4_SCENARIO: run_redaction_step4,
     "selection-waiting": run_selection_waiting,
     "fault-after-snapshot": run_fault_after_snapshot,
     "rollback-step5-cleanup": run_rollback_step5_cleanup,

--- a/src/iac_code/a2a/app.py
+++ b/src/iac_code/a2a/app.py
@@ -12,7 +12,7 @@ from contextlib import asynccontextmanager, suppress
 from email.utils import formatdate
 from pathlib import Path
 from time import time
-from typing import Awaitable, Callable
+from typing import Any, AsyncIterator, Awaitable, Callable, cast
 
 from a2a.auth.user import User
 from a2a.server.context import ServerCallContext
@@ -29,6 +29,12 @@ from iac_code.a2a.agent_card import agent_card_to_client_dict
 from iac_code.a2a.jsonrpc_passthrough import (
     install_jsonrpc_error_data_passthrough,
     install_v03_jsonrpc_error_data_passthrough,
+)
+from iac_code.a2a.projection import (
+    project_a2a_data,
+    project_a2a_text,
+    resolve_a2a_public_path_roots,
+    resolve_a2a_public_path_roots_for_data,
 )
 from iac_code.i18n import _
 
@@ -144,6 +150,146 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
         )
 
 
+class A2AProjectionMiddleware(BaseHTTPMiddleware):
+    """Apply the current A2A delivery policy at the HTTP wire boundary."""
+
+    def __init__(self, app: Any, *, task_store: Any) -> None:
+        super().__init__(app)
+        self._task_store = task_store
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        request_data = await _a2a_request_data(request)
+        response = await call_next(request)
+        request_data = _with_a2a_path_parameters(request, request_data)
+        if request.url.path in {"/health", AGENT_CARD_WELL_KNOWN_PATH}:
+            return response
+
+        content_type = response.headers.get("content-type", "").lower()
+        streaming_response = cast(Any, response)
+        if content_type.startswith("text/event-stream"):
+            streaming_response.body_iterator = self._project_sse(
+                streaming_response.body_iterator,
+                request_data=request_data,
+            )
+            return response
+        if "json" not in content_type:
+            return response
+
+        body = b"".join([_response_chunk_bytes(chunk) async for chunk in streaming_response.body_iterator])
+        try:
+            data = json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return Response(
+                body,
+                status_code=response.status_code,
+                headers=_response_headers_without_length(response),
+                background=response.background,
+            )
+        roots = await self._resolve_roots(data, request_data)
+        projected = project_a2a_data(data, public_path_roots=roots)
+        return Response(
+            json.dumps(projected, ensure_ascii=False, separators=(",", ":")).encode("utf-8"),
+            status_code=response.status_code,
+            headers=_response_headers_without_length(response),
+            background=response.background,
+        )
+
+    async def _project_sse(self, body_iterator: Any, *, request_data: Any) -> AsyncIterator[bytes]:
+        pending = b""
+        async for chunk in body_iterator:
+            pending += _response_chunk_bytes(chunk)
+            while True:
+                frame, separator, pending = _take_sse_frame(pending)
+                if separator is None:
+                    pending = frame
+                    break
+                yield await self._project_sse_frame(frame, request_data=request_data) + separator
+        if pending:
+            yield await self._project_sse_frame(pending, request_data=request_data)
+
+    async def _project_sse_frame(self, frame: bytes, *, request_data: Any) -> bytes:
+        output: list[bytes] = []
+        for line in frame.splitlines(keepends=True):
+            stripped = line.lstrip()
+            if not stripped.startswith(b"data:"):
+                output.append(line)
+                continue
+            prefix_length = len(line) - len(stripped)
+            payload_with_ending = stripped.removeprefix(b"data:")
+            ending = b""
+            if payload_with_ending.endswith(b"\r\n"):
+                payload_with_ending, ending = payload_with_ending[:-2], b"\r\n"
+            elif payload_with_ending.endswith(b"\n"):
+                payload_with_ending, ending = payload_with_ending[:-1], b"\n"
+            try:
+                data = json.loads(payload_with_ending.strip())
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                output.append(line)
+                continue
+            roots = await self._resolve_roots(data, request_data)
+            projected = project_a2a_data(data, public_path_roots=roots)
+            encoded = json.dumps(projected, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+            output.append(line[:prefix_length] + b"data: " + encoded + ending)
+        return b"".join(output)
+
+    async def _resolve_roots(self, response_data: Any, request_data: Any) -> list[dict[str, str]]:
+        return await resolve_a2a_public_path_roots_for_data(
+            self._task_store,
+            response_data=response_data,
+            request_data=request_data,
+        )
+
+
+async def _a2a_request_data(request: Request) -> Any:
+    data: dict[str, Any] = dict(request.query_params)
+    if request.method in {"POST", "PUT", "PATCH"}:
+        try:
+            body = await request.json()
+        except Exception:
+            body = None
+        if isinstance(body, dict):
+            data.update(body)
+        elif body is not None:
+            data["body"] = body
+    return data
+
+
+def _with_a2a_path_parameters(request: Request, request_data: Any) -> dict[str, Any]:
+    """Add REST route identity after routing has populated ``path_params``."""
+
+    data = dict(request_data) if isinstance(request_data, dict) else {"body": request_data}
+    path_params = request.scope.get("path_params")
+    if not isinstance(path_params, dict):
+        return data
+    task_id = path_params.get("id")
+    if isinstance(task_id, str) and task_id and "/tasks/" in request.url.path:
+        data.setdefault("taskId", task_id)
+    context_id = path_params.get("context_id") or path_params.get("contextId")
+    if isinstance(context_id, str) and context_id:
+        data.setdefault("contextId", context_id)
+    return data
+
+
+def _response_chunk_bytes(chunk: Any) -> bytes:
+    if isinstance(chunk, bytes):
+        return chunk
+    if isinstance(chunk, memoryview):
+        return chunk.tobytes()
+    return str(chunk).encode("utf-8")
+
+
+def _response_headers_without_length(response: Response) -> dict[str, str]:
+    return {key: value for key, value in response.headers.items() if key.lower() != "content-length"}
+
+
+def _take_sse_frame(data: bytes) -> tuple[bytes, bytes | None, bytes]:
+    candidates = [(index, separator) for separator in (b"\r\n\r\n", b"\n\n") if (index := data.find(separator)) >= 0]
+    if not candidates:
+        return data, None, b""
+    index, separator = min(candidates, key=lambda item: item[0])
+    return data[:index], separator, data[index + len(separator) :]
+
+
 async def health(request: Request) -> JSONResponse:
     return JSONResponse({"status": "healthy"})
 
@@ -253,6 +399,13 @@ def create_app(
 
     recovery_service = A2APipelineRecoveryService(task_store=components.task_store)
 
+    async def recovery_path_roots(*, context_id: str | None, task_id: str | None) -> list[dict[str, str]]:
+        return await resolve_a2a_public_path_roots(
+            components.task_store,
+            task_id=task_id,
+            context_id=context_id,
+        )
+
     async def get_pipeline_state(request: Request) -> JSONResponse:
         context_id = request.query_params.get("contextId") or None
         task_id = request.query_params.get("taskId") or None
@@ -263,16 +416,28 @@ def create_app(
         if parse_error is not None:
             return JSONResponse({"error": parse_error}, status_code=400)
 
+        call_context = _call_context_from_request(request)
         try:
             state = await recovery_service.get_state(
                 context_id=context_id,
                 task_id=task_id,
                 after_sequence=after_sequence,
-                call_context=_call_context_from_request(request),
+                call_context=call_context,
             )
         except ValueError as exc:
-            return JSONResponse({"error": str(exc)}, status_code=404)
-        return JSONResponse(state)
+            roots = await recovery_path_roots(
+                context_id=context_id,
+                task_id=task_id,
+            )
+            return JSONResponse(
+                {"error": project_a2a_text(str(exc), public_path_roots=roots)},
+                status_code=404,
+            )
+        roots = await recovery_path_roots(
+            context_id=context_id,
+            task_id=task_id,
+        )
+        return JSONResponse(project_a2a_data(state, public_path_roots=roots))
 
     routes: list[BaseRoute] = [
         Route("/health", health, methods=["GET"]),
@@ -290,6 +455,7 @@ def create_app(
     routes.append(Route("/", handle_jsonrpc, methods=["POST"]))
     routes.extend(create_rest_routes(components.handler, enable_v0_3_compat=True))
     app = Starlette(routes=routes, lifespan=lifespan)
+    app.add_middleware(A2AProjectionMiddleware, task_store=components.task_store)
     app.add_middleware(
         A2AAuthMiddleware,
         token=token,

--- a/src/iac_code/a2a/events.py
+++ b/src/iac_code/a2a/events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
@@ -18,15 +19,10 @@ from a2a.types import (
 )
 from google.protobuf.json_format import ParseDict
 
-from iac_code.a2a.artifacts import (
-    sanitize_public_artifact_text,
-    sanitize_public_tool_output_data,
-)
+from iac_code.a2a.artifacts import sanitize_public_artifact_text
 from iac_code.a2a.exposure import A2AExposureType, normalize_a2a_exposure_types
-from iac_code.a2a.metadata_redaction import A2AMetadataEchoRedactor
 from iac_code.i18n import _
 from iac_code.mcp.progress import mcp_progress_metadata, mcp_progress_public_name
-from iac_code.mcp.redaction import sanitize_mcp_public_data
 from iac_code.services.permissions.audit import (
     build_input_summary,
     build_redacted_tool_input,
@@ -51,10 +47,11 @@ from iac_code.types.stream_events import (
 _METADATA_MAX_CHARS = 4000
 _ERROR_TEXT_MAX_CHARS = 1000
 _METADATA_MAX_DEPTH = 32
+_ARTIFACT_CONTAINER_KEYS = {"artifact", "artifacts"}
+_ARTIFACT_PAYLOAD_KEYS = {"content", "bytes", "base64", "raw", "path"}
 logger = logging.getLogger(__name__)
 A2APermissionResolver: TypeAlias = Callable[[PermissionRequestEvent], "bool | Awaitable[bool]"]
 IAC_CODE_SESSION_ID_METADATA_KEY = "iacCodeSessionId"
-_METADATA_REDACTOR = A2AMetadataEchoRedactor()
 
 
 def iac_code_session_metadata(session_id: str) -> dict[str, Any]:
@@ -75,16 +72,12 @@ def _truncate(value: Any, *, _depth: int = 0) -> Any:
     if _depth >= _METADATA_MAX_DEPTH:
         return "[truncated-depth]"
     if isinstance(value, str):
-        return sanitize_public_artifact_text(value)[:_METADATA_MAX_CHARS]
+        return value[:_METADATA_MAX_CHARS]
     if isinstance(value, dict):
         return {str(k): _truncate(v, _depth=_depth + 1) for k, v in value.items()}
     if isinstance(value, list):
         return [_truncate(v, _depth=_depth + 1) for v in value]
     return value
-
-
-def _sanitize_trace_input(value: Any) -> Any:
-    return _METADATA_REDACTOR.redact(_truncate(value))
 
 
 def _public_tool_input_metadata(tool_name: str, tool_input: dict[str, Any]) -> dict[str, Any]:
@@ -183,10 +176,42 @@ def _tool_result_metadata(
     is_error: bool = False,
     public_path_roots: list[dict[str, str]] | None = None,
 ) -> Any:
-    sanitized = sanitize_public_tool_output_data(result, public_path_roots=public_path_roots)
-    if is_error and isinstance(sanitized, str):
-        return sanitize_public_artifact_text(sanitized, public_path_roots=public_path_roots)
-    return _truncate(sanitized)
+    del is_error, public_path_roots
+    return _tool_result_metadata_value(copy.deepcopy(result))
+
+
+def _tool_result_metadata_value(value: Any, *, _depth: int = 0, _artifact_scope: bool = False) -> Any:
+    """Build protobuf-safe trace metadata without applying redaction.
+
+    Artifact payload bodies remain outside the trace metadata, matching the
+    existing artifact externalization contract. All other already-exposed
+    values are preserved, subject only to the existing depth/string bounds.
+    """
+
+    if _depth >= _METADATA_MAX_DEPTH:
+        return "[truncated-depth]"
+    if isinstance(value, str):
+        return value[:_METADATA_MAX_CHARS]
+    if isinstance(value, dict):
+        output: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            key_lower = key_text.lower()
+            if _artifact_scope and key_lower in _ARTIFACT_PAYLOAD_KEYS:
+                continue
+            output[key_text] = _tool_result_metadata_value(
+                item,
+                _depth=_depth + 1,
+                _artifact_scope=_artifact_scope or key_lower in _ARTIFACT_CONTAINER_KEYS,
+            )
+        return output
+    if isinstance(value, list | tuple):
+        return [
+            _tool_result_metadata_value(item, _depth=_depth + 1, _artifact_scope=_artifact_scope) for item in value
+        ]
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    return str(value)[:_METADATA_MAX_CHARS]
 
 
 def _artifact_update_event(*, task_id: str, context_id: str, metadata: dict[str, Any]) -> TaskArtifactUpdateEvent:
@@ -355,13 +380,7 @@ async def publish_stream_event(
                     _artifact_update_event(task_id=task_id, context_id=context_id, metadata=artifact_metadata)
                 )
             return None
-        result_metadata = _tool_result_metadata(
-            event.result,
-            is_error=event.is_error,
-            public_path_roots=event.public_path_roots,
-        )
-        if event.tool_name.startswith("mcp__"):
-            result_metadata = sanitize_mcp_public_data(result_metadata, fallback_summary="")
+        result_metadata = _tool_result_metadata(event.result, is_error=event.is_error)
         tool_metadata = {
             "status": "failed" if event.is_error else "completed",
             "toolUseId": event.tool_use_id,
@@ -476,6 +495,8 @@ async def publish_stream_event(
             state = TaskState.TASK_STATE_INPUT_REQUIRED
         else:
             raw = event.error or "Unknown error"
+            # Provider ErrorEvent is an explicitly retained compatibility
+            # exception; ordinary A2A payloads are projected at the wire edge.
             text = sanitize_public_artifact_text(raw)[:_ERROR_TEXT_MAX_CHARS]
             state = TaskState.TASK_STATE_FAILED
         await _enqueue_status(

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -45,6 +45,7 @@ from iac_code.a2a.pipeline_snapshot import (
     snapshot_needs_backup_commit_repair,
 )
 from iac_code.a2a.pipeline_stream import BACKUP_COMMITTED_EVENT_TYPE, PipelineA2AEventPublisher
+from iac_code.a2a.projection import a2a_safe_mode_enabled
 from iac_code.a2a.runtime_overrides import (
     a2a_request_context,
     configure_runtime_model,
@@ -101,7 +102,7 @@ from iac_code.services.session_backup_state import (
 from iac_code.services.session_storage import SessionStorage
 from iac_code.types.stream_events import TextDeltaEvent
 from iac_code.utils.file_security import atomic_write_text, ensure_private_dir, ensure_private_file
-from iac_code.utils.public_errors import public_exception_summary, sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 from iac_code.utils.public_paths import build_public_path_roots
 
 logger = logging.getLogger(__name__)
@@ -109,16 +110,14 @@ _CONTEXT_LOCK_ACQUIRE_TIMEOUT_SECONDS = 1
 _CANCEL_ACTIVE_TASK_DRAIN_TIMEOUT_SECONDS = 30
 _ERROR_TEXT_MAX_CHARS = 1000
 _DEFERRED_CLEANUP_PROMPTS_FILENAME = "cleanup-deferred-prompts.json"
-_A2A_SAFE_MODE_ENV = "IAC_CODE_A2A_SAFE_MODE"
-_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
-
-
 def _format_exception(exc: BaseException) -> str:
-    return public_exception_summary(exc, max_chars=_ERROR_TEXT_MAX_CHARS)
+    message = str(exc)
+    raw = type(exc).__name__ if not message else f"{type(exc).__name__}: {message}"
+    return raw[:_ERROR_TEXT_MAX_CHARS]
 
 
 def _a2a_safe_mode_enabled() -> bool:
-    return os.environ.get(_A2A_SAFE_MODE_ENV, "").strip().lower() in _TRUTHY_ENV_VALUES
+    return a2a_safe_mode_enabled()
 
 
 A2APermissionResolver: TypeAlias = Callable[[Any], "bool | Awaitable[bool]"]
@@ -741,7 +740,7 @@ def _cleanup_resource_event_data(resource: Any, *, resource_count: int) -> dict[
 def _public_cleanup_error(value: Any) -> str | None:
     if not value:
         return None
-    text = sanitize_public_text(str(value))
+    text = str(value)
     return text[:_ERROR_TEXT_MAX_CHARS] + "..." if len(text) > _ERROR_TEXT_MAX_CHARS else text
 
 
@@ -1020,13 +1019,13 @@ class IacCodeA2AExecutor(AgentExecutor):
                 try:
                     pipeline_input = self._pipeline_input_from_context(context, cwd=cwd)
                 except ValueError as exc:
-                    raise InvalidParamsError(sanitize_public_text(str(exc))) from exc
+                    raise InvalidParamsError(str(exc)) from exc
                 self._validate_pipeline_request_input(pipeline_input, model=model)
             else:
                 try:
                     normal_input = self._normal_input_from_context(context, cwd=cwd)
                 except ValueError as exc:
-                    raise InvalidParamsError(sanitize_public_text(str(exc))) from exc
+                    raise InvalidParamsError(str(exc)) from exc
                 if normal_input.has_images:
                     self._validate_pipeline_request_input(normal_input, model=model)
             if pipeline_mode and requested_task_id is None:
@@ -1068,7 +1067,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                 task_id=task_id,
                 context_id=context_id,
                 state=TaskState.TASK_STATE_FAILED,
-                text=sanitize_public_text(str(exc)),
+                text=str(exc),
             )
             if task is not None:
                 task.state = TASK_STATE_FAILED
@@ -1672,7 +1671,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             cwd = self._resolve_cwd(metadata)
             pipeline_input = parts_to_user_input(message.parts, cwd=cwd)
         except ValueError as exc:
-            raise InvalidParamsError(sanitize_public_text(str(exc))) from exc
+            raise InvalidParamsError(str(exc)) from exc
         model = self._resolve_model(metadata) or self._model
         self._validate_pipeline_request_input(pipeline_input, model=model)
 
@@ -1736,7 +1735,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                 "A2A terminal session backup blocked task publication reason=%s retry_count=%s error=%s",
                 reason.value,
                 getattr(exc, "retry_count", 0),
-                public_exception_summary(exc, max_chars=_ERROR_TEXT_MAX_CHARS),
+                sanitize_strict_text(str(exc))[:_ERROR_TEXT_MAX_CHARS],
             )
             record_backup_blocked = getattr(self._metrics, "record_backup_blocked", None)
             if callable(record_backup_blocked):
@@ -1761,7 +1760,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                         "backupBlocked": {
                             "reason": reason.value,
                             "blockedTerminalState": blocked_terminal_state,
-                            "error": public_exception_summary(exc, max_chars=_ERROR_TEXT_MAX_CHARS),
+                            "error": _format_exception(exc),
                             "recoverable": True,
                         }
                     }
@@ -1993,7 +1992,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             return None
 
     def _log_executor_exception(self, stage: str, *, task_id: str, context_id: str) -> None:
-        logger.exception("A2A executor %s failed (task_id=%s, context_id=%s)", stage, task_id, context_id)
+        logger.error("A2A executor %s failed (task_id=%s, context_id=%s)", stage, task_id, context_id)
 
     async def _publish_mcp_status(
         self,
@@ -2121,8 +2120,8 @@ class IacCodeA2AExecutor(AgentExecutor):
             return
         try:
             await self._push_notifier.notify_task_state(task_id=task_id, context_id=context_id, state=state)
-        except Exception:
-            logger.warning("A2A push notification failed", exc_info=True)
+        except Exception as exc:
+            logger.warning("A2A push notification failed: %s", sanitize_strict_text(str(exc)))
 
 
 def _normal_handoff_has_backup_ack(handoff: dict[str, Any], journal_events: list[dict[str, Any]]) -> bool:

--- a/src/iac_code/a2a/jsonrpc_passthrough.py
+++ b/src/iac_code/a2a/jsonrpc_passthrough.py
@@ -10,6 +10,8 @@ from jsonrpc.jsonrpc2 import JSONRPC20Response
 from sse_starlette.sse import EventSourceResponse
 from starlette.responses import Response
 
+from iac_code.utils.public_errors import sanitize_strict_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,7 +74,10 @@ def install_v03_jsonrpc_error_data_passthrough(jsonrpc_endpoint: Callable[..., A
                 async for item in stream:
                     yield {"data": item.model_dump_json(by_alias=True, exclude_none=True)}
             except Exception as exc:
-                logger.exception("Error during stream generation in v0.3 JSONRPCAdapter")
+                logger.error(
+                    "Error during stream generation in v0.3 JSONRPCAdapter: %s",
+                    sanitize_strict_text(str(exc)),
+                )
                 if getattr(exc, "jsonrpc_error_data_passthrough", False):
                     error = types_v03.InvalidParamsError(message=str(exc), data=getattr(exc, "data", None))
                 else:

--- a/src/iac_code/a2a/metadata_redaction.py
+++ b/src/iac_code/a2a/metadata_redaction.py
@@ -1,38 +1,15 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Iterable, Mapping
 from typing import Any
 
 from a2a.types import Message
 from google.protobuf.json_format import MessageToDict, ParseDict
 
-from iac_code.a2a.artifacts import sanitize_public_artifact_text
-from iac_code.utils.public_errors import all_redaction_suppressed
-
 
 class A2AMetadataEchoRedactor:
-    REDACTED_VALUE = "***"
-    _SENSITIVE_KEY_FRAGMENTS = {
-        "auth",
-        "authorization",
-        "cookie",
-        "credential",
-        "credentials",
-        "passphrase",
-        "password",
-        "passwd",
-        "private_key",
-        "pwd",
-        "secret",
-        "security_token",
-        "session",
-        "signature",
-        "token",
-        "api_key",
-        "access_key",
-        "access_key_id",
-        "access_key_secret",
-    }
+    """Compatibility wrapper that now preserves canonical A2A message data."""
 
     def redact_message_echo(
         self,
@@ -40,22 +17,10 @@ class A2AMetadataEchoRedactor:
         *,
         public_path_roots: Iterable[Mapping[str, str]] | None = None,
     ) -> Message:
-        message_dict = MessageToDict(message, preserving_proto_field_name=False)
-        metadata = message_dict.get("metadata")
-        if isinstance(metadata, Mapping):
-            message_dict["metadata"] = self.redact(metadata, public_path_roots=public_path_roots)
-        parts = message_dict.get("parts")
-        if isinstance(parts, list):
-            for part in parts:
-                if isinstance(part, dict) and isinstance(part.get("text"), str):
-                    part["text"] = sanitize_public_artifact_text(
-                        part["text"],
-                        fallback_summary="",
-                        public_path_roots=public_path_roots,
-                    )
-        redacted_message = Message()
-        ParseDict(message_dict, redacted_message)
-        return redacted_message
+        del public_path_roots
+        result = Message()
+        ParseDict(MessageToDict(message, preserving_proto_field_name=False), result)
+        return result
 
     def redact(
         self,
@@ -63,27 +28,5 @@ class A2AMetadataEchoRedactor:
         *,
         public_path_roots: Iterable[Mapping[str, str]] | None = None,
     ) -> Any:
-        if all_redaction_suppressed():
-            # 环回 web 上下文：敏感键也不打 *** —— 整体原样返回。
-            return value
-        if isinstance(value, Mapping):
-            return {
-                key: self.REDACTED_VALUE
-                if self._is_sensitive_key(key)
-                else self.redact(item, public_path_roots=public_path_roots)
-                for key, item in value.items()
-            }
-        if isinstance(value, list):
-            return [self.redact(item, public_path_roots=public_path_roots) for item in value]
-        if isinstance(value, tuple):
-            return [self.redact(item, public_path_roots=public_path_roots) for item in value]
-        if isinstance(value, str):
-            return sanitize_public_artifact_text(value, fallback_summary="", public_path_roots=public_path_roots)
-        return value
-
-    def _is_sensitive_key(self, key: Any) -> bool:
-        normalized = str(key).lower().replace("-", "_")
-        compact = normalized.replace("_", "")
-        return any(
-            fragment in normalized or fragment.replace("_", "") in compact for fragment in self._SENSITIVE_KEY_FRAGMENTS
-        )
+        del public_path_roots
+        return copy.deepcopy(value)

--- a/src/iac_code/a2a/pipeline_events.py
+++ b/src/iac_code/a2a/pipeline_events.py
@@ -8,8 +8,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from iac_code.a2a.artifacts import UnsafeArtifactNameError, artifact_filename_from_path, sanitize_public_artifact_text
-from iac_code.a2a.events import _tool_result_metadata, _truncate
+from iac_code.a2a.artifacts import UnsafeArtifactNameError, artifact_filename_from_path
+from iac_code.a2a.events import _truncate
+from iac_code.a2a.pipeline_journal import to_json_safe
 from iac_code.mcp.progress import mcp_progress_metadata
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.services.permissions.audit import build_input_summary, build_redacted_tool_input, fingerprint_text
@@ -369,7 +370,7 @@ class PipelineEventTranslator:
                     data={
                         "candidateScope": candidate_scope,
                         "targetCandidateStepId": target_candidate_step_id,
-                        "reason": sanitize_public_artifact_text(str(reason)),
+                        "reason": str(reason),
                     },
                 )
             ]
@@ -381,7 +382,7 @@ class PipelineEventTranslator:
                 "candidateScope": candidate_scope,
                 "targetCandidateStepId": target_candidate_step_id,
                 "nextCandidateAttempt": state.attempt + 1,
-                "reason": sanitize_public_artifact_text(str(reason)),
+                "reason": str(reason),
             }
             envelope = self._envelope("candidate_restart_requested", "candidate", "working", data)
             self._add_candidate_coordinates(envelope, state)
@@ -1208,8 +1209,7 @@ def _event_data(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _warning_event_data(data: dict[str, Any]) -> dict[str, Any]:
-    private_keys = {"ledger_path", "ledgerPath", "load_error", "loadError"}
-    return _event_data({key: value for key, value in data.items() if str(key) not in private_keys})
+    return _event_data(data)
 
 
 def _sanitize_event_value(key: str, value: Any) -> Any:
@@ -1219,8 +1219,6 @@ def _sanitize_event_value(key: str, value: Any) -> Any:
 
         return sanitize_mcp_status_metadata(value)
     if isinstance(value, str):
-        if any(marker in key_lower for marker in ("reason", "error", "message", "traceback")):
-            return sanitize_public_artifact_text(value)
         return value
     if isinstance(value, list):
         return [_sanitize_event_value(key, item) for item in value]
@@ -1486,17 +1484,13 @@ def _tool_result_data(event: ToolResultEvent) -> dict[str, Any]:
         "toolName": event.tool_name,
         "toolUseId": event.tool_use_id,
         "isError": event.is_error,
-        "result": _tool_result_metadata(
-            event.result,
-            is_error=event.is_error,
-            public_path_roots=event.public_path_roots,
-        ),
+        "result": to_json_safe(event.result),
     }
 
 
 def _sanitize_tool_input(tool_input: dict[str, Any]) -> dict[str, Any]:
-    # journal 是本地用户数据；真正远程出口由 pipeline_stream._sanitize_remote_envelope 兜底脱敏，
-    # 故写入时不再脱敏，避免把 [REDACTED]/*** 注入模板 YAML 与 complete_step conclusion。
+    # Journal 是 canonical 功能数据；远程出口只在实际 A2A wire boundary
+    # 按当前 safe mode 投影副本，不能反向污染这里的真实工具输入。
     return dict(tool_input) if isinstance(tool_input, dict) else {}
 
 
@@ -1627,7 +1621,7 @@ def _artifact_from_spec(spec: Any, root: dict[str, Any]) -> dict[str, Any] | Non
         "mediaType": media_type,
         "content": content,
         "role": role,
-        "supersedesPath": sanitize_public_artifact_text(supersedes_path),
+        "supersedesPath": supersedes_path,
         "supersedesKey": fingerprint_text(supersedes_path),
     }
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -73,12 +73,10 @@ from iac_code.services.session_layout import SessionPaths
 from iac_code.services.session_storage import SessionStorage
 from iac_code.types.stream_events import AskUserQuestionEvent, SubPipelineStreamEvent, TextDeltaEvent
 from iac_code.utils.path_locks import PathLockRegistry
-from iac_code.utils.public_errors import public_exception_summary, sanitize_public_text
 
 logger = logging.getLogger(__name__)
 _CONTEXT_LOCK_ACQUIRE_TIMEOUT_SECONDS = 1
 _ERROR_TEXT_MAX_CHARS = 1000
-_AUTH_ERROR_MARKERS = ("api key", "api_key", "access key", "secret", "credential")
 _TERMINAL_SIDECAR_STATUSES = {"completed", "failed", "user_aborted", "discarded", "canceled"}
 _TERMINAL_SNAPSHOT_STATUSES = {"completed", "failed", "canceled"}
 _TERMINAL_A2A_STATUSES = {"completed", "failed", "canceled"}
@@ -121,10 +119,6 @@ _CANCEL_WAITING_INPUT_BACKUP_BLOCKED = WaitingInputCancelResult.BACKUP_BLOCKED
 
 def _retry_text() -> str:
     return _("A temporary error occurred. Please retry.")
-
-
-def _auth_error_text() -> str:
-    return _("Authentication required. Configure credentials and retry.")
 
 
 class RecoverablePipelineInvalidParamsError(InvalidParamsError):
@@ -1878,7 +1872,7 @@ class IacCodeA2APipelineExecutor:
                 status="input_required",
                 data={
                     "reason": reason.value,
-                    "error": public_exception_summary(exc, max_chars=_ERROR_TEXT_MAX_CHARS),
+                    "error": _format_exception(exc),
                     "recoverable": True,
                 },
                 require_durable_metadata=True,
@@ -2711,7 +2705,7 @@ class IacCodeA2APipelineExecutor:
 
         retryable = _is_retryable_executor_error(exc)
         task_state = TASK_STATE_INPUT_REQUIRED if retryable else TASK_STATE_FAILED
-        text = _retry_text() if retryable else _sanitize_error(exc)
+        text = _retry_text() if retryable else _format_exception(exc)
         failure = None if retryable else public_error(message=text, error_type=type(exc).__name__)
         terminal_status_available = retryable or preserve_task_record
         if not retryable and not preserve_task_record:
@@ -3431,7 +3425,7 @@ def _cancel_waiting_input_task_from_sidecar_locked(
             snapshot_store=snapshot_store,
             translator=translator,
             pending_input=pending_input,
-            error=public_exception_summary(exc, max_chars=_ERROR_TEXT_MAX_CHARS),
+            error=_format_exception(exc),
         )
         _record_backup_blocked_metric(
             metrics,
@@ -3463,7 +3457,7 @@ def _cancel_waiting_input_task_from_sidecar_locked(
             snapshot_store=snapshot_store,
             translator=translator,
             pending_input=pending_input,
-            error=public_exception_summary(blocked_exc, max_chars=_ERROR_TEXT_MAX_CHARS),
+            error=_format_exception(blocked_exc),
         )
         _record_backup_blocked_metric(
             metrics,
@@ -3957,7 +3951,7 @@ def _cleanup_resource_handoff_data(resource: Any) -> dict[str, Any]:
 def _public_cleanup_error(value: Any) -> str | None:
     if not value:
         return None
-    text = sanitize_public_text(value)
+    text = str(value)
     return text[:1000] + "..." if len(text) > 1000 else text
 
 
@@ -4818,18 +4812,6 @@ def _a2a_state_from_task_state(state: str) -> int:
     if state == TASK_STATE_WORKING:
         return TaskState.TASK_STATE_WORKING
     return TaskState.TASK_STATE_INPUT_REQUIRED
-
-
-def _sanitize_error(exc: Exception) -> str:
-    msg = str(exc).lower()
-    if any(marker in msg for marker in _AUTH_ERROR_MARKERS):
-        return _auth_error_text()
-    if type(exc).__name__ == "AuthenticationError":
-        return _auth_error_text()
-    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
-    if status == 401:
-        return _auth_error_text()
-    return public_error(message=_format_exception(exc), error_type=type(exc).__name__).summary
 
 
 def _public_error_details_for_a2a(details: dict[str, Any]) -> dict[str, Any]:

--- a/src/iac_code/a2a/pipeline_recovery.py
+++ b/src/iac_code/a2a/pipeline_recovery.py
@@ -11,8 +11,6 @@ from iac_code.a2a.pipeline_snapshot import (
     SNAPSHOT_SCHEMA_VERSION,
     A2APipelineSnapshotStore,
     reduce_pipeline_events,
-    sanitize_pipeline_artifact_uris,
-    sanitize_pipeline_cleanup_private_fields,
     snapshot_needs_backup_commit_repair,
 )
 from iac_code.i18n import _
@@ -186,8 +184,8 @@ class A2APipelineRecoveryService:
         replay_after = after_sequence if after_sequence is not None else _int_value(snapshot.get("lastSequence"), 0)
         events_after_replay = [event for event in replay_events if _int_value(event.get("sequence"), 0) > replay_after]
         return {
-            "snapshot": _json_compatible(_sanitize_public_recovery_payload(snapshot)),
-            "events": _json_compatible(_sanitize_public_recovery_payload(events_after_replay)),
+            "snapshot": _json_compatible(snapshot),
+            "events": _json_compatible(events_after_replay),
         }
 
     async def _verify_task_owner(
@@ -217,10 +215,6 @@ def _json_compatible(value: Any) -> Any:
     if isinstance(value, list):
         return [_json_compatible(item) for item in value]
     return value
-
-
-def _sanitize_public_recovery_payload(value: Any) -> Any:
-    return sanitize_pipeline_cleanup_private_fields(sanitize_pipeline_artifact_uris(value))
 
 
 def _events_for_task(

--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -18,12 +18,11 @@ from iac_code.pipeline.constants import (
     PIPELINE_EVENT_CLEANUP_PROGRESS,
     PIPELINE_EVENT_CLEANUP_STARTED,
 )
-from iac_code.utils.public_errors import sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 from iac_code.utils.state_io import atomic_write_json, atomic_write_text
 
 SNAPSHOT_SCHEMA_VERSION = "1.1"
 logger = logging.getLogger(__name__)
-_PUBLIC_TEXT_MAX_CHARS = 1000
 
 _TERMINAL_STATUS_BY_EVENT_TYPE = {
     "pipeline_completed": "completed",
@@ -37,16 +36,6 @@ _CLEANUP_STATUS_BY_EVENT_TYPE = {
     PIPELINE_EVENT_CLEANUP_FAILED: "failed",
 }
 _KNOWN_CLEANUP_STATUSES = {"pending", "started", "in_progress", "completed", "failed", "skipped"}
-_CLEANUP_ERROR_KEYS = {
-    "error",
-    "errorMessage",
-    "errorSummary",
-    "error_message",
-    "error_summary",
-    "lastError",
-    "last_error",
-}
-_PIPELINE_WARNING_PRIVATE_DATA_KEYS = {"ledger_path", "ledgerPath", "load_error", "loadError"}
 _PENDING_BACKUP_VISIBILITY = "pending_backup"
 _COMMITTED_BACKUP_VISIBILITY = "committed"
 _BACKUP_COMMITTED_EVENT_TYPE = "backup_committed"
@@ -59,11 +48,14 @@ class A2APipelineSnapshotStore:
 
     def save(self, snapshot: dict[str, Any], *, durable: bool = True, compact: bool = False) -> bool:
         previous = self.load()
-        next_snapshot = _sanitize_public_snapshot_private_cleanup_fields(snapshot)
+        next_snapshot = copy.deepcopy(snapshot)
         next_snapshot["snapshotVersion"] = _snapshot_version(previous) + 1
         next_snapshot = to_json_safe(next_snapshot)
         if not isinstance(next_snapshot, dict):
-            logger.warning("Skipping invalid A2A pipeline snapshot for %s", self.path)
+            logger.warning(
+                "Skipping invalid A2A pipeline snapshot for %s",
+                sanitize_strict_text(self.path, fallback_summary="[PATH]"),
+            )
             return False
 
         try:
@@ -79,8 +71,12 @@ class A2APipelineSnapshotStore:
             else:
                 atomic_write_json(self.path, next_snapshot, durable=durable)
             return True
-        except (OSError, TypeError, ValueError):
-            logger.warning("Failed to persist A2A pipeline snapshot to %s", self.path, exc_info=True)
+        except (OSError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to persist A2A pipeline snapshot path=%s error=%s",
+                sanitize_strict_text(self.path, fallback_summary="[PATH]"),
+                sanitize_strict_text(exc),
+            )
             return False
 
     def load(self) -> dict[str, Any] | None:
@@ -88,17 +84,21 @@ class A2APipelineSnapshotStore:
             value = json.loads(self.path.read_text(encoding="utf-8"))
         except FileNotFoundError:
             return None
-        except (UnicodeDecodeError, json.JSONDecodeError, OSError):
-            logger.warning("Failed to load A2A pipeline snapshot from %s", self.path, exc_info=True)
+        except (UnicodeDecodeError, json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "Failed to load A2A pipeline snapshot path=%s error=%s",
+                sanitize_strict_text(self.path, fallback_summary="[PATH]"),
+                sanitize_strict_text(exc),
+            )
             return None
         if not isinstance(value, dict):
             logger.warning(
                 "Invalid A2A pipeline snapshot in %s: expected object, got %s",
-                self.path,
+                sanitize_strict_text(self.path, fallback_summary="[PATH]"),
                 type(value).__name__,
             )
             return None
-        return _sanitize_public_snapshot_private_cleanup_fields(value)
+        return value
 
 
 def reduce_pipeline_events(
@@ -814,7 +814,6 @@ class _PipelineSnapshotReducer:
         item_id = _artifact_item_id(artifact, data, event)
         item["artifactId"] = item_id
         item["id"] = item_id
-        _drop_legacy_artifact_uri(item)
         item["scope"] = _string_or_none(event.get("scope")) or "pipeline"
         item["runId"] = _scope_run_id(event)
         item["sequence"] = _sequence_value(event)
@@ -848,7 +847,6 @@ class _PipelineSnapshotReducer:
 
     def _upsert_tool_result_item(self, event: dict[str, Any]) -> None:
         item = copy.deepcopy(_dict_or_empty(event.get("data")))
-        _drop_legacy_tool_result_artifact_uri(item)
         self._upsert_display_record("toolResults", self._tool_result_indexes, event, item, "toolUseId")
 
     def _apply_stack_current_changed(self, event: dict[str, Any]) -> None:
@@ -892,6 +890,9 @@ class _PipelineSnapshotReducer:
 
     def _apply_cleanup_data(self, data: dict[str, Any], event: dict[str, Any]) -> None:
         cleanup = self._snapshot["cleanup"]
+        for key, value in data.items():
+            if key not in {"status", "resources", "history"}:
+                cleanup[key] = copy.deepcopy(value)
         status = _string_or_none(data.get("status"))
         if status is not None:
             cleanup["status"] = status
@@ -1226,9 +1227,7 @@ def _warning_history_entry(event: dict[str, Any]) -> dict[str, Any]:
 
 
 def _pipeline_warning_public_data(data: dict[str, Any]) -> dict[str, Any]:
-    return copy.deepcopy(
-        {key: value for key, value in data.items() if str(key) not in _PIPELINE_WARNING_PRIVATE_DATA_KEYS}
-    )
+    return copy.deepcopy(data)
 
 
 def _interaction_history_entry(event: dict[str, Any]) -> dict[str, Any]:
@@ -1406,15 +1405,15 @@ def _snapshot_from_existing(existing_snapshot: dict[str, Any] | None) -> dict[st
     cleanup_count = _int_or_none(cleanup.get("resourceCount"))
     if cleanup_count is None:
         cleanup_count = len(cleanup_resources)
-    snapshot["cleanup"] = {
-        "status": _string_or_none(cleanup.get("status")) or "none",
-        "resourceCount": cleanup_count,
-        "resources": cleanup_resources,
-        "history": _dict_list(cleanup.get("history")),
-    }
-    for key in ("statusMessage",):
-        if key in cleanup:
-            snapshot["cleanup"][key] = copy.deepcopy(cleanup[key])
+    snapshot["cleanup"] = copy.deepcopy(cleanup)
+    snapshot["cleanup"].update(
+        {
+            "status": _string_or_none(cleanup.get("status")) or "none",
+            "resourceCount": cleanup_count,
+            "resources": cleanup_resources,
+            "history": _dict_list(cleanup.get("history")),
+        }
+    )
 
     control = snapshot.get("control")
     if not isinstance(control, dict):
@@ -1480,37 +1479,10 @@ def _sanitize_pipeline_warning_history(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def _sanitize_cleanup_private_fields(value: dict[str, Any], *, root_is_cleanup: bool = False) -> dict[str, Any]:
-    sanitized = copy.deepcopy(value)
-    _drop_cleanup_private_fields(sanitized, inside_cleanup=root_is_cleanup)
-    return sanitized
-
-
-def _drop_cleanup_private_fields(value: Any, *, inside_cleanup: bool) -> None:
-    if isinstance(value, dict):
-        if inside_cleanup:
-            for key in ("prompt", "ledgerPath", "ledger_path"):
-                value.pop(key, None)
-            for key in _CLEANUP_ERROR_KEYS & value.keys():
-                value[key] = _sanitize_cleanup_error_value(value[key])
-        for item in value.values():
-            _drop_cleanup_private_fields(item, inside_cleanup=inside_cleanup)
-        cleanup = value.get("cleanup")
-        if cleanup is not None:
-            _drop_cleanup_private_fields(cleanup, inside_cleanup=True)
-    elif isinstance(value, list):
-        for item in value:
-            _drop_cleanup_private_fields(item, inside_cleanup=inside_cleanup)
-
-
-def _sanitize_cleanup_error_value(value: Any) -> Any:
-    if isinstance(value, str):
-        text = sanitize_public_text(value)
-        return text[:_PUBLIC_TEXT_MAX_CHARS] + "..." if len(text) > _PUBLIC_TEXT_MAX_CHARS else text
-    if isinstance(value, dict):
-        return {key: _sanitize_cleanup_error_value(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_sanitize_cleanup_error_value(item) for item in value]
-    return value
+    # Snapshot state is canonical recovery data.  The legacy helper name is
+    # retained for compatibility, but cleanup fields and errors stay intact.
+    del root_is_cleanup
+    return copy.deepcopy(value)
 
 
 def _merge_coordinate(target: dict[str, Any], coordinate: dict[str, Any]) -> None:
@@ -1775,6 +1747,7 @@ def _merge_completion_data(target: dict[str, Any], event: dict[str, Any]) -> Non
         "conclusionField",
         "conclusion",
         "conclusions",
+        "step_conclusions",
         "durationS",
         "earlyExit",
         "failed",

--- a/src/iac_code/a2a/pipeline_stream.py
+++ b/src/iac_code/a2a/pipeline_stream.py
@@ -20,7 +20,6 @@ from iac_code.a2a.events import (
     _extract_artifact_metadata,
 )
 from iac_code.a2a.exposure import A2AExposureType, normalize_a2a_exposure_types
-from iac_code.a2a.metadata_redaction import A2AMetadataEchoRedactor
 from iac_code.a2a.pipeline_events import (
     PIPELINE_EVENTS_EXTENSION_URI,
     PIPELINE_METADATA_SCHEMA_VERSION,
@@ -47,6 +46,7 @@ from iac_code.pipeline.constants import (
 )
 from iac_code.services.permissions.audit import is_aliyun_api_non_read_only_permission_event
 from iac_code.types.stream_events import PermissionRequestEvent, SubPipelineStreamEvent, ToolResultEvent
+from iac_code.utils.public_errors import sanitize_strict_text
 
 PipelinePermissionResolver = Callable[[PermissionRequestEvent], bool | Awaitable[bool]]
 PipelineBeforeEnqueueHook = Callable[[dict[str, Any]], bool | Awaitable[bool]]
@@ -101,10 +101,6 @@ _EXTREME_DEFERRED_EVENT_TYPES = {"text_delta", "thinking_delta"}
 _EXTREME_JOURNAL_FLUSH_EVENTS = 512
 _RECOVERY_STATE_SCOPES = {"step", "candidate", "candidateStep", "candidate_step"}
 _RECOVERY_STATE_STATUSES = {"working"}
-_REMOTE_PAYLOAD_FIELDS = ("data", "input", "permission", "artifact", "error")
-_REMOTE_PAYLOAD_REDACTOR = A2AMetadataEchoRedactor()
-
-
 def backup_committed_delivery_envelope(
     ack_envelope: dict[str, Any],
     committed_envelope: dict[str, Any],
@@ -559,7 +555,7 @@ class PipelineA2AEventPublisher:
             except _SequenceHighWaterUnavailableError:
                 logger.warning("Skipping A2A pipeline event until journal high-water sequence is readable")
                 return None
-            safe_envelope = to_json_safe(_sanitize_remote_envelope(envelope))
+            safe_envelope = to_json_safe(envelope)
             if not isinstance(safe_envelope, dict):
                 logger.warning("Skipping invalid A2A pipeline envelope: %r", envelope)
                 return None
@@ -586,8 +582,8 @@ class PipelineA2AEventPublisher:
                 snapshot_persisted = self.snapshot_store.save(snapshot)
             except _SnapshotCatchUpUnavailableError:
                 logger.warning("Skipping A2A pipeline snapshot save until journal catch-up succeeds")
-            except Exception:
-                logger.warning("Failed to persist A2A pipeline snapshot", exc_info=True)
+            except Exception as exc:
+                logger.warning("Failed to persist A2A pipeline snapshot: %s", sanitize_strict_text(str(exc)))
             if snapshot_persisted:
                 _maybe_inject_test_fault("after_a2a_pipeline_snapshot_saved")
             if require_journal_metadata and not journal_persisted:
@@ -650,8 +646,8 @@ class PipelineA2AEventPublisher:
                 self._extreme_snapshot_loaded = True
                 self._extreme_pending_snapshot_events.clear()
                 _maybe_inject_test_fault("after_a2a_pipeline_snapshot_saved")
-        except Exception:
-            logger.warning("Failed to persist A2A pipeline snapshot", exc_info=True)
+        except Exception as exc:
+            logger.warning("Failed to persist A2A pipeline snapshot: %s", sanitize_strict_text(str(exc)))
 
         if require_journal_metadata and not journal_persisted:
             logger.warning("Skipping A2A pipeline status update because journal metadata was not persisted")
@@ -999,8 +995,11 @@ class PipelineA2AEventPublisher:
                 return None
             artifact_semantic_metadata = _artifact_semantic_metadata(original_artifact, envelope.get("data"))
             artifact_metadata = _extract_artifact_metadata(result, self.artifact_store)
-        except Exception:
-            logger.warning("Failed to externalize A2A pipeline tool artifact", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to externalize A2A pipeline tool artifact: %s",
+                sanitize_strict_text(str(exc)),
+            )
             return None
         if artifact_metadata is None:
             return None
@@ -1034,13 +1033,12 @@ class PipelineA2AEventPublisher:
         return artifact_metadata
 
     async def _enqueue_artifact_update(self, envelope: dict[str, Any], artifact_metadata: dict[str, Any]) -> None:
-        await self.event_queue.enqueue_event(
-            _artifact_update_event(
+        event = _artifact_update_event(
                 task_id=self._delivery_task_id(envelope),
                 context_id=self._delivery_context_id(envelope),
                 metadata=artifact_metadata,
             )
-        )
+        await self.event_queue.enqueue_event(event)
 
     async def _apply_permission_metadata(
         self,
@@ -1143,26 +1141,6 @@ class PipelineA2AEventPublisher:
 def _permission_request_from(event: Any) -> PermissionRequestEvent | None:
     inner = _unwrap_stream_event(event)
     return inner if isinstance(inner, PermissionRequestEvent) else None
-
-
-def _sanitize_remote_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
-    sanitized = dict(envelope)
-    data = sanitized.get("data")
-    conclusion_exempt = isinstance(data, dict) and data.get("toolName") == "complete_step"
-    for field in _REMOTE_PAYLOAD_FIELDS:
-        if field not in sanitized:
-            continue
-        if field == "data" and conclusion_exempt:
-            # complete_step 的 conclusion(在 data.input)是下游必需的关键结构化数据，
-            # 所有场景(含真正远程)均不脱敏(已与用户确认，问题1=B，含 RdsMasterPassword)。
-            continue
-        # 在环境上下文里执行，使 redactor 遵守 ``all_redaction_suppressed()``。
-        # 该抑制标志只由环回 web 服务(create_app(expose_local_paths=True),protect_loopback_app
-        # 环回保护)的中间件设置；真正远程的 A2A 服务从不设置它，故其上下文里始终为 False → 路径 + 密钥
-        # 照常脱敏，远程边界不受影响。而本地 web sink 写入的 journal 会被读回展示，理应保留真实的路径与
-        # 结构化内容(含模板 YAML、结论)，故 web 上下文里 redact 整体原样。
-        sanitized[field] = _REMOTE_PAYLOAD_REDACTOR.redact(sanitized[field])
-    return sanitized
 
 
 def _tool_result_from(event: Any) -> ToolResultEvent | None:

--- a/src/iac_code/a2a/projection.py
+++ b/src/iac_code/a2a/projection.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import os
+import tempfile
+from collections.abc import Iterable, Mapping
+from typing import Any, TypeVar
+
+from google.protobuf.json_format import MessageToDict, ParseDict
+
+from iac_code.i18n import _
+from iac_code.services.permissions.trusted_roots import build_session_trusted_read_directories
+from iac_code.services.session_storage import SessionStorage
+from iac_code.utils.public_errors import PublicError
+from iac_code.utils.public_paths import build_public_path_roots, redact_known_public_paths
+
+IAC_CODE_A2A_SAFE_MODE_ENV = "IAC_CODE_A2A_SAFE_MODE"
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+_TASK_SCOPED_JSONRPC_METHODS = {
+    "CancelTask",
+    "CreateTaskPushNotificationConfig",
+    "DeleteTaskPushNotificationConfig",
+    "GetTask",
+    "GetTaskPushNotificationConfig",
+    "ListTaskPushNotificationConfigs",
+    "SubscribeToTask",
+    "tasks/cancel",
+    "tasks/get",
+    "tasks/pushNotificationConfig/delete",
+    "tasks/pushNotificationConfig/get",
+    "tasks/pushNotificationConfig/list",
+    "tasks/pushNotificationConfig/set",
+    "tasks/resubscribe",
+}
+_ProtoMessageT = TypeVar("_ProtoMessageT")
+
+
+def a2a_safe_mode_enabled() -> bool:
+    """Return the process-wide A2A delivery policy at the current boundary."""
+
+    return os.environ.get(IAC_CODE_A2A_SAFE_MODE_ENV, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def build_a2a_public_path_roots(
+    *,
+    cwd: str,
+    session_id: str | None = None,
+    additional_directories: Iterable[str] | None = None,
+    trusted_read_directories: Iterable[str] | None = None,
+    relative_read_directories: Iterable[str] | None = None,
+) -> list[dict[str, str]]:
+    """Build the shared A2A roots from current, reproducible runtime state."""
+
+    from iac_code.tools.path_safety import get_iac_code_application_root
+
+    additional = [tempfile.gettempdir(), str(get_iac_code_application_root()), *(additional_directories or [])]
+    trusted = list(trusted_read_directories or [])
+    if session_id:
+        session_dir = SessionStorage().session_dir(cwd, session_id)
+        additional.append(str(session_dir))
+        trusted.extend(build_session_trusted_read_directories(session_id, session_dir=session_dir))
+    return build_public_path_roots(
+        cwd=cwd,
+        additional_directories=additional,
+        trusted_read_directories=trusted,
+        relative_read_directories=relative_read_directories,
+    )
+
+
+def project_a2a_text(
+    value: str,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+    safe_mode: bool | None = None,
+) -> str:
+    """Apply the A2A path-only policy without credential redaction."""
+
+    enabled = a2a_safe_mode_enabled() if safe_mode is None else safe_mode
+    if not enabled:
+        return value
+    return redact_known_public_paths(value, public_path_roots)
+
+
+def project_a2a_data(
+    value: Any,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+    safe_mode: bool | None = None,
+) -> Any:
+    """Return an A2A delivery copy selected by the current safe-mode policy.
+
+    Canonical input is never modified. Safe mode only replaces paths proven to
+    be under ``public_path_roots``; it never applies secret-key or credential
+    patterns. Mapping-key collisions use deterministic placeholder keys and do
+    not discard values.
+    """
+
+    enabled = a2a_safe_mode_enabled() if safe_mode is None else safe_mode
+    if not enabled:
+        return copy.deepcopy(value)
+    return _project_path_only(value, public_path_roots=public_path_roots)
+
+
+def project_a2a_proto(
+    message: _ProtoMessageT,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+    safe_mode: bool | None = None,
+) -> _ProtoMessageT:
+    """Project an A2A protobuf message without changing its protocol schema."""
+
+    data = MessageToDict(message, preserving_proto_field_name=False)
+    projected = project_a2a_data(data, public_path_roots=public_path_roots, safe_mode=safe_mode)
+    result = type(message)()
+    ParseDict(projected, result)
+    return result
+
+
+async def resolve_a2a_public_path_roots(
+    task_store: Any,
+    *,
+    task_id: str | None = None,
+    context_id: str | None = None,
+    call_context: Any | None = None,
+    fallback_cwd: str | None = None,
+    request_data: Any = None,
+) -> list[dict[str, str]]:
+    """Rebuild roots from current task/context state without persisting roots."""
+
+    resolved_context_id = context_id
+    if task_id and task_store is not None:
+        try:
+            get_task_record = getattr(task_store, "get_task_record", None)
+            if get_task_record is not None:
+                task = await get_task_record(task_id)
+            else:
+                task = await task_store.get(task_id, context=call_context)
+        except (AttributeError, KeyError, RuntimeError, ValueError):
+            task = None
+        candidate = getattr(task, "context_id", None)
+        if isinstance(candidate, str) and candidate:
+            resolved_context_id = candidate
+    if resolved_context_id and task_store is not None:
+        try:
+            context = await task_store.get_context_record(resolved_context_id)
+        except (AttributeError, KeyError, RuntimeError, ValueError):
+            context = None
+        cwd = getattr(context, "cwd", None)
+        if isinstance(cwd, str) and cwd:
+            session_id = getattr(context, "session_id", None)
+            additional_directories: list[str] = []
+            trusted_read_directories: list[str] = []
+            relative_read_directories: list[str] = []
+            get_runtime_directories = getattr(task_store, "get_context_runtime_path_directories", None)
+            if get_runtime_directories is not None:
+                try:
+                    runtime_directories = await get_runtime_directories(resolved_context_id)
+                except (AttributeError, KeyError, RuntimeError, ValueError):
+                    runtime_directories = None
+                if isinstance(runtime_directories, tuple) and len(runtime_directories) == 3:
+                    additional_directories = list(runtime_directories[0])
+                    trusted_read_directories = list(runtime_directories[1])
+                    relative_read_directories = list(runtime_directories[2])
+            return build_a2a_public_path_roots(
+                cwd=cwd,
+                session_id=session_id if isinstance(session_id, str) else None,
+                additional_directories=additional_directories,
+                trusted_read_directories=trusted_read_directories,
+                relative_read_directories=relative_read_directories,
+            )
+    request_cwd, request_session_id = a2a_runtime_path_context_from_data(request_data)
+    return build_a2a_public_path_roots(
+        cwd=request_cwd or fallback_cwd or os.getcwd(),
+        session_id=request_session_id,
+    )
+
+
+async def resolve_a2a_public_path_roots_for_data(
+    task_store: Any,
+    *,
+    response_data: Any = None,
+    request_data: Any = None,
+    request_bare_id_is_task_id: bool = False,
+    call_context: Any | None = None,
+    fallback_cwd: str | None = None,
+) -> list[dict[str, str]]:
+    """Aggregate roots for every task/context represented at a wire boundary."""
+
+    identities = a2a_identities_from_data(response_data)
+    identities.extend(
+        identity
+        for identity in a2a_identities_from_data(
+            request_data,
+            bare_id_is_task_id=request_bare_id_is_task_id,
+        )
+        if identity not in identities
+    )
+    if not identities:
+        return await resolve_a2a_public_path_roots(
+            task_store,
+            call_context=call_context,
+            fallback_cwd=fallback_cwd,
+            request_data=request_data,
+        )
+
+    roots: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for task_id, context_id in identities:
+        resolved = await resolve_a2a_public_path_roots(
+            task_store,
+            task_id=task_id,
+            context_id=context_id,
+            call_context=call_context,
+            fallback_cwd=fallback_cwd,
+            request_data=request_data,
+        )
+        for root in resolved:
+            key = (root.get("path", ""), root.get("label", ""))
+            if key not in seen:
+                roots.append(root)
+                seen.add(key)
+    return roots
+
+
+def a2a_runtime_path_context_from_data(value: Any, *, _depth: int = 0) -> tuple[str | None, str | None]:
+    """Extract the existing runtime cwd/session metadata from an A2A payload."""
+
+    if _depth >= 16:
+        return None, None
+    if isinstance(value, Mapping):
+        cwd: str | None = None
+        session_id: str | None = None
+        iac_code = value.get("iac_code")
+        if isinstance(iac_code, Mapping):
+            candidate_cwd = iac_code.get("cwd")
+            if isinstance(candidate_cwd, str) and candidate_cwd:
+                cwd = candidate_cwd
+            session_id = _first_nonempty_string(
+                iac_code,
+                ("iacCodeSessionId", "iac_code_session_id", "sessionId", "session_id"),
+            )
+        if cwd and session_id:
+            return cwd, session_id
+        for item in value.values():
+            nested_cwd, nested_session_id = a2a_runtime_path_context_from_data(item, _depth=_depth + 1)
+            cwd = cwd or nested_cwd
+            session_id = session_id or nested_session_id
+            if cwd and session_id:
+                break
+        return cwd, session_id
+    if isinstance(value, (list, tuple)):
+        cwd: str | None = None
+        session_id: str | None = None
+        for item in value:
+            nested_cwd, nested_session_id = a2a_runtime_path_context_from_data(item, _depth=_depth + 1)
+            cwd = cwd or nested_cwd
+            session_id = session_id or nested_session_id
+            if cwd and session_id:
+                break
+        return cwd, session_id
+    return None, None
+
+
+def a2a_identity_from_data(value: Any, *, _depth: int = 0) -> tuple[str | None, str | None]:
+    """Find the first existing A2A task/context identity in request or response data."""
+
+    identities = a2a_identities_from_data(value, _depth=_depth)
+    return identities[0] if identities else (None, None)
+
+
+def a2a_identities_from_data(
+    value: Any,
+    *,
+    bare_id_is_task_id: bool = False,
+    _depth: int = 0,
+) -> list[tuple[str | None, str | None]]:
+    """Find all A2A identities, preserving JSON-RPC request-id semantics."""
+
+    identities: list[tuple[str | None, str | None]] = []
+
+    def add(task_id: str | None, context_id: str | None) -> None:
+        identity = (task_id, context_id)
+        if (task_id or context_id) and identity not in identities:
+            identities.append(identity)
+
+    def visit(item: Any, depth: int, *, allow_bare_id: bool = False) -> None:
+        if depth >= 16:
+            return
+        if isinstance(item, Mapping):
+            task_id = _first_nonempty_string(item, ("taskId", "task_id"))
+            context_id = _first_nonempty_string(item, ("contextId", "context_id"))
+            if task_id is None and context_id is not None:
+                task_id = _first_nonempty_string(item, ("id",))
+            if task_id is None:
+                task_id = _task_id_from_resource_name(item)
+            add(task_id, context_id)
+
+            method = item.get("method")
+            params = item.get("params")
+            if method in _TASK_SCOPED_JSONRPC_METHODS and isinstance(params, Mapping):
+                add(_first_nonempty_string(params, ("taskId", "task_id", "id")), None)
+            elif allow_bare_id and task_id is None and context_id is None:
+                add(_first_nonempty_string(item, ("id",)), None)
+
+            for nested in item.values():
+                visit(nested, depth + 1)
+        elif isinstance(item, (list, tuple)):
+            for nested in item:
+                visit(nested, depth + 1)
+
+    visit(value, _depth, allow_bare_id=bare_id_is_task_id)
+    return identities
+
+
+def _first_nonempty_string(value: Mapping[Any, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        item = value.get(key)
+        if isinstance(item, str) and item:
+            return item
+    return None
+
+
+def _task_id_from_resource_name(value: Mapping[Any, Any]) -> str | None:
+    for key in ("name", "parent"):
+        resource_name = value.get(key)
+        if not isinstance(resource_name, str):
+            continue
+        parts = resource_name.split("/")
+        if len(parts) >= 2 and parts[0] == "tasks" and parts[1]:
+            return parts[1]
+    return None
+
+
+async def project_a2a_exception(
+    exc: BaseException,
+    *,
+    task_store: Any,
+    request_data: Any = None,
+    fallback_cwd: str | None = None,
+) -> PublicError:
+    """Build the existing public-error shape with A2A path-only projection."""
+
+    roots = await resolve_a2a_public_path_roots_for_data(
+        task_store,
+        fallback_cwd=fallback_cwd,
+        request_data=request_data,
+    )
+    error_type = type(exc).__name__
+    message = str(exc)
+    raw_summary = type(exc).__name__ if not message else f"{type(exc).__name__}: {message}"
+    digest = hashlib.sha256(f"{error_type}\0{raw_summary}".encode("utf-8", errors="replace")).hexdigest()
+    error_id = digest[:12]
+    raw_details = {
+        "type": error_type,
+        "error_id": error_id,
+        "traceback": _("Stack trace omitted from public event; see error_id."),
+    }
+    details = project_a2a_data(raw_details, public_path_roots=roots)
+    return PublicError(
+        summary=project_a2a_text(raw_summary, public_path_roots=roots),
+        details=details,
+        error_id=error_id,
+    )
+
+
+def _project_path_only(
+    value: Any,
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None,
+) -> Any:
+    if isinstance(value, str):
+        return redact_known_public_paths(value, public_path_roots)
+    if isinstance(value, Mapping):
+        return _project_mapping(value, public_path_roots=public_path_roots)
+    if isinstance(value, list):
+        return [_project_path_only(item, public_path_roots=public_path_roots) for item in value]
+    if isinstance(value, tuple):
+        return [_project_path_only(item, public_path_roots=public_path_roots) for item in value]
+    return copy.deepcopy(value)
+
+
+def _project_mapping(
+    value: Mapping[Any, Any],
+    *,
+    public_path_roots: Iterable[Mapping[str, str]] | None,
+) -> dict[Any, Any]:
+    unchanged_keys = {
+        key
+        for key in value
+        if not isinstance(key, str) or redact_known_public_paths(key, public_path_roots) == key
+    }
+    used_keys: set[Any] = set()
+    projected: dict[Any, Any] = {}
+    next_path_index = 1
+
+    for key, item in value.items():
+        output_key: Any = key
+        if isinstance(key, str) and redact_known_public_paths(key, public_path_roots) != key:
+            while True:
+                candidate = "[PATH]" if next_path_index == 1 else f"[PATH#{next_path_index}]"
+                next_path_index += 1
+                if candidate not in unchanged_keys and candidate not in used_keys:
+                    output_key = candidate
+                    break
+        used_keys.add(output_key)
+        projected[output_key] = _project_path_only(item, public_path_roots=public_path_roots)
+    return projected

--- a/src/iac_code/a2a/push.py
+++ b/src/iac_code/a2a/push.py
@@ -23,11 +23,12 @@ from google.protobuf.json_format import MessageToDict, ParseDict
 
 from iac_code.a2a.metrics import A2AMetrics, NoOpA2AMetrics
 from iac_code.a2a.persistence import A2APersistenceStore, _protocol_id_file_stem
+from iac_code.a2a.projection import build_a2a_public_path_roots, project_a2a_data
 from iac_code.a2a.push_queue import A2APushJob, A2APushQueue, LocalFileA2APushQueue
 from iac_code.a2a.push_secrets import A2APushSecretKeyring
 from iac_code.a2a.types import validate_protocol_id
 from iac_code.utils.file_security import restrict_file_permissions, safe_replace
-from iac_code.utils.public_errors import public_exception_summary
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -270,8 +271,7 @@ class A2APushSender(PushNotificationSender):
             logger.warning(
                 "Failed to load A2A push configs for task %s: %s",
                 task_id,
-                public_exception_summary(exc, max_chars=500),
-                exc_info=True,
+                sanitize_strict_text(str(exc))[:500],
             )
             return
         payload = MessageToDict(to_stream_response(event), preserving_proto_field_name=False)
@@ -291,8 +291,7 @@ class A2APushSender(PushNotificationSender):
                     "Failed to enqueue A2A push notification for task %s config %s: %s",
                     task_id,
                     config_id,
-                    public_exception_summary(exc, max_chars=500),
-                    exc_info=True,
+                    sanitize_strict_text(str(exc))[:500],
                 )
                 continue
             self._metrics.record_push_enqueued()
@@ -342,7 +341,11 @@ class A2APushNotifier:
         payload = {"taskId": task_id, "contextId": context_id, "state": state}
         for attempt in range(self._max_attempts):
             try:
-                response = await self._http_client.post(config.callback_url, json=payload, timeout=5.0)
+                response = await self._http_client.post(
+                    config.callback_url,
+                    json=project_a2a_data(payload, public_path_roots=self._path_roots(task_id, context_id)),
+                    timeout=5.0,
+                )
                 response.raise_for_status()
                 return True
             except Exception:
@@ -351,6 +354,14 @@ class A2APushNotifier:
                 if self._retry_delay_seconds:
                     await asyncio.sleep(self._retry_delay_seconds)
         return False
+
+    def _path_roots(self, task_id: str, context_id: str) -> list[dict[str, str]]:
+        task = self._persistence.load_task(task_id)
+        resolved_context_id = task.context_id if task is not None else context_id
+        context = self._persistence.load_context(resolved_context_id)
+        if context is None:
+            return build_a2a_public_path_roots(cwd=str(Path.cwd()))
+        return build_a2a_public_path_roots(cwd=context.cwd, session_id=context.session_id)
 
     async def aclose(self) -> None:
         if not self._owns_http_client:

--- a/src/iac_code/a2a/push_worker.py
+++ b/src/iac_code/a2a/push_worker.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import socket
 import time
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Iterable, Mapping
 from ipaddress import ip_address
 from typing import Any, Callable, Protocol, TypeAlias, cast
 from urllib.parse import urlparse, urlunparse
@@ -13,9 +13,10 @@ from urllib.parse import urlparse, urlunparse
 import httpx
 
 from iac_code.a2a.metrics import A2AMetrics, NoOpA2AMetrics
+from iac_code.a2a.projection import project_a2a_data
 from iac_code.a2a.push import InvalidPushNotificationConfigError, validate_push_callback_url
 from iac_code.a2a.push_queue import A2APushJob, A2APushQueue, A2APushRetryPolicy, redact_push_headers
-from iac_code.utils.public_errors import public_exception_summary, sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,10 @@ class A2APushCallbackConnector(Protocol):
 
 
 A2APushHeaderResolver: TypeAlias = Callable[[str, str], "dict[str, str] | Awaitable[dict[str, str]]"]
+A2APushPathRootsResolver: TypeAlias = Callable[
+    [str],
+    "Iterable[Mapping[str, str]] | Awaitable[Iterable[Mapping[str, str]]]",
+]
 
 
 class LoggingA2APushAlertSink:
@@ -40,7 +45,7 @@ class LoggingA2APushAlertSink:
                 "config_id": job.config_id,
                 "url": _safe_callback_url_for_log(job.url),
                 "attempt": job.attempt,
-                "last_error": sanitize_public_text(job.last_error),
+                "last_error": sanitize_strict_text(job.last_error),
                 "headers": redact_push_headers(job.headers),
             },
         )
@@ -80,6 +85,7 @@ class A2APushDeliveryWorker:
         retry_policy: A2APushRetryPolicy | None = None,
         alert_sink: A2APushAlertSink | None = None,
         header_resolver: A2APushHeaderResolver | None = None,
+        path_roots_resolver: A2APushPathRootsResolver | None = None,
         clock: Callable[[], float] = time.time,
         timeout_seconds: float = 5.0,
     ) -> None:
@@ -91,6 +97,7 @@ class A2APushDeliveryWorker:
         self._retry_policy = retry_policy or A2APushRetryPolicy()
         self._alert_sink = alert_sink or LoggingA2APushAlertSink()
         self._header_resolver = header_resolver
+        self._path_roots_resolver = path_roots_resolver
         self._clock = clock
         self._timeout_seconds = timeout_seconds
 
@@ -102,9 +109,10 @@ class A2APushDeliveryWorker:
         started = self._clock()
         try:
             headers = await self._resolve_headers(job)
+            public_path_roots = await self._resolve_path_roots(job)
             response = await self._connector.post(
                 job.url,
-                json=job.payload,
+                json=project_a2a_data(job.payload, public_path_roots=public_path_roots),
                 headers=headers,
                 timeout=self._timeout_seconds,
             )
@@ -112,7 +120,7 @@ class A2APushDeliveryWorker:
                 try:
                     await self._queue.ack(job.job_id)
                 except Exception:
-                    logger.exception(
+                    logger.error(
                         "A2A push notification delivered but queue ack failed; lease recovery will retry ownership",
                         extra={"task_id": job.task_id, "config_id": job.config_id, "job_id": job.job_id},
                     )
@@ -171,6 +179,14 @@ class A2APushDeliveryWorker:
         resolved = cast(dict[str, str], resolved)
         return dict(resolved)
 
+    async def _resolve_path_roots(self, job: A2APushJob) -> Iterable[Mapping[str, str]] | None:
+        if self._path_roots_resolver is None:
+            return None
+        resolved = self._path_roots_resolver(job.task_id)
+        if inspect.isawaitable(resolved):
+            resolved = await resolved
+        return cast(Iterable[Mapping[str, str]], resolved)
+
 
 def _is_transient_delivery_error(exc: Exception) -> bool:
     text = str(exc)
@@ -180,13 +196,13 @@ def _is_transient_delivery_error(exc: Exception) -> bool:
 
 
 def _public_push_error(exc: Exception) -> str:
-    return public_exception_summary(exc, max_chars=1000)
+    return sanitize_strict_text(f"{type(exc).__name__}: {exc}")[:1000]
 
 
 def _safe_callback_url_for_log(url: str) -> str:
     parsed = urlparse(url)
     if not parsed.scheme or parsed.hostname is None:
-        return sanitize_public_text(url)
+        return sanitize_strict_text(url)
     host = parsed.hostname
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
@@ -194,7 +210,7 @@ def _safe_callback_url_for_log(url: str) -> str:
     try:
         port = parsed.port
     except ValueError:
-        return sanitize_public_text(url)
+        return sanitize_strict_text(url)
     if port is not None:
         netloc = f"{netloc}:{port}"
     return urlunparse((parsed.scheme, netloc, parsed.path or "", "", "", ""))

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import json
 import logging
 import time
@@ -377,6 +378,18 @@ class A2ATaskStore(TaskStore):
                     )
 
         raise ValueError(_("A2A context not found"))
+
+    async def get_context_runtime_path_directories(
+        self,
+        context_id: str,
+    ) -> tuple[builtins.list[str], builtins.list[str], builtins.list[str]]:
+        """Return current runtime path directories without persisting them."""
+
+        context_id = validate_protocol_id(context_id)
+        async with self._mutation_lock:
+            record = self._contexts.get(context_id)
+            runtime = record.runtime if record is not None else None
+            return _runtime_path_directories(runtime)
 
     async def discard_context_runtime(self, context_id: str) -> None:
         """Drop a cached runtime so the next turn rebuilds the context cleanly."""
@@ -1068,6 +1081,41 @@ async def _close_runtime(runtime: Any | None) -> None:
     agent_runtime = getattr(runtime, "agent_runtime", None)
     if agent_runtime is not None and agent_runtime is not runtime:
         await _close_runtime(agent_runtime)
+
+
+def _runtime_path_directories(runtime: Any | None) -> tuple[list[str], list[str], list[str]]:
+    """Copy path roots exposed by the current agent runtime."""
+
+    agent_runtime = getattr(runtime, "agent_runtime", runtime)
+    agent_loop = getattr(agent_runtime, "agent_loop", None)
+    if agent_loop is None:
+        return [], [], []
+
+    permission_context = None
+    permission_context_getter = getattr(agent_loop, "_permission_context_getter", None)
+    if callable(permission_context_getter):
+        try:
+            permission_context = permission_context_getter()
+        except Exception:
+            permission_context = None
+    if permission_context is None:
+        permission_context = getattr(agent_loop, "_permission_context", None)
+
+    additional = list(getattr(permission_context, "additional_directories", []) or [])
+    trusted = list(getattr(permission_context, "trusted_read_directories", []) or [])
+    relative = list(getattr(permission_context, "relative_read_directories", []) or [])
+    _extend_unique_strings(trusted, getattr(permission_context, "strict_read_directories", []) or [])
+    _extend_unique_strings(trusted, getattr(agent_loop, "_tool_context_trusted_read_directories", []) or [])
+    _extend_unique_strings(relative, getattr(agent_loop, "_tool_context_relative_read_directories", []) or [])
+    return additional, trusted, relative
+
+
+def _extend_unique_strings(target: list[str], values: Any) -> None:
+    seen = set(target)
+    for value in values:
+        if isinstance(value, str) and value not in seen:
+            target.append(value)
+            seen.add(value)
 
 
 def _close_runtime_task_when_done(

--- a/src/iac_code/a2a/transports/dispatcher.py
+++ b/src/iac_code/a2a/transports/dispatcher.py
@@ -71,6 +71,11 @@ from iac_code.a2a.pipeline_transport_delivery import (
     create_pipeline_transport_delivery_tracker,
     mark_pipeline_transport_delivery_dequeued,
 )
+from iac_code.a2a.projection import (
+    project_a2a_data,
+    resolve_a2a_public_path_roots,
+    resolve_a2a_public_path_roots_for_data,
+)
 from iac_code.a2a.push import (
     A2APushConfigStore,
     A2APushSender,
@@ -86,7 +91,7 @@ from iac_code.i18n import _
 from iac_code.pipeline.config import RunMode, get_run_mode
 from iac_code.services.session_backup import SessionBackupService
 from iac_code.services.session_storage import SessionStorage
-from iac_code.utils.public_errors import public_exception_summary
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 _ACTIVE_MESSAGE_STREAM_COMPLETED = object()
@@ -335,11 +340,13 @@ def create_runtime_components(
     push_worker = None
     push_queue_instance = None
     push_secret_keyring = None
-    if push_notifications:
-        if persistence is None:
-            from iac_code.config import get_config_dir
+    if push_notifications and persistence is None:
+        from iac_code.config import get_config_dir
 
-            persistence = A2APersistenceStore(get_config_dir() / "a2a")
+        persistence = A2APersistenceStore(get_config_dir() / "a2a")
+    task_store = A2ATaskStore(metrics=metrics, persistence=persistence)
+    if push_notifications:
+        assert persistence is not None
         push_secret_keyring = A2APushSecretKeyring(Path(persistence.root) / "push_keys.json")
         push_config_store = A2APushConfigStore(persistence=persistence, secret_keyring=push_secret_keyring)
         if push_queue == "redis-streams":
@@ -370,8 +377,8 @@ def create_runtime_components(
             queue=push_queue_instance,
             metrics=metrics,
             header_resolver=push_config_store.resolve_headers_for_dispatch,
+            path_roots_resolver=lambda task_id: resolve_a2a_public_path_roots(task_store, task_id=task_id),
         )
-    task_store = A2ATaskStore(metrics=metrics, persistence=persistence)
     executor = IacCodeA2AExecutor(
         task_store=task_store,
         model=model,
@@ -645,8 +652,12 @@ class IacCodeRequestHandler(DefaultRequestHandler):
             await producer_task
         except asyncio.CancelledError:
             return
-        except Exception:
-            logger.exception("Active task message producer %s failed", task_id)
+        except Exception as exc:
+            logger.error(
+                "Active task message producer task_id=%s failed: %s",
+                sanitize_strict_text(task_id),
+                sanitize_strict_text(str(exc)),
+            )
 
     async def on_cancel_task(self, params: CancelTaskRequest, context) -> Task | None:
         self._validate_extensions(context)
@@ -773,8 +784,7 @@ class IacCodeRequestHandler(DefaultRequestHandler):
                 logger.warning(
                     "Failed to enqueue A2A push notification for terminal task %s: %s",
                     task.id,
-                    public_exception_summary(exc, max_chars=500),
-                    exc_info=True,
+                    sanitize_strict_text(str(exc))[:500],
                 )
         return task
 
@@ -937,14 +947,25 @@ class A2AJsonRpcDispatcher:
         data = response.json()
         if not isinstance(data, dict):
             raise ValueError("A2A dispatcher response must be a JSON object")
-        return data
+        roots = await resolve_a2a_public_path_roots_for_data(
+            getattr(self._components, "task_store", None),
+            response_data=data,
+            request_data=payload,
+        )
+        return project_a2a_data(data, public_path_roots=roots)
 
     async def dispatch_stream(self, payload: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
         async with self._http_client.stream("POST", "/", json=payload, headers={"A2A-Version": "1.0"}) as response:
             response.raise_for_status()
             async for line in response.aiter_lines():
                 if line.startswith("data:"):
-                    yield json.loads(line.removeprefix("data:").strip())
+                    data = json.loads(line.removeprefix("data:").strip())
+                    roots = await resolve_a2a_public_path_roots_for_data(
+                        getattr(self._components, "task_store", None),
+                        response_data=data,
+                        request_data=payload,
+                    )
+                    yield project_a2a_data(data, public_path_roots=roots)
 
     async def aclose(self) -> None:
         await self._http_client.aclose()

--- a/src/iac_code/a2a/transports/grpc.py
+++ b/src/iac_code/a2a/transports/grpc.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import Any
 
+from google.protobuf.json_format import MessageToDict
+
+from iac_code.a2a.projection import (
+    project_a2a_data,
+    project_a2a_proto,
+    resolve_a2a_public_path_roots_for_data,
+)
 from iac_code.a2a.transports.base import A2ATransportDependencyError
 from iac_code.a2a.transports.dispatcher import A2ARuntimeComponents
+
+_GRPC_REQUEST_DATA: ContextVar[Any] = ContextVar("iac_code_a2a_grpc_request_data", default=None)
 
 
 def require_grpc() -> Any:
@@ -39,7 +49,7 @@ class GrpcA2AServer:
             raise ValueError("gRPC server requires runtime components.")
 
         self._server = grpc.aio.server()
-        servicer = GrpcHandler(self._components.handler)
+        servicer = _projecting_grpc_handler(GrpcHandler, self._components)
         a2a_pb2_grpc.add_A2AServiceServicer_to_server(servicer, self._server)
         self._server.add_insecure_port(f"{self._host}:{self._port}")
         await self._server.start()
@@ -50,3 +60,54 @@ class GrpcA2AServer:
             await self._server.stop(grace=1)
         if self._components is not None:
             await self._components.aclose()
+
+
+def _projecting_grpc_handler(grpc_handler_type: type[Any], components: A2ARuntimeComponents) -> Any:
+    class ProjectingGrpcHandler(grpc_handler_type):
+        async def _handle_unary(
+            self,
+            request: Any,
+            context: Any,
+            handler_func: Any,
+            default_response: Any,
+        ) -> Any:
+            request_data = MessageToDict(request, preserving_proto_field_name=False)
+            token = _GRPC_REQUEST_DATA.set(request_data)
+            try:
+                response = await super()._handle_unary(request, context, handler_func, default_response)
+                roots = await _grpc_roots(components, request_data, response)
+                return project_a2a_proto(response, public_path_roots=roots)
+            finally:
+                _GRPC_REQUEST_DATA.reset(token)
+
+        async def _handle_stream(self, request: Any, context: Any, handler_func: Any):
+            request_data = MessageToDict(request, preserving_proto_field_name=False)
+            token = _GRPC_REQUEST_DATA.set(request_data)
+            try:
+                async for response in super()._handle_stream(request, context, handler_func):
+                    roots = await _grpc_roots(components, request_data, response)
+                    yield project_a2a_proto(response, public_path_roots=roots)
+            finally:
+                _GRPC_REQUEST_DATA.reset(token)
+
+        async def abort_context(self, error: Any, context: Any) -> None:
+            request_data = _GRPC_REQUEST_DATA.get()
+            roots = await _grpc_roots(components, request_data, None)
+            projected = project_a2a_data(
+                {"message": getattr(error, "message", str(error)), "data": getattr(error, "data", None)},
+                public_path_roots=roots,
+            )
+            projected_error = type(error)(message=projected["message"], data=projected.get("data"))
+            await super().abort_context(projected_error, context)
+
+    return ProjectingGrpcHandler(components.handler)
+
+
+async def _grpc_roots(components: A2ARuntimeComponents, request_data: Any, response: Any) -> list[dict[str, str]]:
+    response_data = MessageToDict(response, preserving_proto_field_name=False) if response is not None else None
+    return await resolve_a2a_public_path_roots_for_data(
+        components.task_store,
+        response_data=response_data,
+        request_data=request_data,
+        request_bare_id_is_task_id=True,
+    )

--- a/src/iac_code/a2a/transports/grpc_jsonrpc.py
+++ b/src/iac_code/a2a/transports/grpc_jsonrpc.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from importlib import import_module
 from typing import Any
 
+from iac_code.a2a.projection import project_a2a_exception
 from iac_code.a2a.transports.base import A2ATransportDependencyError
 from iac_code.a2a.transports.dispatcher import A2ARuntimeComponents
-from iac_code.utils.public_errors import public_error_from_exception
 
 
 @dataclass(frozen=True)
@@ -73,13 +73,14 @@ class _JsonRpcServicer:
         from iac_code.a2a.transports.dispatcher import A2AJsonRpcDispatcher
 
         self._dispatcher = A2AJsonRpcDispatcher(components)
+        self._task_store = components.task_store
 
     async def Send(self, request: JsonRpcEnvelope, context: Any) -> JsonRpcEnvelope:  # noqa: N802
         payload = _from_envelope(request)
         try:
             response = await self._dispatcher.dispatch(payload)
         except Exception as exc:
-            return _to_envelope(_jsonrpc_public_error(payload.get("id"), exc))
+            return _to_envelope(await self._jsonrpc_error(payload, exc))
         return _to_envelope(response)
 
     async def Stream(  # noqa: N802
@@ -97,10 +98,18 @@ class _JsonRpcServicer:
                 return
             raise
         except Exception as exc:
-            yield _to_envelope(_jsonrpc_public_error(payload.get("id"), exc), final=True)
+            yield _to_envelope(await self._jsonrpc_error(payload, exc), final=True)
 
     async def aclose(self) -> None:
         await self._dispatcher.aclose()
+
+    async def _jsonrpc_error(self, payload: dict[str, Any], exc: BaseException) -> dict[str, Any]:
+        failure = await project_a2a_exception(
+            exc,
+            task_store=getattr(self, "_task_store", None),
+            request_data=payload,
+        )
+        return _jsonrpc_error(payload.get("id"), failure.summary, error_id=failure.error_id)
 
 
 class GrpcA2AClient:
@@ -137,15 +146,14 @@ def _to_envelope(payload: dict[str, Any], *, final: bool = False, envelope_cls: 
     )
 
 
-def _jsonrpc_public_error(request_id: Any, exc: BaseException) -> dict[str, Any]:
-    failure = public_error_from_exception(exc)
+def _jsonrpc_error(request_id: Any, message: str, *, error_id: str) -> dict[str, Any]:
     return {
         "jsonrpc": "2.0",
         "id": request_id,
         "error": {
             "code": -32603,
-            "message": failure.summary,
-            "data": {"error_id": failure.error_id},
+            "message": message,
+            "data": {"error_id": error_id},
         },
     }
 

--- a/src/iac_code/a2a/transports/redis_streams.py
+++ b/src/iac_code/a2a/transports/redis_streams.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 from importlib import import_module
 from typing import Any
 
+from iac_code.a2a.projection import project_a2a_exception
 from iac_code.a2a.transports.base import A2ATransportDependencyError
 from iac_code.a2a.transports.dispatcher import A2AJsonRpcDispatcher, A2ARuntimeComponents
 from iac_code.a2a.transports.stdio import is_streaming_request
-from iac_code.utils.public_errors import public_error_from_exception
 
 
 @dataclass(frozen=True)
@@ -234,6 +234,7 @@ class RedisStreamsA2AServer:
                         reply_stream,
                         correlation_id=message.correlation_id,
                         request_id=request_id,
+                        request_data=message.payload,
                         exc=exc,
                     )
             else:
@@ -250,6 +251,7 @@ class RedisStreamsA2AServer:
                         reply_stream,
                         correlation_id=message.correlation_id,
                         request_id=request_id,
+                        request_data=message.payload,
                         exc=exc,
                     )
         finally:
@@ -282,9 +284,14 @@ class RedisStreamsA2AServer:
         *,
         correlation_id: str,
         request_id: Any,
+        request_data: dict[str, Any],
         exc: BaseException,
     ) -> None:
-        failure = public_error_from_exception(exc)
+        failure = await project_a2a_exception(
+            exc,
+            task_store=self._components.task_store,
+            request_data=request_data,
+        )
         await self._write_response(
             stream,
             correlation_id=correlation_id,

--- a/src/iac_code/a2a/transports/stdio.py
+++ b/src/iac_code/a2a/transports/stdio.py
@@ -8,9 +8,10 @@ import threading
 from collections.abc import AsyncIterator
 from typing import Any
 
+from iac_code.a2a.projection import project_a2a_exception
 from iac_code.a2a.transports.base import A2AFrameError
 from iac_code.a2a.transports.dispatcher import A2AJsonRpcDispatcher, A2ARuntimeComponents
-from iac_code.utils.public_errors import public_error_from_exception
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -76,8 +77,16 @@ class StdioA2AServer:
                     writer.write(encode_frame(await self._dispatcher.dispatch(payload)))
                     await writer.drain()
             except Exception as exc:
-                logger.exception("A2A stdio transport request failed")
-                failure = public_error_from_exception(exc)
+                failure = await project_a2a_exception(
+                    exc,
+                    task_store=self._components.task_store,
+                    request_data=payload if "payload" in locals() else None,
+                )
+                logger.warning(
+                    "A2A stdio transport request failed: error_id=%s summary=%s",
+                    failure.error_id,
+                    sanitize_strict_text(str(exc)),
+                )
                 response = _error_response(request_id, failure.summary, error_id=failure.error_id)
                 if streaming_request:
                     response["final"] = True

--- a/src/iac_code/a2a/transports/websocket.py
+++ b/src/iac_code/a2a/transports/websocket.py
@@ -11,9 +11,9 @@ from starlette.endpoints import WebSocketEndpoint
 from starlette.routing import WebSocketRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
+from iac_code.a2a.projection import project_a2a_exception
 from iac_code.a2a.transports.dispatcher import A2AJsonRpcDispatcher, A2ARuntimeComponents
 from iac_code.a2a.transports.stdio import is_streaming_request
-from iac_code.utils.public_errors import public_error_from_exception
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,11 @@ class WebSocketA2AServerApp:
                             if not await _send_json(websocket, websocket_event_frame(event, final=False)):
                                 return
                     except Exception as exc:
-                        failure = public_error_from_exception(exc)
+                        failure = await project_a2a_exception(
+                            exc,
+                            task_store=components.task_store,
+                            request_data=payload,
+                        )
                         logger.warning("A2A WebSocket streaming dispatch failed: error_id=%s", failure.error_id)
                         await _send_json(
                             websocket,
@@ -91,7 +95,11 @@ class WebSocketA2AServerApp:
                 try:
                     response = await self.dispatcher.dispatch(payload)
                 except Exception as exc:
-                    failure = public_error_from_exception(exc)
+                    failure = await project_a2a_exception(
+                        exc,
+                        task_store=components.task_store,
+                        request_data=payload,
+                    )
                     logger.warning("A2A WebSocket dispatch failed: error_id=%s", failure.error_id)
                     await _send_json(
                         websocket,

--- a/src/iac_code/acp/convert.py
+++ b/src/iac_code/acp/convert.py
@@ -6,7 +6,6 @@ from typing import Any, Literal
 
 import acp
 
-from iac_code.a2a.artifacts import sanitize_public_tool_output_data
 from iac_code.acp.state import TurnState, display_tool_title
 from iac_code.acp.types import ACPContentBlock
 from iac_code.i18n import _
@@ -31,7 +30,6 @@ from iac_code.types.stream_events import (
     ToolUseStartEvent,
     Usage,
 )
-from iac_code.utils.public_errors import sanitize_public_text
 
 # ``acp.schema`` exposes individual session-update message classes
 # (``AgentMessageChunk``, ``ToolCallStart``, ...) but not a single
@@ -302,7 +300,7 @@ class ACPEventConverter:
                 return [
                     acp.schema.AgentMessageChunk(
                         session_update="agent_message_chunk",
-                        content=acp.schema.TextContentBlock(type="text", text=f"[Error] {sanitize_public_text(error)}"),
+                        content=acp.schema.TextContentBlock(type="text", text=f"[Error] {error}"),
                     )
                 ]
             case PlanEvent(steps=steps):
@@ -366,10 +364,10 @@ def _input_delta_summary_text(accumulated_input: str) -> str:
 
 
 def _public_tool_result_text(value: Any, *, public_path_roots: list[dict[str, str]] | None = None) -> str:
-    sanitized = sanitize_public_tool_output_data(value, public_path_roots=public_path_roots)
-    if isinstance(sanitized, str):
-        return sanitized
-    return json.dumps(sanitized, ensure_ascii=False, default=str)
+    del public_path_roots
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, default=str)
 
 
 # ---------------------------------------------------------------------------

--- a/src/iac_code/acp/server.py
+++ b/src/iac_code/acp/server.py
@@ -36,7 +36,7 @@ from iac_code.utils.project_paths import (
     format_resume_command,
     same_project_path,
 )
-from iac_code.utils.public_errors import public_error_from_exception
+from iac_code.utils.public_errors import public_error_from_exception, sanitize_strict_text
 
 SESSION_IDLE_TIMEOUT = 3600  # 1 hour
 CLEANUP_INTERVAL = 300  # 5 minutes
@@ -655,14 +655,14 @@ class ACPServer:
 
         resolved_session_id = entry.session_id
         if entry.cwd and not same_project_path(entry.cwd, cwd):
-            hint = _public_resume_command(resolved_session_id)
+            hint = _resume_command(entry.cwd, resolved_session_id)
             message = _("Session belongs to another project. Run: {hint}").format(hint=hint)
             raise _invalid_params(
                 message,
                 {
                     "session_id": session_id,
                     "resolved_session_id": resolved_session_id,
-                    "cwd": _PUBLIC_CWD,
+                    "cwd": entry.cwd,
                     "hint": hint,
                 },
             )
@@ -814,11 +814,11 @@ class ACPServer:
                         "code": "auth_required",
                     }
                 ) from exc
-            logger.exception("ACP runtime creation failed")
+            logger.error("ACP runtime creation failed: %s", sanitize_strict_text(str(exc)))
             failure = public_error_from_exception(exc)
             raise acp.RequestError.internal_error(
                 {
-                    "error": failure.summary,
+                    "error": str(exc),
                     "error_id": failure.error_id,
                 }
             ) from exc
@@ -1067,15 +1067,8 @@ def _reject_pipeline_mode_for_acp() -> None:
         raise _invalid_params(_ACP_PIPELINE_MODE_UNSUPPORTED_TEXT)
 
 
-_PUBLIC_CWD = "[PATH]"
-
-
 def _resume_command(cwd: str, session_id: str) -> str:
     return format_resume_command(cwd, session_id)
-
-
-def _public_resume_command(session_id: str) -> str:
-    return format_resume_command(_PUBLIC_CWD, session_id)
 
 
 def _active_session_cwd(session: ACPSession) -> str | None:
@@ -1089,14 +1082,14 @@ def _active_session_project_error(
     active_cwd = _active_session_cwd(session)
     if not active_cwd or same_project_path(active_cwd, cwd):
         return None
-    hint = _public_resume_command(resolved_session_id)
+    hint = _resume_command(active_cwd, resolved_session_id)
     message = _("Session belongs to another project. Run: {hint}").format(hint=hint)
     return _invalid_params(
         message,
         {
             "session_id": session_id,
             "resolved_session_id": resolved_session_id,
-            "cwd": _PUBLIC_CWD,
+            "cwd": active_cwd,
             "hint": hint,
         },
     )
@@ -1106,8 +1099,8 @@ def _resume_candidate_data(entry: SessionEntry) -> dict[str, str | None]:
     return {
         "session_id": entry.session_id,
         "name": entry.name,
-        "cwd": _PUBLIC_CWD,
-        "command": _public_resume_command(entry.session_id),
+        "cwd": entry.cwd,
+        "command": _resume_command(entry.cwd, entry.session_id),
     }
 
 

--- a/src/iac_code/acp/session.py
+++ b/src/iac_code/acp/session.py
@@ -12,7 +12,6 @@ from typing import Any
 
 import acp
 
-from iac_code.a2a.artifacts import sanitize_public_tool_output_data
 from iac_code.acp.convert import ACPEventConverter, _tool_kind, acp_blocks_to_prompt_text
 from iac_code.acp.metrics import ACPMetrics
 from iac_code.acp.slash_registry import ACPSlashRegistry
@@ -30,10 +29,8 @@ from iac_code.agent.message import (
 from iac_code.commands.registry import PromptCommand
 from iac_code.i18n import _
 from iac_code.mcp.errors import MCPConnectionError
-from iac_code.mcp.redaction import sanitize_mcp_public_text
 from iac_code.services.permissions.audit import (
     build_input_summary,
-    build_prompt_tool_input,
     emit_permission_boundary_audit,
     is_permission_audit_non_read_only,
     permission_audit_operation,
@@ -44,7 +41,7 @@ from iac_code.services.telemetry import use_session_id
 from iac_code.state.app_state import lookup_permission, record_permission
 from iac_code.types.permissions import PermissionDecision, PermissionRuleValue
 from iac_code.types.stream_events import PermissionRequestEvent, SubPipelineStreamEvent
-from iac_code.utils.public_errors import public_error
+from iac_code.utils.public_errors import public_error, sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -89,29 +86,25 @@ def _history_tool_content(text: str) -> acp.schema.ContentToolCallContent:
 
 
 def _history_tool_result_text(value: Any) -> str:
-    sanitized = sanitize_public_tool_output_data(value)
-    if isinstance(sanitized, str):
-        return sanitized
-    return json.dumps(sanitized, ensure_ascii=False, default=str)
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, default=str)
 
 
 def _history_tool_input_text(tool_name: str, tool_input: dict[str, Any]) -> str:
+    del tool_name
     if not tool_input:
         return ""
-    return _display_tool_input_text(tool_name, tool_input)
+    return _("Input: {input}").format(
+        input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
+    )
 
 
 def _display_tool_input_text(tool_name: str, tool_input: dict[str, Any]) -> str:
-    if tool_name != "aliyun_api":
-        tool_input_redacted = json.dumps(
-            build_prompt_tool_input(tool_input),
-            ensure_ascii=False,
-            sort_keys=True,
-            default=str,
-        )
-        return _("Input: {input}").format(input=tool_input_redacted)
-    summary = json.dumps(build_input_summary(tool_name, tool_input), ensure_ascii=False, sort_keys=True)
-    return _("Input summary: {summary}").format(summary=summary)
+    del tool_name
+    return _("Input: {input}").format(
+        input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
+    )
 
 
 def _permission_request_event(event: Any) -> PermissionRequestEvent | None:
@@ -270,7 +263,7 @@ def _permission_tool_title(agent_loop, tool_name: str, tool_input: dict[str, Any
 
 
 def _permission_meta_text(value: Any) -> str:
-    text = sanitize_mcp_public_text(value, fallback_summary="")
+    text = str(value)
     if len(text) <= _PERMISSION_META_STRING_MAX_CHARS:
         return text
     marker = _("[truncated]")
@@ -576,7 +569,7 @@ class ACPSession:
             if _is_auth_error(exc):
                 logger.warning("ACP session %s: authentication error: %s", self.id, exc)
                 raise self._request_error_from_prompt_exception(exc, log=False, record_metrics=False) from exc
-            logger.error("ACP session %s: unhandled error: %s", self.id, exc, exc_info=True)
+            logger.error("ACP session %s: unhandled error: %s", self.id, sanitize_strict_text(str(exc)))
             raise self._request_error_from_prompt_exception(exc, log=False, record_metrics=False) from exc
         finally:
             self._current_task = None
@@ -662,11 +655,11 @@ class ACPSession:
                 }
             )
         if log:
-            logger.error("ACP session %s: unhandled error: %s", self.id, exc, exc_info=True)
+            logger.error("ACP session %s: unhandled error: %s", self.id, sanitize_strict_text(str(exc)))
         failure = public_error(message=f"{type(exc).__name__}: {exc}", error_type=type(exc).__name__)
         return acp.RequestError.internal_error(
             {
-                "error": failure.summary,
+                "error": f"{type(exc).__name__}: {exc}",
                 "error_id": failure.error_id,
             }
         )
@@ -900,27 +893,10 @@ class ACPSession:
 
         # Build content with command details and suggested rule.
         tool_title = _permission_tool_title(self.agent_loop, tool_name, event.tool_input)
-        if tool_name == "aliyun_api":
-            input_summary = json.dumps(
-                build_input_summary(tool_name, event.tool_input),
-                ensure_ascii=False,
-                sort_keys=True,
-            )
-            content_text = _("Approve tool call: {tool}\nInput summary: {summary}").format(
-                tool=tool_title,
-                summary=input_summary,
-            )
-        else:
-            tool_input_redacted = json.dumps(
-                build_prompt_tool_input(event.tool_input),
-                ensure_ascii=False,
-                sort_keys=True,
-                default=str,
-            )
-            content_text = _("Approve tool call: {tool}\nInput: {input}").format(
-                tool=tool_title,
-                input=tool_input_redacted,
-            )
+        content_text = _("Approve tool call: {tool}\nInput: {input}").format(
+            tool=tool_title,
+            input=json.dumps(event.tool_input, ensure_ascii=False, sort_keys=True, default=str),
+        )
         if suggestions:
             content_text += "\n" + _("Suggested rule: {rule}").format(rule=_suggestion_display())
 

--- a/src/iac_code/acp/slash_registry.py
+++ b/src/iac_code/acp/slash_registry.py
@@ -13,7 +13,7 @@ import logging
 from iac_code.i18n import _
 from iac_code.services.session_metadata import normalize_session_name
 from iac_code.services.session_storage import SessionStorage
-from iac_code.utils.public_errors import sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -74,8 +74,8 @@ class ACPSlashRegistry:
         try:
             result = await agent_loop.compact()
         except Exception as exc:
-            logger.warning("ACP /compact failed: %s", exc)
-            return _("Compaction failed: {error}").format(error=sanitize_public_text(exc))
+            logger.warning("ACP /compact failed: %s", sanitize_strict_text(str(exc)))
+            return _("Compaction failed: {error}").format(error=str(exc))
 
         if result.status == "empty":
             return _("Nothing to compact: conversation is empty.")
@@ -103,8 +103,8 @@ class ACPSlashRegistry:
         try:
             agent_loop.reset()
         except Exception as exc:
-            logger.warning("ACP /clear failed: %s", exc)
-            return _("Clear failed: {error}").format(error=sanitize_public_text(exc))
+            logger.warning("ACP /clear failed: %s", sanitize_strict_text(str(exc)))
+            return _("Clear failed: {error}").format(error=str(exc))
         return _("Conversation history cleared.")
 
     def _handle_debug(self, args: str) -> str:
@@ -161,7 +161,7 @@ class ACPSlashRegistry:
             name = normalize_session_name(parts[0])
             result = SessionStorage().rename_session(cwd, session_id, name, git_branch=git_branch)
         except ValueError as exc:
-            return sanitize_public_text(exc)
+            return str(exc)
 
         if result == "unchanged":
             return _("Session is already named {name}").format(name=name)

--- a/src/iac_code/cli/headless.py
+++ b/src/iac_code/cli/headless.py
@@ -41,7 +41,7 @@ from iac_code.types.stream_events import (
     ToolUseStartEvent,
 )
 from iac_code.utils.background_housekeeping import start_background_housekeeping
-from iac_code.utils.public_errors import public_error_from_exception, sanitize_public_text
+from iac_code.utils.public_errors import public_error_from_exception, sanitize_strict_text
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -142,7 +142,7 @@ class HeadlessRunner:
         self._runtime: Any | None = None
 
     def _print_provider_not_configured(self, exc: Exception) -> None:
-        logger.error("Provider not configured: {}", exc)
+        logger.error("Provider not configured: {}", sanitize_strict_text(str(exc)))
         hint = _(
             "\n"
             "  {error}\n"
@@ -150,17 +150,17 @@ class HeadlessRunner:
             "  Fix: run  iac-code  then type /auth\n"
             "   or: set  IAC_CODE_API_KEY=<your-key>\n"
             "  Docs: https://aliyun.github.io/iac-code/docs/configuration/authentication\n"
-        ).format(error=sanitize_public_text(exc))
+        ).format(error=str(exc))
         print(hint, file=sys.stderr)
 
     def _print_unexpected_error(self, exc: Exception) -> None:
-        logger.error("Headless execution failed: {}", exc)
-        print(_("Error: {error}").format(error=sanitize_public_text(exc)), file=sys.stderr)
+        logger.error("Headless execution failed: {}", sanitize_strict_text(str(exc)))
+        print(_("Error: {error}").format(error=str(exc)), file=sys.stderr)
 
     def _record_structured_error(self, writer: Any, exc: Exception) -> None:
         if self._output_format != OutputFormat.TEXT:
             failure = public_error_from_exception(exc)
-            writer.handle(ErrorEvent(error=failure.summary, is_retryable=False, error_id=failure.error_id))
+            writer.handle(ErrorEvent(error=str(exc), is_retryable=False, error_id=failure.error_id))
 
     def _create_agent_loop(self) -> Any:
         """Create and return a fully configured AgentLoop."""

--- a/src/iac_code/cli/output_formats.py
+++ b/src/iac_code/cli/output_formats.py
@@ -11,9 +11,7 @@ import sys
 from enum import Enum
 from typing import IO, Any
 
-from iac_code.a2a.artifacts import sanitize_public_tool_output_data
 from iac_code.mcp.progress import mcp_progress_metadata
-from iac_code.mcp.redaction import sanitize_mcp_public_data
 from iac_code.services.permissions.audit import build_input_summary
 from iac_code.tools.cloud.aliyun.result_contract import ALIYUN_HTTP_METADATA_KEY
 from iac_code.tools.result_storage import EXTERNALIZED_RESULT_PATH_METADATA_KEY
@@ -33,7 +31,6 @@ from iac_code.types.stream_events import (
     ToolUseEndEvent,
     ToolUseStartEvent,
 )
-from iac_code.utils.public_errors import sanitize_public_text
 
 
 class OutputFormat(str, Enum):
@@ -45,19 +42,12 @@ class OutputFormat(str, Enum):
 
 
 def _public_tool_result(event: ToolResultEvent) -> Any:
-    result = sanitize_public_tool_output_data(event.result, public_path_roots=event.public_path_roots)
-    return sanitize_mcp_public_data(result, fallback_summary="") if event.tool_name.startswith("mcp__") else result
+    return event.result
 
 
 def _public_tool_metadata(event: ToolResultEvent, metadata: Any) -> Any:
     public_metadata = _strip_internal_tool_metadata(metadata)
-    if event.is_error:
-        public_metadata = _sanitize_public_value(public_metadata, public_path_roots=event.public_path_roots)
-    result = sanitize_public_tool_output_data(
-        public_metadata,
-        public_path_roots=event.public_path_roots,
-    )
-    return sanitize_mcp_public_data(result, fallback_summary="") if event.tool_name.startswith("mcp__") else result
+    return public_metadata
 
 
 def _strip_internal_tool_metadata(metadata: Any) -> Any:
@@ -77,20 +67,6 @@ def _strip_internal_tool_metadata(metadata: Any) -> Any:
     if isinstance(metadata, tuple):
         return [_strip_internal_tool_metadata(item) for item in metadata]
     return metadata
-
-
-def _sanitize_public_value(value: Any, *, public_path_roots: list[dict[str, str]] | None = None) -> Any:
-    if isinstance(value, str):
-        return sanitize_public_text(value, public_path_roots=public_path_roots)
-    if isinstance(value, list):
-        return [_sanitize_public_value(item, public_path_roots=public_path_roots) for item in value]
-    if isinstance(value, tuple):
-        return [_sanitize_public_value(item, public_path_roots=public_path_roots) for item in value]
-    if isinstance(value, dict):
-        return {
-            str(key): _sanitize_public_value(item, public_path_roots=public_path_roots) for key, item in value.items()
-        }
-    return value
 
 
 def stream_json_event_data(event: StreamEvent) -> dict[str, Any]:
@@ -152,9 +128,7 @@ def stream_json_event_data(event: StreamEvent) -> dict[str, Any]:
         return data
 
     data = dataclasses.asdict(event)
-    if isinstance(event, ErrorEvent):
-        data["error"] = sanitize_public_text(event.error)
-    elif isinstance(event, ToolResultEvent):
+    if isinstance(event, ToolResultEvent):
         data.pop("public_path_roots", None)
         if data.get("metadata") is None:
             data.pop("metadata", None)
@@ -186,7 +160,7 @@ class TextWriter:
             self._stream.flush()
             self._has_output = True
         elif isinstance(event, ErrorEvent):
-            sys.stderr.write(f"Error: {sanitize_public_text(event.error)}\n")
+            sys.stderr.write(f"Error: {event.error}\n")
             sys.stderr.flush()
 
     def finalize(self) -> None:
@@ -236,7 +210,7 @@ class JsonWriter:
             if not is_empty_synthetic_max_turns:
                 self._usage = usage
         elif isinstance(event, ErrorEvent):
-            self._error = sanitize_public_text(event.error)
+            self._error = event.error
             self._error_id = event.error_id
 
     def finalize(self) -> None:

--- a/src/iac_code/cli/process_events.py
+++ b/src/iac_code/cli/process_events.py
@@ -10,7 +10,6 @@ from iac_code.cli.output_formats import stream_json_event_data
 from iac_code.cli.process_protocol import ProcessFrameValidationError, SDKErrorPayload, SDKProcessRuntimeError
 from iac_code.providers.manager import ProviderNotConfiguredError
 from iac_code.types.stream_events import ErrorEvent
-from iac_code.utils.public_errors import sanitize_public_text
 
 
 @dataclass(frozen=True)
@@ -35,7 +34,7 @@ class ProcessErrorMapper:
     def from_event(self, event: ErrorEvent) -> SDKErrorPayload:
         return SDKErrorPayload(
             code="stream_error",
-            message=sanitize_public_text(event.error),
+            message=event.error,
             retryable=event.is_retryable,
             error_id=event.error_id,
         )
@@ -48,9 +47,9 @@ class ProcessErrorMapper:
         if isinstance(exc, ProviderNotConfiguredError):
             return SDKErrorPayload(
                 code="provider_not_configured",
-                message=sanitize_public_text(str(exc)),
+                message=str(exc),
                 retryable=False,
             )
         if isinstance(exc, asyncio.CancelledError):
             return SDKErrorPayload(code="turn_canceled", message="Turn canceled.", retryable=False)
-        return SDKErrorPayload(code="internal_error", message=sanitize_public_text(str(exc)), retryable=False)
+        return SDKErrorPayload(code="internal_error", message=str(exc), retryable=False)

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -45,7 +45,8 @@ msgstr "afterSequence muss eine nicht negative Ganzzahl sein"
 msgid "Unsafe artifact filename"
 msgstr "Unsicherer Artefaktdateiname"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/utils/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
 
@@ -119,8 +120,7 @@ msgstr "Aufgabe abgebrochen."
 msgid "Current model {model} does not support image input."
 msgstr "Aktuelles Modell {model} unterstützt keine Bildeingabe."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-#: src/iac_code/a2a/transports/dispatcher.py
+#: src/iac_code/a2a/executor.py src/iac_code/a2a/transports/dispatcher.py
 msgid "Authentication required. Configure credentials and retry."
 msgstr ""
 "Authentifizierung erforderlich. Anmeldedaten konfigurieren und erneut "
@@ -161,6 +161,11 @@ msgstr "A2A-Pipeline-Zustand nicht gefunden"
 #: src/iac_code/a2a/pipeline_recovery.py
 msgid "A2A task/context mismatch"
 msgstr "A2A-Aufgabe und Kontext passen nicht zusammen"
+
+#: src/iac_code/a2a/projection.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
+msgid "Stack trace omitted from public event; see error_id."
+msgstr "Stacktrace im öffentlichen Ereignis ausgelassen; siehe error_id."
 
 #: src/iac_code/a2a/task_store.py
 msgid "A2A task expired"
@@ -215,8 +220,7 @@ msgstr "Aufgabe abgeschlossen."
 msgid "Task failed."
 msgstr "Aufgabe fehlgeschlagen."
 
-#: src/iac_code/acp/convert.py src/iac_code/acp/session.py
-#: src/iac_code/ui/renderer.py
+#: src/iac_code/acp/convert.py src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Input summary: {summary}"
 msgstr "Eingabezusammenfassung: {summary}"
@@ -284,15 +288,6 @@ msgstr "Immer \"{rule}\" ablehnen (diese Sitzung)"
 #: src/iac_code/acp/session.py
 msgid "Always reject this tool"
 msgstr "Dieses Tool immer ablehnen"
-
-#: src/iac_code/acp/session.py
-#, python-brace-format
-msgid ""
-"Approve tool call: {tool}\n"
-"Input summary: {summary}"
-msgstr ""
-"Tool-Aufruf genehmigen: {tool}\n"
-"Eingabezusammenfassung: {summary}"
 
 #: src/iac_code/acp/session.py
 #, python-brace-format
@@ -4567,6 +4562,15 @@ msgstr "Felder werden für Aktion '{action}' nicht unterstützt: {fields}"
 #, python-brace-format
 msgid "Missing required field(s) for action '{action}': {fields}"
 msgstr "Erforderliche Felder für Aktion '{action}' fehlen: {fields}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid ""
+"Deployment parameters contain a redaction placeholder; provide the real "
+"parameter value before deployment."
+msgstr ""
+"Die Bereitstellungsparameter enthalten einen Platzhalter für die "
+"Schwärzung; geben Sie vor der Bereitstellung den tatsächlichen "
+"Parameterwert an."
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -11466,10 +11470,6 @@ msgstr ""
 "  Option 2 - falls Sie github.com nicht erreichen können, führen Sie dies"
 " aus, um über npmmirror zu installieren:"
 
-#: src/iac_code/utils/public_errors.py
-msgid "Stack trace omitted from public event; see error_id."
-msgstr "Stacktrace im öffentlichen Ereignis ausgelassen; siehe error_id."
-
 #: src/iac_code/utils/state_io.py
 #, python-brace-format
 msgid "refusing to follow symlink or reparse point: {path}"
@@ -12688,3 +12688,10 @@ msgstr "Bash zulassen?"
 #~ "Der Schlüssel verweist auf die "
 #~ "Komponente {}, die im Standard-ROS-"
 #~ "Parameterformular nicht verfügbar ist."
+
+#~ msgid ""
+#~ "Approve tool call: {tool}\n"
+#~ "Input summary: {summary}"
+#~ msgstr ""
+#~ "Tool-Aufruf genehmigen: {tool}\n"
+#~ "Eingabezusammenfassung: {summary}"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -46,7 +46,8 @@ msgstr "afterSequence debe ser un entero no negativo"
 msgid "Unsafe artifact filename"
 msgstr "Nombre de archivo de artefacto no seguro"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/utils/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Error desconocido"
 
@@ -120,8 +121,7 @@ msgstr "Tarea cancelada."
 msgid "Current model {model} does not support image input."
 msgstr "El modelo actual {model} no admite entrada de imagen."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-#: src/iac_code/a2a/transports/dispatcher.py
+#: src/iac_code/a2a/executor.py src/iac_code/a2a/transports/dispatcher.py
 msgid "Authentication required. Configure credentials and retry."
 msgstr ""
 "Se requiere autenticación. Configura las credenciales e inténtalo de "
@@ -162,6 +162,11 @@ msgstr "No se encontró el estado del pipeline A2A"
 #: src/iac_code/a2a/pipeline_recovery.py
 msgid "A2A task/context mismatch"
 msgstr "La tarea y el contexto A2A no coinciden"
+
+#: src/iac_code/a2a/projection.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
+msgid "Stack trace omitted from public event; see error_id."
+msgstr "La traza de pila se omitió del evento público; consulta error_id."
 
 #: src/iac_code/a2a/task_store.py
 msgid "A2A task expired"
@@ -216,8 +221,7 @@ msgstr "Tarea completada."
 msgid "Task failed."
 msgstr "La tarea falló."
 
-#: src/iac_code/acp/convert.py src/iac_code/acp/session.py
-#: src/iac_code/ui/renderer.py
+#: src/iac_code/acp/convert.py src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Input summary: {summary}"
 msgstr "Resumen de entrada: {summary}"
@@ -280,15 +284,6 @@ msgstr "Rechazar siempre \"{rule}\" (esta sesión)"
 #: src/iac_code/acp/session.py
 msgid "Always reject this tool"
 msgstr "Rechazar siempre esta herramienta"
-
-#: src/iac_code/acp/session.py
-#, python-brace-format
-msgid ""
-"Approve tool call: {tool}\n"
-"Input summary: {summary}"
-msgstr ""
-"Aprobar llamada de herramienta: {tool}\n"
-"Resumen de entrada: {summary}"
 
 #: src/iac_code/acp/session.py
 #, python-brace-format
@@ -4537,6 +4532,14 @@ msgstr "Los campos no son compatibles con la acción '{action}': {fields}"
 #, python-brace-format
 msgid "Missing required field(s) for action '{action}': {fields}"
 msgstr "Faltan campos obligatorios para la acción '{action}': {fields}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid ""
+"Deployment parameters contain a redaction placeholder; provide the real "
+"parameter value before deployment."
+msgstr ""
+"Los parámetros de despliegue contienen un marcador de redacción; "
+"proporcione el valor real del parámetro antes del despliegue."
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -9136,7 +9139,9 @@ msgstr ""
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "unsliced generated identifier (Length is falsy in JavaScript)"
-msgstr "identificador generado sin recortar (Length es un valor falso en JavaScript)"
+msgstr ""
+"identificador generado sin recortar (Length es un valor falso en "
+"JavaScript)"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 #, python-brace-format
@@ -9196,8 +9201,8 @@ msgid ""
 "A negative or fractional counter never reaches zero; generation stops "
 "only after available positions are exhausted."
 msgstr ""
-"Un contador negativo o fraccionario nunca llega a cero; la generación solo "
-"se detiene cuando se agotan las posiciones disponibles."
+"Un contador negativo o fraccionario nunca llega a cero; la generación "
+"solo se detiene cuando se agotan las posiciones disponibles."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "a non-negative integer for predictable minimum semantics"
@@ -11393,10 +11398,6 @@ msgstr ""
 "  Opción 2 - si no puedes acceder a github.com, ejecuta esto para "
 "instalar vía npmmirror:"
 
-#: src/iac_code/utils/public_errors.py
-msgid "Stack trace omitted from public event; see error_id."
-msgstr "La traza de pila se omitió del evento público; consulta error_id."
-
 #: src/iac_code/utils/state_io.py
 #, python-brace-format
 msgid "refusing to follow symlink or reparse point: {path}"
@@ -12604,3 +12605,10 @@ msgstr "¿Permitir Bash?"
 #~ "La clave se asigna al componente "
 #~ "{}, que no está disponible en el"
 #~ " formulario de parámetros ROS estándar."
+
+#~ msgid ""
+#~ "Approve tool call: {tool}\n"
+#~ "Input summary: {summary}"
+#~ msgstr ""
+#~ "Aprobar llamada de herramienta: {tool}\n"
+#~ "Resumen de entrada: {summary}"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -46,7 +46,8 @@ msgstr "afterSequence doit être un entier non négatif"
 msgid "Unsafe artifact filename"
 msgstr "Nom de fichier d’artefact non sûr"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/utils/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Erreur inconnue"
 
@@ -120,8 +121,7 @@ msgstr "Tâche annulée."
 msgid "Current model {model} does not support image input."
 msgstr "Le modèle actuel {model} ne prend pas en charge l’entrée d’image."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-#: src/iac_code/a2a/transports/dispatcher.py
+#: src/iac_code/a2a/executor.py src/iac_code/a2a/transports/dispatcher.py
 msgid "Authentication required. Configure credentials and retry."
 msgstr "Authentification requise. Configurez les identifiants puis réessayez."
 
@@ -160,6 +160,11 @@ msgstr "État du pipeline A2A introuvable"
 #: src/iac_code/a2a/pipeline_recovery.py
 msgid "A2A task/context mismatch"
 msgstr "La tâche et le contexte A2A ne correspondent pas"
+
+#: src/iac_code/a2a/projection.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
+msgid "Stack trace omitted from public event; see error_id."
+msgstr "Trace de pile omise de l’événement public ; consultez error_id."
 
 #: src/iac_code/a2a/task_store.py
 msgid "A2A task expired"
@@ -214,8 +219,7 @@ msgstr "Tâche terminée."
 msgid "Task failed."
 msgstr "La tâche a échoué."
 
-#: src/iac_code/acp/convert.py src/iac_code/acp/session.py
-#: src/iac_code/ui/renderer.py
+#: src/iac_code/acp/convert.py src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Input summary: {summary}"
 msgstr "Résumé de l'entrée : {summary}"
@@ -278,15 +282,6 @@ msgstr "Toujours refuser \"{rule}\" (cette session)"
 #: src/iac_code/acp/session.py
 msgid "Always reject this tool"
 msgstr "Toujours refuser cet outil"
-
-#: src/iac_code/acp/session.py
-#, python-brace-format
-msgid ""
-"Approve tool call: {tool}\n"
-"Input summary: {summary}"
-msgstr ""
-"Approuver l'appel d'outil : {tool}\n"
-"Résumé de l'entrée : {summary}"
 
 #: src/iac_code/acp/session.py
 #, python-brace-format
@@ -4552,6 +4547,14 @@ msgstr "Les champs ne sont pas pris en charge pour l'action '{action}' : {fields
 #, python-brace-format
 msgid "Missing required field(s) for action '{action}': {fields}"
 msgstr "Champs obligatoires manquants pour l'action '{action}' : {fields}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid ""
+"Deployment parameters contain a redaction placeholder; provide the real "
+"parameter value before deployment."
+msgstr ""
+"Les paramètres de déploiement contiennent un espace réservé de masquage ;"
+" fournissez la valeur réelle du paramètre avant le déploiement."
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -9009,7 +9012,9 @@ msgstr ""
 msgid ""
 "The encoding is valid, but the contract does not provide an environment-"
 "data schema."
-msgstr "L'encodage est valide, mais le contrat ne fournit pas de schéma de données d'environnement."
+msgstr ""
+"L'encodage est valide, mais le contrat ne fournit pas de schéma de "
+"données d'environnement."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid ""
@@ -9250,8 +9255,8 @@ msgid ""
 "A negative or fractional counter never reaches zero; generation stops "
 "only after available positions are exhausted."
 msgstr ""
-"Un compteur négatif ou fractionnaire n'atteint jamais zéro ; la génération "
-"ne s'arrête qu'une fois les positions disponibles épuisées."
+"Un compteur négatif ou fractionnaire n'atteint jamais zéro ; la "
+"génération ne s'arrête qu'une fois les positions disponibles épuisées."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "a non-negative integer for predictable minimum semantics"
@@ -11454,10 +11459,6 @@ msgstr ""
 "  Option 2 - si vous ne pouvez pas accéder à github.com, exécutez ceci "
 "pour installer via npmmirror :"
 
-#: src/iac_code/utils/public_errors.py
-msgid "Stack trace omitted from public event; see error_id."
-msgstr "Trace de pile omise de l’événement public ; consultez error_id."
-
 #: src/iac_code/utils/state_io.py
 #, python-brace-format
 msgid "refusing to follow symlink or reparse point: {path}"
@@ -12670,3 +12671,10 @@ msgstr "Autoriser Bash ?"
 #~ "La clé correspond au composant {}, "
 #~ "qui n'est pas disponible dans le "
 #~ "formulaire de paramètres ROS standard."
+
+#~ msgid ""
+#~ "Approve tool call: {tool}\n"
+#~ "Input summary: {summary}"
+#~ msgstr ""
+#~ "Approuver l'appel d'outil : {tool}\n"
+#~ "Résumé de l'entrée : {summary}"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -41,7 +41,8 @@ msgstr "afterSequence は非負整数である必要があります"
 msgid "Unsafe artifact filename"
 msgstr "安全でないアーティファクトファイル名"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/utils/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "不明なエラー"
 
@@ -105,8 +106,7 @@ msgstr "タスクがキャンセルされました。"
 msgid "Current model {model} does not support image input."
 msgstr "現在のモデル {model} は画像入力をサポートしていません。"
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-#: src/iac_code/a2a/transports/dispatcher.py
+#: src/iac_code/a2a/executor.py src/iac_code/a2a/transports/dispatcher.py
 msgid "Authentication required. Configure credentials and retry."
 msgstr "認証が必要です。認証情報を設定して再試行してください。"
 
@@ -143,6 +143,11 @@ msgstr "A2A パイプライン状態が見つかりません"
 #: src/iac_code/a2a/pipeline_recovery.py
 msgid "A2A task/context mismatch"
 msgstr "A2A タスクとコンテキストが一致しません"
+
+#: src/iac_code/a2a/projection.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
+msgid "Stack trace omitted from public event; see error_id."
+msgstr "公開イベントではスタックトレースを省略しました。error_id を確認してください。"
 
 #: src/iac_code/a2a/task_store.py
 msgid "A2A task expired"
@@ -197,8 +202,7 @@ msgstr "タスクが完了しました。"
 msgid "Task failed."
 msgstr "タスクが失敗しました。"
 
-#: src/iac_code/acp/convert.py src/iac_code/acp/session.py
-#: src/iac_code/ui/renderer.py
+#: src/iac_code/acp/convert.py src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Input summary: {summary}"
 msgstr "入力サマリー: {summary}"
@@ -261,15 +265,6 @@ msgstr "\"{rule}\" を常に拒否（このセッション）"
 #: src/iac_code/acp/session.py
 msgid "Always reject this tool"
 msgstr "このツールを常に拒否"
-
-#: src/iac_code/acp/session.py
-#, python-brace-format
-msgid ""
-"Approve tool call: {tool}\n"
-"Input summary: {summary}"
-msgstr ""
-"ツール呼び出しを承認: {tool}\n"
-"入力サマリー: {summary}"
 
 #: src/iac_code/acp/session.py
 #, python-brace-format
@@ -4312,6 +4307,12 @@ msgstr "アクション '{action}' ではサポートされていないフィー
 #, python-brace-format
 msgid "Missing required field(s) for action '{action}': {fields}"
 msgstr "アクション '{action}' に必須フィールドがありません: {fields}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid ""
+"Deployment parameters contain a redaction placeholder; provide the real "
+"parameter value before deployment."
+msgstr "デプロイパラメーターにマスキング用プレースホルダーが含まれています。デプロイ前に実際のパラメーター値を指定してください。"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -10615,10 +10616,6 @@ msgid ""
 "npmmirror:"
 msgstr "  オプション 2 - github.com にアクセスできない場合は、npmmirror 経由でインストールするために以下を実行してください："
 
-#: src/iac_code/utils/public_errors.py
-msgid "Stack trace omitted from public event; see error_id."
-msgstr "公開イベントではスタックトレースを省略しました。error_id を確認してください。"
-
 #: src/iac_code/utils/state_io.py
 #, python-brace-format
 msgid "refusing to follow symlink or reparse point: {path}"
@@ -11702,3 +11699,10 @@ msgstr "Bash を許可しますか？"
 #~ "which is unavailable in the stock "
 #~ "ROS parameter form."
 #~ msgstr "このキーは、標準 ROS パラメータフォームでは利用できないコンポーネント {} に対応します。"
+
+#~ msgid ""
+#~ "Approve tool call: {tool}\n"
+#~ "Input summary: {summary}"
+#~ msgstr ""
+#~ "ツール呼び出しを承認: {tool}\n"
+#~ "入力サマリー: {summary}"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -45,7 +45,8 @@ msgstr "afterSequence deve ser um inteiro não negativo"
 msgid "Unsafe artifact filename"
 msgstr "Nome de arquivo de artefato inseguro"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/utils/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
@@ -119,8 +120,7 @@ msgstr "Tarefa cancelada."
 msgid "Current model {model} does not support image input."
 msgstr "O modelo atual {model} não oferece suporte a entrada de imagem."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-#: src/iac_code/a2a/transports/dispatcher.py
+#: src/iac_code/a2a/executor.py src/iac_code/a2a/transports/dispatcher.py
 msgid "Authentication required. Configure credentials and retry."
 msgstr "Autenticação necessária. Configure as credenciais e tente novamente."
 
@@ -159,6 +159,11 @@ msgstr "Estado do pipeline A2A não encontrado"
 #: src/iac_code/a2a/pipeline_recovery.py
 msgid "A2A task/context mismatch"
 msgstr "A tarefa e o contexto A2A não correspondem"
+
+#: src/iac_code/a2a/projection.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
+msgid "Stack trace omitted from public event; see error_id."
+msgstr "Rastreamento de pilha omitido do evento público; veja error_id."
 
 #: src/iac_code/a2a/task_store.py
 msgid "A2A task expired"
@@ -213,8 +218,7 @@ msgstr "Tarefa concluída."
 msgid "Task failed."
 msgstr "A tarefa falhou."
 
-#: src/iac_code/acp/convert.py src/iac_code/acp/session.py
-#: src/iac_code/ui/renderer.py
+#: src/iac_code/acp/convert.py src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Input summary: {summary}"
 msgstr "Resumo da entrada: {summary}"
@@ -277,15 +281,6 @@ msgstr "Sempre rejeitar \"{rule}\" (esta sessão)"
 #: src/iac_code/acp/session.py
 msgid "Always reject this tool"
 msgstr "Sempre rejeitar esta ferramenta"
-
-#: src/iac_code/acp/session.py
-#, python-brace-format
-msgid ""
-"Approve tool call: {tool}\n"
-"Input summary: {summary}"
-msgstr ""
-"Aprovar chamada de ferramenta: {tool}\n"
-"Resumo da entrada: {summary}"
 
 #: src/iac_code/acp/session.py
 #, python-brace-format
@@ -4511,6 +4506,14 @@ msgstr "Os campos não são compatíveis com a ação '{action}': {fields}"
 #, python-brace-format
 msgid "Missing required field(s) for action '{action}': {fields}"
 msgstr "Campos obrigatórios ausentes para a ação '{action}': {fields}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid ""
+"Deployment parameters contain a redaction placeholder; provide the real "
+"parameter value before deployment."
+msgstr ""
+"Os parâmetros de implantação contêm um marcador de redação; forneça o "
+"valor real do parâmetro antes da implantação."
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -8870,7 +8873,9 @@ msgstr "A referência de metadados de ambiente não pode ser resolvida localment
 msgid ""
 "The encoding is valid, but the contract does not provide an environment-"
 "data schema."
-msgstr "A codificação é válida, mas o contrato não fornece um schema de dados de ambiente."
+msgstr ""
+"A codificação é válida, mas o contrato não fornece um schema de dados de "
+"ambiente."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid ""
@@ -9109,8 +9114,8 @@ msgid ""
 "A negative or fractional counter never reaches zero; generation stops "
 "only after available positions are exhausted."
 msgstr ""
-"Um contador negativo ou fracionário nunca chega a zero; a geração só para "
-"quando as posições disponíveis se esgotam."
+"Um contador negativo ou fracionário nunca chega a zero; a geração só para"
+" quando as posições disponíveis se esgotam."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "a non-negative integer for predictable minimum semantics"
@@ -11305,10 +11310,6 @@ msgstr ""
 "  Opção 2 - se você não consegue acessar github.com, execute isto para "
 "instalar via npmmirror:"
 
-#: src/iac_code/utils/public_errors.py
-msgid "Stack trace omitted from public event; see error_id."
-msgstr "Rastreamento de pilha omitido do evento público; veja error_id."
-
 #: src/iac_code/utils/state_io.py
 #, python-brace-format
 msgid "refusing to follow symlink or reparse point: {path}"
@@ -12498,3 +12499,10 @@ msgstr "Permitir Bash?"
 #~ "A chave corresponde ao componente {},"
 #~ " que não está disponível no "
 #~ "formulário de parâmetros ROS padrão."
+
+#~ msgid ""
+#~ "Approve tool call: {tool}\n"
+#~ "Input summary: {summary}"
+#~ msgstr ""
+#~ "Aprovar chamada de ferramenta: {tool}\n"
+#~ "Resumo da entrada: {summary}"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -41,7 +41,8 @@ msgstr "afterSequence 必须是非负整数"
 msgid "Unsafe artifact filename"
 msgstr "不安全的工件文件名"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/utils/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "未知错误"
 
@@ -105,8 +106,7 @@ msgstr "任务已取消。"
 msgid "Current model {model} does not support image input."
 msgstr "当前模型 {model} 不支持图片输入。"
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-#: src/iac_code/a2a/transports/dispatcher.py
+#: src/iac_code/a2a/executor.py src/iac_code/a2a/transports/dispatcher.py
 msgid "Authentication required. Configure credentials and retry."
 msgstr "需要身份验证。请配置凭据后重试。"
 
@@ -143,6 +143,11 @@ msgstr "未找到 A2A pipeline 状态"
 #: src/iac_code/a2a/pipeline_recovery.py
 msgid "A2A task/context mismatch"
 msgstr "A2A 任务与上下文不匹配"
+
+#: src/iac_code/a2a/projection.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/utils/public_errors.py
+msgid "Stack trace omitted from public event; see error_id."
+msgstr "公开事件中已省略堆栈跟踪；请查看 error_id。"
 
 #: src/iac_code/a2a/task_store.py
 msgid "A2A task expired"
@@ -195,8 +200,7 @@ msgstr "任务已完成。"
 msgid "Task failed."
 msgstr "任务失败。"
 
-#: src/iac_code/acp/convert.py src/iac_code/acp/session.py
-#: src/iac_code/ui/renderer.py
+#: src/iac_code/acp/convert.py src/iac_code/ui/renderer.py
 #, python-brace-format
 msgid "Input summary: {summary}"
 msgstr "输入摘要：{summary}"
@@ -259,15 +263,6 @@ msgstr "始终拒绝 “{rule}”（本会话）"
 #: src/iac_code/acp/session.py
 msgid "Always reject this tool"
 msgstr "始终拒绝此工具"
-
-#: src/iac_code/acp/session.py
-#, python-brace-format
-msgid ""
-"Approve tool call: {tool}\n"
-"Input summary: {summary}"
-msgstr ""
-"批准工具调用：{tool}\n"
-"输入摘要：{summary}"
 
 #: src/iac_code/acp/session.py
 #, python-brace-format
@@ -4257,6 +4252,12 @@ msgstr "操作 '{action}' 不支持这些字段：{fields}"
 #, python-brace-format
 msgid "Missing required field(s) for action '{action}': {fields}"
 msgstr "操作 '{action}' 缺少必填字段：{fields}"
+
+#: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+msgid ""
+"Deployment parameters contain a redaction placeholder; provide the real "
+"parameter value before deployment."
+msgstr "部署参数包含脱敏占位符；请在部署前提供真实参数值。"
 
 #: src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
 #, python-brace-format
@@ -10440,10 +10441,6 @@ msgid ""
 "npmmirror:"
 msgstr "  方式 2 - 如果无法访问 github.com，运行以下命令通过 npmmirror 安装："
 
-#: src/iac_code/utils/public_errors.py
-msgid "Stack trace omitted from public event; see error_id."
-msgstr "公开事件中已省略堆栈跟踪；请查看 error_id。"
-
 #: src/iac_code/utils/state_io.py
 #, python-brace-format
 msgid "refusing to follow symlink or reparse point: {path}"
@@ -11489,3 +11486,10 @@ msgstr "允许 Bash?"
 #~ "which is unavailable in the stock "
 #~ "ROS parameter form."
 #~ msgstr "该键映射到组件 {}，此组件在原生 ROS 参数表单中不可用。"
+
+#~ msgid ""
+#~ "Approve tool call: {tool}\n"
+#~ "Input summary: {summary}"
+#~ msgstr ""
+#~ "批准工具调用：{tool}\n"
+#~ "输入摘要：{summary}"

--- a/src/iac_code/pipeline/engine/cleanup.py
+++ b/src/iac_code/pipeline/engine/cleanup.py
@@ -22,7 +22,7 @@ from iac_code.pipeline.constants import (
 )
 from iac_code.types.stream_events import StackProgressEvent, ToolResultEvent, ToolUseEndEvent
 from iac_code.utils.path_locks import PathLockRegistry
-from iac_code.utils.public_errors import sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 from iac_code.utils.state_io import atomic_write_text
 
 logger = logging.getLogger(__name__)
@@ -541,12 +541,16 @@ class CleanupLedger:
         try:
             loaded = yaml.safe_load(self.path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
-            logger.warning("Failed to load cleanup ledger %s: %s", self.path, exc)
+            logger.warning(
+                "Failed to load cleanup ledger %s: %s",
+                sanitize_strict_text(str(self.path)),
+                sanitize_strict_text(str(exc)),
+            )
             return _failed_ledger_data(str(exc))
         if not isinstance(loaded, dict):
             logger.warning(
                 "Failed to load cleanup ledger %s: expected mapping, got %s",
-                self.path,
+                sanitize_strict_text(str(self.path)),
                 type(loaded).__name__,
             )
             return _failed_ledger_data(f"expected mapping, got {type(loaded).__name__}")
@@ -655,8 +659,8 @@ class CleanupObserver:
                 if _is_cleanup_stack_tool_name(event.tool_name):
                     logger.warning(
                         "Unmatched cleanup tool result: tool_use_id=%s tool_name=%s",
-                        event.tool_use_id,
-                        event.tool_name,
+                        sanitize_strict_text(event.tool_use_id),
+                        sanitize_strict_text(event.tool_name),
                     )
                     self._ledger.record_tool_result_unmatched(
                         tool_use_id=event.tool_use_id,
@@ -726,16 +730,12 @@ class CleanupObserver:
         mapped_resource_id: str,
         result_resource_id: str,
     ) -> None:
-        safe_tool_use_id = _safe_history_error(tool_use_id) or ""
-        safe_tool_name = _safe_history_error(tool_name) or ""
-        safe_mapped_resource_id = _safe_history_error(mapped_resource_id) or ""
-        safe_result_resource_id = _safe_history_error(result_resource_id) or ""
         logger.warning(
             "Mismatched cleanup tool result: tool_use_id=%s tool_name=%s mapped_resource_id=%s result_resource_id=%s",
-            safe_tool_use_id,
-            safe_tool_name,
-            safe_mapped_resource_id,
-            safe_result_resource_id,
+            sanitize_strict_text(tool_use_id),
+            sanitize_strict_text(tool_name),
+            sanitize_strict_text(mapped_resource_id),
+            sanitize_strict_text(result_resource_id),
         )
         self._ledger.record_tool_result_mismatch(
             tool_use_id=tool_use_id,
@@ -971,8 +971,7 @@ def _cleanup_resource_history_data(resource: CleanupResource) -> dict[str, Any]:
 def _safe_history_error(value: str | None) -> str | None:
     if not value:
         return None
-    text = sanitize_public_text(value)
-    return text[:1000] + "..." if len(text) > 1000 else text
+    return value[:1000] + "..." if len(value) > 1000 else value
 
 
 def _status_from_result(result: dict[str, Any]) -> str | None:

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -15,7 +15,7 @@ from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
-from iac_code.utils.public_errors import sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 
 if TYPE_CHECKING:
     from iac_code.pipeline.engine.types import StepConfig
@@ -24,11 +24,6 @@ logger = logging.getLogger(__name__)
 
 MAX_PARALLEL_CANDIDATES = 5
 MAX_ROLLBACK_TARGETS = 5
-_SENSITIVE_VALIDATION_FIELD_PATTERN = re.compile(
-    r"(?i)(auth|authorization|cookie|credential|credentials|passphrase|password|passwd|private[_-]?key|pwd|secret|"
-    r"session|signature|token|api[_-]?key|access[_-]?key)"
-)
-
 _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
     "reviewing_rerun_after_validate_template_write": (
         "reviewing ran write_file/edit_file after ros_validate_template; "
@@ -206,7 +201,7 @@ class CompleteStepTool(Tool):
             return False, self._format_input_validation_error(self._public_validation_error(e), tool_input)
 
     def _format_input_validation_error(self, error: str, tool_input: dict[str, Any]) -> str:
-        invalid_json = sanitize_public_text(json.dumps(tool_input or {}, ensure_ascii=False))
+        invalid_json = json.dumps(tool_input or {}, ensure_ascii=False)
         example = json.dumps(
             {"conclusion": self._example_from_schema(self._step_config.conclusion_schema)},
             ensure_ascii=False,
@@ -229,21 +224,7 @@ class CompleteStepTool(Tool):
 
     @classmethod
     def _public_validation_error(cls, error: jsonschema.ValidationError) -> str:
-        message = sanitize_public_text(error.message)
-        if not any(_SENSITIVE_VALIDATION_FIELD_PATTERN.search(str(part)) for part in error.path):
-            return message
-
-        instance = error.instance
-        replacements: set[str] = set()
-        if isinstance(instance, str):
-            replacements.add(repr(instance))
-            replacements.add(json.dumps(instance, ensure_ascii=False))
-        elif isinstance(instance, (int, float, bool)) or instance is None:
-            replacements.add(repr(instance))
-            replacements.add(json.dumps(instance, ensure_ascii=False))
-        for value in replacements:
-            message = message.replace(value, "[REDACTED]")
-        return sanitize_public_text(message)
+        return error.message
 
     def _complete_step_schema_hint(self) -> str:
         if not self._step_config.conclusion_schema:
@@ -318,7 +299,11 @@ class CompleteStepTool(Tool):
             return None
         except jsonschema.ValidationError as e:
             public_message = self._public_validation_error(e)
-            logger.warning("Schema validation failed for step %s: %s", self._step_config.step_id, public_message)
+            logger.warning(
+                "Schema validation failed for step %s (validator=%s)",
+                sanitize_strict_text(self._step_config.step_id),
+                sanitize_strict_text(str(e.validator)),
+            )
             return public_message
 
     def _validate_completion_guards(self, conclusion: dict) -> str | None:
@@ -1073,7 +1058,11 @@ class CompleteStepTool(Tool):
         rollback = tool_input.get("rollback_request")
         rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
 
-        logger.debug("[complete_step] step=%s input=%r", self._step_config.step_id, tool_input)
+        logger.debug(
+            "[complete_step] step=%s input=%s",
+            self._step_config.step_id,
+            sanitize_strict_text(repr(tool_input)),
+        )
 
         if rollback_tuple and self._step_config.rollback_count >= self._step_config.max_rollbacks:
             max_rollbacks = self._step_config.max_rollbacks
@@ -1122,7 +1111,11 @@ class CompleteStepTool(Tool):
             rollback_request=rollback_tuple,
         )
 
-        logger.debug("[complete_step] step=%s validation=OK conclusion=%r", self._step_config.step_id, conclusion)
+        logger.debug(
+            "[complete_step] step=%s validation=OK conclusion=%s",
+            self._step_config.step_id,
+            sanitize_strict_text(repr(conclusion)),
+        )
         return ToolResult(
             content=_("Step {step_id} completed. Conclusion submitted.").format(
                 step_id=display_step_name(self._step_config.step_id)

--- a/src/iac_code/pipeline/engine/events.py
+++ b/src/iac_code/pipeline/engine/events.py
@@ -6,8 +6,6 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 
-from iac_code.utils.public_errors import sanitize_public_text
-
 
 class PipelineEventType(str, Enum):
     PIPELINE_STARTED = "pipeline_started"
@@ -56,8 +54,8 @@ def backup_blocked_event(step_id: str | None, reason: object, error: object) -> 
         step_id=step_id,
         timestamp=time.time(),
         data={
-            "reason": sanitize_public_text(str(reason_text)),
-            "error": sanitize_public_text(str(error)),
+            "reason": str(reason_text),
+            "error": str(error),
             "recoverable": True,
         },
     )

--- a/src/iac_code/pipeline/engine/observability.py
+++ b/src/iac_code/pipeline/engine/observability.py
@@ -22,7 +22,7 @@ from iac_code.services.telemetry.names import (
     Metrics,
     Spans,
 )
-from iac_code.utils.public_errors import sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +186,7 @@ class PipelineObservability:
 
     @staticmethod
     def _redact_obvious_secrets(text: str) -> str:
-        redacted = sanitize_public_text(text)
+        redacted = sanitize_strict_text(text)
         for pattern in _SECRET_PATTERNS:
             redacted = pattern.sub("[REDACTED]", redacted)
         return redacted

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -57,7 +57,7 @@ from iac_code.types.stream_events import (
     TextDeltaEvent,
     ThinkingDeltaEvent,
 )
-from iac_code.utils.public_errors import sanitize_public_text
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +98,12 @@ _SIDECAR_ROOT_FILES = {
     ".usage.jsonl.lock",
     "usage.jsonl",
 }
+
+
+def _strict_log_value(value: Any) -> Any:
+    if isinstance(value, str | Path):
+        return sanitize_strict_text(str(value))
+    return value
 
 
 def _entry_exists_no_follow(path: Path) -> bool:
@@ -379,9 +385,9 @@ def _normalize_failed_sub_pipeline_completed_event(event: PipelineEvent) -> None
 
     error = event.data.get("error")
     if error is not None:
-        event.data["error"] = sanitize_public_text(str(error))
+        event.data["error"] = str(error)
     if "error_summary" in event.data:
-        event.data["error_summary"] = sanitize_public_text(str(event.data["error_summary"]))
+        event.data["error_summary"] = str(event.data["error_summary"])
     else:
         event.data["error_summary"] = event.data.get("error") or "Unknown error"
 
@@ -878,10 +884,10 @@ class PipelineRunner:
             data["resource_count"] = resource_count
         logger.warning(
             "Pipeline cleanup tracking unavailable: step_id=%s operation=%s ledger_path=%s error=%s",
-            step_id,
-            operation,
-            ledger.path,
-            status.load_error,
+            _strict_log_value(step_id),
+            _strict_log_value(operation),
+            _strict_log_value(ledger.path),
+            _strict_log_value(status.load_error),
         )
         return PipelineEvent(
             type=PipelineEventType.PIPELINE_WARNING,
@@ -3193,6 +3199,7 @@ class PipelineRunner:
                 candidate_name=candidate_name,
                 reason=reason,
             )
+            log_candidate_name = _strict_log_value(candidate_name)
             logger.info(
                 (
                     "Pipeline candidate cancelled: pipeline=%s session_id=%s parent_step_id=%s "
@@ -3202,14 +3209,14 @@ class PipelineRunner:
                 self._session_id,
                 parent_step_id,
                 idx,
-                candidate_name,
+                log_candidate_name,
                 reason,
                 extra={
                     "pipeline": self._loaded.name,
                     "session_id": self._session_id,
                     "parent_step_id": parent_step_id,
                     "candidate_index": idx,
-                    "candidate_name": candidate_name,
+                    "candidate_name": log_candidate_name,
                     "reason": reason,
                 },
             )
@@ -4305,7 +4312,7 @@ class PipelineRunner:
                     data={
                         "from_step": step.step_id,
                         "to_step": target,
-                        "reason": sanitize_public_text(reason),
+                        "reason": reason,
                         "stale_fields": stale,
                     },
                 )
@@ -4820,9 +4827,12 @@ class PipelineRunner:
                     **failed_attrs,
                 )
                 log_extra = {
-                    "pipeline": self._loaded.name,
-                    "session_id": self._session_id,
-                    **failed_attrs,
+                    key: _strict_log_value(value)
+                    for key, value in {
+                        "pipeline": self._loaded.name,
+                        "session_id": self._session_id,
+                        **failed_attrs,
+                    }.items()
                 }
                 logger.warning(
                     (
@@ -4830,16 +4840,15 @@ class PipelineRunner:
                         "sub_pipeline_name=%s sub_pipeline_id=%s candidate_index=%d "
                         "candidate_name=%s error_type=%s error_summary=%s"
                     ),
-                    self._loaded.name,
-                    self._session_id,
-                    step.step_id,
-                    sub_spec.name,
-                    sub_pipeline_id,
+                    log_extra["pipeline"],
+                    log_extra["session_id"],
+                    log_extra["parent_step_id"],
+                    log_extra["sub_pipeline_name"],
+                    log_extra["sub_pipeline_id"],
                     i,
-                    candidate_name,
-                    error_type,
-                    error_summary,
-                    exc_info=True,
+                    log_extra["candidate_name"],
+                    log_extra["error_type"],
+                    log_extra["error_summary"],
                     extra=log_extra,
                 )
                 state["error"] = error_summary

--- a/src/iac_code/pipeline/engine/public_errors.py
+++ b/src/iac_code/pipeline/engine/public_errors.py
@@ -1,12 +1,52 @@
-"""Compatibility imports for public pipeline failure payloads."""
+"""Canonical pipeline failure payloads.
 
-from iac_code.utils.public_errors import (
-    PublicError,
-    public_error,
-    public_error_from_exception,
-    public_exception_summary,
-    sanitize_public_text,
-)
+Pipeline errors are functional state: they must remain recoverable and are
+projected only when copied to an A2A delivery or observability sink.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from typing import Any
+
+from iac_code.i18n import _
+from iac_code.utils.public_errors import PublicError, public_exception_summary, sanitize_public_text
+
+
+def public_error_from_exception(exc: BaseException, *, fallback_summary: str | None = None) -> PublicError:
+    return public_error(
+        message=str(exc),
+        error_type=type(exc).__name__,
+        fallback_summary=fallback_summary,
+    )
+
+
+def public_error(
+    *,
+    message: Any,
+    error_type: str,
+    fallback_summary: str | None = None,
+    extra_details: dict[str, Any] | None = None,
+) -> PublicError:
+    """Build a structured canonical error without irreversible redaction."""
+
+    if fallback_summary is None:
+        fallback_summary = _("Unknown error")
+    summary = str(message) if message is not None else ""
+    summary = summary or fallback_summary
+    digest = hashlib.sha256(f"{error_type}\0{summary}".encode("utf-8", errors="replace")).hexdigest()
+    error_id = digest[:12]
+    details: dict[str, Any] = {
+        "type": error_type,
+        "error_id": error_id,
+        "traceback": _("Stack trace omitted from public event; see error_id."),
+    }
+    for key, value in (extra_details or {}).items():
+        if value is not None:
+            details[str(key)] = copy.deepcopy(value)
+    return PublicError(summary=summary, details=details, error_id=error_id)
+
 
 __all__ = [
     "PublicError",

--- a/src/iac_code/pipeline/engine/sub_pipeline_executor.py
+++ b/src/iac_code/pipeline/engine/sub_pipeline_executor.py
@@ -25,6 +25,7 @@ from iac_code.pipeline.engine.step_spec import LoadedPipeline, SubPipelineSpec
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.services.session_backup import SessionBackupBlocked
 from iac_code.types.stream_events import SubPipelineStreamEvent
+from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
 
@@ -559,33 +560,33 @@ class SubPipelineExecutor:
                 **attrs,
             )
             log_extra = {
-                "pipeline": self._pipeline.name,
-                "session_id": session_id,
-                "parent_step_id": parent_step_id,
-                "sub_pipeline_name": sub_spec.name,
-                "sub_pipeline_id": sub_pipeline_id,
+                "pipeline": sanitize_strict_text(self._pipeline.name),
+                "session_id": sanitize_strict_text(session_id),
+                "parent_step_id": sanitize_strict_text(parent_step_id or ""),
+                "sub_pipeline_name": sanitize_strict_text(sub_spec.name),
+                "sub_pipeline_id": sanitize_strict_text(sub_pipeline_id),
                 "candidate_index": candidate_index,
-                "candidate_name": candidate_name,
-                "error_summary": error_summary,
-                "error_type": error_type,
+                "candidate_name": sanitize_strict_text(candidate_name),
+                "error_summary": sanitize_strict_text(error_summary),
+                "error_type": sanitize_strict_text(error_type),
             }
             if extra_attrs:
-                log_extra.update(extra_attrs)
+                log_extra.update({key: sanitize_strict_text(value) for key, value in extra_attrs.items()})
             logger.warning(
                 (
                     "Sub-pipeline failed: pipeline=%s session_id=%s parent_step_id=%s "
                     "sub_pipeline_name=%s sub_pipeline_id=%s candidate_index=%d "
                     "candidate_name=%s error_type=%s error_summary=%s"
                 ),
-                self._pipeline.name,
-                session_id,
-                parent_step_id,
-                sub_spec.name,
-                sub_pipeline_id,
+                log_extra["pipeline"],
+                log_extra["session_id"],
+                log_extra["parent_step_id"],
+                log_extra["sub_pipeline_name"],
+                log_extra["sub_pipeline_id"],
                 candidate_index,
-                candidate_name,
-                error_type,
-                error_summary,
+                log_extra["candidate_name"],
+                log_extra["error_type"],
+                log_extra["error_summary"],
                 extra=log_extra,
             )
 
@@ -937,32 +938,32 @@ class SubPipelineExecutor:
                         **sub_pipeline_attrs,
                     )
                     log_extra = {
-                        "pipeline": self._pipeline.name,
-                        "session_id": session_id,
-                        "parent_step_id": parent_step_id,
-                        "sub_pipeline_name": sub_spec.name,
-                        "sub_pipeline_id": sub_pipeline_id,
+                        "pipeline": sanitize_strict_text(self._pipeline.name),
+                        "session_id": sanitize_strict_text(session_id),
+                        "parent_step_id": sanitize_strict_text(parent_step_id or ""),
+                        "sub_pipeline_name": sanitize_strict_text(sub_spec.name),
+                        "sub_pipeline_id": sanitize_strict_text(sub_pipeline_id),
                         "candidate_index": candidate_index,
-                        "candidate_name": candidate_name,
-                        "error_summary": error_summary,
-                        "error_type": error_type,
+                        "candidate_name": sanitize_strict_text(candidate_name),
+                        "error_summary": sanitize_strict_text(error_summary),
+                        "error_type": sanitize_strict_text(error_type),
                         "error_id": failure.error_id,
                     }
-                    logger.exception(
+                    logger.warning(
                         (
                             "Sub-pipeline failed: pipeline=%s session_id=%s parent_step_id=%s "
                             "sub_pipeline_name=%s sub_pipeline_id=%s candidate_index=%d "
                             "candidate_name=%s error_type=%s error_summary=%s"
                         ),
-                        self._pipeline.name,
-                        session_id,
-                        parent_step_id,
-                        sub_spec.name,
-                        sub_pipeline_id,
+                        log_extra["pipeline"],
+                        log_extra["session_id"],
+                        log_extra["parent_step_id"],
+                        log_extra["sub_pipeline_name"],
+                        log_extra["sub_pipeline_id"],
                         candidate_index,
-                        candidate_name,
-                        error_type,
-                        error_summary,
+                        log_extra["candidate_name"],
+                        log_extra["error_type"],
+                        log_extra["error_summary"],
                         extra=log_extra,
                     )
         finally:

--- a/src/iac_code/pipeline/selling/hooks/deploying.py
+++ b/src/iac_code/pipeline/selling/hooks/deploying.py
@@ -12,6 +12,7 @@ from iac_code.types.stream_events import ResourceObservedEvent
 
 _DEPLOYING_STEP_ID = "deploying"
 logger = logging.getLogger(__name__)
+_REDACTION_PLACEHOLDER_TOKENS = {"***", "[redacted]", "<redacted>"}
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,23 @@ class CandidateResolution:
     candidate: dict[str, Any] | None
     result: dict[str, Any] | None
     error: str | None = None
+
+
+def contains_redaction_placeholder(value: Any, *, _seen: set[int] | None = None) -> bool:
+    """Return whether a deployment parameter tree still contains a redaction placeholder."""
+
+    if isinstance(value, str):
+        return value.strip().casefold() in _REDACTION_PLACEHOLDER_TOKENS
+    if not isinstance(value, (dict, list, tuple, set, frozenset)):
+        return False
+    seen = _seen if _seen is not None else set()
+    identity = id(value)
+    if identity in seen:
+        return False
+    seen.add(identity)
+    if isinstance(value, dict):
+        return any(contains_redaction_placeholder(item, _seen=seen) for item in value.values())
+    return any(contains_redaction_placeholder(item, _seen=seen) for item in value)
 
 
 def _candidate_from_result(result: dict[str, Any]) -> dict[str, Any]:

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -2,7 +2,7 @@
 
 你正在为候选方案预估部署费用。优先通过 `ros_preview_template` 形成 Preview-Validated Pricing Parameter Set，并尽量形成完整部署参数集；不要使用 `ros_stack` 执行预览。PreviewStack 不是硬门禁，若完整部署参数暂时无法自动补齐，记录参数缺口后可用当前已选参数调用 `ros_estimate_template_cost` 获取费用预估。
 
-在记录参数缺口前，必须先尽量补齐可生成参数，尤其是普通密码；生成值须满足模板约束，并在展示和摘要中脱敏。库存值和外部输入不得编造，仍按缺口记录。
+在记录参数缺口前，必须先尽量补齐可生成参数，尤其是普通密码；生成值须满足模板约束，并以同一个真实值写入预览、询价、`deployment_parameters`、`preview_validation.parameters` 和 `complete_step.conclusion`，不得写入 `***`、`[REDACTED]` 或 `<redacted>`。库存值和外部输入不得编造，仍按缺口记录。服务端日志由运行时单独脱敏，不要因此改写结构化交接数据。
 
 ## 模板信息
 - 文件路径：`{template.file_path}`

--- a/src/iac_code/pipeline/selling/references/template-parameter-recommendation.md
+++ b/src/iac_code/pipeline/selling/references/template-parameter-recommendation.md
@@ -11,10 +11,10 @@
 
 - 仅推荐 `CreateStack` 前的新建栈参数，由 skill 编排专用 ROS 模板工具和必要的只读资源查询。
 - `PreviewStack` 是预览验证门槛，不是部署成功保证。通过的参数集称为 **Preview-Validated Parameter Set**：表示指定模板来源在当时参数集下可预览。
-- 原始约束快照与 API 响应只在 agent 上下文持有，不写文件；用户要求保存时只能保存脱敏后的摘要。
-- 密码类参数可在用户要求时生成合规随机值，报告与日志中只显示 `***` / `<redacted>`。
+- 原始约束快照与 API 响应只在 agent 上下文持有，不写额外文件；结构化步骤交接和用户结果保留完成任务所需的真实值。
+- 密码类参数可在用户要求时生成合规随机值；同一个真实值必须贯穿预览、询价、结构化步骤交接和部署，不得用脱敏占位符替换。
 - 不编造外部资源、账号资源、AccessKey/Secret/Token/Webhook/LicenseKey/证书/真实域名/已有资源 ID。
-- 敏感值、资源 ID、公网地址、账号 ID、控制台 URL 必须脱敏。
+- 服务端日志由运行时执行严格脱敏；不得为了日志策略改写功能状态或用户结果。
 
 ## 流程
 
@@ -66,7 +66,7 @@ ROS Terraform 类型模板若返回 `TerraformStackNotSupported` / `QueryErrors`
 
 ### 5. 保留原始约束快照（仅上下文）
 
-字段：参数名、原始 `AllowedValues`、`AssociationParameterNames`、`Behavior` / `BehaviorReason`、`IllegalValueByParameterConstraints`、`IllegalValueByRules`、`NotSupportResources`、`QueryErrors`，以及本地模板中的引用证据。展示前必须脱敏。
+字段：参数名、原始 `AllowedValues`、`AssociationParameterNames`、`Behavior` / `BehaviorReason`、`IllegalValueByParameterConstraints`、`IllegalValueByRules`、`NotSupportResources`、`QueryErrors`，以及本地模板中的引用证据。不要向结构化结果注入 `***`、`[REDACTED]` 或 `<redacted>`。
 
 ### 6. 对 AllowedValues 做偏好预筛选
 
@@ -96,7 +96,7 @@ ROS Terraform 类型模板若返回 `TerraformStackNotSupported` / `QueryErrors`
 | 可生成测试输入 | ECS/RDS/Redis/RocketMQ/WordPress 等普通密码（参数名/`NoEcho`/AssociationProperty/描述/资源属性表明是密码，且用户要求代理准备） |
 | 外部 / 账号特定 ❌ 不得编造 | `VpcId`、`VSwitchId`、`SecurityGroupId`、`KeyPairName`、已有 `InstanceId`；真实域名/ICP/DNS/证书；Token/Webhook/AK/SK/LicenseKey/ARMS/MSE 等凭证 |
 
-生成的密码必须满足模板长度、复杂度、`AllowedPattern`、`ConstraintDescription`，日志或临时配置含明文时测试后必须脱敏或删除。
+生成的密码必须满足模板长度、复杂度、`AllowedPattern`、`ConstraintDescription`，并以同一个真实值用于 Preview、询价与后续部署；服务端日志脱敏由运行时负责。
 
 已有资源参数：只读查询可在用户确认后校验；模板会修改资源、DNS、安全组或 RunCommand 的，必须显式确认资源与影响，不自动选择账号内资源。
 
@@ -126,7 +126,7 @@ ros_preview_template(
 ### 11. 展示结果
 
 - 模板来源、地域、最终 `StackName`、共享操作参数（如 `DisableRollback`）。
-- 推荐参数值（敏感值脱敏）；每个参数的来源（API `AllowedValues` / 可推断 / 生成的测试密码 / 用户提供 / 外部未提供）与理由。
+- 推荐参数值；每个参数的来源（API `AllowedValues` / 可推断 / 生成的测试密码 / 用户提供 / 外部未提供）与理由。结构化参数必须保留真实值。
 - `PreviewStack` 状态、资源摘要。
 - 外部输入缺口与用户需提供内容。
 - 是否执行 `CreateStack` 的确认问题。
@@ -141,7 +141,7 @@ ros_preview_template(
 
 部署后注意：
 
-- 报告中的 NoEcho/密码、公网地址、资源 ID、控制台 URL 必须脱敏。
+- 报告和结构化结果保留授权用户完成使用所需的真实参数；不得把 NoEcho/密码替换成脱敏占位符。服务端日志仍由运行时严格脱敏。
 - 不要把 `CREATE_COMPLETE` 当作任务结束信号；按用户意图判断是否需要清理或后续验证。
 
 ## 失败分类

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -136,7 +136,7 @@ PreviewStack 不是硬门禁。它要求完整部署参数，常比询价工具�
 - 优先使用上下文已有值和模板 Default；库存相关参数缺值时，先通过 `ros_get_template_parameter_constraints` 获取合法 `AllowedValues`，必要时再按 [references/cloud-products/](references/cloud-products/) 的可用性 API 与选型策略补足。
 - VpcId、VSwitchId、SecurityGroupId、KeyPairName 等已有资源参数：先查询约束或只读资源候选；API 返回候选不是编造，可作为参数候选参与回溯与 PreviewStack。没有上下文值、模板 Default、用户提供值或 API 返回候选时，才按外部输入缺失处理。
 - 只能在合法候选内筛选或排序，不得编造 API 未返回的库存值；LicenseKey、Token、证书、真实域名等外部输入不得编造。不要仅因参数名是 VpcId、VSwitchId、SecurityGroupId 或 KeyPairName 就跳过参数推荐并直接停止询价。
-- 对可生成参数要主动补齐：普通密码（ECS/RDS/Redis/RocketMQ/WordPress 等密码，或参数名、`NoEcho`、AssociationProperty、描述/约束表明是密码）应生成合规随机值，必须满足模板长度、复杂度、`AllowedPattern`、`ConstraintDescription`，并在展示、日志和摘要中脱敏。
+- 对可生成参数要主动补齐：普通密码（ECS/RDS/Redis/RocketMQ/WordPress 等密码，或参数名、`NoEcho`、AssociationProperty、描述/约束表明是密码）应生成合规随机值，必须满足模板长度、复杂度、`AllowedPattern`、`ConstraintDescription`。同一个真实值必须贯穿预览、询价、`deployment_parameters`、`preview_validation.parameters` 和 `complete_step.conclusion`，不得写入 `***`、`[REDACTED]` 或 `<redacted>`；服务端日志由运行时单独脱敏。
 - `PreviewStack` 因候选组合不可行失败时，按 reference 的回溯规则更换候选；因外部输入缺失失败时，记录缺口，不用占位值伪造，并按上方软门禁规则决定是否继续询价。
 - 最终得到的参数集不写入模板 `Default`；将当前已选、已验证或已用于询价的参数作为结构化数据放入 `complete_step.conclusion.deployment_parameters`，传递给 deploying。`ros_preview_template` 成功时，还必须把 `succeeded: true`、同一个 `template_url` 和预览时使用的 `parameters` 写入 `complete_step.conclusion.preview_validation`；deploying 用它判断同一模板是否已完成预览验证，实际部署参数由 `ros_deploy` 做最终校验。模板 Default 只是参数求解的输入来源之一，不是跨步骤传参介质。
 - PreviewStack 成功但询价失败时，不要丢弃 Preview-Validated Pricing Parameter Set；仍在 `deployment_parameters` 输出该参数集，同时如实报告询价失败原因。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -77,7 +77,7 @@ conclusion_schema:
 参数补全流程：
 1. 先从 `selected_plan.effective_deployment_parameters`、`selected_plan.selected_candidate_result.cost.deployment_parameters`、用户 `parameter_overrides`、模板 Default 和上下文已有值合并当前参数。
 2. 仍缺少模板必填参数时，调用 `ros_get_template_parameter_constraints`，传当前 `parameters` 字典继续求解可用候选。
-3. 对可推断配置（名称、CIDR、布尔值、小整数、非敏感字符串、模板安全默认值）直接给出合规值；对普通密码（ECS/RDS/Redis/RocketMQ/WordPress 等密码，或参数名、`NoEcho`、AssociationProperty、描述/约束表明是密码）生成合规随机值，必须满足长度、复杂度、`AllowedPattern`、`ConstraintDescription`，并在输出、日志和摘要中脱敏。
+3. 对可推断配置（名称、CIDR、布尔值、小整数、非敏感字符串、模板安全默认值）直接给出合规值；对普通密码（ECS/RDS/Redis/RocketMQ/WordPress 等密码，或参数名、`NoEcho`、AssociationProperty、描述/约束表明是密码）生成合规随机值，必须满足长度、复杂度、`AllowedPattern`、`ConstraintDescription`。同一个真实值必须贯穿参数补全、`parameters`、结构化结论和部署，不得替换为 `***`、`[REDACTED]` 或 `<redacted>`；服务端日志由运行时单独脱敏。
 4. 对库存相关参数只在工具/API 返回的合法候选内筛选或排序，不得编造库存值；对 LicenseKey、Token、证书、真实域名、已有资源 ID、VpcId、VSwitchId、SecurityGroupId、KeyPairName 等外部或账号特定输入，不得编造。
 5. 补齐后的参数不再调用预览工具；直接进入 `ros_deploy` 创建类动作，由部署调用做最终参数校验。部署错误指向可调整参数时，继续更换非用户指定参数并按 `ros_deploy` 恢复策略重试；错误指向模板时按模板校验/修复流程处理。
 

--- a/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
+++ b/src/iac_code/pipeline/selling/tools/ros_deploy_tool.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from iac_code.i18n import _
+from iac_code.pipeline.selling.hooks.deploying import contains_redaction_placeholder
 from iac_code.services.permissions.rule_scope import scope_for_rule_source
 from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.tools.cloud.aliyun.ros_stack import RosStack
@@ -263,6 +264,12 @@ class RosDeployTool(Tool):
             return _("Missing required field(s) for action '{action}': {fields}").format(
                 action=action,
                 fields=", ".join(missing_fields),
+            )
+
+        if contains_redaction_placeholder(input.get("parameters")):
+            return _(
+                "Deployment parameters contain a redaction placeholder; "
+                "provide the real parameter value before deployment."
             )
 
         return None

--- a/src/iac_code/services/telemetry/content_serializer.py
+++ b/src/iac_code/services/telemetry/content_serializer.py
@@ -8,6 +8,7 @@ gen_ai.tool.call.arguments, and gen_ai.tool.call.result.
 from __future__ import annotations
 
 import json
+import re
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Any
@@ -21,9 +22,17 @@ from iac_code.tools.cloud.registry import (
     ANONYMOUS_ALIYUN_TOOL_NAMES,
     CREDENTIAL_GATED_ALIYUN_TOOL_NAMES,
 )
+from iac_code.utils.public_errors import sanitize_strict_text
 from iac_code.utils.tool_result_redaction import redact_tool_result_file_content
 
 _MAX_CONTENT_BYTES = 4096
+_REDACTED_VALUE = "[REDACTED]"
+_SENSITIVE_MAPPING_KEY_PATTERN = re.compile(
+    r"(?:auth|authorization|cookie|credential|credentials|passphrase|password|passwd|"
+    r"private[_-]?key|pwd|secret|session|signature|token|api[_-]?key|"
+    r"access[_-]?key(?:[_-]?(?:id|secret))?)",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -55,26 +64,62 @@ def _truncate(s: str, max_bytes: int = _MAX_CONTENT_BYTES) -> str:
 
 
 def _json_dumps(obj: Any) -> str:
-    return json.dumps(obj, ensure_ascii=False, default=str)
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def _strict_text(value: Any) -> str:
+    return sanitize_strict_text("" if value is None else str(value), fallback_summary="")
+
+
+def _is_sensitive_mapping_key(value: str) -> bool:
+    return _SENSITIVE_MAPPING_KEY_PATTERN.search(value) is not None
+
+
+def _strict_json_value(value: Any) -> Any:
+    """Normalize unknown leaves and strict-sanitize before JSON serialization."""
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _strict_text(value)
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for raw_key, item in value.items():
+            raw_key_text = "" if raw_key is None else str(raw_key)
+            key = _strict_text(raw_key_text)
+            if key in result:
+                index = 2
+                while f"{key}#{index}" in result:
+                    index += 1
+                key = f"{key}#{index}"
+            result[key] = _REDACTED_VALUE if _is_sensitive_mapping_key(raw_key_text) else _strict_json_value(item)
+        return result
+    if isinstance(value, (list, tuple)):
+        return [_strict_json_value(item) for item in value]
+    return _strict_text(value)
+
+
+def _strict_json_dumps(obj: Any) -> str:
+    return _json_dumps(_strict_json_value(obj))
 
 
 def _redacted_tool_result_string(value: Any) -> str:
     redacted = redact_tool_result_file_content(value)
     if isinstance(redacted, str):
-        return redacted
-    return _json_dumps(redacted)
+        return _strict_text(redacted)
+    return _strict_json_dumps(redacted)
 
 
 def serialize_user_input(user_input: str) -> str:
     """Serialize a plain user input string to gen_ai.input.messages JSON."""
-    return _json_dumps([{"role": "user", "parts": [{"type": "text", "content": _truncate(user_input)}]}])
+    return _json_dumps([{"role": "user", "parts": [{"type": "text", "content": _truncate(_strict_text(user_input))}]}])
 
 
 def _tool_call_id(block: Any) -> str:
     for attribute in ("tool_use_id", "id"):
         value = getattr(block, attribute, None)
         if isinstance(value, str) and value:
-            return value
+            return _strict_text(value)
     return ""
 
 
@@ -89,16 +134,18 @@ def serialize_input_messages(messages: list) -> str:
         role = getattr(msg, "role", "unknown")
         content = getattr(msg, "content", "")
         if isinstance(content, str):
-            parts = [{"type": "text", "content": _truncate(content)}]
+            parts = [{"type": "text", "content": _truncate(_strict_text(content))}]
         elif isinstance(content, list):
             parts = []
             for block in content:
                 btype = getattr(block, "type", "text")
                 if btype == "text":
-                    parts.append({"type": "text", "content": _truncate(getattr(block, "text", "") or "")})
+                    parts.append(
+                        {"type": "text", "content": _truncate(_strict_text(getattr(block, "text", "") or ""))}
+                    )
                 elif btype == "tool_use":
                     tool_use_id = _tool_call_id(block)
-                    tool_name = getattr(block, "name", "")
+                    tool_name = _strict_text(getattr(block, "name", ""))
                     if tool_use_id and isinstance(tool_name, str):
                         unmatched_tool_names[tool_use_id].append(tool_name)
                     parts.append(
@@ -136,8 +183,8 @@ def serialize_input_messages(messages: list) -> str:
                 else:
                     parts.append({"type": btype})
         else:
-            parts = [{"type": "text", "content": _truncate(str(content))}]
-        result.append({"role": role, "parts": parts})
+            parts = [{"type": "text", "content": _truncate(_strict_text(content))}]
+        result.append({"role": _strict_text(role), "parts": parts})
     return _json_dumps(result)
 
 
@@ -150,7 +197,7 @@ def serialize_output_messages(text: str, finish_reason: str) -> str:
         [
             {
                 "role": "assistant",
-                "parts": [{"type": "text", "content": _truncate(text)}],
+                "parts": [{"type": "text", "content": _truncate(_strict_text(text))}],
                 "finish_reason": finish_reason,
             }
         ]
@@ -159,7 +206,7 @@ def serialize_output_messages(text: str, finish_reason: str) -> str:
 
 def serialize_system_instructions(system: str) -> str:
     """Serialize system prompt to gen_ai.system_instructions JSON string."""
-    return _json_dumps([{"type": "text", "content": _truncate(system)}])
+    return _json_dumps([{"type": "text", "content": _truncate(_strict_text(system))}])
 
 
 def serialize_tool_definitions(tools: list | None) -> str:
@@ -238,8 +285,8 @@ def serialize_tool_arguments(arguments: dict | Any, *, tool_name: str | None = N
     if tool_name in _ALIYUN_TOOL_NAMES:
         return _aliyun_tool_arguments(arguments, tool_name)
     if isinstance(arguments, str):
-        return _truncate(arguments)
-    return _truncate(_json_dumps(arguments))
+        return _truncate(_strict_text(arguments))
+    return _truncate(_strict_json_dumps(arguments))
 
 
 def _aliyun_tool_result(

--- a/src/iac_code/services/telemetry/sanitize.py
+++ b/src/iac_code/services/telemetry/sanitize.py
@@ -18,6 +18,7 @@ from iac_code.services.telemetry.constants import (
     ROS_ALLOWED_PREFIXES,
     TERRAFORM_OFFICIAL_PROVIDERS,
 )
+from iac_code.utils.public_errors import sanitize_strict_text
 
 _CONTROL_CHARS_RE = re.compile(r"[\n\r\t\x00-\x1f]+")
 _MAX_ERROR_MSG_BYTES = 512
@@ -26,12 +27,13 @@ _DEV_VERSION_SUFFIX_RE = re.compile(r"-\d{8}$")
 
 
 def sanitize_error_message(raw: str | None) -> str | None:
-    """Clean and truncate an error message. None under essential-traffic mode."""
+    """Strictly redact, clean, and truncate an explicit telemetry error field."""
     if raw is None:
         return None
     if is_essential_traffic_only():
         return None
-    cleaned = _CONTROL_CHARS_RE.sub(" ", raw).strip()
+    strict = sanitize_strict_text(raw, fallback_summary="")
+    cleaned = _CONTROL_CHARS_RE.sub(" ", strict).strip()
     encoded = cleaned.encode("utf-8")
     if len(encoded) > _MAX_ERROR_MSG_BYTES:
         keep = _MAX_ERROR_MSG_BYTES - len(_TRUNCATION_MARKER.encode("utf-8"))

--- a/src/iac_code/ui/renderer.py
+++ b/src/iac_code/ui/renderer.py
@@ -145,15 +145,8 @@ def _metadata_tool_result_message(rec: "_ToolCallRecord", *, verbose: bool) -> s
 
 
 def _public_tool_result_display_text(tool_name: str, value: object) -> str:
-    text = str(value)
-    if not tool_name.startswith("mcp__"):
-        return text
-
-    from iac_code.a2a.artifacts import sanitize_public_tool_output_data
-    from iac_code.mcp.redaction import sanitize_mcp_public_data
-
-    sanitized = sanitize_public_tool_output_data(text)
-    return str(sanitize_mcp_public_data(sanitized, fallback_summary=""))
+    del tool_name
+    return str(value)
 
 
 def _permission_detail_text(tool_name: str, tool_input: dict[str, Any], tool: Any | None) -> str | None:

--- a/src/iac_code/ui/repl.py
+++ b/src/iac_code/ui/repl.py
@@ -104,7 +104,6 @@ from iac_code.utils.image.clipboard import ClipboardImage, get_image_from_clipbo
 from iac_code.utils.image.format_detect import IMAGE_EXTENSION_REGEX
 from iac_code.utils.json_utils import extract_json_int_value, extract_json_string_value
 from iac_code.utils.project_paths import format_resume_command, same_project_path
-from iac_code.utils.public_errors import sanitize_public_text
 
 if TYPE_CHECKING:
     from iac_code.pipeline import PipelineRunner
@@ -464,11 +463,10 @@ def _safe_mcp_elicitation_display_text(value: Any) -> str:
     raw = str(value or "").strip()
     if not raw:
         return ""
-    sanitized = sanitize_public_text(raw, fallback_summary="")
-    if len(sanitized) <= _MCP_ELICITATION_DISPLAY_MAX_CHARS:
-        return sanitized
+    if len(raw) <= _MCP_ELICITATION_DISPLAY_MAX_CHARS:
+        return raw
     marker = _("[truncated]")
-    return sanitized[: _MCP_ELICITATION_DISPLAY_MAX_CHARS - len(marker)].rstrip() + marker
+    return raw[: _MCP_ELICITATION_DISPLAY_MAX_CHARS - len(marker)].rstrip() + marker
 
 
 _MCP_ELICITATION_INVALID = object()
@@ -2004,12 +2002,6 @@ class InlineREPL:
                     return await self._handle_chat_continue()
             except Exception as exc:
                 error_text = str(exc)
-                from iac_code.mcp.prompt_dispatch import is_mcp_prompt_command
-
-                if is_mcp_prompt_command(cmd):
-                    from iac_code.mcp.redaction import sanitize_mcp_public_text
-
-                    error_text = sanitize_mcp_public_text(error_text, fallback_summary="")
                 self.renderer.print_system_message(
                     _("Command error: {error}").format(error=error_text),
                     style="red",
@@ -2664,10 +2656,7 @@ class InlineREPL:
 
     @staticmethod
     def _safe_cleanup_error(error: str) -> str:
-        from iac_code.utils.public_errors import sanitize_public_text
-
-        sanitized = sanitize_public_text(error)
-        return sanitized[:1000] + "..." if len(sanitized) > 1000 else sanitized
+        return error[:1000] + "..." if len(error) > 1000 else error
 
     def _remove_cleanup_prompts_from_context(self) -> int:
         context_manager = getattr(getattr(self, "_agent_loop", None), "context_manager", None)

--- a/src/iac_code/utils/public_errors.py
+++ b/src/iac_code/utils/public_errors.py
@@ -13,7 +13,7 @@ from typing import Any
 from urllib.parse import quote, unquote, urlsplit
 
 from iac_code.i18n import _
-from iac_code.utils.public_paths import relativize_public_file_uri, sanitize_public_paths
+from iac_code.utils.public_paths import redact_known_public_paths, relativize_public_file_uri, sanitize_public_paths
 
 # 本地 Web workbench 绑定 loopback，转录里出现真实文件路径与密钥既安全又有用（数据只落本地磁盘），
 # 因此需要一个开关关闭「全部脱敏」——路径 [PATH] 与密钥 [REDACTED]/*** 都不再处理。默认 False：
@@ -192,6 +192,34 @@ def sanitize_public_text(
         fallback_summary = _("Unknown error")
     raw_summary = str(value) if value is not None else ""
     return _sanitize_public_summary(raw_summary, public_path_roots=public_path_roots) or fallback_summary
+
+
+def sanitize_strict_text(
+    value: Any,
+    *,
+    fallback_summary: str | None = None,
+    public_path_roots: Iterable[Mapping[str, str]] | None = None,
+) -> str:
+    """Sanitize log/telemetry user data regardless of display suppression.
+
+    This entry point deliberately ignores the local Web no-redaction context and
+    the A2A delivery policy. It is only for service logs and telemetry fields.
+    """
+
+    token = _ALL_REDACTION_SUPPRESSED.set(False)
+    try:
+        sanitized = sanitize_public_text(
+            value,
+            fallback_summary=fallback_summary,
+            public_path_roots=public_path_roots,
+        )
+        # Strict observability sinks must also cover server layouts such as
+        # /srv and /opt when no request-scoped roots are available.  This is
+        # intentionally broader than A2A path-only projection and does not
+        # alter Provider ErrorEvent or other existing public-error behavior.
+        return redact_known_public_paths(sanitized, ({"path": "/", "label": "[PATH]"},))
+    finally:
+        _ALL_REDACTION_SUPPRESSED.reset(token)
 
 
 def _error_id(*, error_type: str, summary: str) -> str:

--- a/src/iac_code/utils/public_paths.py
+++ b/src/iac_code/utils/public_paths.py
@@ -11,9 +11,19 @@ from dataclasses import dataclass
 from urllib.parse import unquote, urlsplit
 
 _CONNECTOR_TOKEN_END_PATTERN = r"""\s+(?:and|at|because|for|from|in|on|to|with)\b(?=\s+[A-Za-z0-9_.-]+\s*[:=])"""
+_NARRATIVE_TOKEN_END_PATTERN = r"""\s+(?=(?:after|before|during|then|while)\b)"""
+_KEY_ASSIGNMENT_TOKEN_END_PATTERN = r"""\s+(?=[A-Za-z0-9_.-]+\s*[:=])"""
 _ABSOLUTE_PATH_TOKEN_END_PATTERN = r"""\s+(?=(?:/(?!/)|[A-Za-z]:[\\/]|\\\\))"""
 _PATH_END_PATTERN = (
-    r"""(?=""" + _CONNECTOR_TOKEN_END_PATTERN + r"""|""" + _ABSOLUTE_PATH_TOKEN_END_PATTERN + r"""|$|[\r\n,;:)"'])"""
+    r"""(?="""
+    + _CONNECTOR_TOKEN_END_PATTERN
+    + r"""|"""
+    + _KEY_ASSIGNMENT_TOKEN_END_PATTERN
+    + r"""|"""
+    + _NARRATIVE_TOKEN_END_PATTERN
+    + r"""|"""
+    + _ABSOLUTE_PATH_TOKEN_END_PATTERN
+    + r"""|$|[\r\n,;:)"'])"""
 )
 _POSIX_PATH_TEXT_PATTERN = re.compile(r"""(?<![A-Za-z0-9._~%:/\]-])/(?!/)[^\r\n,;:)\"']*?""" + _PATH_END_PATTERN)
 _WINDOWS_UNICODE_LIKE_UNC_PATH_TEXT_PATTERN = re.compile(
@@ -24,6 +34,16 @@ _WINDOWS_PATH_TEXT_PATTERN = re.compile(
     r"""(?<![A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\(?!u[0-9A-Fa-f]{4}))[^\r\n,;:)\"']*?""" + _PATH_END_PATTERN
 )
 _ABSOLUTE_PATH_AFTER_SPACE_PATTERN = re.compile(r"""(\s+)(?=(?:/(?!/)|[A-Za-z]:[\\/]|\\\\))""")
+_URI_TOKEN_END_PATTERN = (
+    r"""(?="""
+    + _CONNECTOR_TOKEN_END_PATTERN
+    + r"""|"""
+    + _KEY_ASSIGNMENT_TOKEN_END_PATTERN
+    + r"""|"""
+    + _NARRATIVE_TOKEN_END_PATTERN
+    + r"""|$|[\r\n,;)\"'\]}]|:(?![\\/]|%5[Cc]|%2[Ff]))"""
+)
+_FILE_URI_TEXT_PATTERN = re.compile(r"""file://[^\r\n,;)\"'\]}]*?""" + _URI_TOKEN_END_PATTERN, re.IGNORECASE)
 
 _TRUSTED_ROOT_LABEL = "[trusted]"
 _WORKSPACE_ROOT_LABEL = "."
@@ -84,6 +104,111 @@ def sanitize_public_paths(value: str, public_path_roots: Iterable[Mapping[str, s
     sanitized = _WINDOWS_UNICODE_LIKE_UNC_PATH_TEXT_PATTERN.sub(replace, value)
     sanitized = _WINDOWS_PATH_TEXT_PATTERN.sub(replace, sanitized)
     return _POSIX_PATH_TEXT_PATTERN.sub(replace, sanitized)
+
+
+def redact_known_public_paths(value: str, public_path_roots: Iterable[Mapping[str, str]] | None) -> str:
+    """Replace only paths proven to be under a server root with ``[PATH]``.
+
+    Unlike :func:`sanitize_public_paths`, this is an A2A path-only projection:
+    unmatched absolute paths are preserved and matching paths never expose a
+    root label, relative suffix, directory name, or filename.
+    """
+
+    roots = _normalize_public_path_roots(public_path_roots)
+    if not roots:
+        return value
+
+    leading_length = len(value) - len(value.lstrip())
+    trailing_length = len(value) - len(value.rstrip())
+    scalar_end = len(value) - trailing_length if trailing_length else len(value)
+    scalar = value[leading_length:scalar_end]
+    if scalar:
+        if _file_uri_is_under_roots(scalar, roots) or (
+            _is_absolute_path_token(scalar) and _path_matches_roots(scalar, roots)
+        ):
+            return f"{value[:leading_length]}[PATH]{value[scalar_end:]}"
+
+    def replace_file_uri(match: re.Match[str]) -> str:
+        token = match.group(0)
+        trailing = ""
+        while token and token[-1] in ".,:!?":
+            trailing = token[-1] + trailing
+            token = token[:-1]
+        return f"[PATH]{trailing}" if _file_uri_is_under_roots(token, roots) else match.group(0)
+
+    def replace_path(match: re.Match[str]) -> str:
+        quoted = (
+            match.start() > 0
+            and match.end() < len(match.string)
+            and match.string[match.start() - 1] in {"'", '"'}
+            and match.string[match.start() - 1] == match.string[match.end()]
+        )
+        return _redact_known_path_token(match.group(0), roots, whole_token=quoted)
+
+    redacted = _FILE_URI_TEXT_PATTERN.sub(replace_file_uri, value)
+    redacted = _WINDOWS_UNICODE_LIKE_UNC_PATH_TEXT_PATTERN.sub(replace_path, redacted)
+    redacted = _WINDOWS_PATH_TEXT_PATTERN.sub(replace_path, redacted)
+    return _POSIX_PATH_TEXT_PATTERN.sub(replace_path, redacted)
+
+
+def _redact_known_path_token(
+    token: str,
+    roots: list[_NormalizedRoot],
+    *,
+    whole_token: bool = False,
+) -> str:
+    if whole_token:
+        return "[PATH]" if _path_matches_roots(token, roots) else token
+    parts = re.split(r"(\s+)", token)
+    rendered: list[str] = []
+    for part in parts:
+        if not part or part.isspace():
+            rendered.append(part)
+        else:
+            candidate = part
+            trailing = ""
+            while candidate and candidate[-1] in ".!?":
+                trailing = candidate[-1] + trailing
+                candidate = candidate[:-1]
+            rendered.append(
+                f"[PATH]{trailing}"
+                if _is_absolute_path_token(candidate) and _path_matches_roots(candidate, roots)
+                else part
+            )
+    return "".join(rendered)
+
+
+def _path_matches_roots(path: str, roots: list[_NormalizedRoot]) -> bool:
+    windows = _is_windows_path(path)
+    return any(
+        root.windows == windows
+        and _path_is_under_root(candidate, root.norm_path, windows=windows)
+        for candidate in _candidate_norm_paths(path, windows=windows)
+        for root in roots
+    )
+
+
+def _is_absolute_path_token(path: str) -> bool:
+    return (
+        (path.startswith("/") and not path.startswith("//"))
+        or bool(ntpath.splitdrive(path)[0])
+        or path.startswith("\\\\")
+    )
+
+
+def _file_uri_is_under_roots(uri: str, roots: list[_NormalizedRoot]) -> bool:
+    parsed = urlsplit(uri)
+    if parsed.scheme.lower() != "file":
+        return False
+    path = unquote(parsed.path or "")
+    if parsed.netloc and parsed.netloc.lower() != "localhost":
+        if _looks_like_windows_drive(parsed.netloc):
+            path = parsed.netloc + path
+        elif path:
+            path = f"//{parsed.netloc}{path}"
+    if re.match(r"^/[A-Za-z]:[\\/]", path):
+        path = path[1:]
+    return _path_matches_roots(path, roots)
 
 
 def _sanitize_public_path_token(token: str, roots: list[_NormalizedRoot]) -> str:

--- a/src/iac_code/web/app.py
+++ b/src/iac_code/web/app.py
@@ -63,16 +63,11 @@ WEB_SHUTDOWN_TASK_TIMEOUT_SECONDS = 5.0
 
 
 class _SuppressAllRedactionMiddleware:
-    """Disable all redaction (paths + secrets) for the loopback Web workbench.
+    """Keep the loopback Web request context on the existing local policy.
 
-    The web server binds to loopback only, so surfacing real local paths and
-    secrets in the transcript is safe and useful (the data only lands on local
-    disk); secrets are surfaced too. This pure-ASGI middleware wraps every
-    request in a ``suppress_all_redaction()`` scope. Because it sets the
-    ContextVar in the same task that then awaits the downstream app, the
-    endpoint — and any background pipeline turn task it spawns via
-    ``asyncio.create_task`` (which copies the current context at creation) —
-    runs with all redaction disabled for both the live write path and reloads.
+    User-visible Web data no longer calls generic redactors.  The suppression
+    context remains for unchanged consumers such as permission audit; strict
+    server-log and telemetry sanitizers explicitly ignore it.
     """
 
     def __init__(self, app: Any) -> None:
@@ -110,13 +105,12 @@ def create_app(
     pipeline_action_runner_factory: WebPipelineActionRunnerFactory | None = None,
     expose_local_paths: bool = False,
 ) -> Any:
-    """Create the local Web workbench ASGI app.
+    """Create the loopback-only Web workbench without generic user-data redaction.
 
-    ``expose_local_paths`` disables file-path ([PATH]) redaction across the app
-    (secrets stay redacted). The loopback server entry point turns this on so the
-    transcript shows real local paths; it defaults to off so other callers/tests
-    keep the remote-safe redaction behavior.
+    ``expose_local_paths`` is retained as a compatibility-only argument; all
+    local Web sessions now use the same no-redaction policy.
     """
+    del expose_local_paths
     try:
         from starlette.applications import Starlette
         from starlette.concurrency import run_in_threadpool
@@ -144,7 +138,6 @@ def create_app(
     from iac_code.ui.suggestions.shell_history_provider import ShellHistoryProvider
     from iac_code.ui.suggestions.skill_provider import SkillProvider
     from iac_code.ui.suggestions.types import CompletionToken, SuggestionItem
-    from iac_code.utils.public_errors import public_exception_summary, sanitize_public_text
     from iac_code.web import mcp_settings
     from iac_code.web.cleanup import cleanup_blocks_normal_chat, session_cleanup_summary
     from iac_code.web.commands import WebCommandDispatcher, command_metadata
@@ -521,7 +514,7 @@ def create_app(
             return response
 
     def json_error(message: str, status_code: int, *, code: str | None = None) -> JSONResponse:
-        error = {"message": sanitize_public_text(message)}
+        error = {"message": message}
         if code is not None:
             error["code"] = code
         return JSONResponse({"error": error}, status_code=status_code)
@@ -536,7 +529,7 @@ def create_app(
         )
 
     def public_exception_message(exc: BaseException) -> str:
-        return public_exception_summary(exc, max_chars=500)
+        return str(exc)[:500]
 
     def active_model_selection(session: WebSession) -> WebModelSelection:
         return model_selection_for_session(session)
@@ -2921,7 +2914,7 @@ def create_app(
             {
                 "sessionId": session.session_id,
                 "webSessionId": session.web_session_id,
-                "redacted": True,
+                "redacted": False,
                 "available": True,
                 "mode": session.mode,
                 "cwd": session.cwd,
@@ -4218,7 +4211,7 @@ def create_app(
                 "command": "skill",
                 "error": {
                     "code": "unknown_skill",
-                    "message": sanitize_public_text("unknown skill: {}".format(str(result.get("skill") or "").strip())),
+                    "message": "unknown skill: {}".format(str(result.get("skill") or "").strip()),
                 },
             }
         shell_task: asyncio.Task[Any] | None = None
@@ -4685,10 +4678,9 @@ def create_app(
             },
         )
 
-    app_middleware = [Middleware(_SuppressAllRedactionMiddleware)] if expose_local_paths else []
     return Starlette(
         lifespan=lifespan,
-        middleware=app_middleware,
+        middleware=[Middleware(_SuppressAllRedactionMiddleware)],
         routes=[
             Route("/health", health, methods=["GET"]),
             Route("/api/server/restart", restart_server, methods=["POST"]),

--- a/src/iac_code/web/events.py
+++ b/src/iac_code/web/events.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import logging
 import math
-import re
 from collections import deque
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping
 from contextlib import contextmanager
@@ -46,23 +45,9 @@ from iac_code.types.stream_events import (
     ToolUseStartEvent,
     Usage,
 )
-from iac_code.web.security import redact_secrets
 
 logger = logging.getLogger(__name__)
 PIPELINE_IDENTITY_FIELDS = ("contextId", "taskId", "lastSequence")
-_SECRET_KEY_PATTERN = (
-    r"x[_-]?api[_-]?key|api[_-]?key|apikey|access[_-]?key[_-]?secret|authorization|cookie|credential[_-]?uri|"
-    r"private[_-]?key|secret|token"
-)
-_SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?P<key_quote>['\"]?)\b(?P<key>" + _SECRET_KEY_PATTERN + r")\b(?P=key_quote)"
-    r"(?P<separator>\s*[:=]\s*)(?P<value_quote>['\"]?)"
-    r"(?P<value>(?:Bearer\s+)?[^\s,;'\"}]+)(?P=value_quote)",
-    re.IGNORECASE,
-)
-_BEARER_TOKEN_RE = re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}", re.IGNORECASE)
-_COOKIE_HEADER_RE = re.compile(r"\bCookie\s*:\s*[^\r\n]+", re.IGNORECASE)
-_NAKED_SECRET_RE = re.compile(r"\b(?:sk-[A-Za-z0-9][A-Za-z0-9_-]{7,}|LTAI[A-Za-z0-9]{12,})\b")
 _EVENT_OBSERVER: ContextVar[Callable[[dict[str, Any]], None] | None] = ContextVar(
     "iac_code_web_event_observer",
     default=None,
@@ -107,37 +92,21 @@ def _is_dataclass_instance(value: Any) -> bool:
     return is_dataclass(value) and not isinstance(value, type)
 
 
-def _coerce_for_redaction(value: Any) -> Any:
+def _coerce_for_json(value: Any) -> Any:
     if _is_dataclass_instance(value):
-        return {field.name: _coerce_for_redaction(getattr(value, field.name)) for field in fields(value)}
+        return {field.name: _coerce_for_json(getattr(value, field.name)) for field in fields(value)}
     if isinstance(value, Mapping):
-        return {str(key): _coerce_for_redaction(item) for key, item in value.items()}
+        return {str(key): _coerce_for_json(item) for key, item in value.items()}
     if isinstance(value, (list, tuple, set, frozenset)):
-        return [_coerce_for_redaction(item) for item in value]
+        return [_coerce_for_json(item) for item in value]
     return value
-
-
-def _redact_secret_assignment(match: re.Match[str]) -> str:
-    return "{key_quote}{key}{key_quote}{separator}{value_quote}[REDACTED]{value_quote}".format(
-        key_quote=match.group("key_quote"),
-        key=match.group("key"),
-        separator=match.group("separator"),
-        value_quote=match.group("value_quote"),
-    )
-
-
-def _redact_secret_text(value: str) -> str:
-    redacted = _COOKIE_HEADER_RE.sub("Cookie: [REDACTED]", value)
-    redacted = _SECRET_ASSIGNMENT_RE.sub(_redact_secret_assignment, redacted)
-    redacted = _BEARER_TOKEN_RE.sub("Bearer [REDACTED]", redacted)
-    return _NAKED_SECRET_RE.sub("[REDACTED]", redacted)
 
 
 def _normalize_event_value(value: Any) -> Any:
     if value is None or isinstance(value, (int, bool)):
         return value
     if isinstance(value, str):
-        return _redact_secret_text(value)
+        return value
     if isinstance(value, float):
         if math.isfinite(value):
             return value
@@ -151,28 +120,21 @@ def _normalize_event_value(value: Any) -> Any:
     if isinstance(value, PurePath):
         # POSIX separators keep the serialized path stable across platforms
         # (str() on a Windows path would emit backslashes).
-        return _redact_secret_text(value.as_posix())
+        return value.as_posix()
     if isinstance(value, PathLike):
-        return _redact_secret_text(str(value))
+        return str(value)
     if isinstance(value, (bytes, bytearray, memoryview)):
-        return _redact_secret_text(bytes(value).decode("utf-8", errors="replace"))
+        return bytes(value).decode("utf-8", errors="replace")
     if isinstance(value, Mapping):
         return {str(key): _normalize_event_value(item) for key, item in value.items()}
     if isinstance(value, (list, tuple, set, frozenset)):
         return [_normalize_event_value(item) for item in value]
-    return _redact_secret_text(str(value))
+    return str(value)
 
 
 def normalize_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Return a redacted JSON-safe payload copy."""
-    usage = payload.get("usage")
-    context_usage = payload.get("contextUsage")
-    redacted_payload = redact_secrets(_coerce_for_redaction(payload))
-    if isinstance(usage, Mapping) and isinstance(redacted_payload, dict):
-        redacted_payload["usage"] = _coerce_for_redaction(usage)
-    if isinstance(context_usage, Mapping) and isinstance(redacted_payload, dict):
-        redacted_payload["contextUsage"] = _coerce_for_redaction(context_usage)
-    return _normalize_event_value(redacted_payload)
+    """Return a JSON-safe local Web payload copy without generic redaction."""
+    return _normalize_event_value(_coerce_for_json(payload))
 
 
 def _first_region_id(items: list[dict[str, Any]]) -> str | None:
@@ -191,7 +153,7 @@ def _stack_deployment_succeeded(status: str) -> bool:
 
 
 def make_event(session_id: str, sequence: int, event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
-    """Create a browser-safe event dictionary with redacted payload contents."""
+    """Create a browser-safe event dictionary with JSON-safe payload contents."""
     normalized_payload = normalize_event_payload(payload)
     event = {
         "type": event_type,

--- a/src/iac_code/web/pipeline_actions.py
+++ b/src/iac_code/web/pipeline_actions.py
@@ -343,9 +343,7 @@ class A2APipelineActionRunner:
                 pipeline_input=normalize_pipeline_user_input(pipeline_input),
             )
         except Exception as exc:
-            from iac_code.utils.public_errors import public_exception_summary
-
-            return _action_error(public_exception_summary(exc, max_chars=500), status_code=500)
+            return _action_error(str(exc)[:500], status_code=500)
         terminal_result = await self._terminal_result(session, event_queue.events)
         if terminal_result is not None:
             return terminal_result
@@ -538,12 +536,10 @@ def _string_value(value: Any) -> str | None:
 
 
 def _action_error(message: str, *, status_code: int, terminal_outcome: str | None = None) -> PipelineActionResult:
-    from iac_code.utils.public_errors import sanitize_public_text
-
     return PipelineActionResult(
         accepted=False,
         status_code=status_code,
-        response={"accepted": False, "error": {"message": sanitize_public_text(message)}},
+        response={"accepted": False, "error": {"message": message}},
         terminal_outcome=terminal_outcome,
     )
 

--- a/src/iac_code/web/runtime.py
+++ b/src/iac_code/web/runtime.py
@@ -25,7 +25,6 @@ from iac_code.types.stream_events import (
     SubPipelineStreamEvent,
     Usage,
 )
-from iac_code.utils.public_errors import public_exception_summary
 from iac_code.web.events import WebEventTranslator, usage_payload
 from iac_code.web.session_manager import WebSession, WebSessionManager, _camelize
 
@@ -572,7 +571,7 @@ class WebSessionRuntime:
                         "error",
                         {
                             "turnId": turn_id,
-                            "message": public_exception_summary(exc, max_chars=500),
+                            "message": str(exc)[:500],
                             "retryable": False,
                         },
                     )

--- a/src/iac_code/web/server.py
+++ b/src/iac_code/web/server.py
@@ -261,6 +261,6 @@ def run_web_server(
     _start_update_check()
     if open_browser:
         _schedule_browser_open(url, safe_host, port)
-    # 该服务只绑定 loopback，转录里展示真实本地路径既安全又有用，故关闭文件路径脱敏
-    # (密钥等敏感值仍会脱敏)。见 create_app(expose_local_paths=...)。
+    # 该服务只绑定 loopback，所有本地用户数据均不执行通用路径或凭据脱敏。
+    # 参数保留用于兼容旧调用方；所有 Web app 实例使用相同本地策略。
     uvicorn.run(protect_loopback_app(create_app(expose_local_paths=True)), host=safe_host, port=port)

--- a/src/iac_code/web/shell.py
+++ b/src/iac_code/web/shell.py
@@ -14,7 +14,6 @@ from iac_code.tools.base import ToolContext, ToolRegistry, ToolResult
 from iac_code.tools.tool_executor import ToolCallRequest, ToolExecutor
 from iac_code.types.permissions import PermissionResult, ToolPermissionContext
 from iac_code.types.stream_events import PermissionRequestEvent
-from iac_code.utils.public_errors import public_exception_summary, sanitize_public_text
 from iac_code.web.session_manager import WebSession, WebSessionManager
 
 SHELL_ESCAPE_TOOL_USE_ID = "shell-escape"
@@ -204,7 +203,7 @@ class WebShellEscapeRunner:
             if permission.behavior == "deny":
                 return await publish_end(
                     exit_code=1,
-                    stderr=sanitize_public_text(permission.message) if permission.message else "Permission denied.",
+                    stderr=permission.message if permission.message else "Permission denied.",
                 )
             if permission.behavior == "ask":
                 allowed = await self._ask_permission(session, permission, tool=tool, tool_input=tool_input)
@@ -222,7 +221,7 @@ class WebShellEscapeRunner:
                 )
                 result = results[0] if results else ToolResult.error("Shell command did not return a result.")
             except Exception as exc:
-                result = ToolResult.error(public_exception_summary(exc, max_chars=500))
+                result = ToolResult.error(str(exc)[:500])
             exit_code, stdout, stderr = _parse_tool_result(result)
             return await publish_end(exit_code=exit_code, stdout=stdout, stderr=stderr)
         except asyncio.CancelledError:
@@ -236,7 +235,7 @@ class WebShellEscapeRunner:
             raise
         except Exception as exc:
             if not end_published:
-                return await publish_end(exit_code=1, stderr=public_exception_summary(exc, max_chars=500))
+                return await publish_end(exit_code=1, stderr=str(exc)[:500])
             raise
 
     async def _ask_permission(

--- a/tests/a2a/test_app.py
+++ b/tests/a2a/test_app.py
@@ -278,6 +278,74 @@ def test_pipeline_state_endpoint_returns_recovery_state(tmp_path) -> None:
     assert [event["eventId"] for event in data["events"]] == ["evt-2"]
 
 
+@pytest.mark.parametrize(("safe_mode", "expected_path"), [("1", "[PATH]"), ("0", "raw")])
+def test_pipeline_state_endpoint_projects_recovery_state_at_a2a_boundary(
+    monkeypatch, tmp_path, safe_mode, expected_path
+) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", safe_mode)
+    persistence_dir = tmp_path / "a2a"
+    persistence = A2APersistenceStore(persistence_dir)
+    persistence.save_context(A2AContextSnapshot(context_id="ctx-1", session_id="session-1", cwd=str(tmp_path)))
+    pipeline_dir = SessionStorage().session_dir(str(tmp_path), "session-1") / "pipeline"
+    event = _pipeline_event(1, "evt-1")
+    raw_path = str(tmp_path / "private" / "result.json")
+    event["data"] = {"path": raw_path, "password": "real-secret"}
+    A2APipelineJournal(pipeline_dir).append(event)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([event]))
+    app = create_app(
+        host="127.0.0.1",
+        port=41242,
+        token=None,
+        model="qwen3.6-plus",
+        persistence_dir=persistence_dir,
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/iac-code/pipeline/state?contextId=ctx-1&afterSequence=0")
+
+    data = response.json()
+    assert data["events"][0]["data"]["password"] == "real-secret"
+    if expected_path == "[PATH]":
+        assert data["events"][0]["data"]["path"] == "[PATH]"
+    else:
+        assert data["events"][0]["data"]["path"] == raw_path
+
+
+@pytest.mark.parametrize(("safe_mode", "expected_path"), [("1", "[PATH]"), ("0", "raw")])
+def test_pipeline_state_endpoint_projects_value_error_without_changing_schema(
+    monkeypatch, tmp_path, safe_mode, expected_path
+) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", safe_mode)
+    persistence_dir = tmp_path / "a2a"
+    persistence = A2APersistenceStore(persistence_dir)
+    persistence.save_context(A2AContextSnapshot(context_id="ctx-1", session_id="session-1", cwd=str(tmp_path)))
+    raw_path = str(tmp_path / "private" / "snapshot.json")
+
+    async def fail_get_state(self, **kwargs):
+        raise ValueError(f"recovery failed token=real-secret at {raw_path}")
+
+    monkeypatch.setattr("iac_code.a2a.pipeline_recovery.A2APipelineRecoveryService.get_state", fail_get_state)
+    app = create_app(
+        host="127.0.0.1",
+        port=41242,
+        token=None,
+        model="qwen3.6-plus",
+        persistence_dir=persistence_dir,
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/iac-code/pipeline/state?contextId=ctx-1")
+
+    assert response.status_code == 404
+    assert set(response.json()) == {"error"}
+    assert "real-secret" in response.json()["error"]
+    if expected_path == "[PATH]":
+        assert "[PATH]" in response.json()["error"]
+        assert raw_path not in response.json()["error"]
+    else:
+        assert raw_path in response.json()["error"]
+
+
 def test_pipeline_state_endpoint_repairs_pending_backup_snapshot_after_committed_ack(tmp_path) -> None:
     persistence_dir = tmp_path / "a2a"
     persistence = A2APersistenceStore(persistence_dir)
@@ -2295,8 +2363,8 @@ async def test_cancel_input_required_pipeline_task_backup_blocked_returns_input_
         assert events[-1]["status"] == "input_required"
         assert events[-1]["data"]["reason"] == "terminal"
         assert events[-1]["data"]["recoverable"] is True
-        assert "tok-live" not in events[-1]["data"]["error"]
-        assert "/tmp/iac-code" not in events[-1]["data"]["error"]
+        assert "tok-live" in events[-1]["data"]["error"]
+        assert "/tmp/iac-code" in events[-1]["data"]["error"]
     finally:
         await components.aclose()
 

--- a/tests/a2a/test_events.py
+++ b/tests/a2a/test_events.py
@@ -863,7 +863,7 @@ async def test_tool_use_input_summary_fingerprints_business_field_names() -> Non
 
 
 @pytest.mark.asyncio
-async def test_failed_tool_result_metadata_is_sanitized() -> None:
+async def test_failed_tool_result_metadata_preserves_values_before_wire_projection() -> None:
     queue = FakeEventQueue()
 
     await publish_stream_event(
@@ -881,12 +881,12 @@ async def test_failed_tool_result_metadata_is_sanitized() -> None:
     dumped = dump(queue.events[0])
     tool = dumped["metadata"]["iac_code"]["tool"]
     assert tool["status"] == "failed"
-    assert "hunter2" not in str(tool["result"])
-    assert "/Users/alice" not in str(tool["result"])
+    assert "hunter2" in str(tool["result"])
+    assert "/Users/alice" in str(tool["result"])
 
 
 @pytest.mark.asyncio
-async def test_mcp_tool_result_metadata_redacts_private_markers() -> None:
+async def test_mcp_tool_result_metadata_remains_an_ordinary_raw_tool_result() -> None:
     queue = FakeEventQueue()
 
     await publish_stream_event(
@@ -908,17 +908,16 @@ async def test_mcp_tool_result_metadata_redacts_private_markers() -> None:
 
     dumped = dump(queue.events[0])
     rendered = str(dumped["metadata"]["iac_code"]["tool"]["result"])
-    assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" not in rendered
-    assert "IAC_PRIVATE_NESTED_METADATA_MARKER_56" not in rendered
-    assert "IAC_PRIVATE_QUERY_MARKER_56" not in rendered
-    assert "user:pass" not in rendered
-    assert "/Users/alice" not in rendered
-    assert "[REDACTED]" in rendered
-    assert "[PATH]" in rendered
+    assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" in rendered
+    assert "IAC_PRIVATE_NESTED_METADATA_MARKER_56" in rendered
+    assert "IAC_PRIVATE_QUERY_MARKER_56" in rendered
+    assert "user:pass" in rendered
+    assert "/Users/alice" in rendered
+    assert "[REDACTED]" not in rendered
 
 
 @pytest.mark.asyncio
-async def test_tool_result_metadata_relativizes_paths_under_public_roots() -> None:
+async def test_tool_result_metadata_keeps_paths_canonical_before_wire_projection() -> None:
     queue = FakeEventQueue()
 
     await publish_stream_event(
@@ -945,16 +944,20 @@ async def test_tool_result_metadata_relativizes_paths_under_public_roots() -> No
     dumped = dump(queue.events[0])
     tool = dumped["metadata"]["iac_code"]["tool"]
     assert tool["result"] == (
-        "STDOUT:\n./src/app.py:12\n$IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt\n[PATH]\nExit code: 0"
+        "STDOUT:\n"
+        "/Users/alice/project/src/app.py:12\n"
+        "/Users/alice/.iac-code/tool-results/session-1/result.txt\n"
+        "/Users/alice/private/secret.txt\n"
+        "Exit code: 0"
     )
     rendered = str(dumped)
     assert "public_path_roots" not in rendered
     assert "publicPathRoots" not in rendered
-    assert "/Users/alice" not in rendered
+    assert "/Users/alice" in rendered
 
 
 @pytest.mark.asyncio
-async def test_failed_tool_result_metadata_redacts_malformed_opaque_artifact_uri() -> None:
+async def test_failed_tool_result_metadata_preserves_malformed_opaque_artifact_uri() -> None:
     queue = FakeEventQueue()
     malformed_uri = r"iac-code-artifact://artifact-1/C:\Users\alice\.iac-code\projects\demo\template.yaml"
 
@@ -972,10 +975,7 @@ async def test_failed_tool_result_metadata_redacts_malformed_opaque_artifact_uri
 
     dumped = dump(queue.events[0])
     rendered = str(dumped["metadata"]["iac_code"]["tool"]["result"])
-    assert "[PATH]" in rendered
-    assert "iac-code-artifac[PATH]" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert rendered == f"Tool failed: {malformed_uri}"
 
 
 @pytest.mark.asyncio
@@ -1052,7 +1052,7 @@ async def test_tool_result_artifact_windows_filename_does_not_leak_path(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_tool_result_uri_only_artifact_drops_legacy_file_uri() -> None:
+async def test_tool_result_uri_only_artifact_preserves_existing_fields_before_wire_projection() -> None:
     queue = FakeEventQueue()
     result = {
         "artifact": {
@@ -1088,19 +1088,10 @@ async def test_tool_result_uri_only_artifact_drops_legacy_file_uri() -> None:
     artifact = dumped["metadata"]["iac_code"]["tool"]["result"]["artifact"]
     rendered = str(dumped)
     assert artifact["filename"] == "template.yaml"
-    assert artifact["metadata"] == {"byteSize": 10}
-    assert "uri" not in artifact
-    assert "downloadUrl" not in artifact
-    assert "publicUrl" not in artifact
-    assert "encodedOwnerUrl" not in artifact
-    assert "backupUri" not in artifact
-    assert "sourceUri" not in artifact
-    assert artifact["source"] == "[PATH]"
-    assert "url" not in artifact["parts"][0]
-    assert "uri" not in artifact["parts"][0]["metadata"]
-    assert "file://" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert artifact == result["artifact"]
+    assert "file://" in rendered
+    assert "Users" in rendered
+    assert ".iac-code" in rendered
 
 
 @pytest.mark.asyncio
@@ -1134,7 +1125,7 @@ async def test_tool_result_uri_only_artifact_keeps_valid_opaque_uri() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tool_result_artifact_list_is_sanitized() -> None:
+async def test_tool_result_artifact_list_preserves_values_before_wire_projection() -> None:
     queue = FakeEventQueue()
     legacy_uri = r"file://C:\Users\alice\.iac-code\projects\demo\template.yaml"
     result = {
@@ -1157,19 +1148,15 @@ async def test_tool_result_artifact_list_is_sanitized() -> None:
 
     dumped = dump(queue.events[0])
     artifact = dumped["metadata"]["iac_code"]["tool"]["result"]["artifact"]
-    assert artifact[0] == "[PATH]"
-    assert artifact[1]["filename"] == "template.yaml"
-    assert "uri" not in artifact[1]
-    assert artifact[1]["parts"][0] == "[PATH]"
-    assert "url" not in artifact[1]["parts"][1]
+    assert artifact == result["artifact"]
     rendered = str(dumped)
-    assert "file://" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert "file://" in rendered
+    assert "Users" in rendered
+    assert ".iac-code" in rendered
 
 
 @pytest.mark.asyncio
-async def test_tool_result_artifact_scalar_is_sanitized() -> None:
+async def test_tool_result_artifact_scalar_is_preserved_before_wire_projection() -> None:
     queue = FakeEventQueue()
     result = {"artifact": r"file://C:\Users\alice\.iac-code\projects\demo\template.yaml"}
 
@@ -1182,15 +1169,15 @@ async def test_tool_result_artifact_scalar_is_sanitized() -> None:
 
     dumped = dump(queue.events[0])
     artifact = dumped["metadata"]["iac_code"]["tool"]["result"]["artifact"]
-    assert artifact == "[PATH]"
+    assert artifact == result["artifact"]
     rendered = str(dumped)
-    assert "file://" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert "file://" in rendered
+    assert "Users" in rendered
+    assert ".iac-code" in rendered
 
 
 @pytest.mark.asyncio
-async def test_tool_result_artifact_payload_keys_are_sanitized_case_insensitively() -> None:
+async def test_tool_result_artifact_payload_is_externalized_without_redacting_metadata() -> None:
     queue = FakeEventQueue()
     result = {
         "artifact": {
@@ -1212,18 +1199,16 @@ async def test_tool_result_artifact_payload_keys_are_sanitized_case_insensitivel
 
     dumped = dump(queue.events[0])
     artifact = dumped["metadata"]["iac_code"]["tool"]["result"]["artifact"]
-    assert artifact == {"filename": "result.txt", "metadata": {"label": "safe", "api_key": "[REDACTED]"}}
+    assert artifact == {"filename": "result.txt", "metadata": {"label": "safe", "api_key": "plain-secret"}}
     rendered = str(dumped)
     assert "secret content" not in rendered
     assert "secret raw" not in rendered
     assert "c2VjcmV0" not in rendered
-    assert "plain-secret" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert "plain-secret" in rendered
 
 
 @pytest.mark.asyncio
-async def test_tool_result_metadata_sanitizes_root_artifact_list() -> None:
+async def test_tool_result_metadata_externalizes_root_artifact_list_without_redaction() -> None:
     queue = FakeEventQueue()
     result = [
         {
@@ -1246,15 +1231,19 @@ async def test_tool_result_metadata_sanitizes_root_artifact_list() -> None:
     dumped = dump(queue.events[0])
     rendered = str(dumped)
     artifact = dumped["metadata"]["iac_code"]["tool"]["result"][0]["artifact"]
-    assert artifact == {"filename": "template.yaml", "metadata": {"token": "[REDACTED]"}}
+    assert artifact == {
+        "filename": "template.yaml",
+        "metadata": {"token": "plain-token"},
+        "uri": r"file:///Users/Alice and Bob/.iac-code/projects/demo/template.yaml",
+    }
     assert "RAW-TEMPLATE-CONTENT" not in rendered
-    assert "plain-token" not in rendered
-    assert "Alice and Bob" not in rendered
-    assert ".iac-code" not in rendered
+    assert "plain-token" in rendered
+    assert "Alice and Bob" in rendered
+    assert ".iac-code" in rendered
 
 
 @pytest.mark.asyncio
-async def test_tool_result_metadata_sanitizes_case_variant_artifact_key() -> None:
+async def test_tool_result_metadata_externalizes_case_variant_artifact_key_without_redaction() -> None:
     queue = FakeEventQueue()
     result = {
         "Artifact": {
@@ -1274,14 +1263,17 @@ async def test_tool_result_metadata_sanitizes_case_variant_artifact_key() -> Non
     dumped = dump(queue.events[0])
     rendered = str(dumped)
     artifact = dumped["metadata"]["iac_code"]["tool"]["result"]["Artifact"]
-    assert artifact == {"filename": "template.yaml"}
+    assert artifact == {
+        "filename": "template.yaml",
+        "uri": r"file:///Users/Alice and Bob/.iac-code/projects/demo/template.yaml",
+    }
     assert "RAW-TEMPLATE-CONTENT" not in rendered
-    assert "Alice and Bob" not in rendered
-    assert ".iac-code" not in rendered
+    assert "Alice and Bob" in rendered
+    assert ".iac-code" in rendered
 
 
 @pytest.mark.asyncio
-async def test_failed_tool_result_dict_artifact_payload_is_sanitized() -> None:
+async def test_failed_tool_result_dict_externalizes_artifact_payload_without_redacting_values() -> None:
     queue = FakeEventQueue()
     result = {
         "artifact": {
@@ -1305,12 +1297,12 @@ async def test_failed_tool_result_dict_artifact_payload_is_sanitized() -> None:
     rendered = str(dumped)
     result_metadata = dumped["metadata"]["iac_code"]["tool"]["result"]
     assert result_metadata == {
-        "artifact": {"filename": "template.yaml", "metadata": {"Authorization": "[REDACTED]"}},
-        "api_key": "[REDACTED]",
+        "artifact": {"filename": "template.yaml", "metadata": {"Authorization": "Bearer plain-auth-value"}},
+        "api_key": "secret-key",
     }
     assert "RAW-TEMPLATE-CONTENT" not in rendered
-    assert "plain-auth-value" not in rendered
-    assert "secret-key" not in rendered
+    assert "plain-auth-value" in rendered
+    assert "secret-key" in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -1024,7 +1024,7 @@ async def test_executor_mcp_prompt_missing_required_argument_fails_before_llm(
 
 
 @pytest.mark.asyncio
-async def test_executor_mcp_prompt_server_error_fails_before_llm_and_redacts(
+async def test_executor_mcp_prompt_server_error_fails_before_llm_and_preserves_user_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
@@ -1057,7 +1057,7 @@ async def test_executor_mcp_prompt_server_error_fails_before_llm_and_redacts(
     assert dumped["status"]["state"] == "TASK_STATE_FAILED"
     text = dumped["status"]["message"]["parts"][0]["text"]
     assert text.startswith("RuntimeError: MCP prompt server failed with access_token=")
-    assert "super-secret-token" not in text
+    assert "super-secret-token" in text
 
 
 @pytest.mark.asyncio
@@ -1486,7 +1486,7 @@ async def test_executor_canceled_terminal_backup_blocked_records_cancel_intent(
 
 
 @pytest.mark.asyncio
-async def test_executor_sanitizes_initial_task_echo_paths_without_changing_runtime_prompt(
+async def test_executor_keeps_initial_task_echo_canonical_without_changing_runtime_prompt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     from a2a.types import Message, Part, Role
@@ -1517,13 +1517,11 @@ async def test_executor_sanitizes_initial_task_echo_paths_without_changing_runti
     initial_task = next(event for event in queue.events if isinstance(event, Task))
     rendered = dump(initial_task)
     history = rendered["history"][0]
-    assert history["parts"][0]["text"] == (
-        "paths: ./src/app.py $IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt [PATH]"
-    )
-    assert history["metadata"]["iac_code"]["cwd"] == "."
-    assert str(cwd) not in json.dumps(rendered)
-    assert str(config_dir) not in json.dumps(rendered)
-    assert "/opt/iac-code-outside/config.yaml" not in json.dumps(rendered)
+    assert history["parts"][0]["text"] == prompt
+    assert history["metadata"]["iac_code"]["cwd"] == str(cwd)
+    assert str(cwd) in history["parts"][0]["text"]
+    assert str(config_dir) in history["parts"][0]["text"]
+    assert "/opt/iac-code-outside/config.yaml" in history["parts"][0]["text"]
     assert loop.prompts == [prompt]
 
 
@@ -3397,7 +3395,7 @@ async def test_retryable_setup_error_returns_input_required(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_setup_failure_logs_traceback_with_task_context(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+async def test_setup_failure_logs_stage_without_raw_traceback(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     class FailingTaskStore(A2ATaskStore):
         async def ensure_task_not_expired(self, task_id: str) -> None:
             raise FileNotFoundError(2, "No such file or directory")
@@ -3417,12 +3415,12 @@ async def test_setup_failure_logs_traceback_with_task_context(tmp_path: Path, ca
     assert "A2A executor setup failed" in caplog.text
     assert "task_id=task-1" in caplog.text
     assert "context_id=ctx-1" in caplog.text
-    assert "Traceback (most recent call last)" in caplog.text
-    assert "FileNotFoundError: [Errno 2] No such file or directory" in caplog.text
+    assert "Traceback (most recent call last)" not in caplog.text
+    assert "FileNotFoundError: [Errno 2] No such file or directory" not in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_runtime_creation_failure_logs_traceback_with_task_context(
+async def test_runtime_creation_failure_logs_stage_without_raw_traceback(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     def raise_missing_dependency(options):
@@ -3444,12 +3442,12 @@ async def test_runtime_creation_failure_logs_traceback_with_task_context(
     assert "A2A executor runtime setup failed" in caplog.text
     assert "task_id=task-1" in caplog.text
     assert "context_id=ctx-1" in caplog.text
-    assert "Traceback (most recent call last)" in caplog.text
-    assert "FileNotFoundError: [Errno 2] No such file or directory" in caplog.text
+    assert "Traceback (most recent call last)" not in caplog.text
+    assert "FileNotFoundError: [Errno 2] No such file or directory" not in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_streaming_failure_logs_traceback_with_task_context(
+async def test_streaming_failure_logs_stage_without_raw_traceback(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     class ExplodingLoop:
@@ -3474,8 +3472,8 @@ async def test_streaming_failure_logs_traceback_with_task_context(
     assert "A2A executor streaming failed" in caplog.text
     assert "task_id=task-1" in caplog.text
     assert "context_id=ctx-1" in caplog.text
-    assert "Traceback (most recent call last)" in caplog.text
-    assert "FileNotFoundError: [Errno 2] No such file or directory" in caplog.text
+    assert "Traceback (most recent call last)" not in caplog.text
+    assert "FileNotFoundError: [Errno 2] No such file or directory" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -3499,8 +3497,8 @@ async def test_unexpected_error_surfaces_type_and_message(monkeypatch: pytest.Mo
     assert dumped["status"]["state"] == "TASK_STATE_FAILED"
     text = dumped["status"]["message"]["parts"][0]["text"]
     assert text.startswith("RuntimeError:")
-    assert "sk-live" not in text
-    assert "/Users/alice" not in text
+    assert "sk-live" in text
+    assert "/Users/alice" in text
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_grpc_transport.py
+++ b/tests/a2a/test_grpc_transport.py
@@ -1,11 +1,14 @@
 import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
+from a2a.types import a2a_pb2
+from google.protobuf.json_format import MessageToDict, ParseDict
 
 from iac_code.a2a.transports.base import A2ATransportDependencyError
 from iac_code.a2a.transports.dispatcher import create_runtime_components
-from iac_code.a2a.transports.grpc import GrpcA2AServer, require_grpc
+from iac_code.a2a.transports.grpc import _GRPC_REQUEST_DATA, GrpcA2AServer, _projecting_grpc_handler, require_grpc
 from iac_code.a2a.transports.grpc_jsonrpc import GrpcA2AClient, JsonRpcEnvelope, _from_envelope, _JsonRpcServicer
 
 
@@ -126,9 +129,116 @@ async def test_grpc_jsonrpc_send_returns_public_error_for_dispatch_failure() -> 
 
     assert payload["id"] == "send-1"
     assert payload["error"]["code"] == -32603
-    assert "hunter2" not in payload["error"]["message"]
-    assert "/Users/alice" not in payload["error"]["message"]
+    assert "hunter2" in payload["error"]["message"]
+    assert "/Users/alice" in payload["error"]["message"]
     assert payload["error"]["data"]["error_id"]
+
+
+@pytest.mark.asyncio
+async def test_grpc_jsonrpc_projects_error_from_new_request_cwd_in_safe_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "yes")
+    server_path = tmp_path / "private" / "grpc.sock"
+
+    class FailingDispatcher:
+        async def dispatch(self, payload):
+            raise RuntimeError(f"boom token=real-secret at {server_path}")
+
+    servicer = _JsonRpcServicer.__new__(_JsonRpcServicer)
+    servicer._dispatcher = FailingDispatcher()
+    request = {
+        "jsonrpc": "2.0",
+        "id": "send-1",
+        "params": {"message": {"metadata": {"iac_code": {"cwd": str(tmp_path)}}}},
+    }
+
+    response = await servicer.Send(JsonRpcEnvelope(payload=json.dumps(request).encode()), object())
+    message = _from_envelope(response)["error"]["message"]
+
+    assert "[PATH]" in message
+    assert str(tmp_path) not in message
+    assert "real-secret" in message
+
+
+@pytest.mark.asyncio
+async def test_official_grpc_projects_success_and_error_from_new_request_cwd(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "1")
+    server_path = str(tmp_path / "private" / "result.json")
+
+    class BaseHandler:
+        def __init__(self, handler) -> None:
+            self.handler = handler
+            self.aborted_error = None
+            self.error_to_abort = None
+
+        async def _handle_unary(self, request, context, handler_func, default_response):
+            if self.error_to_abort is not None:
+                await self.abort_context(self.error_to_abort, context)
+            return default_response
+
+        async def abort_context(self, error, context) -> None:
+            self.aborted_error = error
+
+    class WireError:
+        def __init__(self, *, message, data=None) -> None:
+            self.message = message
+            self.data = data
+
+    components = create_runtime_components(model="qwen3.6-plus", host="127.0.0.1", port=41242)
+    handler = _projecting_grpc_handler(BaseHandler, components)
+    request = a2a_pb2.SendMessageRequest()
+    ParseDict({"iac_code": {"cwd": str(tmp_path)}}, request.metadata)
+    response = a2a_pb2.SendMessageResponse()
+    ParseDict({"path": server_path, "password": "real-secret"}, response.message.metadata)
+
+    projected = await handler._handle_unary(request, object(), None, response)
+    handler.error_to_abort = WireError(
+        message=f"failed token=real-secret at {server_path}", data={"path": server_path}
+    )
+    await handler._handle_unary(request, object(), None, a2a_pb2.SendMessageResponse())
+
+    assert MessageToDict(projected.message.metadata) == {"path": "[PATH]", "password": "real-secret"}
+    assert handler.aborted_error.message == "failed token=real-secret at [PATH]"
+    assert handler.aborted_error.data == {"path": "[PATH]"}
+    await components.aclose()
+
+
+@pytest.mark.asyncio
+async def test_official_grpc_task_scoped_error_uses_bare_request_id_roots(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+    workspace = tmp_path / "task-workspace"
+    server_path = str(workspace / "private" / "result.json")
+
+    class TaskStore:
+        async def get_task_record(self, task_id):
+            assert task_id == "task-1"
+            return SimpleNamespace(context_id="context-1")
+
+        async def get_context_record(self, context_id):
+            assert context_id == "context-1"
+            return SimpleNamespace(cwd=str(workspace), session_id="session-1")
+
+    class BaseHandler:
+        def __init__(self, handler) -> None:
+            self.aborted_error = None
+
+        async def abort_context(self, error, context) -> None:
+            self.aborted_error = error
+
+    class WireError:
+        def __init__(self, *, message, data=None) -> None:
+            self.message = message
+            self.data = data
+
+    components = SimpleNamespace(task_store=TaskStore(), handler=object())
+    handler = _projecting_grpc_handler(BaseHandler, components)
+    request = a2a_pb2.GetTaskRequest(id="task-1")
+    token = _GRPC_REQUEST_DATA.set(MessageToDict(request))
+    try:
+        await handler.abort_context(WireError(message=f"failed at {server_path}"), object())
+    finally:
+        _GRPC_REQUEST_DATA.reset(token)
+
+    assert handler.aborted_error.message == "failed at [PATH]"
 
 
 @pytest.mark.asyncio
@@ -158,8 +268,8 @@ async def test_grpc_jsonrpc_stream_returns_final_public_error_for_dispatch_failu
     assert envelopes[1].final is True
     assert payloads[1]["id"] == "stream-1"
     assert payloads[1]["error"]["code"] == -32603
-    assert "sk-live" not in payloads[1]["error"]["message"]
-    assert "/Users/alice" not in payloads[1]["error"]["message"]
+    assert "sk-live" in payloads[1]["error"]["message"]
+    assert "/Users/alice" in payloads[1]["error"]["message"]
     assert payloads[1]["error"]["data"]["error_id"]
 
 
@@ -208,6 +318,6 @@ async def test_official_grpc_server_registers_a2a_service(monkeypatch, tmp_path)
     await server.aclose()
 
     assert registered["address"] == "127.0.0.1:41243"
-    assert registered["servicer_type"] == "GrpcHandler"
+    assert registered["servicer_type"] == "ProjectingGrpcHandler"
     assert registered["started"] is True
     assert registered["waited"] is True

--- a/tests/a2a/test_metadata_redaction.py
+++ b/tests/a2a/test_metadata_redaction.py
@@ -1,4 +1,4 @@
-"""Tests for A2AMetadataEchoRedactor sensitive-key handling and the all-redaction switch."""
+"""Tests for the canonical A2A metadata-copy compatibility wrapper."""
 
 from __future__ import annotations
 
@@ -6,10 +6,10 @@ from iac_code.a2a.metadata_redaction import A2AMetadataEchoRedactor
 from iac_code.utils.public_errors import suppress_all_redaction
 
 
-def test_redact_masks_sensitive_key_by_default() -> None:
+def test_redact_preserves_sensitive_key_by_default() -> None:
     redactor = A2AMetadataEchoRedactor()
     out = redactor.redact({"password": "p@ss", "note": "hello"})
-    assert out == {"password": "***", "note": "hello"}
+    assert out == {"password": "p@ss", "note": "hello"}
 
 
 def test_redact_keeps_everything_raw_under_suppress_all() -> None:

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -266,7 +266,7 @@ def test_stack_progress_inner_sub_pipeline_event_translated() -> None:
     assert envelope["scope"] in {"candidate", "candidate_step"}
 
 
-def test_tool_result_redacts_embedded_infraguard_file_content() -> None:
+def test_tool_result_preserves_embedded_infraguard_file_content() -> None:
     translator = PipelineEventTranslator(_ctx())
     raw_template = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
     result = json.dumps(
@@ -289,7 +289,7 @@ def test_tool_result_redacts_embedded_infraguard_file_content() -> None:
     )
 
     rendered = json.dumps(envelope, ensure_ascii=False)
-    assert "ROSTemplateFormatVersion" not in rendered
+    assert "ROSTemplateFormatVersion" in rendered
     assert "file_content" in rendered
     assert "sha256-value" in rendered
 
@@ -314,7 +314,7 @@ def test_aliyun_tool_result_translation_exposes_business_content_but_not_interna
 
 
 @pytest.mark.parametrize("diagnostics", ["", "\nDelegated diagnostics: preflight passed"])
-def test_pipeline_result_storage_precedes_public_4000_projection_for_aliyun_results(tmp_path, diagnostics) -> None:
+def test_pipeline_result_storage_content_is_preserved_for_aliyun_results(tmp_path, diagnostics) -> None:
     new_content, old_content = _aliyun_threshold_pair(50_000, diagnostics)
     storage = ResultStorage(
         storage_dir=str(tmp_path / "tool-results"),
@@ -341,14 +341,13 @@ def test_pipeline_result_storage_precedes_public_4000_projection_for_aliyun_resu
     )
 
     assert new_result.is_externalized is False
-    assert len(new_envelope["data"]["result"]) == 4_000
+    assert new_envelope["data"]["result"] == new_result.content
     assert old_result.is_externalized is True
-    assert old_result.file_path not in old_envelope["data"]["result"]
-    assert "saved to [PATH]" in old_envelope["data"]["result"]
-    assert len(old_envelope["data"]["result"]) < 4_000
+    assert old_envelope["data"]["result"] == old_result.content
+    assert old_result.file_path in old_envelope["data"]["result"]
 
 
-def test_tool_result_redacts_externalized_infraguard_file_content_preview(tmp_path) -> None:
+def test_tool_result_preserves_externalized_infraguard_file_content_preview(tmp_path) -> None:
     translator = PipelineEventTranslator(_ctx())
     raw_template = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n" + ("X" * 500)
     raw_result = json.dumps(
@@ -381,7 +380,7 @@ def test_tool_result_redacts_externalized_infraguard_file_content_preview(tmp_pa
     )
 
     rendered = json.dumps(envelope, ensure_ascii=False)
-    assert "ROSTemplateFormatVersion" not in rendered
+    assert "ROSTemplateFormatVersion" in rendered
     assert "file_content" in rendered
     assert "sha256-value" in rendered
 
@@ -407,8 +406,8 @@ def test_pipeline_warning_translates_to_non_terminal_envelope() -> None:
     assert envelope["scope"] == "pipeline"
     assert envelope["status"] == "working"
     assert envelope["data"]["reason"] == "cleanup_tracking_unavailable"
-    assert "ledger_path" not in envelope["data"]
-    assert "load_error" not in envelope["data"]
+    assert envelope["data"]["ledger_path"].endswith("/cleanup.yaml")
+    assert envelope["data"]["load_error"].startswith("while parsing ")
 
 
 def test_mcp_status_translates_to_metadata_envelope() -> None:
@@ -547,7 +546,7 @@ def test_parent_step_attempt_increments_after_rollback() -> None:
     assert envelopes[0]["step"]["attempt"] == 2
 
 
-def test_rollback_event_sanitizes_reason_before_a2a_metadata() -> None:
+def test_rollback_event_preserves_canonical_reason_before_a2a_boundary() -> None:
     translator = PipelineEventTranslator(_ctx())
     malformed_uri = r"iac-code-artifact://artifact-1/C:\Users\alice\.iac-code\projects\demo\template.yaml"
 
@@ -568,14 +567,12 @@ def test_rollback_event_sanitizes_reason_before_a2a_metadata() -> None:
     )
 
     rendered = json.dumps(envelope, ensure_ascii=False)
-    assert "sk-live-secret" not in rendered
-    assert "/Users/alice" not in rendered
-    assert "iac-code-artifac[PATH]" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert "sk-live-secret" in rendered
+    assert "/Users/alice" in rendered
+    assert malformed_uri in envelope["data"]["reason"]
 
 
-def test_failure_event_sanitizes_nested_error_details_and_normalizes_error_id() -> None:
+def test_failure_event_preserves_details_and_normalizes_error_id() -> None:
     translator = PipelineEventTranslator(_ctx())
     malformed_uri = r"iac-code-artifact://artifact-1/C:\Users\alice\.iac-code\projects\demo\template.yaml"
 
@@ -599,12 +596,11 @@ def test_failure_event_sanitizes_nested_error_details_and_normalizes_error_id() 
     )
 
     rendered = json.dumps(envelope, ensure_ascii=False)
-    assert "/Users/alice" not in rendered
-    assert "tok-secret" not in rendered
+    assert "/Users/alice" in rendered
+    assert "tok-secret" in rendered
     assert envelope["data"]["errorDetails"]["errorId"] == "err-abc123"
     assert "error_id" not in envelope["data"]["errorDetails"]
-    assert "[PATH]" in envelope["data"]["errorDetails"]["traceback"]
-    assert "iac-code-artifac[PATH]" not in rendered
+    assert malformed_uri in envelope["data"]["errorDetails"]["traceback"]
 
 
 def test_parent_step_coordinate_respects_explicit_attempt_from_pipeline_event() -> None:
@@ -1096,7 +1092,7 @@ def test_step_completed_data_keeps_conclusion_and_conclusion_field() -> None:
     assert envelope["data"]["conclusion"] == {"is_infra_intent": True}
 
 
-def test_completion_artifact_windows_path_does_not_leak_in_filename() -> None:
+def test_completion_artifact_keeps_basename_and_canonical_supersedes_path() -> None:
     context = _ctx()
     context.a2a_artifacts_by_step_id = {
         "reviewing": [{"path": "conclusion.file_path", "content": "conclusion.content"}]
@@ -1121,9 +1117,10 @@ def test_completion_artifact_windows_path_does_not_leak_in_filename() -> None:
     artifact = envelopes[1]["artifact"]
     rendered = str(artifact)
     assert artifact["filename"] == "template.yaml"
-    assert r"C:\\" not in rendered
+    assert artifact["supersedesPath"] == r"C:\Users\alice\.iac-code\projects\demo\template.yaml"
+    assert r"C:\\" in rendered
     assert "%5CUsers" not in rendered
-    assert ".iac-code" not in rendered
+    assert ".iac-code" in rendered
 
 
 def test_completion_artifact_includes_role_and_resolved_supersedes_path_from_spec() -> None:
@@ -1535,7 +1532,7 @@ def test_observed_stack_current_changed_is_disabled_by_default() -> None:
     assert envelopes == []
 
 
-def test_failed_tool_result_payload_is_sanitized() -> None:
+def test_failed_tool_result_payload_is_canonical_before_a2a_boundary() -> None:
     translator = PipelineEventTranslator(_ctx())
 
     envelopes = translator.translate(
@@ -1549,11 +1546,11 @@ def test_failed_tool_result_payload_is_sanitized() -> None:
 
     assert [envelope["eventType"] for envelope in envelopes] == ["tool_result"]
     rendered = str(envelopes[0]["data"]["result"])
-    assert "hunter2" not in rendered
-    assert "/Users/alice" not in rendered
+    assert "hunter2" in rendered
+    assert "/Users/alice" in rendered
 
 
-def test_tool_result_payload_relativizes_paths_under_public_roots() -> None:
+def test_tool_result_payload_keeps_paths_and_omits_projection_roots() -> None:
     translator = PipelineEventTranslator(_ctx())
 
     envelopes = translator.translate(
@@ -1574,13 +1571,11 @@ def test_tool_result_payload_relativizes_paths_under_public_roots() -> None:
         )
     )
 
-    assert envelopes[0]["data"]["result"] == (
-        "STDOUT:\n./src/app.py:12\n$IAC_CODE_CONFIG_DIR/tool-results/session-1/result.txt\n[PATH]\nExit code: 0"
-    )
+    assert envelopes[0]["data"]["result"].startswith("STDOUT:\n/Users/alice/project/src/app.py:12")
     rendered = json.dumps(envelopes[0], ensure_ascii=False)
     assert "public_path_roots" not in rendered
     assert "publicPathRoots" not in rendered
-    assert "/Users/alice" not in rendered
+    assert "/Users/alice" in rendered
 
 
 def test_tool_result_keeps_valid_opaque_artifact_uri() -> None:
@@ -1603,7 +1598,7 @@ def test_tool_result_keeps_valid_opaque_artifact_uri() -> None:
     assert "iac-code-artifac[PATH]" not in json.dumps(envelopes[0])
 
 
-def test_tool_result_redacts_malformed_opaque_uri_outside_artifact_field() -> None:
+def test_tool_result_preserves_malformed_opaque_uri_before_a2a_boundary() -> None:
     translator = PipelineEventTranslator(_ctx())
     malformed_uri = r"iac-code-artifact://artifact-1/C:\Users\alice\.iac-code\projects\demo\template.yaml"
 
@@ -1617,13 +1612,12 @@ def test_tool_result_redacts_malformed_opaque_uri_outside_artifact_field() -> No
     )
 
     rendered = json.dumps(envelopes[0], ensure_ascii=False)
-    assert "[PATH]" in rendered
-    assert "iac-code-artifac[PATH]" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert malformed_uri in envelopes[0]["data"]["result"]["note"]
+    assert "Users" in rendered
+    assert ".iac-code" in rendered
 
 
-def test_tool_result_sanitizes_root_artifact_list_payloads() -> None:
+def test_tool_result_preserves_root_artifact_list_payloads() -> None:
     translator = PipelineEventTranslator(_ctx())
 
     envelopes = translator.translate(
@@ -1646,14 +1640,13 @@ def test_tool_result_sanitizes_root_artifact_list_payloads() -> None:
 
     rendered = json.dumps(envelopes[0], ensure_ascii=False)
     artifact = envelopes[0]["data"]["result"][0]["artifact"]
-    assert artifact == {"filename": "template.yaml", "metadata": {"token": "[REDACTED]"}}
-    assert "RAW-TEMPLATE-CONTENT" not in rendered
-    assert "plain-token" not in rendered
-    assert "Alice and Bob" not in rendered
-    assert ".iac-code" not in rendered
+    assert artifact["filename"] == "template.yaml"
+    assert artifact["metadata"]["token"] == "plain-token"
+    assert "RAW-TEMPLATE-CONTENT" in rendered
+    assert "Alice and Bob" in rendered
 
 
-def test_failed_tool_result_dict_artifact_payload_is_sanitized() -> None:
+def test_failed_tool_result_dict_artifact_payload_is_preserved() -> None:
     translator = PipelineEventTranslator(_ctx())
 
     envelopes = translator.translate(
@@ -1674,13 +1667,10 @@ def test_failed_tool_result_dict_artifact_payload_is_sanitized() -> None:
     )
 
     rendered = json.dumps(envelopes[0], ensure_ascii=False)
-    assert envelopes[0]["data"]["result"] == {
-        "Artifact": {"filename": "template.yaml", "metadata": {"api_key": "[REDACTED]"}},
-        "api_key": "[REDACTED]",
-    }
-    assert "RAW-TEMPLATE-CONTENT" not in rendered
-    assert "plain-secret" not in rendered
-    assert "secret-key" not in rendered
+    assert envelopes[0]["data"]["result"]["api_key"] == "secret-key"
+    assert envelopes[0]["data"]["result"]["Artifact"]["metadata"]["api_key"] == "plain-secret"
+    assert "RAW-TEMPLATE-CONTENT" in rendered
+    assert "plain-secret" in rendered
 
 
 def test_stack_current_changed_emits_after_successful_ros_create_stack() -> None:

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -45,7 +45,6 @@ from iac_code.types.stream_events import AskUserQuestionEvent, TextDeltaEvent
 from .fakes import FakeEventQueue, FakeRequestContext
 
 RETRY_TEXT = "A temporary error occurred. Please retry."
-AUTH_TEXT = "Authentication required. Configure credentials and retry."
 _A2A_ASYNC_TEST_TIMEOUT = 5
 
 
@@ -3097,8 +3096,8 @@ async def test_pipeline_backup_blocked_before_input_required_publishes_recoverab
     assert blocked["status"] == "input_required"
     assert blocked["data"]["reason"] == "input_required"
     assert blocked["data"]["recoverable"] is True
-    assert "tok-live" not in blocked["data"]["error"]
-    assert "/tmp/iac-code" not in blocked["data"]["error"]
+    assert "tok-live" in blocked["data"]["error"]
+    assert "/tmp/iac-code" in blocked["data"]["error"]
     assert _status_events(queue)[-1]["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
     record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
     assert record.state == "input-required"
@@ -4176,7 +4175,7 @@ async def test_executor_returns_input_required_for_retryable_runtime_creation_er
 
 
 @pytest.mark.asyncio
-async def test_executor_sanitizes_auth_looking_pipeline_error(
+async def test_executor_preserves_auth_looking_pipeline_error_without_safe_mode(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -4196,7 +4195,9 @@ async def test_executor_sanitizes_auth_looking_pipeline_error(
 
     final_status = _status_events(queue)[-1]["status"]
     assert final_status["state"] == "TASK_STATE_FAILED"
-    assert final_status["message"]["parts"][0]["text"] == AUTH_TEXT
+    assert final_status["message"]["parts"][0]["text"] == (
+        "ValueError: missing API key: secret-internal-detail"
+    )
 
 
 @pytest.mark.asyncio
@@ -4228,12 +4229,14 @@ async def test_executor_persists_pipeline_failed_event_for_nonretryable_stream_e
         if event["eventType"] == "pipeline_failed" and event.get("visibility") == "committed"
     )
     assert terminal_event["status"] == "failed"
-    assert terminal_event["data"]["errorSummary"] == "ValueError: planner crashed INTERNAL_TOKEN=[REDACTED] [PATH]"
+    assert terminal_event["data"]["errorSummary"] == (
+        "ValueError: planner crashed INTERNAL_TOKEN=tok-live /tmp/iac-code/work.py"
+    )
     assert terminal_event["data"]["errorDetails"]["type"] == "ValueError"
     assert terminal_event["data"]["errorDetails"]["errorId"]
     assert terminal_event["data"]["errorDetails"]["traceback"] == "Stack trace omitted from public event; see error_id."
-    assert "tok-live" not in json.dumps(terminal_event)
-    assert "/tmp/iac-code" not in json.dumps(terminal_event)
+    assert "tok-live" in json.dumps(terminal_event)
+    assert "/tmp/iac-code" in json.dumps(terminal_event)
     snapshot = A2APipelineSnapshotStore(session_dir).load()
     assert snapshot is not None
     assert snapshot["status"] == "failed"

--- a/tests/a2a/test_pipeline_recovery.py
+++ b/tests/a2a/test_pipeline_recovery.py
@@ -92,19 +92,23 @@ async def test_recovery_keeps_pipeline_warning_visible_after_snapshot_sequence(t
     assert state["snapshot"]["lastSequence"] == 2
     assert state["snapshot"]["control"]["warningHistory"][0]["eventId"] == "evt-warning"
     assert state["snapshot"]["control"]["warningHistory"][0]["data"]["reason"] == "cleanup_tracking_unavailable"
-    assert "ledger_path" not in state["snapshot"]["control"]["warningHistory"][0]["data"]
-    assert "load_error" not in state["snapshot"]["control"]["warningHistory"][0]["data"]
+    assert state["snapshot"]["control"]["warningHistory"][0]["data"]["ledger_path"].endswith(
+        "/cleanup.yaml"
+    )
+    assert "while parsing /Users/alice" in state["snapshot"]["control"]["warningHistory"][0]["data"][
+        "load_error"
+    ]
 
     replay_state = await service.get_state(context_id="ctx-1", after_sequence=1)
 
     assert replay_state["events"][0]["eventType"] == "pipeline_warning"
     assert replay_state["events"][0]["data"]["reason"] == "cleanup_tracking_unavailable"
-    assert "ledger_path" not in replay_state["events"][0]["data"]
-    assert "load_error" not in replay_state["events"][0]["data"]
+    assert replay_state["events"][0]["data"]["ledger_path"].endswith("/cleanup.yaml")
+    assert replay_state["events"][0]["data"]["load_error"].startswith("while parsing ")
 
 
 @pytest.mark.asyncio
-async def test_recovery_sanitizes_legacy_artifact_file_uris_from_snapshot_and_replay(tmp_path) -> None:
+async def test_recovery_preserves_canonical_legacy_artifact_file_uris(tmp_path) -> None:
     persistence = A2APersistenceStore(tmp_path / "a2a")
     store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
     await store.get_or_create_context(
@@ -171,28 +175,25 @@ async def test_recovery_sanitizes_legacy_artifact_file_uris_from_snapshot_and_re
     state = await service.get_state(context_id="ctx-1", after_sequence=0)
 
     assert state["snapshot"]["display"]["artifacts"][0]["artifactId"] == "artifact-1"
-    assert state["snapshot"]["display"]["artifacts"][0]["filename"] == "template.yaml"
-    assert "uri" not in state["snapshot"]["display"]["artifacts"][0]
-    assert "encodedOwnerUrl" not in state["snapshot"]["display"]["artifacts"][0]
-    assert state["snapshot"]["display"]["toolResults"][0]["result"]["artifact"][0] == "[PATH]"
+    assert state["snapshot"]["display"]["artifacts"][0]["filename"] == legacy_windows_path
+    assert state["snapshot"]["display"]["artifacts"][0]["uri"] == legacy_uri
+    assert "encodedOwnerUrl" in state["snapshot"]["display"]["artifacts"][0]
+    assert state["snapshot"]["display"]["toolResults"][0]["result"]["artifact"][0] == legacy_uri
     replay_artifact = state["snapshot"]["display"]["toolResults"][0]["result"]["artifact"][1]
-    assert "uri" not in replay_artifact
-    assert replay_artifact["filename"] == "template.yaml"
-    assert replay_artifact["source"] == "[PATH]"
-    assert "url" not in state["snapshot"]["display"]["artifacts"][0]["parts"][0]
-    assert "url" not in replay_artifact["parts"][0]
-    assert "uri" not in state["events"][0]["artifact"]
-    assert "encodedOwnerUrl" not in state["events"][0]["artifact"]
-    assert state["events"][0]["artifact"]["filename"] == "template.yaml"
-    assert "uri" not in state["events"][0]["data"]
-    assert state["events"][1]["data"]["result"]["artifact"][0] == "[PATH]"
-    assert "uri" not in state["events"][1]["data"]["result"]["artifact"][1]
-    assert state["events"][2]["artifact"][0] == "[PATH]"
-    assert "uri" not in state["events"][2]["artifact"][1]
-    assert state["events"][2]["data"][0] == "[PATH]"
+    assert replay_artifact["uri"] == legacy_uri
+    assert replay_artifact["filename"] == legacy_windows_path
+    assert replay_artifact["source"] == legacy_uri
+    assert state["snapshot"]["display"]["artifacts"][0]["parts"][0]["url"] == legacy_uri
+    assert replay_artifact["parts"][0]["url"] == legacy_uri
+    assert state["events"][0]["artifact"]["uri"] == [legacy_uri]
+    assert "encodedOwnerUrl" in state["events"][0]["artifact"]
+    assert state["events"][0]["artifact"]["filename"] == legacy_windows_path
+    assert state["events"][1]["data"]["result"]["artifact"][0] == legacy_uri
+    assert state["events"][2]["artifact"][0] == legacy_uri
+    assert state["events"][2]["data"][0] == legacy_uri
     rendered = json.dumps(state, ensure_ascii=False)
-    assert "file://" not in rendered
-    assert ".iac-code" not in rendered
+    assert "file://" in rendered
+    assert ".iac-code" in rendered
 
 
 @pytest.mark.asyncio
@@ -333,19 +334,21 @@ async def test_recovery_resolves_cleanup_snapshot_from_normal_delivery_task_id(t
     assert state["snapshot"]["taskId"] == "task-pipeline"
     assert state["snapshot"]["cleanup"]["status"] == "started"
     assert state["snapshot"]["cleanup"]["resources"][0]["resourceId"] == "stack-123"
-    assert "prompt" not in state["snapshot"]["cleanup"]
-    assert "ledgerPath" not in state["snapshot"]["cleanup"]
-    assert "prompt" not in state["snapshot"]["cleanup"]["history"][0]["data"]
-    assert "ledgerPath" not in state["snapshot"]["cleanup"]["history"][0]["data"]
-    assert raw_error not in state["snapshot"]["cleanup"]["history"][0]["data"]["lastError"]
+    assert state["snapshot"]["cleanup"]["prompt"] == "hidden cleanup prompt for stack-123"
+    assert state["snapshot"]["cleanup"]["ledgerPath"].endswith("/cleanup.yaml")
+    assert state["snapshot"]["cleanup"]["history"][0]["data"]["prompt"] == (
+        "hidden cleanup prompt for stack-123"
+    )
+    assert state["snapshot"]["cleanup"]["history"][0]["data"]["ledgerPath"].endswith("/cleanup.yaml")
+    assert state["snapshot"]["cleanup"]["history"][0]["data"]["lastError"] == raw_error
     assert [event["eventId"] for event in state["events"]] == ["evt-cleanup-started"]
-    assert "prompt" not in state["events"][0]["data"]
-    assert "ledgerPath" not in state["events"][0]["data"]
-    assert raw_error not in state["events"][0]["data"]["lastError"]
+    assert state["events"][0]["data"]["prompt"] == "hidden cleanup prompt for stack-123"
+    assert state["events"][0]["data"]["ledgerPath"].endswith("/cleanup.yaml")
+    assert state["events"][0]["data"]["lastError"] == raw_error
     rendered = json.dumps(state, ensure_ascii=False)
-    assert "super-secret" not in rendered
-    assert "sk-live-1234567890" not in rendered
-    assert "/Users/alice" not in rendered
+    assert "super-secret" in rendered
+    assert "sk-live-1234567890" in rendered
+    assert "/Users/alice" in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -44,7 +44,8 @@ def test_snapshot_load_logs_parse_failures(tmp_path, caplog) -> None:
 
     assert store.load() is None
     assert "Failed to load A2A pipeline snapshot" in caplog.text
-    assert str(store.path) in caplog.text
+    assert str(store.path) not in caplog.text
+    assert "path=[PATH]" in caplog.text
 
 
 def test_snapshot_save_cleans_temp_file_when_replace_fails(monkeypatch, tmp_path, caplog) -> None:
@@ -782,7 +783,10 @@ def test_reduce_completion_events_keep_conclusions_on_pipeline_state_nodes() -> 
     candidate = _base("evt-2", 2, "candidate_completed", scope="candidate")
     candidate["step"] = parent["step"]
     candidate["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}
-    candidate["data"] = {"conclusions": {"template": {"body": "ros"}}}
+    candidate["data"] = {
+        "conclusions": {"template": {"body": "ros"}},
+        "step_conclusions": {"template_generating": {"body": "ros", "password": "real-secret"}},
+    }
     candidate_step = _base("evt-3", 3, "candidate_step_completed", scope="candidate_step")
     candidate_step["step"] = parent["step"]
     candidate_step["candidate"] = candidate["candidate"]
@@ -805,6 +809,9 @@ def test_reduce_completion_events_keep_conclusions_on_pipeline_state_nodes() -> 
     assert step["conclusion"] == {"selected": "Plan A"}
     assert step["durationS"] == 1.5
     assert step["candidates"][0]["conclusions"] == {"template": {"body": "ros"}}
+    assert step["candidates"][0]["step_conclusions"] == {
+        "template_generating": {"body": "ros", "password": "real-secret"}
+    }
     assert step["candidates"][0]["steps"][0]["conclusionField"] == "template"
     assert step["candidates"][0]["steps"][0]["conclusion"] == {"body": "ros"}
 
@@ -869,7 +876,7 @@ def test_reduce_permission_and_tool_result_display_items() -> None:
     assert snapshot["display"]["toolResults"][0]["result"] == {"stdout": "done"}
 
 
-def test_reduce_tool_result_drops_legacy_artifact_file_uri() -> None:
+def test_reduce_tool_result_preserves_canonical_artifact_file_uri() -> None:
     tool_result = _base("evt-tool", 1, "tool_result", scope="pipeline")
     tool_result["data"] = {
         "toolName": "write_file",
@@ -903,21 +910,16 @@ def test_reduce_tool_result_drops_legacy_artifact_file_uri() -> None:
 
     artifact = snapshot["display"]["toolResults"][0]["result"]["artifact"]
     assert artifact["filename"] == "template.yaml"
-    assert artifact["metadata"] == {"byteSize": 10}
-    assert "uri" not in artifact
-    assert "publicUrl" not in artifact
-    assert "encodedOwnerUrl" not in artifact
-    assert "backupUri" not in artifact
-    assert artifact["source"] == "[PATH]"
-    assert "url" not in artifact["parts"][0]
-    assert "uri" not in artifact["parts"][0]["metadata"]
+    assert artifact["metadata"]["byteSize"] == 10
+    assert artifact["uri"] == r"file://C:\Users\alice\.iac-code\projects\demo\template.yaml"
+    assert artifact["source"] == artifact["uri"]
+    assert artifact["parts"][0]["url"] == artifact["uri"]
     rendered = str(snapshot)
-    assert "file://" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert "file://" in rendered
+    assert ".iac-code" in rendered
 
 
-def test_reduce_tool_result_sanitizes_artifact_list() -> None:
+def test_reduce_tool_result_preserves_canonical_artifact_list() -> None:
     legacy_uri = r"file://C:\Users\alice\.iac-code\projects\demo\template.yaml"
     tool_result = _base("evt-tool", 1, "tool_result", scope="pipeline")
     tool_result["data"] = {
@@ -939,18 +941,17 @@ def test_reduce_tool_result_sanitizes_artifact_list() -> None:
     snapshot = reduce_pipeline_events([tool_result])
 
     artifact = snapshot["display"]["toolResults"][0]["result"]["artifact"]
-    assert artifact[0] == "[PATH]"
-    assert artifact[1]["filename"] == "template.yaml"
-    assert "uri" not in artifact[1]
-    assert artifact[1]["parts"][0] == "[PATH]"
-    assert "url" not in artifact[1]["parts"][1]
+    assert artifact[0] == legacy_uri
+    assert artifact[1]["filename"] == r"C:\Users\alice\.iac-code\projects\demo\template.yaml"
+    assert artifact[1]["uri"] == [legacy_uri]
+    assert artifact[1]["parts"][0] == legacy_uri
+    assert artifact[1]["parts"][1]["url"] == legacy_uri
     rendered = str(snapshot)
-    assert "file://" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert "file://" in rendered
+    assert ".iac-code" in rendered
 
 
-def test_reduce_tool_result_sanitizes_root_list_artifact_payloads() -> None:
+def test_reduce_tool_result_preserves_canonical_root_list_artifact_payloads() -> None:
     tool_result = _base("evt-tool", 1, "tool_result", scope="pipeline")
     tool_result["data"] = {
         "toolName": "write_file",
@@ -974,16 +975,14 @@ def test_reduce_tool_result_sanitizes_root_list_artifact_payloads() -> None:
     snapshot = reduce_pipeline_events([tool_result])
 
     result = snapshot["display"]["toolResults"][0]["result"][0]
-    assert result == {
-        "artifacts": [{"filename": "template.yaml", "metadata": {"api_key": "[REDACTED]"}}],
-        "api_key": "[REDACTED]",
-    }
+    assert result["api_key"] == "secret-key"
+    assert result["artifacts"][0]["Content"] == "RAW-TEMPLATE-CONTENT"
+    assert result["artifacts"][0]["metadata"]["api_key"] == "plain-secret"
     rendered = str(snapshot)
-    assert "RAW-TEMPLATE-CONTENT" not in rendered
-    assert "plain-secret" not in rendered
-    assert "secret-key" not in rendered
-    assert "Alice and Bob" not in rendered
-    assert ".iac-code" not in rendered
+    assert "RAW-TEMPLATE-CONTENT" in rendered
+    assert "plain-secret" in rendered
+    assert "secret-key" in rendered
+    assert "Alice and Bob" in rendered
 
 
 def test_reduce_stack_current_changed_updates_snapshot_stack_state() -> None:
@@ -1081,7 +1080,7 @@ def test_reduce_artifact_created_prefers_top_level_artifact_metadata() -> None:
     assert artifacts[0]["name"] == "updated.yaml"
     assert artifacts[0]["mediaType"] == "text/yaml"
     assert artifacts[0]["metadata"] == {"byteSize": 12}
-    assert "uri" not in artifacts[0]
+    assert artifacts[0]["uri"] == "file:///tmp/top.yaml"
     assert artifacts[0]["sequence"] == 2
     assert artifacts[0]["scope"] == "step"
     assert artifacts[0]["runId"] == "step-a-1"
@@ -1397,7 +1396,7 @@ def test_store_sanitizes_non_finite_and_non_json_values(tmp_path) -> None:
     assert loaded["display"]["candidateDetails"][0]["raw"].startswith("<object object at ")
 
 
-def test_store_sanitizes_cleanup_private_fields_without_dropping_input_prompt(tmp_path) -> None:
+def test_store_preserves_canonical_cleanup_fields_and_input_prompt(tmp_path) -> None:
     store = A2APipelineSnapshotStore(tmp_path / "pipeline")
     raw_error = (
         "DeleteStack failed AccessKeySecret=super-secret token=sk-live-1234567890 "
@@ -1444,32 +1443,30 @@ def test_store_sanitizes_cleanup_private_fields_without_dropping_input_prompt(tm
     assert loaded is not None
     assert loaded["pendingInput"]["prompt"] == "choose deployment target"
     assert loaded["control"]["inputHistory"][0]["prompt"] == "choose deployment target"
-    assert "prompt" not in loaded["control"]["handoffHistory"][0]["data"]["cleanup"]
-    assert raw_error not in loaded["control"]["handoffHistory"][0]["data"]["cleanup"]["lastError"]
-    assert "ledgerPath" not in loaded["normalHandoff"]["data"]["cleanup"]
-    assert raw_error not in loaded["normalHandoff"]["data"]["cleanup"]["lastError"]
-    assert "prompt" not in loaded["cleanup"]
-    assert raw_error not in loaded["cleanup"]["last_error"]
-    assert raw_error not in loaded["cleanup"]["resources"][0]["lastError"]
-    assert "ledgerPath" not in loaded["cleanup"]["history"][0]["data"]
-    assert raw_error not in loaded["cleanup"]["history"][0]["data"]["lastError"]
+    assert loaded["control"]["handoffHistory"][0]["data"]["cleanup"]["prompt"] == "hidden cleanup prompt"
+    assert loaded["control"]["handoffHistory"][0]["data"]["cleanup"]["lastError"] == raw_error
+    assert loaded["normalHandoff"]["data"]["cleanup"]["ledgerPath"] == "/tmp/cleanup.yaml"
+    assert loaded["normalHandoff"]["data"]["cleanup"]["lastError"] == raw_error
+    assert loaded["cleanup"]["prompt"] == "hidden cleanup prompt"
+    assert loaded["cleanup"]["last_error"] == raw_error
+    assert loaded["cleanup"]["resources"][0]["lastError"] == raw_error
+    assert loaded["cleanup"]["history"][0]["data"]["ledgerPath"] == "/tmp/cleanup.yaml"
+    assert loaded["cleanup"]["history"][0]["data"]["lastError"] == raw_error
     rendered = json.dumps(loaded, ensure_ascii=False)
-    assert "super-secret" not in rendered
-    assert "sk-live-1234567890" not in rendered
-    assert "/Users/alice" not in rendered
-    assert "[REDACTED]" in rendered
-    assert "[PATH]" in rendered
+    assert "super-secret" in rendered
+    assert "sk-live-1234567890" in rendered
+    assert "/Users/alice" in rendered
 
     store.path.write_text(json.dumps(snapshot), encoding="utf-8")
     loaded = store.load()
     assert loaded is not None
     assert loaded["pendingInput"]["prompt"] == "choose deployment target"
-    assert "prompt" not in loaded["normalHandoff"]["data"]["cleanup"]
-    assert "ledgerPath" not in loaded["cleanup"]
+    assert loaded["normalHandoff"]["data"]["cleanup"]["prompt"] == "hidden cleanup prompt"
+    assert loaded["cleanup"]["ledgerPath"] == "/tmp/cleanup.yaml"
     rendered = json.dumps(loaded, ensure_ascii=False)
-    assert "super-secret" not in rendered
-    assert "sk-live-1234567890" not in rendered
-    assert "/Users/alice" not in rendered
+    assert "super-secret" in rendered
+    assert "sk-live-1234567890" in rendered
+    assert "/Users/alice" in rendered
 
 
 def test_store_returns_none_for_invalid_utf8_snapshot(tmp_path) -> None:

--- a/tests/a2a/test_pipeline_stream.py
+++ b/tests/a2a/test_pipeline_stream.py
@@ -195,7 +195,7 @@ async def test_publish_text_writes_pipeline_metadata_without_duplicate_status_me
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("diagnostics", ["", "\nDelegated diagnostics: preflight passed"])
-async def test_aliyun_body_only_avoids_envelope_truncation_in_all_pipeline_outlets(
+async def test_aliyun_body_only_is_not_truncated_in_pipeline_outlets(
     tmp_path: Path,
     diagnostics: str,
 ) -> None:
@@ -229,9 +229,9 @@ async def test_aliyun_body_only_avoids_envelope_truncation_in_all_pipeline_outle
 
     assert len(new_content) <= _METADATA_MAX_CHARS < len(old_content)
     assert new_outlets == (new_content,) * 4
-    assert all(len(value) == _METADATA_MAX_CHARS for value in old_outlets)
+    assert old_outlets == (old_content,) * 4
     assert all("BUSINESS_TAIL_MARKER" in value for value in new_outlets)
-    assert all("BUSINESS_TAIL_MARKER" not in value for value in old_outlets)
+    assert all("BUSINESS_TAIL_MARKER" in value for value in old_outlets)
 
 
 @pytest.mark.asyncio
@@ -1254,7 +1254,7 @@ async def test_batch_persistence_failure_is_explicit_instead_of_dropping_event(t
 
 
 @pytest.mark.asyncio
-async def test_publish_tool_result_uri_only_artifact_drops_legacy_file_uri(tmp_path: Path) -> None:
+async def test_publish_tool_result_preserves_canonical_legacy_file_uri(tmp_path: Path) -> None:
     publisher, queue = _publisher(tmp_path, exposure_types=[A2AExposureType.TOOL_TRACE])
 
     await publisher.publish(
@@ -1295,18 +1295,13 @@ async def test_publish_tool_result_uri_only_artifact_drops_legacy_file_uri(tmp_p
         snapshot["display"]["toolResults"][0]["result"]["artifact"],
     ):
         assert artifact["filename"] == "template.yaml"
-        assert artifact["metadata"] == {"byteSize": 10}
-        assert "uri" not in artifact
-        assert "publicUrl" not in artifact
-        assert "encodedOwnerUrl" not in artifact
-        assert "backupUri" not in artifact
-        assert artifact["source"] == "[PATH]"
-        assert "url" not in artifact["parts"][0]
-        assert "uri" not in artifact["parts"][0]["metadata"]
+        assert artifact["metadata"]["byteSize"] == 10
+        assert artifact["uri"] == r"file://C:\Users\alice\.iac-code\projects\demo\template.yaml"
+        assert artifact["source"] == artifact["uri"]
+        assert artifact["parts"][0]["url"] == artifact["uri"]
     rendered = str((status, journal_event, snapshot))
-    assert "file://" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
+    assert "file://" in rendered
+    assert ".iac-code" in rendered
 
 
 @pytest.mark.asyncio
@@ -1347,10 +1342,7 @@ async def test_publish_pipeline_write_file_result_does_not_infer_artifact_from_t
 
 
 @pytest.mark.asyncio
-async def test_publish_tool_trace_preserves_paths_in_journal_when_suppressed(tmp_path: Path) -> None:
-    # 环回 web(expose_local_paths)下抑制路径脱敏时:journal / 远程状态 / 快照均保留真实路径,
-    # 以便「重新加载」会话时能从 journal 重建出真路径(否则重载会退回 [PATH])。密钥恒脱敏。
-    # 真正远程 A2A 服务从不设该抑制标志,其脱敏由下方 without-suppression 用例锁定。
+async def test_publish_tool_trace_is_canonical_even_in_legacy_suppression_context(tmp_path: Path) -> None:
     publisher, queue = _publisher(tmp_path, exposure_types=[A2AExposureType.TOOL_TRACE])
     raw_path = "/Users/alice/.iac-code/settings.yml"
 
@@ -1375,21 +1367,16 @@ async def test_publish_tool_trace_preserves_paths_in_journal_when_suppressed(tmp
     journal = publisher.journal.read_all()
     snapshot = publisher.snapshot_store.load()
     assert snapshot is not None
-    # journal 里明确保留真实路径(重载数据源)。
     assert any(raw_path in json.dumps(entry) for entry in journal)
     rendered = json.dumps((published, journal, snapshot))
     assert raw_path in rendered
     assert "[PATH]" not in rendered
-    # 全抑制上下文(环回 web):journal/远程状态/快照连密钥也原样,供重载还原完整 YAML/结论。
     assert "sk-test-secret" in rendered
     assert "sk-result-secret" in rendered
 
 
 @pytest.mark.asyncio
-async def test_publish_tool_trace_redacts_paths_without_suppression(tmp_path: Path) -> None:
-    # 无抑制(真正远程 A2A 服务的默认上下文):本地通道 + 远程状态 + journal + 快照一律把路径脱敏
-    # 成 [PATH],密钥 ***。这锁定远程边界:只有 loopback web 显式 suppress_all_redaction() 时才
-    # 放行真路径(见 ..._preserves_paths_in_journal_when_suppressed),默认绝不外泄本地路径。
+async def test_publish_tool_trace_remains_canonical_without_suppression(tmp_path: Path) -> None:
     class LocalAwareQueue(FakeEventQueue):
         def __init__(self) -> None:
             super().__init__()
@@ -1415,7 +1402,6 @@ async def test_publish_tool_trace_redacts_paths_without_suppression(tmp_path: Pa
     )
     raw_path = "/Users/alice/project/template.yml"
 
-    # 不进入 suppress_all_redaction():模拟远程服务的默认上下文。
     await publisher.publish(
         ToolUseEndEvent(
             tool_use_id="toolu-local",
@@ -1424,14 +1410,13 @@ async def test_publish_tool_trace_redacts_paths_without_suppression(tmp_path: Pa
         )
     )
 
-    # 直通后本地 sink 拿到原始 input（web 实时流用）；远程/journal/快照仍由 serve 层脱敏。
     assert queue.local_envelopes[0]["data"]["input"] == {"api_key": "sk-test-secret", "path": raw_path}
     remote = dump(queue.events[0])["metadata"]["iac_code"]["pipeline"]
-    assert remote["data"]["input"] == {"api_key": "***", "path": "[PATH]"}
-    assert publisher.journal.read_all()[0]["data"]["input"]["path"] == "[PATH]"
+    assert remote["data"]["input"] == {"api_key": "sk-test-secret", "path": raw_path}
+    assert publisher.journal.read_all()[0]["data"]["input"]["path"] == raw_path
     snapshot = publisher.snapshot_store.load()
     assert snapshot is not None
-    assert raw_path not in json.dumps(snapshot)
+    assert snapshot["display"]["toolResults"] == []
 
 
 @pytest.mark.asyncio
@@ -1643,25 +1628,25 @@ async def test_publish_externalized_conclusion_artifact_preserves_final_metadata
     artifact_status = status_events[-1]
     assert artifact_status["eventType"] == "artifact_created"
     assert artifact_status["artifact"]["role"] == "final"
-    assert artifact_status["artifact"]["supersedesPath"] == "[PATH]"
+    assert artifact_status["artifact"]["supersedesPath"] == raw_superseded_path
     assert artifact_status["artifact"]["supersedesKey"] == supersedes_key
     assert artifact_status["data"]["role"] == "final"
-    assert artifact_status["data"]["supersedesPath"] == "[PATH]"
+    assert artifact_status["data"]["supersedesPath"] == raw_superseded_path
     assert artifact_status["data"]["supersedesKey"] == supersedes_key
 
     journal_event = publisher.journal.read_all()[-1]
     assert journal_event["artifact"]["role"] == "final"
-    assert journal_event["artifact"]["supersedesPath"] == "[PATH]"
+    assert journal_event["artifact"]["supersedesPath"] == raw_superseded_path
     assert journal_event["artifact"]["supersedesKey"] == supersedes_key
     assert journal_event["data"]["role"] == "final"
-    assert journal_event["data"]["supersedesPath"] == "[PATH]"
+    assert journal_event["data"]["supersedesPath"] == raw_superseded_path
     assert journal_event["data"]["supersedesKey"] == supersedes_key
 
     snapshot = publisher.snapshot_store.load()
     assert snapshot is not None
     artifact = snapshot["display"]["artifacts"][0]
     assert artifact["role"] == "final"
-    assert artifact["supersedesPath"] == "[PATH]"
+    assert artifact["supersedesPath"] == raw_superseded_path
     assert artifact["supersedesKey"] == supersedes_key
     artifact_metadata = (
         artifact_status["artifact"],
@@ -1670,7 +1655,7 @@ async def test_publish_externalized_conclusion_artifact_preserves_final_metadata
         journal_event["data"],
         artifact,
     )
-    assert raw_superseded_path not in str(artifact_metadata)
+    assert all(item["supersedesPath"] == raw_superseded_path for item in artifact_metadata)
 
 
 @pytest.mark.asyncio
@@ -2361,25 +2346,3 @@ async def test_publish_hard_interrupt_false_parent_without_candidate_does_not_em
 
     event_types = [event["eventType"] for event in publisher.journal.read_all()]
     assert event_types == ["interrupt_received", "interrupt_classified"]
-
-
-def test_sanitize_remote_envelope_exempts_complete_step_conclusion() -> None:
-    from iac_code.a2a.pipeline_stream import _sanitize_remote_envelope
-
-    envelope = {
-        "data": {
-            "toolName": "complete_step",
-            "toolUseId": "toolu-x",
-            "input": {"deployment_parameters": {"RdsMasterPassword": "S3cret!"}},
-        }
-    }
-    out = _sanitize_remote_envelope(envelope)
-    assert out["data"]["input"]["deployment_parameters"]["RdsMasterPassword"] == "S3cret!"
-
-
-def test_sanitize_remote_envelope_still_redacts_non_complete_step() -> None:
-    from iac_code.a2a.pipeline_stream import _sanitize_remote_envelope
-
-    envelope = {"data": {"toolName": "write_file", "input": {"password": "S3cret!"}}}
-    out = _sanitize_remote_envelope(envelope)
-    assert out["data"]["input"]["password"] == "***"

--- a/tests/a2a/test_projection.py
+++ b/tests/a2a/test_projection.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, StreamingResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from iac_code.a2a.app import A2AProjectionMiddleware
+from iac_code.a2a.projection import (
+    a2a_identities_from_data,
+    a2a_identity_from_data,
+    a2a_safe_mode_enabled,
+    build_a2a_public_path_roots,
+    project_a2a_data,
+    resolve_a2a_public_path_roots_for_data,
+)
+
+
+def test_a2a_safe_mode_uses_shared_truthy_values(monkeypatch) -> None:
+    for value in ("1", " true ", "YES", "On"):
+        monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", value)
+        assert a2a_safe_mode_enabled() is True
+    for value in ("", "0", "false", "enabled", "no"):
+        monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", value)
+        assert a2a_safe_mode_enabled() is False
+
+
+def test_a2a_roots_always_include_application_root(tmp_path, monkeypatch) -> None:
+    application_root = tmp_path / "installed-iac-code"
+    monkeypatch.setattr(
+        "iac_code.tools.path_safety.get_iac_code_application_root",
+        lambda: application_root,
+    )
+
+    roots = build_a2a_public_path_roots(cwd=str(tmp_path / "workspace"))
+
+    assert any(root["path"] == str(application_root) for root in roots)
+
+
+def test_project_a2a_data_safe_mode_off_returns_unredacted_deep_copy() -> None:
+    canonical = {"password": "secret-value", "path": "/server-root/private/result.json"}
+
+    projected = project_a2a_data(
+        canonical,
+        public_path_roots=[{"path": "/server-root", "label": "."}],
+        safe_mode=False,
+    )
+
+    assert projected == canonical
+    assert projected is not canonical
+    projected["path"] = "changed"
+    assert canonical["path"] == "/server-root/private/result.json"
+
+
+def test_project_a2a_data_safe_mode_on_is_path_only() -> None:
+    canonical = {
+        "password": "secret-value",
+        "server": "/server-root/private/result.json",
+        "cloud": "/home/cloud-user/bootstrap.sh",
+    }
+
+    projected = project_a2a_data(
+        canonical,
+        public_path_roots=[{"path": "/server-root", "label": "."}],
+        safe_mode=True,
+    )
+
+    assert projected == {
+        "password": "secret-value",
+        "server": "[PATH]",
+        "cloud": "/home/cloud-user/bootstrap.sh",
+    }
+    assert canonical["server"] == "/server-root/private/result.json"
+
+
+def test_project_a2a_data_mapping_key_collisions_do_not_drop_values() -> None:
+    canonical = {
+        "/server-root/a": "first",
+        "[PATH]": "existing",
+        "/server-root/b": "second",
+        "[PATH#2]": "existing-second",
+    }
+
+    projected = project_a2a_data(
+        canonical,
+        public_path_roots=[{"path": "/server-root", "label": "."}],
+        safe_mode=True,
+    )
+
+    assert projected == {
+        "[PATH#3]": "first",
+        "[PATH]": "existing",
+        "[PATH#4]": "second",
+        "[PATH#2]": "existing-second",
+    }
+    assert canonical == {
+        "/server-root/a": "first",
+        "[PATH]": "existing",
+        "/server-root/b": "second",
+        "[PATH#2]": "existing-second",
+    }
+
+
+def test_a2a_identity_ignores_jsonrpc_request_id_and_finds_nested_task() -> None:
+    assert a2a_identity_from_data(
+        {"jsonrpc": "2.0", "id": "request-17", "result": {"id": "task-1", "contextId": "context-1"}}
+    ) == ("task-1", "context-1")
+
+
+def test_a2a_identity_does_not_treat_bare_jsonrpc_id_as_task_id() -> None:
+    assert a2a_identity_from_data({"jsonrpc": "2.0", "id": "request-17", "error": {"code": -32603}}) == (
+        None,
+        None,
+    )
+
+
+def test_a2a_identity_uses_task_scoped_jsonrpc_params_id_not_request_id() -> None:
+    request = {"jsonrpc": "2.0", "id": "request-17", "method": "GetTask", "params": {"id": "task-1"}}
+
+    assert a2a_identity_from_data(request) == ("task-1", None)
+
+
+def test_a2a_identities_collect_every_task_in_list_response() -> None:
+    response = {
+        "result": {
+            "tasks": [
+                {"id": "task-1", "contextId": "context-1"},
+                {"id": "task-2", "contextId": "context-2"},
+            ]
+        }
+    }
+
+    assert a2a_identities_from_data(response) == [
+        ("task-1", "context-1"),
+        ("task-2", "context-2"),
+    ]
+
+
+class _ProjectionTaskStore:
+    def __init__(self, cwd: str) -> None:
+        self.cwd = cwd
+
+    async def get_task_record(self, task_id: str):
+        assert task_id == "task-1"
+        return SimpleNamespace(context_id="context-1")
+
+    async def get_context_record(self, context_id: str):
+        assert context_id == "context-1"
+        return SimpleNamespace(cwd=self.cwd, session_id="session-1")
+
+
+class _ProjectionTaskStoreWithRuntimeRoots(_ProjectionTaskStore):
+    def __init__(self, cwd: str, trusted_root: str) -> None:
+        super().__init__(cwd)
+        self.trusted_root = trusted_root
+
+    async def get_context_runtime_path_directories(self, context_id: str):
+        assert context_id == "context-1"
+        return [], [self.trusted_root], []
+
+
+class _MultiProjectionTaskStore:
+    def __init__(self, contexts: dict[str, tuple[str, str, str]]) -> None:
+        self.contexts = contexts
+
+    async def get_task_record(self, task_id: str):
+        return SimpleNamespace(context_id=self.contexts[task_id][0])
+
+    async def get_context_record(self, context_id: str):
+        cwd, session_id = next(
+            (cwd, session_id)
+            for stored_context_id, cwd, session_id in self.contexts.values()
+            if stored_context_id == context_id
+        )
+        return SimpleNamespace(cwd=cwd, session_id=session_id)
+
+
+def test_http_projection_middleware_replays_request_and_applies_path_only_policy(tmp_path, monkeypatch) -> None:
+    server_path = str(tmp_path / "private" / "result.json")
+
+    async def echo(request: Request) -> JSONResponse:
+        body = await request.json()
+        return JSONResponse({"taskId": body["taskId"], "path": server_path, "password": body["password"]})
+
+    app = Starlette(routes=[Route("/", echo, methods=["POST"])])
+    app.add_middleware(A2AProjectionMiddleware, task_store=_ProjectionTaskStore(str(tmp_path)))
+
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+    with TestClient(app) as client:
+        safe = client.post("/", json={"taskId": "task-1", "password": "real-secret"}).json()
+    assert safe == {"taskId": "task-1", "path": "[PATH]", "password": "real-secret"}
+
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "false")
+    with TestClient(app) as client:
+        raw = client.post("/", json={"taskId": "task-1", "password": "real-secret"}).json()
+    assert raw == {"taskId": "task-1", "path": server_path, "password": "real-secret"}
+
+
+def test_http_projection_uses_new_request_cwd_before_task_context_exists(tmp_path, monkeypatch) -> None:
+    server_path = str(tmp_path / "private" / "result.json")
+
+    async def fail(_request: Request) -> JSONResponse:
+        return JSONResponse({"error": f"failed at {server_path}", "password": "real-secret"}, status_code=500)
+
+    app = Starlette(routes=[Route("/", fail, methods=["POST"])])
+    app.add_middleware(A2AProjectionMiddleware, task_store=SimpleNamespace())
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/",
+            json={
+                "jsonrpc": "2.0",
+                "id": "request-1",
+                "params": {"message": {"metadata": {"iac_code": {"cwd": str(tmp_path)}}}},
+            },
+        )
+
+    assert response.json() == {"error": "failed at [PATH]", "password": "real-secret"}
+
+
+def test_http_jsonrpc_task_scoped_error_uses_params_task_workspace(tmp_path, monkeypatch) -> None:
+    workspace = tmp_path / "task-workspace"
+    server_path = str(workspace / "private" / "result.json")
+    store = _MultiProjectionTaskStore(
+        {"task-1": ("context-1", str(workspace), "session-1")}
+    )
+
+    async def fail(_request: Request) -> JSONResponse:
+        return JSONResponse({"jsonrpc": "2.0", "id": "request-1", "error": {"message": server_path}})
+
+    app = Starlette(routes=[Route("/", fail, methods=["POST"])])
+    app.add_middleware(A2AProjectionMiddleware, task_store=store)
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/",
+            json={"jsonrpc": "2.0", "id": "request-1", "method": "GetTask", "params": {"id": "task-1"}},
+        )
+
+    assert response.json()["error"]["message"] == "[PATH]"
+
+
+def test_http_rest_projection_uses_task_id_from_routed_path_parameter(tmp_path, monkeypatch) -> None:
+    server_path = str(tmp_path / "private" / "result.json")
+
+    async def fail(_request: Request) -> JSONResponse:
+        return JSONResponse({"error": f"failed at {server_path}"}, status_code=500)
+
+    app = Starlette(routes=[Route("/tasks/{id}", fail)])
+    app.add_middleware(A2AProjectionMiddleware, task_store=_ProjectionTaskStore(str(tmp_path)))
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+
+    with TestClient(app) as client:
+        response = client.get("/tasks/task-1")
+
+    assert response.json() == {"error": "failed at [PATH]"}
+
+
+def test_http_projection_includes_current_runtime_trusted_directories(tmp_path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    trusted = tmp_path / "shared"
+    server_path = str(trusted / "private" / "result.json")
+
+    async def result(_request: Request) -> JSONResponse:
+        return JSONResponse({"taskId": "task-1", "path": server_path})
+
+    app = Starlette(routes=[Route("/", result)])
+    app.add_middleware(
+        A2AProjectionMiddleware,
+        task_store=_ProjectionTaskStoreWithRuntimeRoots(str(workspace), str(trusted)),
+    )
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+
+    with TestClient(app) as client:
+        response = client.get("/")
+
+    assert response.json() == {"taskId": "task-1", "path": "[PATH]"}
+
+
+def test_http_projection_aggregates_roots_for_list_tasks_response(tmp_path, monkeypatch) -> None:
+    workspace_one = tmp_path / "workspace-one"
+    workspace_two = tmp_path / "workspace-two"
+    store = _MultiProjectionTaskStore(
+        {
+            "task-1": ("context-1", str(workspace_one), "session-1"),
+            "task-2": ("context-2", str(workspace_two), "session-2"),
+        }
+    )
+
+    async def list_tasks(_request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "tasks": [
+                    {
+                        "id": "task-1",
+                        "contextId": "context-1",
+                        "path": str(workspace_one / "result.json"),
+                    },
+                    {
+                        "id": "task-2",
+                        "contextId": "context-2",
+                        "path": str(workspace_two / "result.json"),
+                    },
+                ]
+            }
+        )
+
+    app = Starlette(routes=[Route("/", list_tasks)])
+    app.add_middleware(A2AProjectionMiddleware, task_store=store)
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+
+    with TestClient(app) as client:
+        response = client.get("/")
+
+    assert [task["path"] for task in response.json()["tasks"]] == ["[PATH]", "[PATH]"]
+
+
+@pytest.mark.asyncio
+async def test_task_scoped_request_and_grpc_bare_id_resolve_task_workspace_roots(tmp_path) -> None:
+    workspace = tmp_path / "task-workspace"
+    store = _MultiProjectionTaskStore(
+        {"task-1": ("context-1", str(workspace), "session-1")}
+    )
+
+    jsonrpc_roots = await resolve_a2a_public_path_roots_for_data(
+        store,
+        request_data={"jsonrpc": "2.0", "id": "request-1", "method": "GetTask", "params": {"id": "task-1"}},
+    )
+    grpc_roots = await resolve_a2a_public_path_roots_for_data(
+        store,
+        request_data={"id": "task-1"},
+        request_bare_id_is_task_id=True,
+    )
+
+    assert any(root["path"] == str(workspace) for root in jsonrpc_roots)
+    assert any(root["path"] == str(workspace) for root in grpc_roots)
+
+
+def test_http_projection_middleware_projects_sse_frames_incrementally(tmp_path, monkeypatch) -> None:
+    server_path = str(tmp_path / "private" / "result.json")
+    payload = json.dumps({"taskId": "task-1", "path": server_path, "password": "real-secret"})
+    split_at = len(payload) // 2
+
+    async def stream(_request: Request) -> StreamingResponse:
+        async def chunks():
+            yield "event: message\ndata: " + payload[:split_at]
+            yield payload[split_at:] + "\n\n"
+
+        return StreamingResponse(chunks(), media_type="text/event-stream")
+
+    app = Starlette(routes=[Route("/stream", stream)])
+    app.add_middleware(A2AProjectionMiddleware, task_store=_ProjectionTaskStore(str(tmp_path)))
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "on")
+
+    with TestClient(app) as client:
+        response = client.get("/stream")
+
+    data_line = next(line for line in response.text.splitlines() if line.startswith("data: "))
+    assert json.loads(data_line.removeprefix("data: ")) == {
+        "taskId": "task-1",
+        "path": "[PATH]",
+        "password": "real-secret",
+    }

--- a/tests/a2a/test_push_worker.py
+++ b/tests/a2a/test_push_worker.py
@@ -269,6 +269,103 @@ async def test_push_worker_delivers_and_acks_success(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_push_retry_reloads_safe_mode_and_keeps_queued_payload_canonical(monkeypatch) -> None:
+    raw_path = "/srv/iac-code/private/result.json"
+
+    class RetryQueue:
+        def __init__(self) -> None:
+            self.current = A2APushJob(
+                job_id="job-1",
+                task_id="task-1",
+                config_id="cfg-1",
+                url="https://callback.example/a2a",
+                payload={"path": raw_path, "password": "real-secret"},
+                headers={},
+            )
+
+        async def claim(self, *, now=None):
+            job, self.current = self.current, None
+            return job
+
+        async def retry(self, job):
+            self.current = job
+
+        async def ack(self, job_id):
+            assert job_id == "job-1"
+
+        async def dead_letter(self, job):
+            raise AssertionError(f"unexpected dead letter: {job}")
+
+    class SequencedConnector:
+        def __init__(self) -> None:
+            self.statuses = [503, 204]
+            self.payloads = []
+
+        async def post(self, url, *, json, headers, timeout):
+            self.payloads.append(json)
+            return FakeResponse(self.statuses.pop(0))
+
+    queue = RetryQueue()
+    connector = SequencedConnector()
+    worker = A2APushDeliveryWorker(
+        queue=queue,
+        connector=connector,
+        metrics=NoOpA2AMetrics(),
+        retry_policy=A2APushRetryPolicy(initial_delay_seconds=0.0, jitter_ratio=0.0, max_attempts=2),
+        path_roots_resolver=lambda _task_id: [{"path": "/srv/iac-code", "label": "."}],
+        clock=lambda: 100.0,
+    )
+
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "false")
+    assert await worker.run_once() is False
+    assert connector.payloads[0] == {"path": raw_path, "password": "real-secret"}
+    assert queue.current.payload == {"path": raw_path, "password": "real-secret"}
+
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+    assert await worker.run_once() is True
+    assert connector.payloads[1] == {"path": "[PATH]", "password": "real-secret"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("enqueue_safe_mode", "send_safe_mode", "expected_path"),
+    [("false", "true", "[PATH]"), ("true", "false", "/srv/iac-code/private/result.json")],
+)
+async def test_push_first_send_uses_current_safe_mode_without_mutating_canonical_job(
+    monkeypatch,
+    tmp_path,
+    enqueue_safe_mode,
+    send_safe_mode,
+    expected_path,
+) -> None:
+    raw_path = "/srv/iac-code/private/result.json"
+    queue = LocalFileA2APushQueue(tmp_path)
+    connector = RecordingConnector()
+    worker = A2APushDeliveryWorker(
+        queue=queue,
+        connector=connector,
+        metrics=NoOpA2AMetrics(),
+        path_roots_resolver=lambda _task_id: [{"path": "/srv/iac-code", "label": "."}],
+    )
+    job = A2APushJob(
+        job_id="job-first-send",
+        task_id="task-1",
+        config_id="cfg-1",
+        url="https://callback.example/a2a",
+        payload={"path": raw_path, "password": "real-secret"},
+        headers={},
+    )
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", enqueue_safe_mode)
+    await queue.enqueue(job)
+
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", send_safe_mode)
+    assert await worker.run_once() is True
+
+    assert connector.posts[0]["json"] == {"path": expected_path, "password": "real-secret"}
+    assert job.payload == {"path": raw_path, "password": "real-secret"}
+
+
+@pytest.mark.asyncio
 async def test_push_worker_does_not_retry_or_dead_letter_when_ack_fails_after_callback_success() -> None:
     class AckFailingQueue:
         def __init__(self) -> None:

--- a/tests/a2a/test_redis_streams_transport.py
+++ b/tests/a2a/test_redis_streams_transport.py
@@ -203,7 +203,9 @@ async def test_redis_server_creates_group_and_reads_with_consumer_group(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_redis_server_returns_sanitized_error_when_dispatch_fails() -> None:
+async def test_redis_server_returns_raw_error_when_safe_mode_is_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("IAC_CODE_A2A_SAFE_MODE", raising=False)
+
     class FailingDispatcher:
         async def dispatch(self, payload):
             raise RuntimeError(
@@ -234,10 +236,9 @@ async def test_redis_server_returns_sanitized_error_when_dispatch_fails() -> Non
     error = response.payload["error"]
     assert error["code"] == -32603
     assert "dispatch failed" in error["message"]
-    assert "sk-redissecret123" not in error["message"]
-    assert "Authorization: Bearer" not in error["message"]
-    assert "/Users/alice" not in error["message"]
-    assert "[REDACTED]" in error["message"]
+    assert "sk-redissecret123" in error["message"]
+    assert "Authorization: Bearer" in error["message"]
+    assert "/Users/alice" in error["message"]
     assert error["data"]["error_id"]
     assert redis.acked == [("requests", "iac-code", "9-0")]
     assert redis.operations[-2:] == [("xadd", "responses"), ("xack", "requests")]
@@ -245,7 +246,50 @@ async def test_redis_server_returns_sanitized_error_when_dispatch_fails() -> Non
 
 
 @pytest.mark.asyncio
-async def test_redis_server_returns_final_error_when_stream_dispatch_fails() -> None:
+async def test_redis_server_projects_error_from_new_request_cwd_in_safe_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "on")
+    server_path = tmp_path / "private" / "redis.sock"
+
+    class FailingDispatcher:
+        async def dispatch(self, payload):
+            raise RuntimeError(f"dispatch failed token=real-secret at {server_path}")
+
+    redis = FakeRedis()
+    components = create_runtime_components(model="qwen3.6-plus", host="127.0.0.1", port=41242)
+    server = RedisStreamsA2AServer(
+        redis=redis,
+        components=components,
+        request_stream="requests",
+        response_stream="responses",
+        consumer_group="iac-code",
+    )
+    server._dispatcher = FailingDispatcher()
+    request = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {"message": {"metadata": {"iac_code": {"cwd": str(tmp_path)}}}},
+    }
+    fields = {
+        "correlation_id": "corr-server",
+        "reply_stream": "responses",
+        "payload": json.dumps(request),
+    }
+
+    await server._process_entry("9-0", fields)
+
+    response = parse_redis_entry("1-0", redis.streams["responses"][0])
+    message = response.payload["error"]["message"]
+    assert "[PATH]" in message
+    assert str(tmp_path) not in message
+    assert "real-secret" in message
+    await server.aclose()
+
+
+@pytest.mark.asyncio
+async def test_redis_server_returns_raw_final_error_when_safe_mode_is_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("IAC_CODE_A2A_SAFE_MODE", raising=False)
+
     class FailingStreamingDispatcher:
         async def dispatch_stream(self, payload):
             yield {"jsonrpc": "2.0", "id": payload["id"], "result": {"delta": "hello"}}
@@ -276,8 +320,8 @@ async def test_redis_server_returns_final_error_when_stream_dispatch_fails() -> 
     assert second.final is True
     error = second.payload["error"]
     assert error["code"] == -32603
-    assert "tok-redistreamsecret123" not in error["message"]
-    assert "/Users/alice" not in error["message"]
+    assert "tok-redistreamsecret123" in error["message"]
+    assert "/Users/alice" in error["message"]
     assert error["data"]["error_id"]
     assert redis.acked == [("requests", "iac-code", "9-0")]
     assert redis.operations[-2:] == [("xadd", "responses"), ("xack", "requests")]

--- a/tests/a2a/test_stdio_transport.py
+++ b/tests/a2a/test_stdio_transport.py
@@ -104,7 +104,9 @@ async def test_stdio_server_handles_unary_request() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stdio_server_sanitizes_outer_dispatch_errors() -> None:
+async def test_stdio_server_returns_raw_outer_dispatch_errors_without_safe_mode(monkeypatch) -> None:
+    monkeypatch.delenv("IAC_CODE_A2A_SAFE_MODE", raising=False)
+
     client_to_server, client_writer = make_stream_pair()
     server_to_client, server_writer = make_stream_pair()
     components = create_runtime_components(model="qwen3.6-plus", host="127.0.0.1", port=41242)
@@ -126,11 +128,39 @@ async def test_stdio_server_sanitizes_outer_dispatch_errors() -> None:
     error = response["error"]
     assert error["code"] == -32603
     assert "dispatch failed" in error["message"]
-    assert "sk-stdiosecret123" not in error["message"]
-    assert "Authorization: Bearer" not in error["message"]
-    assert "/Users/alice" not in error["message"]
-    assert "[REDACTED]" in error["message"]
-    assert "[PATH]" in error["message"]
+    assert "sk-stdiosecret123" in error["message"]
+    assert "Authorization: Bearer" in error["message"]
+    assert "/Users/alice" in error["message"]
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_projects_error_from_new_request_cwd_in_safe_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "1")
+    client_to_server, client_writer = make_stream_pair()
+    server_to_client, server_writer = make_stream_pair()
+    components = create_runtime_components(model="qwen3.6-plus", host="127.0.0.1", port=41242)
+    server = StdioA2AServer(components=components, reader=client_to_server, writer=server_writer)
+    server_path = tmp_path / "private" / "stdio.sock"
+    server._dispatcher.dispatch = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError(f"dispatch failed at {server_path}; token=real-secret")
+    )
+    task = asyncio.create_task(server.serve())
+    request = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "ping",
+        "params": {"message": {"metadata": {"iac_code": {"cwd": str(tmp_path)}}}},
+    }
+
+    try:
+        client_writer.write(encode_frame(request))
+        response = decode_frame(await asyncio.wait_for(server_to_client.readline(), timeout=1))
+    finally:
+        await close_stdio_server(client_writer, task, components)
+
+    assert "[PATH]" in response["error"]["message"]
+    assert str(tmp_path) not in response["error"]["message"]
+    assert "real-secret" in response["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -273,6 +273,38 @@ async def test_cleanup_preserves_context_during_reconciliation_and_execution_sta
 
 
 @pytest.mark.asyncio
+async def test_context_runtime_path_directories_include_permission_and_tool_context_roots(tmp_path) -> None:
+    permission_context = SimpleNamespace(
+        additional_directories=[str(tmp_path / "additional")],
+        trusted_read_directories=[str(tmp_path / "trusted")],
+        relative_read_directories=[str(tmp_path / "relative")],
+        strict_read_directories=[str(tmp_path / "application-root")],
+    )
+    agent_loop = SimpleNamespace(
+        _permission_context_getter=None,
+        _permission_context=permission_context,
+        _tool_context_trusted_read_directories=[str(tmp_path / "tool-trusted")],
+        _tool_context_relative_read_directories=[str(tmp_path / "tool-relative")],
+    )
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    context = await store.get_or_create_context(
+        context_id="ctx-runtime-roots",
+        cwd=str(tmp_path),
+        runtime_factory=lambda _session_id: SimpleNamespace(agent_loop=agent_loop),
+    )
+
+    assert await store.get_context_runtime_path_directories(context.context_id) == (
+        [str(tmp_path / "additional")],
+        [
+            str(tmp_path / "trusted"),
+            str(tmp_path / "application-root"),
+            str(tmp_path / "tool-trusted"),
+        ],
+        [str(tmp_path / "relative"), str(tmp_path / "tool-relative")],
+    )
+
+
+@pytest.mark.asyncio
 async def test_refresh_context_from_session_closes_runtime_and_applies_proven_handoff(monkeypatch, tmp_path) -> None:
     config_dir = tmp_path / "config"
     cwd = tmp_path / "workspace"

--- a/tests/a2a/test_transport_dispatcher.py
+++ b/tests/a2a/test_transport_dispatcher.py
@@ -421,7 +421,8 @@ async def test_message_stream_does_not_acknowledge_transport_delivery_when_close
 
 
 @pytest.mark.asyncio
-async def test_dispatcher_stream_redacts_sensitive_message_metadata_echo(monkeypatch, tmp_path) -> None:
+async def test_dispatcher_stream_preserves_message_metadata_echo_without_safe_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("IAC_CODE_A2A_SAFE_MODE", raising=False)
     loop = FakeAgentLoop([TextDeltaEvent(text="streamed")])
     runtime = FakeRuntime(agent_loop=loop, session_id="session-1")
     monkeypatch.setattr("iac_code.a2a.executor.create_agent_runtime", lambda options: runtime)
@@ -464,25 +465,25 @@ async def test_dispatcher_stream_redacts_sensitive_message_metadata_echo(monkeyp
 
     echoed_metadata = events[0]["result"]["history"][0]["metadata"]
     assert echoed_metadata["iac_code"] == {
-        "cwd": ".",
+        "cwd": str(tmp_path),
         "iac_code_model": "qwen3.6-plus",
-        "iac_code_api_key": "***",
-        "alibaba_cloud_access_key_id": "***",
-        "alibaba_cloud_access_key_secret": "***",
-        "alibaba_cloud_security_token": "***",
+        "iac_code_api_key": "provider-secret",
+        "alibaba_cloud_access_key_id": "ak-id-secret",
+        "alibaba_cloud_access_key_secret": "ak-secret",
+        "alibaba_cloud_security_token": "sts-token-secret",
         "alibaba_cloud_region_id": "cn-hangzhou",
     }
     assert echoed_metadata["custom"] == {
-        "apikey": "***",
-        "nested": [{"accessKeySecret": "***"}],
+        "apikey": "custom-api-key",
+        "nested": [{"accessKeySecret": "nested-ak-secret"}],
     }
     rendered = str(events[0])
-    assert "provider-secret" not in rendered
-    assert "ak-id-secret" not in rendered
-    assert "ak-secret" not in rendered
-    assert "sts-token-secret" not in rendered
-    assert "custom-api-key" not in rendered
-    assert "nested-ak-secret" not in rendered
+    assert "provider-secret" in rendered
+    assert "ak-id-secret" in rendered
+    assert "ak-secret" in rendered
+    assert "sts-token-secret" in rendered
+    assert "custom-api-key" in rendered
+    assert "nested-ak-secret" in rendered
     await components.aclose()
 
 
@@ -862,6 +863,24 @@ async def test_active_message_stream_cancellation_cancels_producer() -> None:
         await asyncio.wait_for(stream_task, timeout=_STREAM_TEST_TIMEOUT)
     assert producer_cancelled.is_set()
     assert active_task._reference_count == 0
+
+
+@pytest.mark.asyncio
+async def test_active_message_producer_failure_log_uses_strict_sanitizer(caplog, tmp_path) -> None:
+    server_path = str(tmp_path / "private" / "result.json")
+
+    async def fail() -> None:
+        raise RuntimeError(f"failed at {server_path} with password=real-secret")
+
+    producer = asyncio.create_task(fail())
+    handler = IacCodeRequestHandler.__new__(IacCodeRequestHandler)
+    await handler._cleanup_active_message_producer(producer, f"task-at-{server_path}")
+
+    record = next(record for record in caplog.records if record.message.startswith("Active task message producer"))
+    assert server_path not in record.message
+    assert "real-secret" not in record.message
+    assert "[PATH]" in record.message
+    assert "[REDACTED]" in record.message
 
 
 def _active_task_identity(components: A2ARuntimeComponents) -> SimpleNamespace:

--- a/tests/a2a/test_websocket_transport.py
+++ b/tests/a2a/test_websocket_transport.py
@@ -71,7 +71,9 @@ async def test_websocket_app_reports_invalid_json_frame() -> None:
 
 
 @pytest.mark.asyncio
-async def test_websocket_app_returns_public_error_for_unary_dispatch_failure(monkeypatch) -> None:
+async def test_websocket_app_returns_raw_error_for_unary_dispatch_failure_without_safe_mode(monkeypatch) -> None:
+    monkeypatch.delenv("IAC_CODE_A2A_SAFE_MODE", raising=False)
+
     class FailingDispatcher:
         async def dispatch(self, payload: dict[str, Any]) -> dict[str, Any]:
             raise RuntimeError("boom with DB_PASSWORD=hunter2 at /Users/alice/.iac-code/settings.yml")
@@ -95,14 +97,54 @@ async def test_websocket_app_returns_public_error_for_unary_dispatch_failure(mon
     assert response["final"] is True
     assert response["payload"]["id"] == "err-1"
     assert response["payload"]["error"]["code"] == -32603
-    assert "hunter2" not in response["payload"]["error"]["message"]
-    assert "/Users/alice" not in response["payload"]["error"]["message"]
+    assert "hunter2" in response["payload"]["error"]["message"]
+    assert "/Users/alice" in response["payload"]["error"]["message"]
     assert response["payload"]["error"]["data"]["error_id"]
     await components.aclose()
 
 
 @pytest.mark.asyncio
-async def test_websocket_app_returns_final_public_error_for_stream_dispatch_failure(monkeypatch) -> None:
+async def test_websocket_app_projects_error_from_new_request_cwd_in_safe_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "true")
+    server_path = tmp_path / "private" / "settings.yml"
+
+    class FailingDispatcher:
+        async def dispatch(self, payload: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError(f"boom token=real-secret at {server_path}")
+
+        async def aclose(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "iac_code.a2a.transports.websocket.A2AJsonRpcDispatcher", lambda components: FailingDispatcher()
+    )
+    components = create_runtime_components(model="qwen3.6-plus", host="127.0.0.1", port=41242)
+    app = WebSocketA2AServerApp(components=components, path="/a2a").create_app()
+
+    from starlette.testclient import TestClient
+
+    request = {
+        "jsonrpc": "2.0",
+        "id": "err-1",
+        "method": "message/send",
+        "params": {"message": {"metadata": {"iac_code": {"cwd": str(tmp_path)}}}},
+    }
+    with TestClient(app) as client:
+        with client.websocket_connect("/a2a") as websocket:
+            websocket.send_text(json.dumps(request))
+            response = websocket.receive_json()
+
+    message = response["payload"]["error"]["message"]
+    assert "[PATH]" in message
+    assert str(tmp_path) not in message
+    assert "real-secret" in message
+    await components.aclose()
+
+
+@pytest.mark.asyncio
+async def test_websocket_app_returns_raw_final_error_for_stream_dispatch_failure_without_safe_mode(monkeypatch) -> None:
+    monkeypatch.delenv("IAC_CODE_A2A_SAFE_MODE", raising=False)
+
     class FailingStreamDispatcher:
         async def dispatch_stream(self, payload: dict[str, Any]):
             yield {"jsonrpc": "2.0", "id": payload["id"], "result": {"state": "working"}}
@@ -130,7 +172,7 @@ async def test_websocket_app_returns_final_public_error_for_stream_dispatch_fail
     assert response["final"] is True
     assert response["payload"]["id"] == "stream-1"
     assert response["payload"]["error"]["code"] == -32603
-    assert "sk-live" not in response["payload"]["error"]["message"]
-    assert "/Users/alice" not in response["payload"]["error"]["message"]
+    assert "sk-live" in response["payload"]["error"]["message"]
+    assert "/Users/alice" in response["payload"]["error"]["message"]
     assert response["payload"]["error"]["data"]["error_id"]
     await components.aclose()

--- a/tests/a2a_e2e/test_run_recovery_scenarios.py
+++ b/tests/a2a_e2e/test_run_recovery_scenarios.py
@@ -258,6 +258,184 @@ def test_scenario1_performance_backup_is_registered_and_requires_real_cloud() ->
         raise AssertionError("scenario1-performance-backup should require --allow-real-cloud")
 
 
+def test_redaction_step4_is_registered_requires_real_cloud_and_forces_safe_mode(tmp_path: Path) -> None:
+    runner = _load_runner()
+
+    assert runner._SCENARIOS[runner.REDACTION_STEP4_SCENARIO] is runner.run_redaction_step4
+    args = SimpleNamespace(allow_real_cloud=False, deterministic=False)
+    try:
+        runner._validate_scenario_execution(args, runner.REDACTION_STEP4_SCENARIO)
+    except SystemExit as exc:
+        assert "--allow-real-cloud" in str(exc)
+    else:
+        raise AssertionError("redaction-step4 should require --allow-real-cloud")
+
+    harness_args = SimpleNamespace(
+        server_cwd=str(tmp_path),
+        run_dir=str(tmp_path / "run"),
+        run_root=str(tmp_path),
+        cwd="",
+        host="127.0.0.1",
+        port=0,
+        no_auto_approve_permissions=False,
+        provider="",
+        model="",
+        api_base="",
+        deterministic=False,
+        fault_at="",
+    )
+    harness = runner.ScenarioHarness(harness_args, scenario=runner.REDACTION_STEP4_SCENARIO)
+
+    assert harness.server_env["IAC_CODE_A2A_SAFE_MODE"] == "true"
+
+
+def test_step4_redaction_audit_preserves_credentials_tokens_and_only_hides_paths() -> None:
+    runner = _load_runner()
+    server_root = "/srv/iac-code-e2e"
+    canonical = {
+        "status": "waiting_input",
+        "pendingInput": {
+            "step": {"id": "confirm_and_select"},
+            "options": [{"name": "economy"}, {"name": "balanced"}],
+        },
+        "steps": [
+            {
+                "conclusion": {
+                    "deployment_parameters": {"RdsMasterUserPassword": "real-generated-value"},
+                    "preview_validation": {"parameters": {"RdsMasterUserPassword": "real-generated-value"}},
+                    "template_url": f"{server_root}/workspace/backend.yml",
+                }
+            }
+        ],
+        "display": {"usage": {"totalTokens": 1234}},
+        "failedToolCall": {
+            "path": f"{server_root}-rerun/src/iac_code/a2a/app.py",
+            "result": f"File not found: {server_root}-rerun/src/iac_code/a2a/app.py",
+        },
+    }
+    public = json.loads(json.dumps(canonical))
+    public["steps"][0]["conclusion"]["template_url"] = "[PATH]"
+
+    audit = runner._build_step4_redaction_audit(
+        canonical,
+        public,
+        known_server_paths=(server_root,),
+        safe_mode="true",
+    )
+
+    assert all(runner._step4_redaction_checks(audit).values())
+    assert "real-generated-value" not in json.dumps(audit)
+    assert audit["canonicalKnownServerPathOccurrences"] == 1
+    assert audit["publicKnownServerPathOccurrences"] == 0
+
+    leaked_public = json.loads(json.dumps(public))
+    leaked_public["steps"][0]["conclusion"]["template_url"] = f"{server_root}/workspace/backend.yml"
+    leaked_audit = runner._build_step4_redaction_audit(
+        canonical,
+        leaked_public,
+        known_server_paths=(server_root,),
+        safe_mode="true",
+    )
+
+    assert leaked_audit["publicKnownServerPathOccurrences"] == 1
+    assert runner._step4_redaction_checks(leaked_audit)["safe mode hides known server paths from public state"] is False
+
+    public["steps"][0]["conclusion"]["deployment_parameters"]["RdsMasterUserPassword"] = "***"
+    broken_audit = runner._build_step4_redaction_audit(
+        canonical,
+        public,
+        known_server_paths=(server_root,),
+        safe_mode="true",
+    )
+    broken_checks = runner._step4_redaction_checks(broken_audit)
+
+    assert broken_checks["public functional parameters contain no redaction placeholders"] is False
+    assert broken_checks["public credential fields match canonical values"] is False
+
+    broken_canonical = json.loads(json.dumps(canonical))
+    broken_canonical["steps"][0]["conclusion"]["deployment_parameters"]["RdsMasterUserPassword"] = "***"
+    broken_canonical["display"]["usage"]["totalTokens"] = "***"
+    canonical_audit = runner._build_step4_redaction_audit(
+        broken_canonical,
+        public,
+        known_server_paths=(server_root,),
+        safe_mode="true",
+    )
+    canonical_checks = runner._step4_redaction_checks(canonical_audit)
+
+    assert canonical_checks["canonical functional parameters contain no redaction placeholders"] is False
+    assert canonical_checks["canonical token counters are numeric when present"] is False
+
+
+def test_redaction_step4_stops_before_selection_and_writes_only_audit(monkeypatch, tmp_path: Path) -> None:
+    runner = _load_runner()
+    prompts: list[str] = []
+    server_root = str(tmp_path / "server")
+    canonical = {
+        "status": "waiting_input",
+        "pendingInput": {
+            "step": {"id": "confirm_and_select"},
+            "options": [{"name": "economy"}, {"name": "balanced"}],
+        },
+        "steps": [
+            {
+                "conclusion": {
+                    "deployment_parameters": {"RdsMasterUserPassword": "real-generated-value"},
+                    "template_url": f"{server_root}/backend.yml",
+                }
+            }
+        ],
+        "display": {"usage": {"totalTokens": 1234}},
+    }
+    public = {"snapshot": json.loads(json.dumps(canonical))}
+    public["snapshot"]["steps"][0]["conclusion"]["template_url"] = "[PATH]"
+
+    class FakeHarness:
+        def __init__(self) -> None:
+            self.context_id = "ctx-1"
+            self.pipeline_task_id = "task-1"
+            self.cwd = server_root
+            self.server_cwd = server_root
+            self.server_url = "http://127.0.0.1:1"
+            self.run_dir = tmp_path
+            self.server_env = {"IAC_CODE_A2A_SAFE_MODE": "true"}
+            self.checks = {}
+            self.snapshots = {}
+            self.notes = []
+
+        def stream(self, *, prompt: str, name: str, context_id: str, task_id: str):
+            prompts.append(prompt)
+            assert name == "01-redaction-step4"
+            assert context_id == ""
+            assert task_id == ""
+            return runner.StreamSummary(
+                name=name,
+                prompt=prompt,
+                task_id=self.pipeline_task_id,
+                context_id=self.context_id,
+                status_states=["TASK_STATE_INPUT_REQUIRED"],
+                pipeline_event_types=["input_required"],
+                last_input_required_step_id="confirm_and_select",
+            )
+
+    harness = FakeHarness()
+
+    def fake_run_with_harness(_args, _scenario, callback):
+        callback(harness)
+        return 0 if all(harness.checks.values()) else 1
+
+    monkeypatch.setattr(runner, "_run_with_harness", fake_run_with_harness)
+    monkeypatch.setattr(runner, "_load_canonical_pipeline_snapshot", lambda _h: canonical)
+    monkeypatch.setattr(runner, "_fetch_pipeline_state_for_redaction_audit", lambda _h: public)
+    args = SimpleNamespace(redaction_step4_prompt=runner.REDACTION_STEP4_PROMPT)
+
+    assert runner.run_redaction_step4(args, runner.REDACTION_STEP4_SCENARIO) == 0
+    assert prompts == [runner.REDACTION_STEP4_PROMPT]
+    audit = json.loads((tmp_path / "redaction-audit.json").read_text(encoding="utf-8"))
+    assert "real-generated-value" not in json.dumps(audit)
+    assert any("no selection input was sent" in note for note in harness.notes)
+
+
 def test_answer_intervening_ask_inputs_reaches_selection(tmp_path: Path) -> None:
     runner = _load_runner()
     initial = runner.StreamSummary(

--- a/tests/acp/test_convert.py
+++ b/tests/acp/test_convert.py
@@ -138,7 +138,7 @@ def test_error_event_to_message_chunk() -> None:
     assert "Rate limit exceeded" in updates[0].content.text
 
 
-def test_error_event_to_message_chunk_redacts_public_error() -> None:
+def test_error_event_to_message_chunk_preserves_local_error() -> None:
     converter = ACPEventConverter(turn_id="turn-1")
     updates = converter.event_to_updates(
         ErrorEvent(
@@ -149,11 +149,11 @@ def test_error_event_to_message_chunk_redacts_public_error() -> None:
 
     text = updates[0].content.text
     assert "[Error]" in text
-    assert "session-secret" not in text
-    assert "refresh-secret" not in text
+    assert "session-secret" in text
+    assert "refresh-secret" in text
 
 
-def test_error_event_to_message_chunk_handles_artifact_aware_public_text() -> None:
+def test_error_event_to_message_chunk_preserves_artifact_aware_text() -> None:
     converter = ACPEventConverter(turn_id="turn-1")
     encoded_path = "file%3A%2F%2F%2FUsers%2Falice%2F.iac-code%2Fprojects%2Fdemo%2Ftemplate.yaml"
     uri = "iac-code-artifact://artifact-1/template.yaml"
@@ -161,7 +161,7 @@ def test_error_event_to_message_chunk_handles_artifact_aware_public_text() -> No
     updates = converter.event_to_updates(ErrorEvent(error=f"failed at {encoded_path}; see {uri}.", is_retryable=False))
 
     text = updates[0].content.text
-    assert text == f"[Error] failed at [PATH]; see {uri}."
+    assert text == f"[Error] failed at {encoded_path}; see {uri}."
 
 
 # ---------------------------------------------------------------------------
@@ -635,8 +635,7 @@ def test_aliyun_tool_result_exposes_business_content_but_not_internal_http_metad
     assert "aliyun_body_v1" not in str(updates)
 
 
-def test_failed_tool_result_content_is_sanitized() -> None:
-    """Failed tool result payloads must not expose raw exception details to ACP clients."""
+def test_failed_tool_result_content_is_preserved_for_local_acp() -> None:
     converter = ACPEventConverter(turn_id="turn-1")
     converter.event_to_updates(ToolUseStartEvent(tool_use_id="t1", name="bash"))
     encoded_uri = (
@@ -653,15 +652,14 @@ def test_failed_tool_result_content_is_sanitized() -> None:
     )
 
     rendered = str(updates[0].content[0].content.text)
-    assert "hunter2" not in rendered
-    assert "/Users/alice" not in rendered
-    assert "%5CUsers" not in rendered
-    assert ".iac-code" not in rendered
+    assert "hunter2" in rendered
+    assert "/Users/alice" in rendered
+    assert "%5CUsers" in rendered
+    assert ".iac-code" in rendered
     assert updates[1].status == "failed"
 
 
-def test_successful_tool_result_content_is_sanitized() -> None:
-    """Successful tool results can still contain local paths and must be public-safe."""
+def test_successful_tool_result_content_is_preserved_for_local_acp() -> None:
     converter = ACPEventConverter(turn_id="turn-1")
     converter.event_to_updates(ToolUseStartEvent(tool_use_id="t1", name="bash"))
     encoded_path = "file%3A%2F%2F%2FUsers%2FAlice%20Smith%2F.iac-code%2Fprojects%2Fdemo%2Ftemplate.yaml"
@@ -677,13 +675,13 @@ def test_successful_tool_result_content_is_sanitized() -> None:
     )
 
     rendered = str(updates[0].content[0].content.text)
-    assert rendered == f"ok [PATH]; see {uri}"
-    assert "Alice" not in rendered
-    assert ".iac-code" not in rendered
+    assert rendered == f"ok {encoded_path}; see {uri}"
+    assert "Alice" in rendered
+    assert ".iac-code" in rendered
     assert updates[1].status == "completed"
 
 
-def test_successful_tool_result_relativizes_public_paths() -> None:
+def test_successful_tool_result_preserves_public_paths() -> None:
     converter = ACPEventConverter(turn_id="turn-1")
     converter.event_to_updates(ToolUseStartEvent(tool_use_id="t1", name="bash"))
 
@@ -698,12 +696,12 @@ def test_successful_tool_result_relativizes_public_paths() -> None:
     )
 
     rendered = str(updates[0].content[0].content.text)
-    assert rendered == "./src/app.py\n[PATH]"
-    assert "/Users/alice" not in rendered
+    assert rendered == "/Users/alice/project/src/app.py\n/Users/alice/private/secret.txt"
+    assert "/Users/alice" in rendered
     assert updates[1].status == "completed"
 
 
-def test_successful_tool_result_dict_is_sanitized_and_serialized() -> None:
+def test_successful_tool_result_dict_is_preserved_and_serialized() -> None:
     converter = ACPEventConverter(turn_id="turn-1")
     converter.event_to_updates(ToolUseStartEvent(tool_use_id="t1", name="write_file"))
 
@@ -723,10 +721,10 @@ def test_successful_tool_result_dict_is_sanitized_and_serialized() -> None:
     )
 
     rendered = str(updates[0].content[0].content.text)
-    assert '"filename": "template.yaml"' in rendered
-    assert "secret content" not in rendered
-    assert "Alice Smith" not in rendered
-    assert ".iac-code" not in rendered
+    assert '"filename": "C:\\\\Users\\\\Alice Smith\\\\.iac-code\\\\projects\\\\demo\\\\template.yaml"' in rendered
+    assert "secret content" in rendered
+    assert "Alice Smith" in rendered
+    assert ".iac-code" in rendered
     assert updates[1].status == "completed"
 
 

--- a/tests/acp/test_error_handling.py
+++ b/tests/acp/test_error_handling.py
@@ -109,7 +109,7 @@ async def test_prompt_agent_loop_exception_becomes_request_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_prompt_agent_loop_exception_redacts_public_error() -> None:
+async def test_prompt_agent_loop_exception_preserves_local_error() -> None:
     class LeakyLoop:
         async def run_streaming(self, prompt: str):
             raise RuntimeError("DB_PASSWORD=hunter2 /Users/alice/.iac-code/settings.yml")
@@ -122,8 +122,8 @@ async def test_prompt_agent_loop_exception_redacts_public_error() -> None:
         await session.prompt([acp.schema.TextContentBlock(type="text", text="boom")])
 
     rendered = str(exc_info.value.data)
-    assert "hunter2" not in rendered
-    assert "/Users/alice" not in rendered
+    assert "hunter2" in rendered
+    assert "/Users/alice" in rendered
     assert exc_info.value.data["error_id"]
 
 

--- a/tests/acp/test_permission_rules.py
+++ b/tests/acp/test_permission_rules.py
@@ -477,8 +477,8 @@ async def test_mcp_permission_content_uses_concise_registered_tool_name():
 
 
 @pytest.mark.asyncio
-async def test_content_uses_safe_input_summary_for_aliyun_api():
-    """ToolCallUpdate content does not expose raw Aliyun request input."""
+async def test_content_preserves_local_aliyun_api_tool_input():
+    """ACP is local, so permission content keeps the actual Aliyun input."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
     event = _make_event(
@@ -498,10 +498,11 @@ async def test_content_uses_safe_input_summary_for_aliyun_api():
 
     await session._request_permission(event)
 
-    assert "Input summary:" in conn.last_content
-    assert "product" in conn.last_content
-    assert "action" in conn.last_content
-    for forbidden in (
+    assert "Input:" in conn.last_content
+    assert "Input summary:" not in conn.last_content
+    for expected in (
+        "product",
+        "action",
         "secret-value",
         "signature-secret",
         "bearer-secret",
@@ -511,11 +512,11 @@ async def test_content_uses_safe_input_summary_for_aliyun_api():
         "Authorization",
         "PrivateKey",
     ):
-        assert forbidden not in conn.last_content
+        assert expected in conn.last_content
 
 
 @pytest.mark.asyncio
-async def test_content_preserves_redacted_non_aliyun_tool_input():
+async def test_content_preserves_raw_non_aliyun_tool_input():
     """Non-Aliyun permission prompts keep decision-critical input visible."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
@@ -529,13 +530,13 @@ async def test_content_preserves_redacted_non_aliyun_tool_input():
     assert "Input:" in conn.last_content
     assert "Input summary:" not in conn.last_content
     assert "git status --short" in conn.last_content
-    assert "secret-value" not in conn.last_content
-    assert "apiKey" not in conn.last_content
+    assert "secret-value" in conn.last_content
+    assert "apiKey" in conn.last_content
 
 
 @pytest.mark.asyncio
-async def test_content_fingerprints_business_fields_in_non_aliyun_tool_input():
-    """Non-Aliyun permission prompts hide business field names and values."""
+async def test_content_preserves_business_fields_in_non_aliyun_tool_input():
+    """Local ACP permission prompts keep business field names and values."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
     event = _make_event(
@@ -550,13 +551,13 @@ async def test_content_fingerprints_business_fields_in_non_aliyun_tool_input():
     await session._request_permission(event)
 
     assert "git status --short" in conn.last_content
-    for forbidden in ("customerEmail", "customer-prod-123", "alice@example.com", "tenant-id"):
-        assert forbidden not in conn.last_content
+    for expected in ("customerEmail", "customer-prod-123", "alice@example.com", "tenant-id"):
+        assert expected in conn.last_content
 
 
 @pytest.mark.asyncio
-async def test_content_redacts_space_separated_secret_flags_and_preserves_paths():
-    """Non-Aliyun permission prompts redact CLI secret flags without hiding paths."""
+async def test_content_preserves_space_separated_secret_flags_and_paths():
+    """Local ACP permission prompts preserve command flags and paths."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
     event = _make_event(
@@ -572,16 +573,15 @@ async def test_content_redacts_space_separated_secret_flags_and_preserves_paths(
     await session._request_permission(event)
 
     assert "/Users/alice/project/main.tf" in conn.last_content
-    assert "--token [REDACTED]" in conn.last_content
-    assert "--password [REDACTED]" in conn.last_content
-    assert "--api-key [REDACTED]" in conn.last_content
-    for forbidden in ("abc123value", "hunter2", "sk-live-secret", "[PATH]"):
-        assert forbidden not in conn.last_content
+    for expected in ("abc123value", "hunter2", "sk-live-secret"):
+        assert expected in conn.last_content
+    assert "[REDACTED]" not in conn.last_content
+    assert "[PATH]" not in conn.last_content
 
 
 @pytest.mark.asyncio
-async def test_content_redacts_env_secret_assignments_without_false_flag_matches():
-    """Non-Aliyun permission prompts redact env-style secrets without hiding paths."""
+async def test_content_preserves_env_secret_assignments_and_paths():
+    """Local ACP permission prompts preserve env assignments and paths."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
     event = _make_event(
@@ -598,18 +598,17 @@ async def test_content_redacts_env_secret_assignments_without_false_flag_matches
 
     await session._request_permission(event)
 
-    assert "OPENAI_API_KEY=[REDACTED]" in conn.last_content
-    assert "AWS_SECRET_ACCESS_KEY=[REDACTED]" in conn.last_content
-    assert "ALIBABA_CLOUD_ACCESS_KEY_SECRET=[REDACTED]" in conn.last_content
+    assert "OPENAI_API_KEY=sk-openai" in conn.last_content
+    assert "AWS_SECRET_ACCESS_KEY='aws-secret'" in conn.last_content
+    assert "ALIBABA_CLOUD_ACCESS_KEY_SECRET=aliyun-secret" in conn.last_content
     assert "my-secret value" in conn.last_content
     assert "/Users/alice/project/main.tf" in conn.last_content
-    for forbidden in ("sk-openai", "aws-secret", "aliyun-secret", "[PATH]"):
-        assert forbidden not in conn.last_content
+    assert "[PATH]" not in conn.last_content
 
 
 @pytest.mark.asyncio
-async def test_content_redacts_long_json_and_escaped_quote_secret_values():
-    """Non-Aliyun permission prompts redact secrets before long-string slicing."""
+async def test_content_preserves_long_json_and_escaped_quote_secret_values():
+    """Local ACP permission prompts preserve long command input."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
     long_secret = "sk-" + ("x" * 260) + "tail-secret"
@@ -628,16 +627,17 @@ async def test_content_redacts_long_json_and_escaped_quote_secret_values():
 
     await session._request_permission(event)
 
-    assert "OPENAI_API_KEY=[REDACTED]" in conn.last_content
+    assert f"OPENAI_API_KEY={long_secret}" in conn.last_content
     assert "apiKey" in conn.last_content
     assert "/Users/alice/project/main.tf" in conn.last_content
-    for forbidden in (long_secret, "tail-secret", "sk-json-secret", "escaped-tail-secret", "[PATH]"):
-        assert forbidden not in conn.last_content
+    for expected in (long_secret, "tail-secret", "sk-json-secret", "escaped-tail-secret"):
+        assert expected in conn.last_content
+    assert "[PATH]" not in conn.last_content
 
 
 @pytest.mark.asyncio
-async def test_content_marks_truncated_long_non_aliyun_tool_input():
-    """Non-Aliyun permission prompts make long decision input truncation explicit."""
+async def test_content_preserves_long_non_aliyun_tool_input():
+    """Local ACP permission prompts keep the complete decision input."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
     command = ("echo safe && " * 40) + "rm -rf /"
@@ -645,13 +645,13 @@ async def test_content_marks_truncated_long_non_aliyun_tool_input():
 
     await session._request_permission(event)
 
-    assert '"truncated": true' in conn.last_content
+    assert '"truncated": true' not in conn.last_content
     assert "rm -rf /" in conn.last_content
 
 
 @pytest.mark.asyncio
-async def test_content_preserves_priority_fields_in_wide_non_aliyun_tool_input():
-    """Non-Aliyun permission prompts do not let low-value fields hide command/path."""
+async def test_content_preserves_all_fields_in_wide_non_aliyun_tool_input():
+    """Local ACP permission prompts keep all supplied fields."""
     conn = _FakeConn(_make_allowed_outcome(_OPTION_ALLOW_ONCE))
     session = _make_session(_FakeLoop(), conn)
     tool_input: dict[str, object] = {f"field_{index}": index for index in range(100)}
@@ -661,8 +661,8 @@ async def test_content_preserves_priority_fields_in_wide_non_aliyun_tool_input()
     await session._request_permission(event)
 
     assert "rm -rf /" in conn.last_content
-    assert '"_truncated"' in conn.last_content
-    assert "field_99" not in conn.last_content
+    assert '"_truncated"' not in conn.last_content
+    assert "field_99" in conn.last_content
 
 
 @pytest.mark.asyncio

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -301,7 +301,9 @@ async def test_mcp_permission_request_wire_includes_safe_metadata() -> None:
     assert tool_call.title == "MCP yuque/search-docs"
     wire = tool_call.model_dump(by_alias=True, exclude_none=True, exclude_defaults=True)
     wire_text = json.dumps(wire, sort_keys=True)
-    assert "IAC_PRIVATE_PERMISSION_TOKEN_37" not in wire_text
+    permission = wire["_meta"]["iac_code"]["permission"]
+    assert "IAC_PRIVATE_PERMISSION_TOKEN_37" in json.dumps(wire["content"], sort_keys=True)
+    assert "IAC_PRIVATE_PERMISSION_TOKEN_37" not in json.dumps(permission, sort_keys=True)
     for internal_value in (
         "internal-session-id-37",
         "secret-rule-source",
@@ -311,7 +313,6 @@ async def test_mcp_permission_request_wire_includes_safe_metadata() -> None:
         "max_file_bytes",
     ):
         assert internal_value not in wire_text
-    permission = wire["_meta"]["iac_code"]["permission"]
     assert permission["permissionId"] == "perm-mcp_tool1"
     assert permission["toolName"] == "mcp__yuque__search_docs"
     assert permission["toolUseId"] == "mcp_tool1"

--- a/tests/acp/test_scenarios.py
+++ b/tests/acp/test_scenarios.py
@@ -384,8 +384,8 @@ def test_a4_history_message_to_updates_all_types() -> None:
     updates = _history_message_to_updates(asst_business_tool)
     rendered = json.dumps([update.model_dump(mode="json") for update in updates], ensure_ascii=False)
     assert "git status --short" in rendered
-    for forbidden in ("customerEmail", "customer-prod-123", "alice@example.com", "tenant-id"):
-        assert forbidden not in rendered
+    for expected in ("customerEmail", "customer-prod-123", "alice@example.com", "tenant-id"):
+        assert expected in rendered
 
     asst_secret_flag_tool = Message(
         role="assistant",
@@ -406,11 +406,8 @@ def test_a4_history_message_to_updates_all_types() -> None:
     updates = _history_message_to_updates(asst_secret_flag_tool)
     rendered = json.dumps([update.model_dump(mode="json") for update in updates], ensure_ascii=False)
     assert "/Users/alice/project/main.tf" in rendered
-    assert "--token [REDACTED]" in rendered
-    assert "--password [REDACTED]" in rendered
-    assert "--api-key [REDACTED]" in rendered
-    for forbidden in ("abc123value", "hunter2", "sk-live-secret", "[PATH]"):
-        assert forbidden not in rendered
+    for expected in ("abc123value", "hunter2", "sk-live-secret"):
+        assert expected in rendered
 
     asst_env_secret_tool = Message(
         role="assistant",
@@ -431,13 +428,11 @@ def test_a4_history_message_to_updates_all_types() -> None:
     )
     updates = _history_message_to_updates(asst_env_secret_tool)
     rendered = json.dumps([update.model_dump(mode="json") for update in updates], ensure_ascii=False)
-    assert "OPENAI_API_KEY=[REDACTED]" in rendered
-    assert "AWS_SECRET_ACCESS_KEY=[REDACTED]" in rendered
-    assert "ALIBABA_CLOUD_ACCESS_KEY_SECRET=[REDACTED]" in rendered
+    assert "OPENAI_API_KEY=sk-openai" in rendered
+    assert "AWS_SECRET_ACCESS_KEY='aws-secret'" in rendered
+    assert "ALIBABA_CLOUD_ACCESS_KEY_SECRET=aliyun-secret" in rendered
     assert "my-secret value" in rendered
     assert "/Users/alice/project/main.tf" in rendered
-    for forbidden in ("sk-openai", "aws-secret", "aliyun-secret", "[PATH]"):
-        assert forbidden not in rendered
 
     long_env_secret = "sk-" + ("x" * 260) + "tail-secret"
     asst_long_secret_tool = Message(
@@ -460,11 +455,11 @@ def test_a4_history_message_to_updates_all_types() -> None:
     )
     updates = _history_message_to_updates(asst_long_secret_tool)
     rendered = json.dumps([update.model_dump(mode="json") for update in updates], ensure_ascii=False)
-    assert "OPENAI_API_KEY=[REDACTED]" in rendered
+    assert long_env_secret in rendered
     assert "apiKey" in rendered
     assert "/Users/alice/project/main.tf" in rendered
-    for forbidden in (long_env_secret, "tail-secret", "sk-json-secret", "escaped-tail-secret", "[PATH]"):
-        assert forbidden not in rendered
+    for expected in ("tail-secret", "sk-json-secret", "escaped-tail-secret"):
+        assert expected in rendered
 
     asst_aliyun_tool = Message(
         role="assistant",
@@ -487,13 +482,12 @@ def test_a4_history_message_to_updates_all_types() -> None:
     )
     updates = _history_message_to_updates(asst_aliyun_tool)
     rendered = json.dumps([update.model_dump(mode="json") for update in updates], ensure_ascii=False)
-    assert "Input summary:" in rendered
-    assert "secret-value" not in rendered
-    assert "signature-secret" not in rendered
-    assert "bearer-secret" not in rendered
-    assert "AccessKeySecret" not in rendered
-    assert "Signature" not in rendered
-    assert "Authorization" not in rendered
+    assert "secret-value" in rendered
+    assert "signature-secret" in rendered
+    assert "bearer-secret" in rendered
+    assert "AccessKeySecret" in rendered
+    assert "Signature" in rendered
+    assert "Authorization" in rendered
 
     user_result = Message(
         role="user",
@@ -520,9 +514,8 @@ def test_a4_history_message_to_updates_all_types() -> None:
     )
     updates = _history_message_to_updates(user_success_with_path)
     rendered = str(updates[0].content[0].content.text)
-    assert rendered == "wrote [PATH]"
-    assert "Alice" not in rendered
-    assert ".iac-code" not in rendered
+    assert "file%3A%2F%2F%2FUsers%2FAlice" in rendered
+    assert ".iac-code" in rendered
 
     user_err = Message(
         role="user",
@@ -541,12 +534,10 @@ def test_a4_history_message_to_updates_all_types() -> None:
     assert len(updates) == 2
     assert updates[0].status == "in_progress"
     rendered = updates[0].content[0].content.text
-    assert "hunter2" not in rendered
-    assert "/Users/alice" not in rendered
-    assert "%2FUsers" not in rendered
-    assert ".iac-code" not in rendered
-    assert "DB_PASSWORD=[REDACTED]" in rendered
-    assert "[PATH]" in rendered
+    assert "hunter2" in rendered
+    assert "/Users/alice" in rendered
+    assert "%2FUsers" in rendered
+    assert ".iac-code" in rendered
     assert updates[1].status == "failed"
 
     asst_str = Message(role="assistant", content="plain text assistant")
@@ -1972,7 +1963,7 @@ async def test_acp_mcp_prompt_command_persists_expanded_prompt(tmp_path) -> None
 
 
 @pytest.mark.asyncio
-async def test_acp_mcp_prompt_server_error_raises_request_error_without_leaking_secret() -> None:
+async def test_acp_mcp_prompt_server_error_returns_local_details() -> None:
     registry = CommandRegistry()
     registry.register(
         PromptCommand(
@@ -2000,7 +1991,7 @@ async def test_acp_mcp_prompt_server_error_raises_request_error_without_leaking_
 
     payload = getattr(exc_info.value, "data", {}) or {}
     assert payload["error"].startswith("RuntimeError: MCP prompt server failed with access_token=")
-    assert "super-secret-token" not in payload["error"]
+    assert "super-secret-token" in payload["error"]
     assert loop.continued is False
     assert conn.updates == []
 

--- a/tests/acp/test_server_coverage.py
+++ b/tests/acp/test_server_coverage.py
@@ -363,8 +363,7 @@ async def test_fork_session_from_storage_loads_history(monkeypatch, tmp_path) ->
 
 
 @pytest.mark.asyncio
-async def test_create_runtime_non_auth_exception_returns_public_error(monkeypatch) -> None:
-    """Non-auth runtime creation errors are returned as sanitized ACP errors."""
+async def test_create_runtime_non_auth_exception_returns_local_error(monkeypatch, caplog) -> None:
 
     def _raise_generic(options):
         raise RuntimeError("disk full for sk-live-secret at /Users/alice/.iac-code/settings.yml")
@@ -377,13 +376,20 @@ async def test_create_runtime_non_auth_exception_returns_public_error(monkeypatc
     server = ACPServer()
     server.on_connect(FakeConn())
 
-    with pytest.raises(acp.RequestError) as exc_info:
+    with (
+        caplog.at_level(logging.ERROR, logger="iac_code.acp.server"),
+        pytest.raises(acp.RequestError) as exc_info,
+    ):
         await server.new_session(cwd="/tmp")
 
     rendered = str(exc_info.value.data)
-    assert "sk-live-secret" not in rendered
-    assert "/Users/alice" not in rendered
+    assert "sk-live-secret" in rendered
+    assert "/Users/alice" in rendered
     assert exc_info.value.data["error_id"]
+    assert "sk-live-secret" not in caplog.text
+    assert "/Users/alice" not in caplog.text
+    assert "[REDACTED]" in caplog.text
+    assert "[PATH]" in caplog.text
 
 
 # ===========================================================================

--- a/tests/acp/test_sessions.py
+++ b/tests/acp/test_sessions.py
@@ -668,13 +668,11 @@ async def test_resume_active_session_from_other_cwd_raises_hint(monkeypatch: pyt
 
     assert isinstance(exc_info.value.data, dict)
     expected_hint = format_resume_command("/source project;unsafe", "test-session")
-    assert exc_info.value.data["cwd"] == "[PATH]"
-    assert exc_info.value.data["hint"] != expected_hint
-    assert "/source project" not in exc_info.value.data["hint"]
+    assert exc_info.value.data["cwd"] == "/source project;unsafe"
+    assert exc_info.value.data["hint"] == expected_hint
     assert sid in str(exc_info.value)
-    assert expected_hint not in str(exc_info.value)
-    assert "/source project" not in str(exc_info.value)
-    assert "[PATH]" in str(exc_info.value)
+    assert expected_hint in str(exc_info.value)
+    assert "/source project" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -703,12 +701,10 @@ async def test_resume_resolved_name_rejects_active_session_from_other_cwd(
 
     assert isinstance(exc_info.value.data, dict)
     expected_hint = format_resume_command("/other project;unsafe", "same-id")
-    assert exc_info.value.data["cwd"] == "[PATH]"
-    assert exc_info.value.data["hint"] != expected_hint
-    assert "/other project" not in exc_info.value.data["hint"]
-    assert expected_hint not in str(exc_info.value)
-    assert "/other project" not in str(exc_info.value)
-    assert "[PATH]" in str(exc_info.value)
+    assert exc_info.value.data["cwd"] == "/other project;unsafe"
+    assert exc_info.value.data["hint"] == expected_hint
+    assert expected_hint in str(exc_info.value)
+    assert "/other project" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -850,11 +846,11 @@ async def test_resume_session_single_cross_project_match_raises_hint(monkeypatch
 
     assert isinstance(exc_info.value.data, dict)
     expected_hint = format_resume_command("/other project;unsafe", "foreign-session-123")
-    assert exc_info.value.data["hint"] != expected_hint
-    assert "/other project" not in exc_info.value.data["hint"]
+    assert exc_info.value.data["hint"] == expected_hint
+    assert exc_info.value.data["cwd"] == foreign_cwd
     assert "foreign-session-123" in str(exc_info.value)
-    assert expected_hint not in str(exc_info.value)
-    assert "/other project" not in str(exc_info.value)
+    assert expected_hint in str(exc_info.value)
+    assert "/other project" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -882,10 +878,9 @@ async def test_resume_session_ambiguous_name_raises_candidates(monkeypatch: pyte
     assert isinstance(exc_info.value.data, dict)
     candidates = exc_info.value.data["candidates"]
     commands_by_id = {candidate["session_id"]: candidate["command"] for candidate in candidates}
-    assert commands_by_id["candidate-a"] != format_resume_command("/project a;bad", "candidate-a")
-    assert commands_by_id["candidate-b"] != format_resume_command("/project-b", "candidate-b")
-    assert "/project a" not in commands_by_id["candidate-a"]
-    assert "/project-b" not in commands_by_id["candidate-b"]
+    assert commands_by_id["candidate-a"] == format_resume_command("/project a;bad", "candidate-a")
+    assert commands_by_id["candidate-b"] == format_resume_command("/project-b", "candidate-b")
+    assert {candidate["cwd"] for candidate in candidates} == {"/project a;bad", "/project-b"}
 
 
 @pytest.mark.asyncio

--- a/tests/acp/test_slash_registry.py
+++ b/tests/acp/test_slash_registry.py
@@ -126,7 +126,7 @@ async def test_compact_failed_status(registry: ACPSlashRegistry) -> None:
 
 
 @pytest.mark.asyncio
-async def test_compact_exception(registry: ACPSlashRegistry) -> None:
+async def test_compact_exception(registry: ACPSlashRegistry, caplog) -> None:
     agent_loop = MagicMock()
 
     async def _compact():
@@ -137,11 +137,13 @@ async def test_compact_exception(registry: ACPSlashRegistry) -> None:
     agent_loop.compact = _compact
     result = await registry.execute("/compact", agent_loop=agent_loop)
     assert "network error" in result
-    assert "sk-compactsecret123" not in result
-    assert "Authorization: Bearer" not in result
-    assert "/Users/alice" not in result
-    assert "[REDACTED]" in result
-    assert "[PATH]" in result
+    assert "sk-compactsecret123" in result
+    assert "Authorization: Bearer" in result
+    assert "/Users/alice" in result
+    assert "sk-compactsecret123" not in caplog.text
+    assert "/Users/alice" not in caplog.text
+    assert "[REDACTED]" in caplog.text
+    assert "[PATH]" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -158,16 +160,18 @@ async def test_clear_success(registry: ACPSlashRegistry) -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_exception(registry: ACPSlashRegistry) -> None:
+async def test_clear_exception(registry: ACPSlashRegistry, caplog) -> None:
     agent_loop = MagicMock()
     agent_loop.reset.side_effect = RuntimeError("db error\nCookie: session=sk-clearsecret123\ncache: ~/.iac-code/cache")
     result = await registry.execute("/clear", agent_loop=agent_loop)
     assert "db error" in result
-    assert "sk-clearsecret123" not in result
-    assert "Cookie:" not in result
-    assert "~/.iac-code" not in result
-    assert "[REDACTED]" in result
-    assert "[PATH]" in result
+    assert "sk-clearsecret123" in result
+    assert "Cookie:" in result
+    assert "~/.iac-code" in result
+    assert "sk-clearsecret123" not in caplog.text
+    assert "~/.iac-code" not in caplog.text
+    assert "[REDACTED]" in caplog.text
+    assert "[PATH]" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -370,7 +374,7 @@ async def test_rename_value_error_returns_message(registry: ACPSlashRegistry) ->
 
 
 @pytest.mark.asyncio
-async def test_rename_value_error_sanitizes_public_output(registry: ACPSlashRegistry) -> None:
+async def test_rename_value_error_preserves_local_output(registry: ACPSlashRegistry) -> None:
     agent_loop = MagicMock()
     agent_loop._cwd = "/project"
     agent_loop._session_id = "session-1"
@@ -385,10 +389,8 @@ async def test_rename_value_error_sanitizes_public_output(registry: ACPSlashRegi
         result = await registry.execute("/rename deploy-prod", agent_loop=agent_loop)
 
     assert "Duplicate session" in result
-    assert "/Users/alice" not in result
-    assert "sk-renamesecret123" not in result
-    assert "[PATH]" in result
-    assert "[REDACTED]" in result
+    assert "/Users/alice" in result
+    assert "sk-renamesecret123" in result
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_headless.py
+++ b/tests/cli/test_headless.py
@@ -417,7 +417,7 @@ async def test_json_output():
 
 
 @pytest.mark.asyncio
-async def test_json_output_reports_sanitized_runtime_creation_error():
+async def test_json_output_reports_local_runtime_creation_error():
     """Creation-time failures should be represented in the machine-readable JSON output."""
     buf = io.StringIO()
     runner = _make_runner(OutputFormat.JSON, buf)
@@ -433,12 +433,12 @@ async def test_json_output_reports_sanitized_runtime_creation_error():
     parsed = json.loads(buf.getvalue())
     assert "error" in parsed
     assert parsed["error_id"]
-    assert "hunter2" not in parsed["error"]
-    assert "/Users/alice" not in parsed["error"]
+    assert "hunter2" in parsed["error"]
+    assert "/Users/alice" in parsed["error"]
 
 
 @pytest.mark.asyncio
-async def test_stream_json_output_reports_sanitized_runtime_creation_error():
+async def test_stream_json_output_reports_local_runtime_creation_error():
     """Creation-time failures should be represented in the machine-readable stream-json output."""
     buf = io.StringIO()
     runner = _make_runner(OutputFormat.STREAM_JSON, buf)
@@ -454,8 +454,8 @@ async def test_stream_json_output_reports_sanitized_runtime_creation_error():
     parsed = json.loads(buf.getvalue())
     assert parsed["type"] == "error"
     assert parsed["error_id"]
-    assert "hunter2" not in parsed["error"]
-    assert "/Users/alice" not in parsed["error"]
+    assert "hunter2" in parsed["error"]
+    assert "/Users/alice" in parsed["error"]
 
 
 @pytest.mark.asyncio
@@ -1522,8 +1522,7 @@ async def test_no_api_key_prints_friendly_error():
 
 
 @pytest.mark.asyncio
-async def test_provider_not_configured_sanitizes_public_stderr():
-    """Provider setup errors may include paths or secrets; stderr must keep only public details."""
+async def test_provider_not_configured_preserves_local_stderr_details():
     buf = io.StringIO()
     err_buf = io.StringIO()
     runner = _make_runner(OutputFormat.TEXT, buf)
@@ -1545,16 +1544,14 @@ async def test_provider_not_configured_sanitizes_public_stderr():
     assert exit_code == EXIT_ERROR
     err_output = err_buf.getvalue()
     assert "Cannot load provider" in err_output
-    assert "sk-headlesssecret123" not in err_output
-    assert "Authorization: Bearer" not in err_output
-    assert "/Users/alice" not in err_output
-    assert "[REDACTED]" in err_output
-    assert "[PATH]" in err_output
+    assert "sk-headlesssecret123" in err_output
+    assert "Authorization: Bearer" in err_output
+    assert "/Users/alice" in err_output
     assert "/auth" in err_output
 
 
 @pytest.mark.asyncio
-async def test_provider_not_configured_during_runtime_creation_sanitizes_public_stderr():
+async def test_provider_not_configured_during_runtime_creation_preserves_local_stderr():
     buf = io.StringIO()
     err_buf = io.StringIO()
     runner = _make_runner(OutputFormat.TEXT, buf)
@@ -1573,16 +1570,14 @@ async def test_provider_not_configured_during_runtime_creation_sanitizes_public_
     assert exit_code == EXIT_ERROR
     err_output = err_buf.getvalue()
     assert "Cannot load provider" in err_output
-    assert "sk-createagentsecret123" not in err_output
-    assert r"C:\Users" not in err_output
-    assert r"Alice Smith\.iac-code" not in err_output
-    assert "[REDACTED]" in err_output
-    assert "[PATH]" in err_output
+    assert "sk-createagentsecret123" in err_output
+    assert r"C:\Users" in err_output
+    assert r"Alice Smith\.iac-code" in err_output
     assert "/auth" in err_output
 
 
 @pytest.mark.asyncio
-async def test_unexpected_error_during_runtime_creation_sanitizes_public_stderr():
+async def test_unexpected_error_during_runtime_creation_preserves_local_stderr():
     buf = io.StringIO()
     err_buf = io.StringIO()
     runner = _make_runner(OutputFormat.TEXT, buf)
@@ -1601,8 +1596,6 @@ async def test_unexpected_error_during_runtime_creation_sanitizes_public_stderr(
     assert exit_code == EXIT_ERROR
     err_output = err_buf.getvalue()
     assert "runtime failed" in err_output
-    assert "plain-secret" not in err_output
-    assert r"C:\Users" not in err_output
-    assert r"Alice Smith\.iac-code" not in err_output
-    assert "[REDACTED]" in err_output
-    assert "[PATH]" in err_output
+    assert "plain-secret" in err_output
+    assert r"C:\Users" in err_output
+    assert r"Alice Smith\.iac-code" in err_output

--- a/tests/cli/test_output_formats.py
+++ b/tests/cli/test_output_formats.py
@@ -138,7 +138,7 @@ class TestJsonWriter:
         assert result["error"] == "something went wrong"
         assert result["error_id"] == "err-abc123"
 
-    def test_error_event_is_sanitized(self) -> None:
+    def test_error_event_is_preserved_for_local_json(self) -> None:
         stream = io.StringIO()
         writer = JsonWriter(stream)
         writer.handle(
@@ -150,10 +150,10 @@ class TestJsonWriter:
         writer.finalize()
 
         result = json.loads(stream.getvalue())
-        assert "sk-live" not in result["error"]
-        assert "/Users/alice" not in result["error"]
+        assert "sk-live" in result["error"]
+        assert "/Users/alice" in result["error"]
 
-    def test_error_event_redacts_encoded_paths_and_preserves_valid_artifact_uri(self) -> None:
+    def test_error_event_preserves_encoded_path_and_artifact_uri(self) -> None:
         stream = io.StringIO()
         writer = JsonWriter(stream)
         encoded_path = "file%3A%2F%2F%2FUsers%2Falice%2F.iac-code%2Fprojects%2Fdemo%2Ftemplate.yaml"
@@ -162,9 +162,9 @@ class TestJsonWriter:
         writer.finalize()
 
         result = json.loads(stream.getvalue())
-        assert result["error"] == f"failed at [PATH]; see {uri}."
+        assert result["error"] == f"failed at {encoded_path}; see {uri}."
 
-    def test_failed_tool_result_is_sanitized(self) -> None:
+    def test_failed_tool_result_is_preserved_for_local_json(self) -> None:
         stream = io.StringIO()
         writer = JsonWriter(stream)
         writer.handle(
@@ -180,10 +180,10 @@ class TestJsonWriter:
         result = json.loads(stream.getvalue())
         tool = result["tool_uses"][0]
         assert tool["is_error"] is True
-        assert "hunter2" not in tool["result"]
-        assert "/Users/alice" not in tool["result"]
+        assert "hunter2" in tool["result"]
+        assert "/Users/alice" in tool["result"]
 
-    def test_successful_tool_result_is_sanitized_without_losing_valid_artifact_uri(self) -> None:
+    def test_successful_tool_result_preserves_path_and_artifact_uri(self) -> None:
         stream = io.StringIO()
         writer = JsonWriter(stream)
         encoded_path = "file%3A%2F%2F%2FUsers%2Falice%2F.iac-code%2Fprojects%2Fdemo%2Ftemplate.yaml"
@@ -202,10 +202,10 @@ class TestJsonWriter:
         result = json.loads(stream.getvalue())
         tool = result["tool_uses"][0]
         rendered = json.dumps(tool, ensure_ascii=False)
-        assert tool["result"]["message"] == "wrote [PATH]"
+        assert tool["result"]["message"] == f"wrote {encoded_path}"
         assert tool["result"]["artifact"]["uri"] == uri
-        assert "%2FUsers" not in rendered
-        assert ".iac-code" not in rendered
+        assert "%2FUsers" in rendered
+        assert ".iac-code" in rendered
 
     def test_synthetic_max_turns_does_not_overwrite_previous_usage(self) -> None:
         stream = io.StringIO()
@@ -325,7 +325,7 @@ class TestStreamJsonWriter:
         assert data["type"] == "tool_result"
         assert "metadata" not in data
 
-    def test_tool_result_relativizes_public_paths_without_emitting_roots(self) -> None:
+    def test_tool_result_preserves_paths_without_emitting_projection_roots(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         writer.handle(
@@ -340,12 +340,12 @@ class TestStreamJsonWriter:
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
         assert data["type"] == "tool_result"
-        assert data["result"] == "./src/app.py\n[PATH]"
+        assert data["result"] == "/Users/alice/project/src/app.py\n/Users/alice/private/secret.txt"
         assert "public_path_roots" not in data
         assert "publicPathRoots" not in rendered
-        assert "/Users/alice" not in rendered
+        assert "/Users/alice" in rendered
 
-    def test_tool_result_redacts_embedded_file_content_json_string(self) -> None:
+    def test_tool_result_preserves_embedded_file_content_json_string(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         writer.handle(
@@ -365,11 +365,11 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
-        assert "ROSTemplateFormatVersion" not in rendered
+        assert "ROSTemplateFormatVersion" in rendered
         assert "file_content" in rendered
         assert "sha256-value" in rendered
 
-    def test_tool_result_redacts_externalized_file_content_preview(self, tmp_path) -> None:
+    def test_tool_result_preserves_externalized_file_content_preview(self, tmp_path) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         raw_result = json.dumps(
@@ -394,7 +394,7 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
-        assert "ROSTemplateFormatVersion" not in rendered
+        assert "ROSTemplateFormatVersion" in rendered
         assert "file_content" in rendered
         assert "sha256-value" in rendered
 
@@ -594,7 +594,7 @@ class TestStreamJsonWriter:
         assert "passed · 0 findings" not in rendered
         assert "metadata" not in data
 
-    def test_failed_tool_result_redacts_encoded_malformed_artifact_uri(self) -> None:
+    def test_failed_tool_result_preserves_encoded_malformed_artifact_uri(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         encoded_uri = (
@@ -613,12 +613,11 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
-        assert "[PATH]" in rendered
-        assert "%5CUsers" not in rendered
-        assert "Users" not in rendered
-        assert ".iac-code" not in rendered
+        assert encoded_uri in rendered
+        assert "%5CUsers" in rendered
+        assert ".iac-code" in rendered
 
-    def test_successful_tool_result_and_metadata_are_sanitized(self) -> None:
+    def test_successful_tool_result_and_metadata_are_preserved(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         encoded_uri = (
@@ -645,13 +644,13 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
-        assert "[PATH]" in rendered
-        assert "secret content" not in rendered
-        assert "Alice Smith" not in rendered
-        assert "%5CAlice" not in rendered
-        assert ".iac-code" not in rendered
+        assert encoded_uri in rendered
+        assert "secret content" in rendered
+        assert "Alice Smith" in rendered
+        assert "%5CAlice" in rendered
+        assert ".iac-code" in rendered
 
-    def test_error_event_is_sanitized(self) -> None:
+    def test_error_event_is_preserved_for_local_stream_json(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         writer.handle(
@@ -663,8 +662,8 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         assert data["type"] == "error"
-        assert "session-secret" not in data["error"]
-        assert "refresh-secret" not in data["error"]
+        assert "session-secret" in data["error"]
+        assert "refresh-secret" in data["error"]
 
     def test_error_event_preserves_error_id(self) -> None:
         stream = io.StringIO()
@@ -777,7 +776,7 @@ class TestStreamJsonWriter:
         ):
             assert forbidden not in rendered
 
-    def test_failed_tool_result_is_sanitized(self) -> None:
+    def test_failed_tool_result_is_preserved(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         writer.handle(
@@ -791,10 +790,10 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         assert data["is_error"] is True
-        assert "hunter2" not in data["result"]
-        assert "/Users/alice" not in data["result"]
+        assert "hunter2" in data["result"]
+        assert "/Users/alice" in data["result"]
 
-    def test_failed_tool_result_metadata_is_sanitized(self) -> None:
+    def test_failed_tool_result_metadata_is_preserved(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         writer.handle(
@@ -814,11 +813,11 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
-        assert "hunter2" not in rendered
-        assert "/Users/alice" not in rendered
-        assert data["metadata"]["step_result"]["error"] == "Schema failed DB_PASSWORD=[REDACTED] at [PATH]"
+        assert "hunter2" in rendered
+        assert "/Users/alice" in rendered
+        assert data["metadata"]["step_result"]["error"].endswith("/Users/alice/.iac-code/settings.yml")
 
-    def test_failed_tool_result_metadata_relativizes_public_paths(self) -> None:
+    def test_failed_tool_result_metadata_preserves_public_paths(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         writer.handle(
@@ -839,10 +838,10 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
-        assert "/Users/alice" not in rendered
-        assert data["metadata"]["step_result"]["error"] == "Schema failed at ./logs/result.txt"
+        assert "/Users/alice" in rendered
+        assert data["metadata"]["step_result"]["error"] == "Schema failed at /Users/alice/project/logs/result.txt"
 
-    def test_mcp_tool_result_redacts_private_markers_in_result_and_metadata(self) -> None:
+    def test_ordinary_mcp_tool_result_is_preserved_for_local_stream(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
         writer.handle(
@@ -868,13 +867,11 @@ class TestStreamJsonWriter:
 
         data = json.loads(stream.getvalue())
         rendered = json.dumps(data, ensure_ascii=False)
-        assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" not in rendered
-        assert "IAC_PRIVATE_NESTED_METADATA_MARKER_56" not in rendered
-        assert "IAC_PRIVATE_QUERY_MARKER_56" not in rendered
-        assert "/Users/alice" not in rendered
-        assert "user:pass" not in rendered
-        assert "[REDACTED]" in rendered
-        assert "[PATH]" in rendered
+        assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" in rendered
+        assert "IAC_PRIVATE_NESTED_METADATA_MARKER_56" in rendered
+        assert "IAC_PRIVATE_QUERY_MARKER_56" in rendered
+        assert "/Users/alice" in rendered
+        assert "user:pass" in rendered
 
     def test_mcp_progress_includes_canonical_public_metadata(self) -> None:
         stream = io.StringIO()

--- a/tests/cli/test_process_events.py
+++ b/tests/cli/test_process_events.py
@@ -23,7 +23,7 @@ def test_process_event_serializer_hides_partial_tool_input() -> None:
     }
 
 
-def test_process_event_serializer_sanitizes_tool_result() -> None:
+def test_process_event_serializer_preserves_local_tool_result() -> None:
     serializer = ProcessEventSerializer()
 
     event = ToolResultEvent(
@@ -34,9 +34,9 @@ def test_process_event_serializer_sanitizes_tool_result() -> None:
     )
 
     rendered = json.dumps(serializer.serialize(event), ensure_ascii=False)
-    assert "sk-live12345" not in rendered
-    assert "/Users/alice" not in rendered
-    assert "settings.yml" not in rendered
+    assert "sk-live12345" in rendered
+    assert "/Users/alice" in rendered
+    assert "settings.yml" in rendered
 
 
 def test_process_event_serializer_normal_aliyun_result_reuses_stream_json_projection() -> None:

--- a/tests/mcp/test_runtime_integration.py
+++ b/tests/mcp/test_runtime_integration.py
@@ -1035,7 +1035,7 @@ async def test_repl_mcp_elicitation_cancels_without_printing_when_non_interactiv
 
 
 @pytest.mark.asyncio
-async def test_repl_mcp_elicitation_sanitizes_and_bounds_interactive_text(monkeypatch) -> None:
+async def test_repl_mcp_elicitation_preserves_and_bounds_interactive_text(monkeypatch) -> None:
     from iac_code.ui.repl import InlineREPL
 
     class CapturingConsole:
@@ -1067,8 +1067,8 @@ async def test_repl_mcp_elicitation_sanitizes_and_bounds_interactive_text(monkey
 
     printed = "\n".join(console.printed)
     assert result == {"action": "accept"}
-    assert "super-secret-token" not in printed
-    assert "[REDACTED]" in printed
+    assert "super-secret-token" in printed
+    assert "[REDACTED]" not in printed
     assert all(len(line) <= 1100 for line in console.printed)
     assert console.prompts
 

--- a/tests/pipeline/engine/test_cleanup.py
+++ b/tests/pipeline/engine/test_cleanup.py
@@ -241,7 +241,7 @@ def test_observer_marks_ros_stack_delete_failed(tmp_path) -> None:
     assert updated.last_error
 
 
-def test_update_resource_sanitizes_durable_last_error(tmp_path) -> None:
+def test_update_resource_preserves_durable_canonical_last_error(tmp_path) -> None:
     ledger = CleanupLedger(tmp_path / "cleanup.yaml")
     resource = CleanupResource.from_observed(_observed_stack(), reason="rollback requested")
     ledger.mark_cleanup_required([resource], source_step_id="deploying", reason="rollback requested")
@@ -263,11 +263,12 @@ def test_update_resource_sanitizes_durable_last_error(tmp_path) -> None:
     resource_error = data["cleanup_resources"][0]["last_error"]
     history_error = data["history"][-1]["last_error"]
     for value in (resource_error, history_error):
-        assert "super-secret" not in value
-        assert "sk-live" not in value
-        assert "bearer-secret" not in value
-        assert "/Users/alice" not in value
-        assert "[REDACTED]" in value or "[PATH]" in value
+        assert "super-secret" in value
+        assert "sk-live" in value
+        assert "bearer-secret" in value
+        assert "/Users/alice" in value
+        assert "[REDACTED]" not in value
+        assert "[PATH]" not in value
 
 
 def test_observer_tracks_aliyun_api_delete_then_get_stack_polling(tmp_path) -> None:
@@ -637,11 +638,7 @@ def test_observer_rejects_persisted_mapping_result_stack_id_mismatch(tmp_path, c
     assert history[-1]["type"] == "cleanup_tool_result_mismatch"
     assert history[-1]["tool_use_id"] == "toolu-delete-a"
     assert history[-1]["mapped_resource_id"] == "stack-a"
-    assert history[-1]["result_resource_id"] != unsafe_stack_id
-    assert "super-secret" not in history[-1]["result_resource_id"]
-    assert "/Users/alice" not in history[-1]["result_resource_id"]
-    assert "[REDACTED]" in history[-1]["result_resource_id"]
-    assert "[PATH]" in history[-1]["result_resource_id"]
+    assert history[-1]["result_resource_id"] == unsafe_stack_id
     assert history[-1]["tool_name"] == "ros_stack"
     assert "Mismatched cleanup tool result" in caplog.text
     assert "super-secret" not in caplog.text

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1329,7 +1329,7 @@ class TestSchemaValidation:
         assert "name" in result.content
         assert result.metadata is None
 
-    def test_invalid_tool_input_error_redacts_previous_invalid_input(self):
+    def test_invalid_tool_input_error_preserves_previous_invalid_input_for_llm_retry(self):
         config = StepConfig(
             step_id="test",
             conclusion_field="out",
@@ -1350,13 +1350,14 @@ class TestSchemaValidation:
         )
 
         assert not valid
-        assert "tok-completestepsecret123" not in error
-        assert r"C:\Users" not in error
-        assert r"Alice Smith\.iac-code" not in error
-        assert "[REDACTED]" in error
-        assert "[PATH]" in error
+        assert "tok-completestepsecret123" in error
+        assert "config_path" in error
+        assert "Alice Smith" in error
+        assert "settings.yml" in error
+        assert "[REDACTED]" not in error
+        assert "[PATH]" not in error
 
-    def test_invalid_conclusion_schema_error_redacts_secret_value(self):
+    def test_invalid_conclusion_schema_error_preserves_value_for_llm_retry(self):
         config = StepConfig(
             step_id="test",
             conclusion_field="out",
@@ -1372,11 +1373,13 @@ class TestSchemaValidation:
         valid, error = tool.validate_input({"conclusion": {"admin_token": "tok-completestepsecret123"}})
 
         assert not valid
-        assert "tok-completestepsecret123" not in error
-        assert "[REDACTED]" in error
+        assert "tok-completestepsecret123" in error
+        assert "[REDACTED]" not in error
 
     @pytest.mark.asyncio
-    async def test_execute_schema_error_redacts_sensitive_field_value(self):
+    async def test_execute_schema_error_preserves_functional_value_but_strictly_sanitizes_log(
+        self, caplog: pytest.LogCaptureFixture
+    ):
         config = StepConfig(
             step_id="test",
             conclusion_field="out",
@@ -1401,10 +1404,11 @@ class TestSchemaValidation:
 
         assert r1.is_error
         assert r2.is_error
-        assert "tok-plainsecret123" not in r1.content
-        assert "tok-plainsecret123" not in r2.content
-        assert "[REDACTED]" in r1.content
-        assert "[REDACTED]" in r2.metadata["step_result"].error
+        assert "tok-plainsecret123" in r1.content
+        assert "tok-plainsecret123" in r2.content
+        assert "tok-plainsecret123" in r2.metadata["step_result"].error
+        assert "tok-plainsecret123" not in caplog.text
+        assert "validator=type" in caplog.text
 
     @pytest.mark.asyncio
     async def test_retry_succeeds_after_fix(self):

--- a/tests/pipeline/engine/test_pipeline_observability.py
+++ b/tests/pipeline/engine/test_pipeline_observability.py
@@ -947,7 +947,7 @@ def test_metrics_use_bounded_attrs_while_events_keep_debug_context():
 
     event_attrs = log_event.call_args.args[1]
     assert event_attrs["session_id"] == "sid"
-    assert event_attrs["cwd"] == "/repo"
+    assert event_attrs["cwd"] == "[PATH]"
     assert event_attrs["sub_pipeline_id"] == "evaluate_candidate_abc123"
     assert event_attrs["candidate_name"] == "customer-specific candidate"
     assert event_attrs["error_summary"] == "unique customer path failed"

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -998,8 +998,8 @@ async def test_backup_blocked_after_step_yields_recoverable_event_without_failed
     assert blocked_events[0].step_id == "a"
     assert blocked_events[0].data["reason"] == BackupReason.PIPELINE_STEP_COMPLETED.value
     assert blocked_events[0].data["recoverable"] is True
-    assert "/Users/alice" not in blocked_events[0].data["error"]
-    assert "abc123" not in blocked_events[0].data["error"]
+    assert "/Users/alice" in blocked_events[0].data["error"]
+    assert "abc123" in blocked_events[0].data["error"]
     assert not any(isinstance(event, PipelineEvent) and event.type == PipelineEventType.STEP_FAILED for event in events)
     assert not any(
         isinstance(event, PipelineEvent) and event.type == PipelineEventType.PIPELINE_COMPLETED for event in events
@@ -2687,23 +2687,24 @@ class TestParallelSubPipelineStep:
         assert failed_event.data["candidate_index"] == 0
         assert failed_event.data["candidate_name"] == "Plan A"
         assert failed_event.data["sub_pipeline_name"] == "evaluate_candidate"
-        assert failed_event.data["error_summary"] == "lost worker token=[REDACTED] [PATH]"
+        raw_error = "lost worker token=abc123 /Users/alice/project"
+        assert failed_event.data["error_summary"] == raw_error
         assert failed_event.data["error_details"]["type"] == "RuntimeError"
         assert "error_id" in failed_event.data["error_details"]
-        assert "abc123" not in str(failed_event.data)
-        assert "/Users/alice" not in str(failed_event.data)
+        assert "abc123" in str(failed_event.data)
+        assert "/Users/alice" in str(failed_event.data)
         evaluated = runner.context.get_conclusion("evaluated")
         assert evaluated == [
             {
                 "candidate": {"name": "Plan A"},
                 "failed": True,
-                "error": "lost worker token=[REDACTED] [PATH]",
+                "error": raw_error,
                 "error_details": failed_event.data["error_details"],
             }
         ]
         failed_save = next(save for save in reversed(runner.session.saved) if save[2] == "parallel candidate failed")
         failed_state = failed_save[3]["execution"]["candidates"]["0"]
-        assert failed_state["error"] == "lost worker token=[REDACTED] [PATH]"
+        assert failed_state["error"] == raw_error
         assert failed_state["error_details"] == failed_event.data["error_details"]
         runner._observability.sub_pipeline_completed.assert_called_once_with(
             duration_ms=33.0,
@@ -2714,7 +2715,7 @@ class TestParallelSubPipelineStep:
             candidate_index=0,
             candidate_name="Plan A",
             total_steps=1,
-            error_summary="lost worker token=[REDACTED] [PATH]",
+            error_summary=raw_error,
             error_type="RuntimeError",
             error_id=failed_event.data["error_details"]["error_id"],
         )
@@ -3258,15 +3259,15 @@ class TestParallelSubPipelineStep:
             and event.data.get("failed") is True
         )
         rendered_event = str(failed_event.data)
-        assert "secret-value" not in rendered_event
-        assert "/Users/alice" not in rendered_event
+        assert "secret-value" in rendered_event
+        assert "/Users/alice" in rendered_event
         assert failed_event.data["error"] == failed_event.data["error_summary"]
         assert failed_event.data["error_details"]["type"] == "SubPipelineFailed"
         assert failed_event.data["error_details"]["error_id"]
 
         evaluated = runner.context.get_conclusion("evaluated")
-        assert "secret-value" not in str(evaluated)
-        assert "/Users/alice" not in str(evaluated)
+        assert "secret-value" in str(evaluated)
+        assert "/Users/alice" in str(evaluated)
         assert evaluated[0]["error"] == failed_event.data["error_summary"]
         assert evaluated[0]["error_details"]["error_id"] == failed_event.data["error_details"]["error_id"]
 
@@ -3861,6 +3862,11 @@ class TestParallelCleanupOnClose:
     async def test_aclose_cancels_candidates_and_resets_state(self, tmp_path, caplog):
         caplog.set_level(logging.INFO, logger="iac_code.pipeline.engine.pipeline_runner")
         runner = self._build_runner(tmp_path)
+        candidate_names = [str(tmp_path / "Plan A"), str(tmp_path / "Plan B")]
+        runner.context.set_conclusion(
+            "architecture",
+            {"candidates": [{"name": candidate_names[0]}, {"name": candidate_names[1]}]},
+        )
         runner._observability.candidate_cancelled = MagicMock()
         released = asyncio.Event()  # never set → candidates hang after first event
 
@@ -3916,13 +3922,13 @@ class TestParallelCleanupOnClose:
             call(
                 parent_step_id="eval",
                 candidate_index=0,
-                candidate_name="Plan A",
+                candidate_name=candidate_names[0],
                 reason="parallel_cleanup",
             ),
             call(
                 parent_step_id="eval",
                 candidate_index=1,
-                candidate_name="Plan B",
+                candidate_name=candidate_names[1],
                 reason="parallel_cleanup",
             ),
         ]
@@ -3933,6 +3939,8 @@ class TestParallelCleanupOnClose:
         assert {record.candidate_index for record in log_records} == {0, 1}
         assert {record.parent_step_id for record in log_records} == {"eval"}
         assert {record.reason for record in log_records} == {"parallel_cleanup"}
+        assert {record.candidate_name for record in log_records} == {"[PATH]"}
+        assert all(candidate_name not in record.message for record in log_records for candidate_name in candidate_names)
 
 
 class TestClearSidecar:
@@ -4281,7 +4289,7 @@ class TestInvalidRollbackTarget:
         assert seen_targets_by_step["c"] == ["a", "b"]
 
     @pytest.mark.asyncio
-    async def test_failed_step_event_uses_public_error_payload(self, tmp_path):
+    async def test_failed_step_event_uses_canonical_error_payload(self, tmp_path):
         runner = _build_two_step_runner(tmp_path)
         runner._observability.step_failed = MagicMock()
 
@@ -4304,9 +4312,9 @@ class TestInvalidRollbackTarget:
         assert len(failed) == 1
         payload = failed[0].data
         rendered = str(payload)
-        assert "session-secret" not in rendered
-        assert "/tmp/iac-code" not in rendered
-        assert payload["error"] == "provider failed [REDACTED]"
+        assert "session-secret" in rendered
+        assert "/tmp/iac-code" in rendered
+        assert payload["error"] == "provider failed Cookie=session-secret /tmp/iac-code/config.yml"
         assert payload["error_summary"] == payload["error"]
         assert runner._observability.step_failed.call_args.kwargs["error_id"]
         assert payload["error_details"]["type"] == "StepFailed"
@@ -4460,7 +4468,7 @@ class TestInvalidRollbackTarget:
         runner._observability.step_failed.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_invalid_rollback_target_step_failed_redacts_public_payload(self, tmp_path):
+    async def test_invalid_rollback_target_step_failed_preserves_canonical_payload(self, tmp_path):
         runner = _build_two_step_runner(tmp_path)
         runner._observability.step_completed = MagicMock()
         runner._observability.step_failed = MagicMock()
@@ -4482,13 +4490,12 @@ class TestInvalidRollbackTarget:
         assert len(failed) == 1
         payload = failed[0].data
         rendered = str(payload)
-        assert "secret-one" not in rendered
-        assert "LTAIabc123456789" not in rendered
-        assert "/Users/alice" not in rendered
+        assert "secret-one" in rendered
+        assert "LTAIabc123456789" in rendered
         assert payload["error"] == payload["error_summary"]
         assert payload["error_details"]["type"] == "StepFailed"
         assert payload["error_details"]["step_id"] == "a"
-        assert "secret-one" not in runner._observability.step_failed.call_args.kwargs["error_summary"]
+        assert "secret-one" in runner._observability.step_failed.call_args.kwargs["error_summary"]
         assert runner._observability.step_failed.call_args.kwargs["error_id"]
 
     @pytest.mark.asyncio

--- a/tests/pipeline/engine/test_public_errors.py
+++ b/tests/pipeline/engine/test_public_errors.py
@@ -3,177 +3,34 @@ import pytest
 from iac_code.pipeline.engine.public_errors import public_error, sanitize_public_text
 
 
-def test_public_error_redacts_bare_provider_keys_config_paths_and_uses_stable_id() -> None:
-    first = public_error(
-        message=(
-            "Incorrect API key provided: sk-first-secret123 from ~/.iac-code/settings.yml "
-            "and $HOME/.iac-code/.credentials.yml and /etc/iac-code/settings.yml"
-        ),
-        error_type="AuthenticationError",
-    )
-    second = public_error(
-        message=(
-            "Incorrect API key provided: sk-second-secret456 from ~/.iac-code/settings.yml "
-            "and $HOME/.iac-code/.credentials.yml and /etc/iac-code/settings.yml"
-        ),
-        error_type="AuthenticationError",
-    )
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Incorrect API key provided: sk-first-secret123 from ~/.iac-code/settings.yml",
+        "failed OPENAI_API_KEY=sk-live DB_PASSWORD=hunter2 at /tmp/iac/file.py",
+        r"failed at C:\Users\Alice Smith\.iac-code\settings.yml",
+        r"failed at \\server\share\Alice Smith\.iac-code\settings.yml",
+        "failed at /Users/alice/My Project/.iac-code/settings.yml",
+        "failed at file%3A%2F%2F%2FUsers%2Falice%2F.iac-code%2Ftemplate.yaml",
+        r"failed at file:///Users/Alice and Bob/.iac-code/template.yaml",
+    ],
+)
+def test_pipeline_public_error_preserves_canonical_message(message: str) -> None:
+    failure = public_error(message=message, error_type="RuntimeError")
 
-    rendered = str({"summary": first.summary, "details": first.details})
-    assert "sk-first-secret123" not in rendered
-    assert "~/.iac-code" not in rendered
-    assert "$HOME/.iac-code" not in rendered
-    assert "/etc/iac-code" not in rendered
-    assert first.error_id == second.error_id
-
-
-def test_public_error_redacts_prefixed_secrets_and_common_local_paths() -> None:
-    failure = public_error(
-        message=(
-            "failed OPENAI_API_KEY=sk-live ALIYUN_ACCESS_KEY_SECRET=aliyun-secret "
-            "DB_PASSWORD=hunter2 at /tmp/iac/file.py and /private/var/folders/aa/bb.py"
-        ),
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "sk-live" not in rendered
-    assert "aliyun-secret" not in rendered
-    assert "hunter2" not in rendered
-    assert "/tmp/iac" not in rendered
-    assert "/private/var/folders" not in rendered
-    assert "OPENAI_API_KEY=[REDACTED]" in failure.summary
-    assert "ALIYUN_ACCESS_KEY_SECRET=[REDACTED]" in failure.summary
-    assert "DB_PASSWORD=[REDACTED]" in failure.summary
-    assert "[PATH]" in failure.summary
+    assert failure.summary == message
+    assert failure.details["type"] == "RuntimeError"
     assert failure.details["traceback"] == "Stack trace omitted from public event; see error_id."
     assert failure.error_id
+    assert "[PATH]" not in failure.summary
+    assert "[REDACTED]" not in failure.summary
 
 
-def test_public_error_redacts_windows_paths_with_spaces() -> None:
-    failure = public_error(
-        message=r"failed at C:\Users\Alice Smith\.iac-code\settings.yml and C:\Program Files\iac-code\config.yml",
-        error_type="RuntimeError",
-    )
+def test_pipeline_public_error_id_uses_the_raw_canonical_message() -> None:
+    first = public_error(message="token=first", error_type="RuntimeError")
+    second = public_error(message="token=second", error_type="RuntimeError")
 
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert r"C:\Users" not in rendered
-    assert r"Alice Smith\.iac-code" not in rendered
-    assert r"C:\Program Files" not in rendered
-    assert "[PATH]" in failure.summary
-
-
-def test_public_error_redacts_windows_forward_slash_and_unc_paths_with_spaces() -> None:
-    failure = public_error(
-        message=(
-            "failed at C:/Users/Alice Smith/.iac-code/settings.yml and "
-            r"\\server\share\Alice Smith\.iac-code\settings.yml and "
-            "//server/share/Alice Smith/.iac-code/settings.yml"
-        ),
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "Alice Smith" not in rendered
-    assert ".iac-code" not in rendered
-    assert "server" not in rendered
-    assert "//server/share" not in rendered
-    assert "[PATH]" in failure.summary
-
-
-def test_public_error_redacts_unix_paths_with_spaces() -> None:
-    failure = public_error(
-        message="failed at /Users/alice/My Project/.iac-code/settings.yml and /tmp/iac code/output.log",
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "My Project" not in rendered
-    assert ".iac-code" not in rendered
-    assert "iac code" not in rendered
-    assert "[PATH]" in failure.summary
-
-
-def test_public_error_redacts_path_without_swallowing_following_secret() -> None:
-    failure = public_error(
-        message="Duplicate session stored at /Users/alice/.iac-code/projects/session.json with api_key=sk-secret123",
-        error_type="ValueError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "/Users/alice" not in rendered
-    assert "sk-secret123" not in rendered
-    assert "[PATH]" in failure.summary
-    assert "api_key=[REDACTED]" in failure.summary
-
-
-def test_public_error_redacts_encoded_local_paths_and_malformed_artifact_uris() -> None:
-    encoded_file_uri = "file%3A%2F%2F%2FUsers%2Falice%2F.iac-code%2Fprojects%2Fdemo%2Ftemplate.yaml"
-    encoded_artifact_uri = (
-        "iac-code-artifact%3A%2F%2Fartifact-1%2FC%3A%5CUsers%5Calice%5C.iac-code%5Cprojects%5Cdemo%5Ctemplate.yaml"
-    )
-
-    failure = public_error(
-        message=f"failed at {encoded_file_uri} and {encoded_artifact_uri}",
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "%2FUsers" not in rendered
-    assert "%5CUsers" not in rendered
-    assert "Users" not in rendered
-    assert ".iac-code" not in rendered
-    assert "iac-code-artifac[PATH]" not in rendered
-    assert "[PATH]" in failure.summary
-
-
-def test_public_error_redacts_raw_file_and_artifact_uris_with_spaces() -> None:
-    failure = public_error(
-        message=(
-            r"failed at file:///Users/Alice and Bob/.iac-code/projects/demo/template.yaml and next; "
-            r"then iac-code-artifact://artifact-1/C:\Users\Alice and Bob\.iac-code\projects\demo\template.yaml "
-            "with done"
-        ),
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "Alice and Bob" not in rendered
-    assert ".iac-code" not in rendered
-    assert "file://" not in rendered
-    assert "iac-code-artifac[PATH]" not in rendered
-    assert failure.summary == "failed at [PATH]; then [PATH]"
-
-
-def test_public_error_redacts_paths_before_newlines() -> None:
-    failure = public_error(
-        message=(
-            "failed at file:///Users/Alice Smith/.iac-code/projects/demo/template.yaml\nnext line "
-            "and /Users/Alice Smith/.iac-code/projects/demo/settings.yml\r\nmore"
-        ),
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "Alice Smith" not in rendered
-    assert ".iac-code" not in rendered
-    assert failure.summary == "failed at [PATH]\nnext line and [PATH]\r\nmore"
-
-
-def test_public_error_redacts_connector_words_inside_final_filename() -> None:
-    failure = public_error(
-        message=(
-            "failed at file:///Users/Alice Smith/.iac-code/projects/demo/template from prod.yaml and done "
-            "plus /Users/Alice Smith/.iac-code/projects/demo/hello and world.yaml with ok"
-        ),
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "from prod.yaml" not in rendered
-    assert "and world.yaml" not in rendered
-    assert ".iac-code" not in rendered
-    assert failure.summary == "failed at [PATH]"
+    assert first.error_id != second.error_id
 
 
 @pytest.mark.parametrize(
@@ -209,83 +66,13 @@ def test_sanitize_public_text_preserves_normal_https_urls() -> None:
     assert sanitize_public_text("see https://example.test/doc") == "see https://example.test/doc"
 
 
-def test_public_error_redacts_quoted_serialized_secret_values() -> None:
-    failure = public_error(
-        message='config {"api_key": "plain-secret", "nested": {"token": "tok-secret"}} '
-        "and {'access_key_secret': 'aliyun-secret'}",
-        error_type="RuntimeError",
-    )
+def test_pipeline_public_error_preserves_structured_extra_details() -> None:
+    extra = {
+        "credentials": {"Authorization": "Bearer secret-value"},
+        "path": "/Users/alice/.iac-code/settings.yml",
+    }
 
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "plain-secret" not in rendered
-    assert "tok-secret" not in rendered
-    assert "aliyun-secret" not in rendered
-    assert "[REDACTED]" in failure.summary
+    failure = public_error(message="failed", error_type="RuntimeError", extra_details=extra)
 
-
-def test_public_error_redacts_quoted_authorization_objects_with_secret_first() -> None:
-    failure = public_error(
-        message='headers {"Authorization": {"credentials": "bearer-secret-123", "scheme": "Bearer"}} '
-        "and {'Authorization': {'credentials': 'other-secret-456', 'scheme': 'Bearer'}}",
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": failure.summary, "details": failure.details})
-    assert "bearer-secret-123" not in rendered
-    assert "other-secret-456" not in rendered
-    assert "[REDACTED]" in failure.summary
-
-
-def test_public_error_redacts_auth_cookie_credentials_and_uses_sanitized_error_id() -> None:
-    first = public_error(
-        message=(
-            "failed Authorization: Basic abc123 Cookie=session-cookie credentials=cred-secret "
-            "private_key=key-secret session=sess-secret pwd=pwd-secret passwd=passwd-secret"
-        ),
-        error_type="RuntimeError",
-    )
-    second = public_error(
-        message=(
-            "failed Authorization: Basic def456 Cookie=other-cookie credentials=other-secret "
-            "private_key=other-key session=other-session pwd=other-pwd passwd=other-passwd"
-        ),
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": first.summary, "details": first.details})
-    for raw_secret in (
-        "abc123",
-        "session-cookie",
-        "cred-secret",
-        "key-secret",
-        "sess-secret",
-        "pwd-secret",
-        "passwd-secret",
-    ):
-        assert raw_secret not in rendered
-    assert "[REDACTED]" in first.summary
-    assert first.error_id == second.error_id
-
-
-def test_public_error_redacts_acs_authorization_cookie_lists_and_signed_query_values() -> None:
-    first = public_error(
-        message=(
-            "failed Authorization: ACS3-HMAC-SHA256 Credential=LTAIabc123456789,Signature=secret-one "
-            "Cookie: sid=first; refresh=second "
-            "url=https://example.test/?Signature=query-secret&x-acs-security-token=query-token"
-        ),
-        error_type="RuntimeError",
-    )
-    second = public_error(
-        message=(
-            "failed Authorization: ACS3-HMAC-SHA256 Credential=LTAIdef123456789,Signature=secret-two "
-            "Cookie: sid=third; refresh=fourth "
-            "url=https://example.test/?Signature=other-secret&x-acs-security-token=other-token"
-        ),
-        error_type="RuntimeError",
-    )
-
-    rendered = str({"summary": first.summary, "details": first.details})
-    for raw_secret in ("secret-one", "first", "second", "query-secret", "query-token", "LTAIabc123456789"):
-        assert raw_secret not in rendered
-    assert first.error_id == second.error_id
+    assert failure.details["credentials"] == extra["credentials"]
+    assert failure.details["path"] == extra["path"]

--- a/tests/pipeline/engine/test_sub_pipeline_executor.py
+++ b/tests/pipeline/engine/test_sub_pipeline_executor.py
@@ -782,7 +782,9 @@ class TestSubPipelineExecutor:
         assert resumed_steps == ["cost_estimating"]
 
     @pytest.mark.asyncio
-    async def test_allocator_failure_does_not_publish_previous_attempt_for_next_sub_step(self, tmp_path, monkeypatch):
+    async def test_allocator_failure_does_not_publish_previous_attempt_for_next_sub_step(
+        self, tmp_path, monkeypatch, caplog
+    ):
         """A later allocator failure must not report the previous sub-step's attempt id."""
         (tmp_path / "prompts").mkdir(exist_ok=True)
         (tmp_path / "prompts" / "template.md").write_text("Generate template for {candidate}", encoding="utf-8")
@@ -849,8 +851,12 @@ class TestSubPipelineExecutor:
         assert terminal.data["failed"] is True
         assert terminal.data["error_details"]["type"] == "RuntimeError"
         assert "error_id" in terminal.data["error_details"]
-        assert "abc123" not in terminal.data["error_summary"]
-        assert "/Users/alice" not in terminal.data["error_summary"]
+        assert "abc123" in terminal.data["error_summary"]
+        assert "/Users/alice" in terminal.data["error_summary"]
+        assert "abc123" not in caplog.text
+        assert "/Users/alice" not in caplog.text
+        assert "token=[REDACTED]" in caplog.text
+        assert "[PATH]" in caplog.text
 
     @pytest.mark.asyncio
     async def test_rollback_persistence_drops_stale_target_and_downstream_conclusions(self, tmp_path, monkeypatch):
@@ -1224,7 +1230,7 @@ class TestSubPipelineExecutor:
         assert sub_step_failed[0].step_id == "template_generating"
         assert sub_step_failed[0].data["error_details"]["type"] == "StepFailed"
         assert sub_step_failed[0].data["error_details"]["error_id"]
-        assert "secret-value" not in str(sub_step_failed[0].data)
+        assert "secret-value" in str(sub_step_failed[0].data)
         assert terminal[0].data["failed"] is True
 
     @pytest.mark.asyncio
@@ -1578,7 +1584,7 @@ class TestSubPipelineRollbackEmitsSubStepFailed:
         assert failed_events[0].data["error_details"]["target"] == "totally_invalid_step_id"
 
     @pytest.mark.asyncio
-    async def test_invalid_rollback_target_sub_step_failed_event_redacts_public_error(self, tmp_path):
+    async def test_invalid_rollback_target_sub_step_failed_event_preserves_canonical_error(self, tmp_path):
         (tmp_path / "prompts").mkdir(exist_ok=True)
         (tmp_path / "prompts" / "template.md").write_text("Gen template", encoding="utf-8")
         (tmp_path / "prompts" / "cost.md").write_text("Cost", encoding="utf-8")
@@ -1633,9 +1639,9 @@ class TestSubPipelineRollbackEmitsSubStepFailed:
             e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_STEP_FAILED
         )
         rendered = str(failed_event.data)
-        assert "abc123" not in rendered
-        assert "bad_token=[REDACTED]" in failed_event.data["error"]
-        assert failed_event.data["error_details"]["target"] == "bad_token=[REDACTED]"
+        assert "abc123" in rendered
+        assert "bad_token=abc123" in failed_event.data["error"]
+        assert failed_event.data["error_details"]["target"] == "bad_token=abc123"
 
 
 class TestBuildSubContext:
@@ -1707,7 +1713,7 @@ class TestFailedCandidateErrorPropagated:
         assert result.error_details["type"] == "ValueError"
 
     @pytest.mark.asyncio
-    async def test_execute_exception_error_details_do_not_expose_traceback(self, tmp_path, monkeypatch):
+    async def test_execute_exception_keeps_canonical_error_without_runtime_traceback(self, tmp_path, monkeypatch):
         async def failing_execute(*args, **kwargs):
             raise RuntimeError("secret stack path token=abc123 /Users/alice/project")
             if False:
@@ -1741,8 +1747,8 @@ class TestFailedCandidateErrorPropagated:
         assert result.failed is True
         assert result.error_details["type"] == "RuntimeError"
         assert "error_id" in result.error_details
-        assert "abc123" not in result.error
-        assert "/Users/alice" not in result.error
+        assert "abc123" in result.error
+        assert "/Users/alice" in result.error
         assert "Traceback" not in str(result.to_dict())
 
     def test_sub_pipeline_result_error_details_defaults_none(self):

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -406,7 +406,8 @@ class TestCostPrompt:
     def test_prompt_is_not_duplicate_output_reference(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")
         assert "Preview-Validated Pricing Parameter Set" in body
-        assert "deployment_parameters" not in body
+        assert "`deployment_parameters`" in body
+        assert "不得写入 `***`、`[REDACTED]` 或 `<redacted>`" in body
         assert "询价失败但 PreviewStack 已成功" not in body
         assert "字段为字符串" not in body
 

--- a/tests/pipeline/selling/tools/test_ros_deploy_tool.py
+++ b/tests/pipeline/selling/tools/test_ros_deploy_tool.py
@@ -554,6 +554,88 @@ async def test_delete_and_create_validates_replacement_before_delete(monkeypatch
     assert fake_stack.calls == []
 
 
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {"Password": "***"},
+        {"Nested": [{"Password": " [REDACTED] "}]},
+        {"Password": "<ReDaCtEd>"},
+    ],
+)
+def test_deployment_actions_reject_recursive_redaction_placeholders(parameters):
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    valid, error = RosDeployTool().validate_input(
+        {
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "parameters": parameters,
+        }
+    )
+
+    assert valid is False
+    assert "redaction placeholder" in error
+    assert "Password" not in error
+
+
+@pytest.mark.parametrize("value", ["business***suffix", "prefix [REDACTED] suffix", "<redacted>-label"])
+def test_deployment_actions_allow_strings_that_only_contain_placeholder_text(value):
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    valid, error = RosDeployTool().validate_input(
+        {
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "parameters": {"Banner": value},
+        }
+    )
+
+    assert valid is True
+    assert error == ""
+
+
+def test_deployment_actions_do_not_treat_parameter_names_as_values():
+    from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+    valid, error = RosDeployTool().validate_input(
+        {
+            "action": "create",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "parameters": {"<ReDaCtEd>": "real-value"},
+        }
+    )
+
+    assert valid is True
+    assert error == ""
+
+
+@pytest.mark.asyncio
+async def test_delete_and_create_rejects_placeholder_before_deleting_owned_stack(monkeypatch, tmp_path):
+    guard_state = {"ros_deploy_owned_stack_ids": {"stack-old": {"action": "create"}}}
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "demo.yml").write_text("ROSTemplateFormatVersion: '2015-09-01'\n", encoding="utf-8")
+    tool, fake_stack = _deploy_tool(monkeypatch, guard_state=guard_state, results=[])
+
+    result = await tool.execute(
+        tool_input={
+            "action": "delete_and_create",
+            "stack_id": "stack-old",
+            "stack_name": "demo",
+            "template_url": "templates/demo.yml",
+            "parameters": {"Database": {"Password": "[REDACTED]"}},
+        },
+        context=ToolContext(cwd=str(tmp_path), pipeline_mode=True),
+    )
+
+    assert result.is_error is True
+    assert "redaction placeholder" in result.content
+    assert fake_stack.calls == []
+
+
 @pytest.mark.asyncio
 async def test_delete_and_create_rejects_missing_local_template_before_delete(monkeypatch, tmp_path):
     guard_state = {"ros_deploy_owned_stack_ids": {"stack-old": {"action": "create"}}}

--- a/tests/test_services/test_telemetry/test_content_serializer.py
+++ b/tests/test_services/test_telemetry/test_content_serializer.py
@@ -411,6 +411,13 @@ def test_serialize_tool_definitions():
     assert result[0]["description"] == "Run a command"
 
 
+def test_serialize_tool_definition_description_keeps_diagnostic_metadata_raw():
+    description = "Run /Users/alice/private/tool with token=tool-owned-description"
+    result = json.loads(serialize_tool_definitions([FakeToolDef(name="bash", description=description)]))
+
+    assert result[0]["description"] == description
+
+
 def test_serialize_tool_definitions_empty():
     assert serialize_tool_definitions(None) == "[]"
     assert serialize_tool_definitions([]) == "[]"
@@ -459,6 +466,61 @@ def test_serialize_tool_result_redacts_non_string_content():
     assert "ROSTemplateFormatVersion" not in result
     assert "file_content" in result
     assert "sha256-value" in result
+
+
+def test_content_serializers_strictly_sanitize_before_serialization_and_truncation(monkeypatch):
+    from iac_code.utils.public_errors import suppress_all_redaction
+
+    class SensitiveLeaf:
+        def __str__(self) -> str:
+            return "password=hunter2 /Users/alice/private.txt"
+
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "1")
+    with suppress_all_redaction():
+        arguments = serialize_tool_arguments(
+            {
+                "/Users/alice/key": SensitiveLeaf(),
+                "nested_json": '{"token":"secret-value","path":"/Users/alice/result.json"}',
+            }
+        )
+
+    parsed = json.loads(arguments)
+    assert "/Users/alice" not in arguments
+    assert "hunter2" not in arguments
+    assert "secret-value" not in arguments
+    assert parsed["[PATH]"] == "password=[REDACTED] [PATH]"
+    assert "[REDACTED]" in parsed["nested_json"]
+
+
+def test_content_serializers_redact_structured_sensitive_mapping_values():
+    payload = {
+        "password": "hunter2",
+        "apiKey": "plain-secret",
+        "config": {
+            "access_key_secret": "aliyun-secret",
+            "token": 123456,
+            "region_id": "cn-hangzhou",
+        },
+        "credentials": {"profile": "production"},
+    }
+
+    arguments = json.loads(serialize_tool_arguments(payload))
+    result = json.loads(serialize_tool_result(FakeToolResult(content=payload)))
+
+    expected = {
+        "password": "[REDACTED]",
+        "apiKey": "[REDACTED]",
+        "config": {
+            "access_key_secret": "[REDACTED]",
+            "token": "[REDACTED]",
+            "region_id": "cn-hangzhou",
+        },
+        "credentials": "[REDACTED]",
+    }
+    assert arguments == expected
+    assert result == expected
+    assert payload["password"] == "hunter2"
+    assert payload["config"]["token"] == 123456
 
 
 def test_truncation_for_large_content():

--- a/tests/test_services/test_telemetry/test_sanitize.py
+++ b/tests/test_services/test_telemetry/test_sanitize.py
@@ -37,6 +37,23 @@ def test_error_message_newlines_replaced_with_space():
     assert sanitize_error_message("line1\nline2\rline3\tend") == "line1 line2 line3 end"
 
 
+def test_error_message_strictly_redacts_credentials_and_paths():
+    assert sanitize_error_message("password=hunter2 at /Users/alice/private.txt") == "password=[REDACTED] at [PATH]"
+
+
+def test_error_message_strict_redaction_ignores_local_suppression_and_a2a_safe_mode(monkeypatch):
+    from iac_code.utils.public_errors import suppress_all_redaction
+
+    monkeypatch.setenv("IAC_CODE_A2A_SAFE_MODE", "1")
+    with suppress_all_redaction():
+        assert sanitize_error_message("token=secret-value /tmp/private.txt") == "token=[REDACTED] [PATH]"
+
+
+def test_error_message_strictly_redacts_arbitrary_server_layouts():
+    assert sanitize_error_message("failed at /srv/iac-code/private/x.txt") == "failed at [PATH]"
+    assert sanitize_error_message("failed at /opt/iac-code/private/x.txt") == "failed at [PATH]"
+
+
 def test_error_message_truncated_at_512_bytes():
     raw = "x" * 1000
     out = sanitize_error_message(raw)

--- a/tests/ui/test_renderer_helpers.py
+++ b/tests/ui/test_renderer_helpers.py
@@ -552,7 +552,7 @@ class TestRendererHelpers:
         assert "tech_stack_nodejs" not in output
         assert "not of type" not in output
 
-    def test_render_tool_result_sanitizes_mcp_public_output_without_mutating_result(self):
+    def test_render_tool_result_preserves_local_mcp_output_without_mutating_result(self):
         renderer = make_renderer()
         raw_result = (
             "command=IAC_PRIVATE_COMMAND_ARG_MARKER_56 "
@@ -565,12 +565,11 @@ class TestRendererHelpers:
         line = renderer._render_tool_result(record)
 
         assert line is not None
-        assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" not in line.plain
-        assert "IAC_PRIVATE_NESTED_METADATA_MARKER_56" not in line.plain
-        assert "IAC_PRIVATE_QUERY_MARKER_56" not in line.plain
-        assert "/Users/alice" not in line.plain
-        assert "[REDACTED]" in line.plain
-        assert "[PATH]" in line.plain
+        assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" in line.plain
+        assert "IAC_PRIVATE_NESTED_METADATA_MARKER_56" in line.plain
+        assert "IAC_PRIVATE_QUERY_MARKER_56" in line.plain
+        assert "/Users/alice" in line.plain
+        assert "[REDACTED]" not in line.plain
         assert record.result == raw_result
 
     def test_render_progress_groups_include_resource_rows(self):

--- a/tests/ui/test_repl_integration.py
+++ b/tests/ui/test_repl_integration.py
@@ -916,7 +916,7 @@ async def test_handle_command_reports_disabled_skill():
 
 
 @pytest.mark.asyncio
-async def test_handle_mcp_prompt_command_error_is_redacted():
+async def test_handle_mcp_prompt_command_error_is_raw_for_local_repl():
     from iac_code.commands.registry import CommandRegistry, PromptCommand
     from iac_code.skills.frontmatter import SkillFrontmatter
     from iac_code.skills.skill_definition import SkillDefinition
@@ -955,9 +955,8 @@ async def test_handle_mcp_prompt_command_error_is_redacted():
     await repl._handle_command("/mcp__ros__review template=vpc")
 
     message = repl.renderer.print_system_message.call_args.args[0]
-    assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" not in message
-    assert "user:pass" not in message
-    assert "[REDACTED]" in message
+    assert "IAC_PRIVATE_COMMAND_ARG_MARKER_56" in message
+    assert "https://user:pass@example.test/mcp" in message
 
 
 @patch("iac_code.ui.repl.ProviderManager")

--- a/tests/utils/test_public_paths.py
+++ b/tests/utils/test_public_paths.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ntpath
 
-from iac_code.utils.public_paths import build_public_path_roots, sanitize_public_paths
+from iac_code.utils.public_paths import build_public_path_roots, redact_known_public_paths, sanitize_public_paths
 
 
 def test_build_public_path_roots_includes_config_and_trusted_directories(tmp_path, monkeypatch) -> None:
@@ -71,3 +71,70 @@ def test_sanitize_public_paths_keeps_posix_roots_platform_independent(monkeypatc
     )
 
     assert sanitized == "paths: ./src/app.py ./logs/result.txt"
+
+
+def test_redact_known_public_paths_replaces_only_confirmed_server_paths() -> None:
+    roots = [{"path": "/server-root", "label": "."}]
+
+    assert (
+        redact_known_public_paths(
+            "server=/server-root/private/file target=/home/cloud-user/bootstrap.sh",
+            roots,
+        )
+        == "server=[PATH] target=/home/cloud-user/bootstrap.sh"
+    )
+
+
+def test_redact_known_public_paths_preserves_narrative_text_after_path() -> None:
+    roots = [{"path": "/srv/iac-code", "label": "."}]
+
+    cases = {
+        "failed at /srv/iac-code/private/result.json while reading": "failed at [PATH] while reading",
+        "failed at /srv/iac-code/private/result.json and retry": "failed at [PATH] and retry",
+        "failed at /srv/iac-code/private/result.json please retry": "failed at [PATH] please retry",
+        "path /srv/iac-code/private/result.json was missing": "path [PATH] was missing",
+    }
+
+    for value, expected in cases.items():
+        assert redact_known_public_paths(value, roots) == expected
+
+
+def test_redact_known_public_paths_supports_full_and_quoted_paths_with_spaces() -> None:
+    roots = [{"path": "/srv/iac-code", "label": "."}]
+
+    assert redact_known_public_paths("/srv/iac-code/Plan A/result.json", roots) == "[PATH]"
+    assert (
+        redact_known_public_paths('failed at "/srv/iac-code/Plan A/result.json" please retry', roots)
+        == 'failed at "[PATH]" please retry'
+    )
+
+
+def test_redact_known_public_paths_preserves_text_after_windows_path() -> None:
+    roots = [{"path": r"C:\iac-code", "label": "."}]
+
+    assert (
+        redact_known_public_paths(r"failed at C:\iac-code\private\result.json please retry", roots)
+        == "failed at [PATH] please retry"
+    )
+
+
+def test_redact_known_public_paths_replaces_confirmed_file_uri_only() -> None:
+    roots = [{"path": "/server-root", "label": "."}]
+
+    assert (
+        redact_known_public_paths(
+            "local=file:///server-root/private/result.json remote=file:///home/cloud-user/result.json",
+            roots,
+        )
+        == "local=[PATH] remote=file:///home/cloud-user/result.json"
+    )
+
+
+def test_redact_known_public_paths_uses_exact_placeholder_for_windows_and_unc() -> None:
+    roots = [
+        {"path": r"C:\\iac-code\\workspace", "label": "."},
+        {"path": r"\\\\server\\share", "label": "[trusted]"},
+    ]
+
+    assert redact_known_public_paths(r"C:\\iac-code\\workspace\\a.txt", roots) == "[PATH]"
+    assert redact_known_public_paths(r"\\\\server\\share\\a.txt", roots) == "[PATH]"

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -3058,7 +3058,7 @@ def test_suggestions_hide_thinking_enabled_command(tmp_path) -> None:
     assert all("thinking_enabled" not in value for value in values)
 
 
-def test_patch_session_redacts_secret_like_unsupported_field_names(tmp_path) -> None:
+def test_patch_session_reports_secret_like_unsupported_field_names_locally(tmp_path) -> None:
     from iac_code.web.app import create_app
     from iac_code.web.session_manager import WebSessionManager
 
@@ -3071,8 +3071,7 @@ def test_patch_session_redacts_secret_like_unsupported_field_names(tmp_path) -> 
 
     assert response.status_code == 400
     assert response.headers["content-type"].startswith("application/json")
-    assert "sk-test-secret" not in response.text
-    assert "[REDACTED]" in response.json()["error"]["message"]
+    assert "sk-test-secret" in response.text
 
 
 def test_patch_session_rejects_invalid_payload_without_partial_mutation(tmp_path) -> None:
@@ -3103,7 +3102,7 @@ def test_patch_session_rejects_invalid_payload_without_partial_mutation(tmp_path
     assert session.allow_user_escapes.shell is False
 
 
-def test_session_debug_route_returns_redacted_status_snapshot(tmp_path) -> None:
+def test_session_debug_route_returns_local_status_snapshot(tmp_path) -> None:
     from iac_code.web.app import create_app
     from iac_code.web.session_manager import WebSessionManager
 
@@ -3127,7 +3126,7 @@ def test_session_debug_route_returns_redacted_status_snapshot(tmp_path) -> None:
     assert payload["pendingPermissionCount"] == 0
     assert payload["pendingQuestionCount"] == 0
     assert payload["currentTurnActive"] is False
-    assert payload["lastError"]["message"] == "apiKey=[REDACTED]"
+    assert payload["lastError"]["message"] == "apiKey=sk-test-secret"
     assert payload["pipeline"]["pipelineRunId"] == "ctx-1"
     assert payload["pipeline"]["taskId"] == "task-1"
     assert payload["pipeline"]["contextId"] == "ctx-1"
@@ -3143,7 +3142,7 @@ def test_session_debug_route_returns_redacted_status_snapshot(tmp_path) -> None:
     assert "toolTimeline" in payload
     assert "providerSummary" in payload
     assert "cloudSummary" in payload
-    assert "sk-test-secret" not in response.text
+    assert "sk-test-secret" in response.text
 
 
 def test_session_status_route_includes_runtime_pipeline_usage_and_cleanup_sections(tmp_path) -> None:
@@ -3214,7 +3213,7 @@ def test_session_status_route_includes_estimated_context_usage(tmp_path) -> None
     assert payload["contextUsage"]["messageCount"] == 2
 
 
-def test_session_prompt_route_returns_truthful_redacted_snapshot(tmp_path) -> None:
+def test_session_prompt_route_returns_truthful_local_snapshot(tmp_path) -> None:
     from iac_code.agent.message import Message
     from iac_code.web.app import create_app
     from iac_code.web.session_manager import WebSessionManager
@@ -3232,7 +3231,7 @@ def test_session_prompt_route_returns_truthful_redacted_snapshot(tmp_path) -> No
     assert response.headers["content-type"].startswith("application/json")
     payload = response.json()
     assert payload["sessionId"] == session.session_id
-    assert payload["redacted"] is True
+    assert payload["redacted"] is False
     assert payload["available"] is True
     assert payload["mode"] == "pipeline"
     assert payload["cwd"] == str(project)
@@ -3248,10 +3247,10 @@ def test_session_prompt_route_returns_truthful_redacted_snapshot(tmp_path) -> No
     assert "toolDefinitions" in payload
     assert "memorySections" in payload
     assert "cleanupPromptSummary" in payload
-    assert "sk-test-secret" not in response.text
+    assert "sk-test-secret" in response.text
 
 
-def test_session_prompt_route_populates_available_sources_and_redacts_secrets(tmp_path, monkeypatch) -> None:
+def test_session_prompt_route_populates_available_local_sources(tmp_path, monkeypatch) -> None:
     from iac_code.web.app import create_app
     from iac_code.web.memory import save_project_instruction
     from iac_code.web.session_manager import WebSessionManager
@@ -3314,10 +3313,10 @@ def test_session_prompt_route_populates_available_sources_and_redacts_secrets(tm
     assert payload["cleanupPromptSummary"]["status"] == "pending"
     assert payload["sources"]["pipeline"]["snapshot"]["lastSequence"] == 42
     assert payload["sources"]["pipeline"]["currentStep"]["id"] == "confirm"
+    # Provider summaries intentionally expose only configuration state, not credential values.
     assert "sk-realpromptsecret" not in response.text
-    assert "sk-memorysecret" not in response.text
-    assert "super-secret" not in response.text
-    assert "[REDACTED]" in response.text
+    assert "sk-memorysecret" in response.text
+    assert "super-secret" in response.text
 
 
 def test_status_and_debug_merge_recovered_pipeline_snapshot(tmp_path, monkeypatch) -> None:
@@ -3372,11 +3371,11 @@ def test_status_and_debug_merge_recovered_pipeline_snapshot(tmp_path, monkeypatc
         assert pipeline["waitingInput"]["kind"] == "approval"
         assert pipeline["handoff"]["status"] == "pending"
         assert pipeline["cleanup"]["status"] == "pending"
-        assert pipeline["warningHistory"][0]["message"] == "warning apiKey=[REDACTED]"
+        assert pipeline["warningHistory"][0]["message"] == "warning apiKey=sk-warningsecret123456"
         assert pipeline["rollbackHistory"] == [{"from": "deploy", "to": "review", "reason": "fix"}]
         assert pipeline["candidateRestarts"] == [{"candidateName": "Plan B", "count": 1}]
         assert "sk-statussecret" not in response.text
-        assert "sk-warningsecret" not in response.text
+        assert "sk-warningsecret" in response.text
         assert response.json()["providerSummary"]["credentialConfigured"] is True
 
 

--- a/tests/web/test_app_path_redaction.py
+++ b/tests/web/test_app_path_redaction.py
@@ -1,44 +1,43 @@
-"""Tests for the loopback Web workbench all-redaction suppression middleware."""
+"""Local Web sessions retain the no-redaction context for unchanged consumers."""
 
 from __future__ import annotations
 
-import asyncio
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
 
-from iac_code.utils.public_errors import all_redaction_suppressed
+
+def test_create_app_installs_local_redaction_suppression_middleware() -> None:
+    from iac_code.web.app import create_app
+
+    for app in (create_app(), create_app(expose_local_paths=True)):
+        middleware_names = {middleware.cls.__name__ for middleware in app.user_middleware}
+        assert "_SuppressAllRedactionMiddleware" in middleware_names
 
 
-def test_middleware_suppresses_all_redaction_during_request_and_resets() -> None:
+def test_expose_local_paths_compatibility_flag_does_not_change_local_payloads() -> None:
+    from iac_code.web.app import create_app
+
+    default_app = create_app()
+    compatibility_app = create_app(expose_local_paths=True)
+
+    assert [item.cls for item in default_app.user_middleware] == [
+        item.cls for item in compatibility_app.user_middleware
+    ]
+
+
+def test_web_suppression_keeps_existing_permission_audit_behavior() -> None:
+    from iac_code.services.permissions.audit import sanitize_free_text
     from iac_code.web.app import _SuppressAllRedactionMiddleware
 
-    seen: dict[str, bool] = {}
+    async def audit_text(_request):
+        return PlainTextResponse(sanitize_free_text("read /tmp/private/result.json") or "")
 
-    async def downstream(scope, receive, send) -> None:
-        seen["during"] = all_redaction_suppressed()
-        # A background task created inside the request copies the current context,
-        # so it must keep redaction suppressed even after the request returns.
-        seen["task"] = None
+    app = Starlette(routes=[Route("/", audit_text)])
+    app.add_middleware(_SuppressAllRedactionMiddleware)
 
-        async def _bg() -> None:
-            seen["task"] = all_redaction_suppressed()
+    with TestClient(app) as client:
+        response = client.get("/")
 
-        task = asyncio.create_task(_bg())
-        await task
-
-    middleware = _SuppressAllRedactionMiddleware(downstream)
-
-    assert all_redaction_suppressed() is False
-    asyncio.run(middleware({"type": "http"}, None, None))
-    assert seen["during"] is True
-    assert seen["task"] is True
-    # ContextVar must reset once the request scope exits.
-    assert all_redaction_suppressed() is False
-
-
-def test_create_app_wires_middleware_only_when_exposing_local_paths() -> None:
-    from iac_code.web.app import _SuppressAllRedactionMiddleware, create_app
-
-    def _has_suppress_mw(app) -> bool:
-        return any(mw.cls is _SuppressAllRedactionMiddleware for mw in app.user_middleware)
-
-    assert _has_suppress_mw(create_app(expose_local_paths=True)) is True
-    assert _has_suppress_mw(create_app()) is False
+    assert response.text == "read /tmp/private/result.json"

--- a/tests/web/test_blocking_flow.py
+++ b/tests/web/test_blocking_flow.py
@@ -566,7 +566,7 @@ def test_session_detail_includes_pending_blocking_payloads(tmp_path) -> None:
             "payload": {
                 "action": "shell",
                 "command": "echo ok",
-                "apiKey": "[REDACTED]",
+                "apiKey": "sk-unsafe12345678",
                 "requestId": permission_id,
                 "sessionId": session.session_id,
                 "message": "Allow shell?",

--- a/tests/web/test_commands.py
+++ b/tests/web/test_commands.py
@@ -26,7 +26,7 @@ def _web_metadata_path(manager: WebSessionManager, cwd: str, session_id: str):
     return manager.storage.session_dir(cwd, session_id) / "web-session.json"
 
 
-def test_status_command_returns_redacted_session_status(tmp_path) -> None:
+def test_status_command_returns_local_session_status(tmp_path) -> None:
     manager, dispatcher = _dispatcher(tmp_path)
     session = manager.create_session(session_id="session-1")
     manager.add_permission_request(
@@ -45,9 +45,9 @@ def test_status_command_returns_redacted_session_status(tmp_path) -> None:
     assert response["status"]["sessionId"] == session.session_id
     assert response["status"]["mode"] == "normal"
     assert response["status"]["pendingPermissionCount"] == 1
-    assert response["status"]["pendingPermissions"][0]["payload"]["apiKey"] == "[REDACTED]"
-    assert "super-secret-value" not in str(response)
-    assert "sk-unsafe" not in str(response)
+    assert response["status"]["pendingPermissions"][0]["payload"]["apiKey"] == "sk-unsafe12345678"
+    assert "super-secret-value" in str(response)
+    assert "sk-unsafe" in str(response)
 
 
 def test_mcp_command_returns_server_listing(tmp_path) -> None:
@@ -1056,8 +1056,7 @@ async def test_shell_escape_runner_turns_permission_setup_error_into_terminal_ev
 
     assert result["exitCode"] == 1
     assert result["stdout"] == ""
-    assert "sk-shellsecret" not in result["stderr"]
-    assert "[REDACTED]" in result["stderr"]
+    assert "sk-shellsecret" in result["stderr"]
     assert [event["type"] for event in session.events.replay_after(0)] == [
         "local.shell.start",
         "local.shell.end",
@@ -1065,7 +1064,7 @@ async def test_shell_escape_runner_turns_permission_setup_error_into_terminal_ev
 
 
 @pytest.mark.asyncio
-async def test_shell_escape_runner_redacts_executor_exception(tmp_path) -> None:
+async def test_shell_escape_runner_preserves_local_executor_exception(tmp_path) -> None:
     from iac_code.types.permissions import PermissionResult, ToolPermissionContext
     from iac_code.web.shell import WebShellEscapeRunner
 
@@ -1086,8 +1085,7 @@ async def test_shell_escape_runner_redacts_executor_exception(tmp_path) -> None:
     result = await runner.run(session, "echo hi")
 
     assert result["exitCode"] == 1
-    assert "sk-executorsecret" not in result["stderr"]
-    assert "[REDACTED]" in result["stderr"]
+    assert "sk-executorsecret" in result["stderr"]
     assert [event["type"] for event in session.events.replay_after(0)] == ["local.shell.start", "local.shell.end"]
 
 
@@ -1308,8 +1306,8 @@ async def test_command_route_publishes_finished_when_shell_runner_raises(tmp_pat
     assert [event["type"] for event in events] == ["local.shell.start", "local.shell.end", "command.finished"]
     assert events[1]["payload"]["shellUseId"] == events[0]["payload"]["shellUseId"]
     assert events[1]["payload"]["toolUseId"] == events[0]["payload"]["toolUseId"]
-    assert events[1]["payload"]["stderr"] == "RuntimeError: runner boom"
-    assert events[-1]["payload"]["result"]["error"]["message"] == "RuntimeError: runner boom"
+    assert events[1]["payload"]["stderr"] == "runner boom"
+    assert events[-1]["payload"]["result"]["error"]["message"] == "runner boom"
 
 
 @pytest.mark.asyncio
@@ -1384,7 +1382,7 @@ async def test_command_route_fallback_end_matches_concurrent_shell_escape_start(
     ]
     assert [payload["shellUseId"] for payload in shell_end_payloads] == ["second-shell", "first-shell"]
     assert shell_end_payloads[1]["toolUseId"] == "first-shell"
-    assert shell_end_payloads[1]["stderr"] == "RuntimeError: first boom"
+    assert shell_end_payloads[1]["stderr"] == "first boom"
 
 
 @pytest.mark.asyncio
@@ -1448,7 +1446,7 @@ async def test_command_route_fallback_end_does_not_borrow_concurrent_shell_id_wi
         event["payload"] for event in session.events.replay_after(0) if event["type"] == "local.shell.end"
     ]
     assert [payload["command"] for payload in shell_end_payloads] == ["second", "first"]
-    assert shell_end_payloads[1]["stderr"] == "RuntimeError: first boom"
+    assert shell_end_payloads[1]["stderr"] == "first boom"
     assert shell_end_payloads[1]["shellUseId"] != "second-shell"
     assert shell_end_payloads[1]["toolUseId"] == shell_end_payloads[1]["shellUseId"]
 
@@ -1598,7 +1596,7 @@ async def test_command_route_fallback_end_matches_same_command_concurrent_start(
         event["payload"] for event in session.events.replay_after(0) if event["type"] == "local.shell.end"
     ]
     assert [payload["shellUseId"] for payload in shell_end_payloads] == ["second-shell", "first-shell"]
-    assert shell_end_payloads[1]["stderr"] == "RuntimeError: first boom"
+    assert shell_end_payloads[1]["stderr"] == "first boom"
 
 
 @pytest.mark.asyncio
@@ -1681,7 +1679,7 @@ async def test_command_route_fallback_end_does_not_borrow_running_same_command_s
         event["payload"] for event in session.events.replay_after(0) if event["type"] == "local.shell.end"
     ]
     assert [payload["shellUseId"] for payload in shell_end_payloads] == ["first-shell", "second-shell"]
-    assert shell_end_payloads[0]["stderr"] == "RuntimeError: first boom"
+    assert shell_end_payloads[0]["stderr"] == "first boom"
     assert shell_end_payloads[1]["stderr"] == ""
 
 
@@ -1820,7 +1818,7 @@ async def test_command_route_does_not_duplicate_mixed_legacy_shell_end_when_runn
 
 
 @pytest.mark.asyncio
-async def test_command_route_matches_redacted_shell_command_when_runner_raises_after_legacy_end(tmp_path) -> None:
+async def test_command_route_matches_raw_shell_command_when_runner_raises_after_legacy_end(tmp_path) -> None:
     from iac_code.web.app import create_app
 
     manager = _manager(tmp_path)
@@ -1863,8 +1861,8 @@ async def test_command_route_matches_redacted_shell_command_when_runner_raises_a
     events = session.events.replay_after(0)
     assert [event["type"] for event in events].count("local.shell.end") == 1
     assert [event["type"] for event in events] == ["local.shell.start", "local.shell.end", "command.finished"]
-    assert events[0]["payload"]["command"] == "echo API_KEY=[REDACTED]"
-    assert events[1]["payload"]["command"] == "echo API_KEY=[REDACTED]"
+    assert events[0]["payload"]["command"] == "echo API_KEY=abcd1234"
+    assert events[1]["payload"]["command"] == "echo API_KEY=abcd1234"
     assert events[1]["payload"]["stderr"] == "legacy end"
 
 

--- a/tests/web/test_events.py
+++ b/tests/web/test_events.py
@@ -85,7 +85,7 @@ async def _read_stream_response(
     return status, response_headers, b"".join(body_chunks).decode()
 
 
-def test_event_buffer_assigns_monotonic_sequence_and_redacts_payload() -> None:
+def test_event_buffer_assigns_monotonic_sequence_and_preserves_local_payload() -> None:
     from iac_code.web.events import WebEventBuffer
 
     buffer = WebEventBuffer("session-1")
@@ -104,9 +104,9 @@ def test_event_buffer_assigns_monotonic_sequence_and_redacts_payload() -> None:
     assert first["sequence"] == 1
     assert first["sessionId"] == "session-1"
     assert first["createdAt"]
-    assert first["payload"]["apiKey"] == "[REDACTED]"
-    assert first["payload"]["nested"]["access_key_secret"] == "[REDACTED]"
-    assert first["payload"]["items"][0]["token"] == "[REDACTED]"
+    assert first["payload"]["apiKey"] == "sk-unsafe"
+    assert first["payload"]["nested"]["access_key_secret"] == "secret-value"
+    assert first["payload"]["items"][0]["token"] == "token-value"
     assert second["sequence"] == 2
     json.dumps(first)
 
@@ -328,10 +328,10 @@ def test_make_event_preserves_pipeline_identity_fields_at_top_level() -> None:
     assert event["contextId"] == "ctx-1"
     assert event["taskId"] == "task-1"
     assert event["lastSequence"] == 42
-    assert event["payload"]["secret"] == "[REDACTED]"
+    assert event["payload"]["secret"] == "unsafe"
 
 
-def test_make_event_normalizes_payload_to_json_safe_values_and_redacts_secrets() -> None:
+def test_make_event_normalizes_payload_to_json_safe_values_without_local_redaction() -> None:
     from iac_code.web.events import encode_sse, make_event
 
     @dataclass
@@ -381,10 +381,10 @@ def test_make_event_normalizes_payload_to_json_safe_values_and_redacts_secrets()
     assert payload["blob"] == "hello �"
     assert sorted(payload["tags"]) == ["ros", "terraform"]
     assert payload["items"] == ["relative.txt", "nested"]
-    assert payload["mapping"] == {"1": "/tmp/one", "secret": "[REDACTED]"}
-    assert payload["metadata"] == {"title": "resource", "token": "[REDACTED]"}
+    assert payload["mapping"] == {"1": "/tmp/one", "secret": "unsafe"}
+    assert payload["metadata"] == {"title": "resource", "token": "unsafe"}
     assert payload["unknown"] == "unknown-object"
-    assert payload["apiKey"] == "[REDACTED]"
+    assert payload["apiKey"] == "/tmp/unsafe"
 
 
 def test_make_event_normalizes_non_finite_floats_for_browser_safe_json() -> None:

--- a/tests/web/test_pipeline.py
+++ b/tests/web/test_pipeline.py
@@ -1694,7 +1694,7 @@ async def test_pipeline_action_runner_rejects_executor_failed_status_without_suc
     assert result.terminal_outcome == "failed"
     message = result.response["error"]["message"]
     assert "Pipeline failed" in message
-    assert "/Users/alice" not in message
+    assert "/Users/alice" in message
 
 
 def test_pipeline_interrupt_route_rejects_persisted_task_without_live_active_pipeline(monkeypatch, tmp_path) -> None:

--- a/tests/web/test_runtime_messages.py
+++ b/tests/web/test_runtime_messages.py
@@ -1174,7 +1174,7 @@ def test_web_session_runtime_publishes_error_when_input_conversion_fails(tmp_pat
     assert _event_types(events) == ["error", "turn.done"]
     assert events[0]["payload"] == {
         "turnId": result["turnId"],
-        "message": "ValueError: file reference escapes the workspace",
+        "message": "file reference escapes the workspace",
         "retryable": False,
     }
     assert events[1]["payload"]["failed"] is True
@@ -1221,7 +1221,7 @@ def test_normal_interrupt_with_attachments_preserves_draft_instead_of_dropping_r
     assert session.events.replay_after(0) == []
 
 
-def test_web_session_runtime_redacts_internal_exception_messages(tmp_path, monkeypatch) -> None:
+def test_web_session_runtime_preserves_local_exception_messages(tmp_path, monkeypatch) -> None:
     from iac_code.web.runtime import WebSessionRuntime, WebTurnRequest
     from iac_code.web.session_manager import WebSessionManager
 
@@ -1241,8 +1241,7 @@ def test_web_session_runtime_redacts_internal_exception_messages(tmp_path, monke
 
     assert result["accepted"] is False
     assert _event_types(events) == ["error", "turn.done"]
-    assert "sk-runtimesecret" not in events[0]["payload"]["message"]
-    assert "[REDACTED]" in events[0]["payload"]["message"]
+    assert "sk-runtimesecret" in events[0]["payload"]["message"]
 
 
 def test_web_session_runtime_requires_injected_manager(tmp_path) -> None:

--- a/tests/web/test_tool_events.py
+++ b/tests/web/test_tool_events.py
@@ -2783,14 +2783,14 @@ def test_stack_progress_event_payload_includes_region_progress_and_redacted_erro
                 "resourceId": "vpc-1",
                 "regionId": "cn-hangzhou",
                 "status": "CREATE_FAILED",
-                "statusReason": "api_key=[REDACTED] failed",
+                "statusReason": "api_key=sk-stack12345678 failed",
             }
         ],
         "elapsedSeconds": 12,
     }
 
 
-def test_stack_instances_progress_event_payload_includes_region_progress_and_redacted_errors() -> None:
+def test_stack_instances_progress_event_payload_includes_region_progress_and_local_errors() -> None:
     from iac_code.types.stream_events import StackInstancesProgressEvent
     from iac_code.web.events import WebEventTranslator
 
@@ -2830,7 +2830,7 @@ def test_stack_instances_progress_event_payload_includes_region_progress_and_red
                 "stackId": "stack-i-1",
                 "regionId": "cn-shanghai",
                 "status": "OUTDATED",
-                "statusReason": "AccessKeySecret=[REDACTED] blocked",
+                "statusReason": "AccessKeySecret=LTAI123456789012 blocked",
             }
         ],
         "elapsedSeconds": 6,
@@ -2886,7 +2886,7 @@ def test_translator_assistant_text_delta_uses_delta_key() -> None:
     }
 
 
-def test_translator_tool_result_redacts_key_based_secret_values() -> None:
+def test_translator_tool_result_preserves_local_key_based_values() -> None:
     from iac_code.web.events import WebEventTranslator
 
     translator = WebEventTranslator("session-1")
@@ -2912,18 +2912,18 @@ def test_translator_tool_result_redacts_key_based_secret_values() -> None:
         "resultKind": "artifact",
         "summary": {
             "message": "created template",
-            "apiKey": "[REDACTED]",
+            "apiKey": "sk-unsafe",
         },
         "artifacts": [
             {
                 "path": "/tmp/template.yaml",
-                "access_key_secret": "[REDACTED]",
+                "access_key_secret": "secret-value",
             }
         ],
     }
 
 
-def test_translator_tool_result_redacts_secret_assignments_inside_strings() -> None:
+def test_translator_tool_result_preserves_local_assignments_inside_strings() -> None:
     from iac_code.web.events import WebEventTranslator
 
     translator = WebEventTranslator("session-1")
@@ -2939,14 +2939,11 @@ def test_translator_tool_result_redacts_secret_assignments_inside_strings() -> N
     )
 
     assert event["type"] == "tool.result"
-    assert event["payload"]["summary"] == "created with api_key=[REDACTED] and token: [REDACTED]"
-    assert event["payload"]["artifacts"] == [
-        "access_key_secret=[REDACTED]",
-        {"raw": "token: [REDACTED]"},
-    ]
+    assert event["payload"]["summary"] == "created with api_key=sk-real and token: abc"
+    assert event["payload"]["artifacts"] == ["access_key_secret=secret", {"raw": "token: abc"}]
 
 
-def test_translator_tool_result_redacts_bare_string_secrets() -> None:
+def test_translator_tool_result_preserves_local_bare_string_values() -> None:
     from iac_code.web.events import WebEventTranslator
 
     translator = WebEventTranslator("session-1")
@@ -2963,15 +2960,14 @@ def test_translator_tool_result_redacts_bare_string_secrets() -> None:
     )
 
     payload_text = json.dumps(event["payload"], sort_keys=True)
-    assert "sk-1234567890abcd" not in payload_text
-    assert "abc.def.ghi" not in payload_text
-    assert "sk-abcdefgh12345678" not in payload_text
-    assert "LTAI1234567890abcdef" not in payload_text
-    assert "sk-json123456789" not in payload_text
-    assert payload_text.count("[REDACTED]") >= 5
+    assert "sk-1234567890abcd" in payload_text
+    assert "abc.def.ghi" in payload_text
+    assert "sk-abcdefgh12345678" in payload_text
+    assert "LTAI1234567890abcdef" in payload_text
+    assert "sk-json123456789" in payload_text
 
 
-def test_translator_tool_result_redacts_cookie_bytes_and_fallback_strings() -> None:
+def test_translator_tool_result_preserves_local_cookie_bytes_and_fallback_strings() -> None:
     from iac_code.web.events import WebEventTranslator
 
     translator = WebEventTranslator("session-1")
@@ -2988,16 +2984,16 @@ def test_translator_tool_result_redacts_cookie_bytes_and_fallback_strings() -> N
     )
 
     payload_text = json.dumps(event["payload"], sort_keys=True)
-    assert "supersecret" not in payload_text
-    assert "alsosensitive" not in payload_text
-    assert "sk-bytes12345678" not in payload_text
-    assert "sk-object12345678" not in payload_text
-    assert "secret-one" not in payload_text
-    assert "secret-two" not in payload_text
-    assert event["payload"]["summary"] == "Cookie: [REDACTED]"
+    assert "supersecret" in payload_text
+    assert "alsosensitive" in payload_text
+    assert "sk-bytes12345678" in payload_text
+    assert "sk-object12345678" in payload_text
+    assert "secret-one" in payload_text
+    assert "secret-two" in payload_text
+    assert event["payload"]["summary"] == "Cookie: sid=supersecret; pref=alsosensitive"
 
 
-def test_translator_tool_result_redacts_structured_header_secret_keys() -> None:
+def test_translator_tool_result_preserves_local_structured_header_values() -> None:
     from iac_code.web.events import WebEventTranslator
 
     translator = WebEventTranslator("session-1")
@@ -3020,15 +3016,15 @@ def test_translator_tool_result_redacts_structured_header_secret_keys() -> None:
     assert event["payload"]["artifacts"] == [
         {
             "headers": {
-                "X-Api-Key": "[REDACTED]",
-                "Private-Key": "[REDACTED]",
+                "X-Api-Key": "plain-secret-value",
+                "Private-Key": "plain-private-value",
             },
-            "privateKey": "[REDACTED]",
+            "privateKey": "camel-private-value",
         }
     ]
 
 
-def test_translator_tool_result_redacts_json_like_x_api_key_strings() -> None:
+def test_translator_tool_result_preserves_local_json_like_x_api_key_strings() -> None:
     from iac_code.web.events import WebEventTranslator
 
     translator = WebEventTranslator("session-1")
@@ -3041,9 +3037,9 @@ def test_translator_tool_result_redacts_json_like_x_api_key_strings() -> None:
     )
 
     payload_text = json.dumps(event["payload"], sort_keys=True)
-    assert "plain-secret-value" not in payload_text
-    assert "plain-private-value" not in payload_text
-    assert "another-secret-value" not in payload_text
+    assert "plain-secret-value" in payload_text
+    assert "plain-private-value" in payload_text
+    assert "another-secret-value" in payload_text
 
 
 def test_publishing_translator_output_assigns_buffer_sequence(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- preserve canonical pipeline, persistence, recovery, and deployment data while applying purpose-aware projections at external boundaries
- enable path-only redaction for A2A output when `IAC_CODE_A2A_SAFE_MODE` is enabled, while keeping local Web, REPL, headless, and ACP data unchanged
- keep logs and telemetry on strict user-data sanitization paths, and reject redaction placeholders before cloud creation or destructive replacement
- cover A2A transports, recovery, push/retry, telemetry serialization, selling deployment gates, and a real step-4 redaction E2E scenario

## Why

Generic redaction was mutating functional values such as generated deployment credentials and could pollute state carried into later pipeline steps. This change separates canonical functional data from purpose-specific public and observability projections.

## Validation

- full test suite: 13,274 passed, 2 skipped
- `make lint`
- focused E2E/unit regression: 62 passed
- real `redaction-step4` E2E: 13/13 checks passed; stopped before deployment
