### PR TITLE
fix(pipeline): drive terminal outcome from final step conclusion status

### DIFF
--- a/src/iac_code/pipeline/engine/handoff.py
+++ b/src/iac_code/pipeline/engine/handoff.py
@@ -19,6 +19,31 @@ def terminal_outcome_from_completed_event(data: dict) -> TerminalOutcome:
     return "completed"
 
 
+def terminal_outcome_from_final_conclusion(conclusion: dict | None) -> TerminalOutcome | None:
+    """Map a terminal step's structured conclusion ``status`` to a terminal outcome.
+
+    Steps that report their own outcome (e.g. the deploying step's
+    ``status: success|failed|cancelled``) must drive the pipeline terminal
+    outcome. Otherwise a step that completed its agent turn but concluded with
+    ``status: failed`` (e.g. WAF blocked CreateStack, or ``statuses.failed>0``)
+    would be reported as a successful ``pipeline_completed``.
+
+    Returns ``None`` when the conclusion carries no recognizable failure/cancel
+    signal so callers keep the existing default ``completed`` behavior.
+    """
+    if not isinstance(conclusion, dict):
+        return None
+    status = conclusion.get("status")
+    if not isinstance(status, str):
+        return None
+    normalized = status.strip().lower()
+    if normalized == "failed":
+        return "failed"
+    if normalized in {"cancelled", "canceled"}:
+        return "canceled"
+    return None
+
+
 def build_handoff_summary(
     pipeline_name: str,
     outcome: TerminalOutcome,

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -28,7 +28,11 @@ from iac_code.pipeline.engine.cleanup import (
 from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.display_replay import DISPLAY_TRANSCRIPT_FILENAME
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType, backup_blocked_event
-from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_outcome_from_completed_event
+from iac_code.pipeline.engine.handoff import (
+    build_handoff_summary,
+    terminal_outcome_from_completed_event,
+    terminal_outcome_from_final_conclusion,
+)
 from iac_code.pipeline.engine.interrupt import InterruptController, InterruptVerdict
 from iac_code.pipeline.engine.loader import load_pipeline_dir
 from iac_code.pipeline.engine.observability import PipelineObservability
@@ -1036,6 +1040,40 @@ class PipelineRunner:
             )
 
         self._try_save_sidecar_sync("completed", "save_normal_handoff", save)
+
+    def _terminal_conclusion_outcome_data(self, completed_step_id: str | None = None) -> dict[str, Any]:
+        """Derive PIPELINE_COMPLETED failure/cancel flags from the final step's conclusion.
+
+        A terminal step (e.g. the deploying step) can finish its agent turn yet
+        conclude with ``status: failed`` / ``cancelled`` (WAF blocked CreateStack,
+        ``statuses.failed>0``, user cancel, ...). Without reflecting that in the
+        terminal event payload, ``terminal_outcome_from_completed_event`` would
+        report a false ``completed`` outcome and mask the real failure.
+
+        Returns an empty dict when the final conclusion carries no failure/cancel
+        signal, so callers keep the existing default ``completed`` behavior.
+        """
+        step_id = completed_step_id or self._terminal_current_step_id()
+        if not step_id:
+            return {}
+        conclusion_field = next(
+            (s.conclusion_field for s in self._loaded.steps if s.step_id == step_id),
+            None,
+        )
+        if conclusion_field is None:
+            return {}
+        conclusion = self.context.get_conclusion(conclusion_field)
+        if not isinstance(conclusion, dict):
+            return {}
+        outcome = terminal_outcome_from_final_conclusion(conclusion)
+        if outcome is None:
+            return {}
+        data: dict[str, Any] = {"terminal_conclusion_status": conclusion.get("status")}
+        if outcome == "failed":
+            data["failed"] = True
+        elif outcome == "canceled":
+            data["canceled"] = True
+        return data
 
     def _terminal_current_step_id(self) -> str:
         try:
@@ -4346,12 +4384,15 @@ class PipelineRunner:
                         yield blocked_event
                         return
                     emit_step_success_observability()
-                    emit_pipeline_completed(failed=False, early_exit=False)
+                    terminal_conclusion_data = self._terminal_conclusion_outcome_data(completed_step_id)
+                    emit_pipeline_completed(
+                        failed=bool(terminal_conclusion_data.get("failed")), early_exit=False
+                    )
                     pipeline_completed_event = PipelineEvent(
                         type=PipelineEventType.PIPELINE_COMPLETED,
                         step_id=None,
                         timestamp=time.time(),
-                        data={"total_steps": self.state_machine.total_steps},
+                        data={"total_steps": self.state_machine.total_steps, **terminal_conclusion_data},
                     )
                 else:
                     emit_step_success_observability()
@@ -4444,12 +4485,15 @@ class PipelineRunner:
             if blocked_event is not None:
                 yield blocked_event
                 return
-            emit_pipeline_completed(failed=False, early_exit=False)
+            terminal_conclusion_data = self._terminal_conclusion_outcome_data(
+                completed_step_id if isinstance(completed_step_id, str) else None
+            )
+            emit_pipeline_completed(failed=bool(terminal_conclusion_data.get("failed")), early_exit=False)
             yield PipelineEvent(
                 type=PipelineEventType.PIPELINE_COMPLETED,
                 step_id=None,
                 timestamp=time.time(),
-                data={"total_steps": self.state_machine.total_steps},
+                data={"total_steps": self.state_machine.total_steps, **terminal_conclusion_data},
             )
         elif step_result is None or step_result.status == StepStatus.FAILED:
             if not terminal_backup_completed:

--- a/tests/pipeline/engine/test_pipeline_handoff.py
+++ b/tests/pipeline/engine/test_pipeline_handoff.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 
 import yaml
 
-from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_outcome_from_completed_event
+from iac_code.pipeline.engine.handoff import (
+    build_handoff_summary,
+    terminal_outcome_from_completed_event,
+    terminal_outcome_from_final_conclusion,
+)
 from iac_code.pipeline.engine.pipeline_runner import PipelineRunner
 
 
@@ -67,6 +71,59 @@ def test_terminal_outcome_from_completed_event_canceled():
 
 def test_terminal_outcome_failed_wins_over_early_exit():
     assert terminal_outcome_from_completed_event({"failed": True, "early_exit": True}) == "failed"
+
+
+def test_terminal_outcome_from_final_conclusion_failed():
+    assert terminal_outcome_from_final_conclusion({"status": "failed"}) == "failed"
+
+
+def test_terminal_outcome_from_final_conclusion_cancelled_variants():
+    assert terminal_outcome_from_final_conclusion({"status": "cancelled"}) == "canceled"
+    assert terminal_outcome_from_final_conclusion({"status": "canceled"}) == "canceled"
+
+
+def test_terminal_outcome_from_final_conclusion_success_is_none():
+    # Success must not force any override; callers keep the default completed outcome.
+    assert terminal_outcome_from_final_conclusion({"status": "success"}) is None
+
+
+def test_terminal_outcome_from_final_conclusion_missing_or_invalid():
+    assert terminal_outcome_from_final_conclusion(None) is None
+    assert terminal_outcome_from_final_conclusion({}) is None
+    assert terminal_outcome_from_final_conclusion({"status": 123}) is None
+
+
+def test_terminal_conclusion_outcome_data_failed(tmp_path):
+    runner = _make_runner(tmp_path)
+    runner.context.set_conclusion("intent", {"status": "failed", "error": "WAF blocked"})
+
+    data = runner._terminal_conclusion_outcome_data("step")
+
+    assert data.get("failed") is True
+    assert "canceled" not in data
+    assert data.get("terminal_conclusion_status") == "failed"
+    assert terminal_outcome_from_completed_event(data) == "failed"
+
+
+def test_terminal_conclusion_outcome_data_cancelled(tmp_path):
+    runner = _make_runner(tmp_path)
+    runner.context.set_conclusion("intent", {"status": "cancelled"})
+
+    data = runner._terminal_conclusion_outcome_data("step")
+
+    assert data.get("canceled") is True
+    assert "failed" not in data
+    assert terminal_outcome_from_completed_event(data) == "canceled"
+
+
+def test_terminal_conclusion_outcome_data_success_is_empty(tmp_path):
+    runner = _make_runner(tmp_path)
+    runner.context.set_conclusion("intent", {"status": "success", "stack_id": "stack-1"})
+
+    data = runner._terminal_conclusion_outcome_data("step")
+
+    assert data == {}
+    assert terminal_outcome_from_completed_event({"total_steps": 1, **data}) == "completed"
 
 
 def test_build_handoff_summary_includes_only_configured_fields_and_deterministic_metadata():


### PR DESCRIPTION
## 背景
针对 Session `8fc911f4c6204f85ab541ce352aaacce`：deploying 步骤已出现 WAF 拦截（WAF_CLIENT_UNCLASSIFIED）与 `quality_signals.failed_statuses=1`，但 `pendingTerminal` 仍触发 `pipeline_completed`、`pendingNormalHandoff.Outcome=completed`，形成假成功。

## 根因
终态 Outcome 只依据步骤执行状态，不看末步结论 `status`。`deploying` 结论 `status=failed/cancelled` 时仍走 `emit_pipeline_completed(failed=False)`，`terminal_outcome_from_completed_event` 缺省返回 `completed`。

## 改动
- `handoff.py`：新增 `terminal_outcome_from_final_conclusion()`，把末步结论 `status` 映射为 failed/canceled（success/未知返回 None，不干预）。
- `pipeline_runner.py`：新增 `_terminal_conclusion_outcome_data()`，在 auto_advance 终态与循环收尾终态分支据末步结论向 `PIPELINE_COMPLETED` 注入 `failed/canceled` 并对齐 observability。
- 新增 8 个单测。

## 测试
`pytest tests/pipeline/engine/{test_pipeline_handoff,test_pipeline_observability,test_pipeline_runner,test_complete_step_tool}.py` 298 passed；ruff 通过。