### PR TITLE
fix(selling): 兑现 action=create 资源意图，修复 VPC 创建意图未落实

### DIFF
--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
@@ -99,11 +99,15 @@ conclusion_schema:
 如果 intent 中存在 `resource_intents`，它是架构设计的硬约束：
 
 - 只有 `action=create` 的资源可以作为本方案要新建的资源。不要把 `action=use_existing` 或 `action=reference` 的资源设计成新建资源。
+- intent 中每个 `action=create` 的资源必须在每个 candidate 中兑现为新建资源：candidate 的 `resource_intents` 必须保留该资源且 `action=create`，不得把它降级为 `use_existing`/`reference`，也不得把它退化为已有资源参数（如把要新建的 VPC 改成 `VpcId` 参数）或直接丢弃。
 - `action=use_existing/reference` 必须作为已有资源引用，后续模板中应通过参数（如 `VpcId`）或用户提供 ID 引用，不得生成对应的新建资源。换句话说，use_existing/reference 必须作为已有资源引用。
 - `action=forbid` 的资源不得出现在候选方案的新增资源里，也不得作为“顺手补齐”的依赖加入。
-- 将 `resource_intents` 原样或按方案收窄后写入每个 candidate，供模板生成步骤继续执行同一约束。
+- 将 `resource_intents` 原样或按方案收窄后写入每个 candidate，供模板生成步骤继续执行同一约束。收窄只允许追加推断出的辅助资源或补充说明，不允许改写、降级或删除 intent 中已有的 `action=create` 条目。
+- 如果某个 `action=create` 的资源确实无法在方案中兑现（如与其它约束冲突），不要静默降级；在 rollback_request 中请求回退到 intent_parsing 说明冲突。
 
 示例：intent 表示“已有 VPC 中创建安全组”时，candidate 应包含 `resource_intents: [{"product": "VPC", "action": "use_existing"}, {"product": "SecurityGroup", "action": "create"}]`。不得生成 VSwitch，也不得设计成“创建 VPC + VSwitch + SecurityGroup”。
+
+示例：intent 表示“创建一个 VPC 和一个 VSwitch”（`resource_intents: [{"product": "VPC", "action": "create"}, {"product": "VSwitch", "action": "create"}]`）时，每个 candidate 都必须同时新建 VPC 和 VSwitch。不得把 VPC 改成 `use_existing` 或 `VpcId` 参数、只在已有 VPC 内创建 VSwitch——那会让用户的 VPC 创建意图落空。
 
 ## 输出
 调用 `complete_step` 提交结论。字段定义见 tool schema。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/evals.json
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/evals.json
@@ -172,6 +172,33 @@
         {"name": "within_budget", "check": "所有方案的monthly_cost_range上限不超过500 CNY"},
         {"name": "no_overengineering", "check": "不包含SLB集群、多可用区等超出预算的高可用配置"}
       ]
+    },
+    {
+      "id": 9,
+      "name": "create-vpc-and-vswitch-both-fulfilled",
+      "prompt": "创建一个VPC，并在里面创建一个VSwitch",
+      "intent_context": {
+        "is_infra_intent": true,
+        "confidence": "high",
+        "cloud_platform": "aliyun",
+        "business_type": "网络基础设施",
+        "core_requirements": ["VPC", "VSwitch"],
+        "resource_intents": [
+          {"product": "VPC", "action": "create", "source": "user"},
+          {"product": "VSwitch", "action": "create", "source": "user"}
+        ],
+        "non_functional": {"high_availability": false, "security_level": "basic"},
+        "scale_hint": null,
+        "budget_constraint": null,
+        "additional_notes": "用户明确要求新建 VPC 和 VSwitch"
+      },
+      "expected_behavior": "只输出1个方案；candidate 的 resource_intents 中 VPC 和 VSwitch 均保持 action=create，不得把 VPC 降级为 use_existing 或已有参数",
+      "assertions": [
+        {"name": "single_candidate", "check": "candidates数组长度为1"},
+        {"name": "vpc_create_fulfilled", "check": "candidate.resource_intents 中包含 {product: VPC, action: create}，且不存在 {product: VPC, action: use_existing}"},
+        {"name": "vswitch_create_fulfilled", "check": "candidate.resource_intents 中包含 {product: VSwitch, action: create}"},
+        {"name": "no_extra_resources", "check": "products 只含 VPC/VSwitch 相关资源，不含 ECS/RDS/SLB 等"}
+      ]
     }
   ]
 }

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-intent/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-intent/SKILL.md
@@ -192,8 +192,10 @@ conclusion_schema:
 - “已有 VPC 下创建安全组” → `core_requirements: ["VPC", "SecurityGroup"]`，`resource_intents: [{"product": "VPC", "action": "use_existing", "role": "attach_security_group_to", "source": "user"}, {"product": "SecurityGroup", "action": "create", "source": "user"}]`
 - 最小表达也必须保留生命周期：`{"product": "VPC", "action": "use_existing"}`、`{"product": "SecurityGroup", "action": "create"}`
 - “选择一个已有 VPC，创建一个 VSwitch” → `resource_intents: [{"product": "VPC", "action": "use_existing", "source": "user"}, {"product": "VSwitch", "action": "create", "source": "user"}]`
