### PR TITLE
feat(pipeline): structure failure reasons and recovery paths in step conclusions

### DIFF
--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -30,7 +30,7 @@ API 调用完成后调用 `complete_step` 提交费用预估。
 - 两个字段都存在时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
 - 任一字段缺失时只展示可用价格，并在 `api_raw_summary` 中说明缺失字段；询价失败时仍填写 `"询价失败"`。
 
-若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。
+若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。若预览曾失败、经修复或调整后才成功，必须同时写入 `recovered: true`，并把每次失败的具体错误和处置按时间序写入 `failure_history`，不得用最终成功掩盖恢复过程。
 
 ## 注意事项
 - 不要读取项目文件或记忆，所需的上下文已在上方提供。

--- a/src/iac_code/pipeline/selling/prompts/deploying.md
+++ b/src/iac_code/pipeline/selling/prompts/deploying.md
@@ -47,7 +47,7 @@
 ```
 
 ## 输出
-部署完成后调用 `complete_step` 提交部署结果。
+部署完成后调用 `complete_step` 提交部署结果。部署失败时，结论必须包含本次尝试的结构化错误详情（`error_message`，能拿到时附 `error_code` 和 `failed_stack_status`），并把每次失败与恢复动作按时间序写入 `recovery_attempts`；重试后不得复用上一次的失败结论文案。
 
 ## 错误处理
 - 模板校验失败 → 就地修复模板后重试（最多 5 轮）

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -47,6 +47,26 @@ conclusion_schema:
           type: string
         error:
           type: string
+        recovered:
+          type: boolean
+          description: 预览曾失败、经修复或调整后最终成功时为 true；一次成功时可省略
+        failure_history:
+          type: array
+          description: 预览失败-重试-恢复路径的结构化记录，按时间序追加每次失败
+          items:
+            type: object
+            required: [error]
+            additionalProperties: false
+            properties:
+              error:
+                type: string
+                description: 该次预览失败的具体错误消息（如 body_file invalid）
+              error_code:
+                type: string
+                description: 该次预览失败的结构化错误码
+              resolution:
+                type: string
+                description: 针对该次失败采取的处置（如修复模板、调整参数、重试）
       allOf:
         - if:
             properties:
@@ -198,6 +218,7 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 - 若修复了模板，设置 `template_fixed: true` 并在 `fix_summary` 中说明修复内容；仅形成或输出 `deployment_parameters` 不算模板修复
 - `deployment_parameters` 填当前已选、已验证或已用于 `ros_estimate_template_cost` 的参数字典；PreviewStack 成功但询价失败时仍填该参数集；没有任何可用参数时填 `{}`
 - `preview_validation` 填 `ros_preview_template` 的结构化状态：成功时填 `{"succeeded": true, "template_url": "<当前模板文件路径>", "parameters": <预览通过的同一参数字典>}`；失败或未执行时填 `{"succeeded": false, "error": "<原因>"}`
+- 预览曾失败（如 body_file invalid、参数不合法）、经修复或调整后最终成功时，不得只写 `succeeded: true` 掩盖恢复过程：必须同时设置 `recovered: true`，并把每次失败按时间序写入 `failure_history`（`error` 填该次具体错误消息，能拿到错误码时填 `error_code`，`resolution` 填对应处置），让失败-重试-恢复路径在结论中可追溯
 - `missing_deployment_parameters` 填完整部署或 PreviewStack 仍缺少的参数及原因；没有缺口时可省略或填 `[]`
 - `parameter_set_summary` 可简要说明参数来源、可用性筛选、PreviewStack 验证结果以及是否使用软门禁继续询价
 - 询价失败时 `monthly_estimate` 填 "询价失败"，`resources` 为空数组，`error` 说明原因

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -23,7 +23,37 @@ conclusion_schema:
       type: object
     error:
       type: string
-      description: 失败原因（status 为 failed 时必填）
+      description: 失败原因（status 为 failed 时必填）；必须包含本次尝试的具体错误信息，不得复用与上次重试相同的泛化文案
+    error_code:
+      type: string
+      description: 本次失败的结构化错误码（如 ROS CreateStack / ContinueCreateStack 返回的 Code 或资源事件 StatusReason 中的错误码）
+    error_message:
+      type: string
+      description: 本次失败的具体错误消息（如 ROS 返回的 Message 或失败资源事件的 StatusReason 原文）
+    failed_stack_status:
+      type: string
+      description: 失败时 Stack 的最终状态（如 CREATE_FAILED、ROLLBACK_COMPLETE）
+    recovery_attempts:
+      type: array
+      description: 按时间序记录每次失败与恢复动作，让重试路径在结论中可追溯
+      items:
+        type: object
+        required: [action, outcome]
+        additionalProperties: false
+        properties:
+          action:
+            type: string
+            description: 本次恢复动作（如 create、continue_create、delete_and_create、wait、fix_template、adjust_parameters）
+          error_code:
+            type: string
+            description: 该次尝试失败时的错误码
+          error_message:
+            type: string
+            description: 该次尝试失败时的具体错误消息
+          outcome:
+            type: string
+            enum: [failed, recovered, abandoned]
+            description: 该次尝试的结果
   allOf:
     - if:
         properties:
@@ -38,7 +68,7 @@ conclusion_schema:
             const: failed
         required: [status]
       then:
-        required: [error]
+        required: [error, error_message]
 ---
 
 # 阿里云 ROS 部署技能
@@ -131,6 +161,12 @@ conclusion_schema:
 > **template_url 支持本地文件路径**：`ros_deploy` 的创建类动作中，`template_url` 可传当前工作目录内的本地文件路径（如 `./template.yml`），工具会自动读取文件内容。避免将大模板内容直接作为参数传递。
 
 ## 错误处理
+
+### 失败结论必须结构化、可区分
+最终返回 `status: failed` 时，结论必须让人不看日志也能定位根因：
+- `error` 写本次失败的完整原因；`error_message` 写本次失败的具体错误消息（如 ROS 返回的 Message 或失败资源事件的 StatusReason 原文）；能拿到错误码时在 `error_code` 写结构化错误码（如 CreateStack/ContinueCreateStack 返回的 Code）；`failed_stack_status` 写 Stack 最终状态。
+- 每一次失败与恢复动作按时间序追加到 `recovery_attempts`（`action` + 该次的 `error_code`/`error_message` + `outcome`），让失败-重试-恢复路径在结论中可见。
+- 步骤被重试时，禁止照抄上一次的失败结论；必须写入本次尝试实际观察到的错误详情，确保每次重试的结论内容可区分。
 
 ### 部署失败
 分析错误原因：

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -149,6 +149,55 @@ class TestSkillFrontmatter:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(missing_error, schema)
 
+    def test_preview_validation_can_record_recovery_path(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+        conclusion = {
+            "monthly_estimate": "¥100/月",
+            "currency": "CNY",
+            "resources": [{"type": "ALIYUN::ECS::InstanceGroup", "cost": "¥100/月"}],
+            "template_fixed": False,
+            "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+            "preview_validation": {
+                "succeeded": True,
+                "template_url": "templates/a.yml",
+                "parameters": {"ZoneId": "cn-hangzhou-k"},
+                "recovered": True,
+                "failure_history": [
+                    {
+                        "error": "body_file invalid",
+                        "error_code": "InvalidTemplateBody",
+                        "resolution": "修复模板后重试预览",
+                    }
+                ],
+            },
+        }
+
+        jsonschema.validate(conclusion, schema)
+
+    def test_preview_validation_failure_history_items_require_error(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+        conclusion = {
+            "monthly_estimate": "¥100/月",
+            "currency": "CNY",
+            "resources": [{"type": "ALIYUN::ECS::InstanceGroup", "cost": "¥100/月"}],
+            "template_fixed": False,
+            "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+            "preview_validation": {
+                "succeeded": True,
+                "template_url": "templates/a.yml",
+                "parameters": {"ZoneId": "cn-hangzhou-k"},
+                "recovered": True,
+                "failure_history": [{"resolution": "重试"}],
+            },
+        }
+
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(conclusion, schema)
+
 
 class TestSkillContentRosOnly:
     @pytest.fixture()
@@ -254,6 +303,11 @@ class TestSkillContentRosOnly:
         assert "template_url" in body
         assert "parameters" in body
         assert "deploying" in body
+
+    def test_body_requires_recovery_path_when_preview_recovered(self, body):
+        assert "recovered: true" in body
+        assert "failure_history" in body
+        assert "失败-重试-恢复路径" in body
 
     def test_preview_stack_is_not_hard_gate_for_pricing(self, body):
         assert "PreviewStack 不是硬门禁" in body
@@ -432,6 +486,12 @@ class TestCostPrompt:
         body = COST_PROMPT_MD.read_text(encoding="utf-8")
         assert "preview_validation" in body
         assert "PreviewStack 成功证明" in body
+
+    def test_prompt_requires_recovery_path_when_preview_recovered(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+        assert "recovered: true" in body
+        assert "failure_history" in body
+        assert "不得用最终成功掩盖恢复过程" in body
 
     def test_prompt_names_template_url_value_for_pricing_tools(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")

--- a/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
@@ -62,11 +62,90 @@ class TestSkillFrontmatter:
         schema = fm["conclusion_schema"]
 
         jsonschema.validate({"status": "success", "stack_id": "stack-123"}, schema)
-        jsonschema.validate({"status": "failed", "error": "CREATE_FAILED"}, schema)
+        jsonschema.validate(
+            {"status": "failed", "error": "CREATE_FAILED", "error_message": "Resource CREATE failed"},
+            schema,
+        )
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate({"status": "success"}, schema)
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate({"status": "failed"}, schema)
+
+    def test_failed_conclusion_requires_structured_error_message(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"status": "failed", "error": "CREATE_FAILED"}, schema)
+
+    def test_failed_conclusion_accepts_structured_error_details_and_recovery_attempts(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+
+        conclusion = {
+            "status": "failed",
+            "error": "CreateStack 失败：安全组配额不足",
+            "error_code": "QuotaExceeded.SecurityGroup",
+            "error_message": "The maximum number of security groups is exceeded.",
+            "failed_stack_status": "CREATE_FAILED",
+            "recovery_attempts": [
+                {
+                    "action": "create",
+                    "error_code": "QuotaExceeded.SecurityGroup",
+                    "error_message": "The maximum number of security groups is exceeded.",
+                    "outcome": "failed",
+                },
+                {
+                    "action": "continue_create",
+                    "error_code": "QuotaExceeded.SecurityGroup",
+                    "error_message": "The maximum number of security groups is exceeded.",
+                    "outcome": "abandoned",
+                },
+            ],
+        }
+        jsonschema.validate(conclusion, schema)
+
+    def test_recovery_attempts_items_require_action_and_outcome(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+
+        base = {
+            "status": "failed",
+            "error": "CREATE_FAILED",
+            "error_message": "Resource CREATE failed",
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(dict(base, recovery_attempts=[{"action": "create"}]), schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(dict(base, recovery_attempts=[{"outcome": "failed"}]), schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                dict(base, recovery_attempts=[{"action": "create", "outcome": "unknown"}]),
+                schema,
+            )
+
+    def test_success_conclusion_can_record_recovery_attempts(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        schema = fm["conclusion_schema"]
+
+        conclusion = {
+            "status": "success",
+            "stack_id": "stack-123",
+            "recovery_attempts": [
+                {
+                    "action": "create",
+                    "error_code": "InvalidParameter",
+                    "error_message": "ZoneId is sold out",
+                    "outcome": "failed",
+                },
+                {"action": "continue_create", "outcome": "recovered"},
+            ],
+        }
+        jsonschema.validate(conclusion, schema)
 
 
 class TestSkillContentRosOnly:
@@ -215,6 +294,13 @@ class TestSkillContentRosOnly:
     def test_contains_error_handling(self, body):
         assert "部署失败" in body
 
+    def test_failed_conclusion_guidance_requires_distinguishable_retries(self, body):
+        assert "失败结论必须结构化、可区分" in body
+        assert "error_message" in body
+        assert "error_code" in body
+        assert "recovery_attempts" in body
+        assert "禁止照抄上一次的失败结论" in body
+
     def test_no_template_generation(self, body):
         assert "模板生成流程" not in body
         assert "参数化规则" not in body
@@ -311,6 +397,12 @@ class TestDeployingPrompt:
         assert "`selected_plan.preview_ready_for_create` 为 `true`" in body
         assert "快速创建路径见技能" in body
         assert "跳过例行 `ros_validate_template`" not in body
+
+    def test_prompt_requires_structured_failure_details_in_conclusion(self):
+        body = DEPLOYING_PROMPT_MD.read_text(encoding="utf-8")
+        assert "error_message" in body
+        assert "recovery_attempts" in body
+        assert "不得复用上一次的失败结论文案" in body
 
 
 class TestSkillDiscovery:


### PR DESCRIPTION
## 背景
Aone 需求 #84518490：Pipeline 步骤结论未结构化记录失败原因与恢复路径（Session 43b8f91f 部署步骤 7-9 结论字节级相同仅有 status=failed；Session 69f59a80 preview 在 cost_estimating 期间 body_file invalid 后隐式恢复未体现）。

## 变更
- `iac-aliyun-deploying` conclusion_schema：新增 `error_code` / `error_message` / `failed_stack_status` / `recovery_attempts[]`；`status=failed` 时必填 `error_message`，使每次重试结论可区分、根因可追溯。
- `iac-aliyun-cost` `preview_validation`：新增 `recovered` / `failure_history[]`，预览失败-重试-恢复路径在 cost 结论中可见。
- 同步更新 `prompts/deploying.md`、`prompts/cost_estimating.md` 与两个技能正文指引，禁止跨重试复用同一失败文案。
- 补充两个技能测试的 schema/正文断言。

## 测试
- `tests/pipeline/selling/skills` 154 passed；全量 pytest 13280 passed（2 个失败为父提交同样失败的既有环境相关问题）；ruff 全过。