+- “创建一个 VPC 和一个 VSwitch” → `resource_intents: [{"product": "VPC", "action": "create", "source": "user"}, {"product": "VSwitch", "action": "create", "source": "user"}]`；两个资源都要新建，不要把 VPC 标成 `use_existing`
 - “只创建安全组，不创建 VSwitch” → `resource_intents: [{"product": "SecurityGroup", "action": "create", "source": "user"}, {"product": "VSwitch", "action": "forbid", "source": "user"}]`
 - 用户没有说明某资源是已有资源时，不要擅自把该资源标成 `action: "use_existing"`
+- 用户没有表达新建语义（说的是“已有”“选择一个”“使用现有”等）的资源，不要擅自把该资源标成 `action: "create"`；`action: "create"` 意味着后续候选和模板必须真正新建该资源，误标会导致方案与用户需求偏离
 
 ### 情况 C — 非阿里云平台需求
 `is_infra_intent: false`，`category: "other"`。在 `rejection_reason` 或 `platform_note` 中说明当前流程只支持阿里云，不能继续生成非阿里云方案；如果用户通过澄清文本改写为阿里云目标，则按情况 B 处理。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -53,11 +53,14 @@ conclusion_schema:
 候选架构可能包含 `resource_intents`。该字段优先级高于自然语言描述：
 
 - `resource_intents` 中 `action=create` 的资源才允许出现在 ROS `Resources` 中作为新建资源。
+- `resource_intents` 中所有 `action=create` 的资源都必须出现在 ROS `Resources` 中作为新建资源；任何一个 create 资源缺失（例如被改成 Parameter 或直接省略）都视为模板与意图不一致，必须修复模板；若确实无法在模板中新建，通过 rollback_request 回到 architecture_planning，不得静默降级。
 - action=use_existing/reference 的资源必须建模为 Parameters 或外部引用，不得在 Resources 中创建。例如“已有 VPC 中创建安全组”时，应定义 `VpcId` Parameter，并让 SecurityGroup 的 `VpcId` 引用该参数。
 - `action=forbid` 的资源不得在模板中创建；除非用户明确要求引用已有资源，也不要生成相关 Parameter。
 - 如果 candidate 的自然语言、products 和生命周期字段冲突，以生命周期字段为准；冲突严重无法生成时，通过 rollback_request 回到 architecture_planning。
 
 示例：`resource_intents: [{"product": "SecurityGroup", "action": "create"}, {"product": "VPC", "action": "use_existing"}]` 时，只生成 `ALIYUN::ECS::SecurityGroup`，不要生成 `ALIYUN::ECS::VPC` 或 `ALIYUN::ECS::VSwitch`。
+
+示例：`resource_intents: [{"product": "VPC", "action": "create"}, {"product": "VSwitch", "action": "create"}]` 时，`Resources` 中必须同时包含 `ALIYUN::ECS::VPC` 和 `ALIYUN::ECS::VSwitch`；不得把 VPC 改成 `VpcId` Parameter 只创建 VSwitch。
 
 ## 参数化规则
 

--- a/tests/pipeline/selling/skills/test_iac_aliyun_architecture_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_architecture_skill.py
@@ -26,6 +26,17 @@ def test_architecture_consumes_intent_resource_lifecycle_contract():
     assert "forbidden_resources" not in body
 
 
+def test_architecture_requires_create_intents_to_be_fulfilled_in_candidates():
+    body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "每个 `action=create` 的资源必须在每个 candidate 中兑现为新建资源" in body
+    assert "不得把它降级为 `use_existing`/`reference`" in body
+    assert "不允许改写、降级或删除 intent 中已有的 `action=create` 条目" in body
+    assert "不要静默降级" in body
+    assert "每个 candidate 都必须同时新建 VPC 和 VSwitch" in body
+    assert "让用户的 VPC 创建意图落空" in body
+
+
 def test_architecture_prompt_guides_optional_memory_lookup_for_planning_context():
     body = PROMPT_FILE.read_text(encoding="utf-8")
 

--- a/tests/pipeline/selling/skills/test_iac_aliyun_intent_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_intent_skill.py
@@ -177,6 +177,16 @@ def test_intent_guidance_preserves_existing_resource_lifecycle():
     assert "forbidden_resources" not in body
 
 
+def test_intent_guidance_forbids_unwarranted_create_or_use_existing_marking():
+    body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "不要擅自把该资源标成 `action: \"use_existing\"`" in body
+    assert "不要擅自把该资源标成 `action: \"create\"`" in body
+    assert "“创建一个 VPC 和一个 VSwitch”" in body
+    assert "两个资源都要新建，不要把 VPC 标成 `use_existing`" in body
+    assert "误标会导致方案与用户需求偏离" in body
+
+
 def test_intent_skill_only_supports_aliyun_and_rejects_other_clouds():
     body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
     prompt = PROMPT_FILE.read_text(encoding="utf-8")

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -120,6 +120,13 @@ class TestSkillContentRosOnly:
         assert "已有 VPC 中创建安全组" in body
         assert "forbidden_resources" not in body
 
+    def test_requires_all_create_intents_to_appear_in_resources(self, body):
+        assert "所有 `action=create` 的资源都必须出现在 ROS `Resources` 中" in body
+        assert "视为模板与意图不一致" in body
+        assert "不得静默降级" in body
+        assert "必须同时包含 `ALIYUN::ECS::VPC` 和 `ALIYUN::ECS::VSwitch`" in body
+        assert "不得把 VPC 改成 `VpcId` Parameter 只创建 VSwitch" in body
+
     def test_file_write_details_stay_in_step_prompt(self, body):
         assert "并写入文件" in body
         assert "生成的模板默认放在当前工作目录" in body


### PR DESCRIPTION
## 背景
针对 Session `ec63773c4daa458dbd70d490ad068c37`（Aone #84541872）：intent_parsing 列出 VPC 与 VSwitch 两个 create resource_intent，但 architecture_planning/模板把 VPC 退化为已有参数，只在已有 VPC 内创建 VSwitch，VPC 创建意图未被兑现。

## 根因
selling 流程的生命周期契约只单向约束了 `use_existing/reference/forbid` 不得新建，缺少反向约束：`action=create` 的资源必须在候选与模板中被兑现，导致 VPC 的 create 意图被静默降级。

## 变更
- **iac-aliyun-architecture/SKILL.md**：intent 中每个 `action=create` 资源必须在每个 candidate 中兑现为新建资源，禁止降级为 use_existing/reference/参数或丢弃；无法兑现时 rollback 回 intent_parsing；补充"创建 VPC + VSwitch"正向示例。
- **iac-aliyun-template-generating/SKILL.md**：candidate `resource_intents` 中所有 `action=create` 资源必须全部出现在 ROS `Resources`，缺失视为模板与意图不一致。
- **iac-aliyun-intent/SKILL.md**：用户未表达新建语义时不得擅自标 `create`，与已有 use_existing 规则对称；补充"创建一个 VPC 和一个 VSwitch"示例。
- 同步契约测试并新增 architecture evals 用例 `create-vpc-and-vswitch-both-fulfilled`。

## 测试
`uv run pytest tests/pipeline/selling/ -n auto` → 351 passed；`ruff check` 通过。
