### PR TITLE
fix(ros): gate unusable local templates before the first API call

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -6412,12 +6412,58 @@ msgstr ""
 "/HTTP-URL."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file does not exist."
+msgstr "Die lokale ROS-Vorlagendatei existiert nicht."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template path is not a regular file."
+msgstr "Der lokale ROS-Vorlagenpfad ist keine reguläre Datei."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "Die lokale ROS Template-Datei kann nicht gelesen werden."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the 32 MiB limit."
+msgstr "Die lokale ROS-Vorlagendatei überschreitet die Grenze von 32 MiB."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file is not valid UTF-8."
 msgstr "Die lokale ROS Vorlagendatei ist nicht gültig UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Check the template path for typos and write the template to that path "
+"before validating it again."
+msgstr ""
+"Prüfen Sie den Vorlagenpfad auf Tippfehler und schreiben Sie die Vorlage "
+"an diesen Pfad, bevor Sie sie erneut validieren."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Point TemplateURL at the template file itself rather than a directory or "
+"device."
+msgstr ""
+"Richten Sie TemplateURL auf die Vorlagendatei selbst und nicht auf ein "
+"Verzeichnis oder Gerät."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr ""
+"Bestätigen Sie, dass die Datei vorhanden ist, lesbar ist und als UTF-8 "
+"gespeichert ist."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Reduce the template size, or upload it and pass an OSS/HTTP TemplateURL "
+"instead."
+msgstr ""
+"Verringern Sie die Vorlagengröße, oder laden Sie sie hoch und übergeben "
+"Sie stattdessen eine OSS-/HTTP-TemplateURL."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Save the template as UTF-8 text before validating it again."
+msgstr "Speichern Sie die Vorlage als UTF-8-Text, bevor Sie sie erneut validieren."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6426,12 +6472,6 @@ msgid ""
 msgstr ""
 "TemplateURL/local TemplateBody scheiterte vor dem Betreten des Parsers; "
 "der ROS API wurde nicht aufgerufen."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr ""
-"Bestätigen Sie, dass die Datei vorhanden ist, lesbar ist und als UTF-8 "
-"gespeichert ist."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12695,3 +12735,4 @@ msgstr "Bash zulassen?"
 #~ msgstr ""
 #~ "Tool-Aufruf genehmigen: {tool}\n"
 #~ "Eingabezusammenfassung: {summary}"
+

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6383,12 +6383,56 @@ msgstr ""
 "OSS/HTTP."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file does not exist."
+msgstr "El archivo de plantilla ROS local no existe."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template path is not a regular file."
+msgstr "La ruta de la plantilla ROS local no es un archivo regular."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "El archivo de plantilla local ROS no se puede leer."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the 32 MiB limit."
+msgstr "El archivo de plantilla ROS local supera el límite de 32 MiB."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file is not valid UTF-8."
 msgstr "El archivo de plantilla local ROS no es válido UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Check the template path for typos and write the template to that path "
+"before validating it again."
+msgstr ""
+"Compruebe si la ruta de la plantilla tiene errores tipográficos y escriba"
+" la plantilla en esa ruta antes de volver a validarla."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Point TemplateURL at the template file itself rather than a directory or "
+"device."
+msgstr ""
+"Apunte TemplateURL al archivo de plantilla en sí, no a un directorio o "
+"dispositivo."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "Confirme que el archivo existe, es legible, y se guarda como UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Reduce the template size, or upload it and pass an OSS/HTTP TemplateURL "
+"instead."
+msgstr ""
+"Reduzca el tamaño de la plantilla, o súbala y pase una TemplateURL de "
+"OSS/HTTP en su lugar."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Save the template as UTF-8 text before validating it again."
+msgstr "Guarde la plantilla como texto UTF-8 antes de volver a validarla."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6397,10 +6441,6 @@ msgid ""
 msgstr ""
 "TemplateURL/local TemplateBody falló antes de entrar en el Parser; el ROS"
 " API no fue llamado."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "Confirme que el archivo existe, es legible, y se guarda como UTF-8."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12612,3 +12652,4 @@ msgstr "¿Permitir Bash?"
 #~ msgstr ""
 #~ "Aprobar llamada de herramienta: {tool}\n"
 #~ "Resumen de entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6405,12 +6405,56 @@ msgstr ""
 "OSS/HTTP."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file does not exist."
+msgstr "Le fichier de modèle ROS local n'existe pas."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template path is not a regular file."
+msgstr "Le chemin du modèle ROS local n'est pas un fichier régulier."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "Le fichier modèle local ROS ne peut pas être lu."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the 32 MiB limit."
+msgstr "Le fichier de modèle ROS local dépasse la limite de 32 Mio."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file is not valid UTF-8."
 msgstr "Le fichier modèle local ROS n'est pas valide UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Check the template path for typos and write the template to that path "
+"before validating it again."
+msgstr ""
+"Vérifiez les fautes de frappe dans le chemin du modèle et écrivez le "
+"modèle à ce chemin avant de le valider à nouveau."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Point TemplateURL at the template file itself rather than a directory or "
+"device."
+msgstr ""
+"Faites pointer TemplateURL vers le fichier de modèle lui-même plutôt que "
+"vers un répertoire ou un périphérique."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "Confirmer que le fichier existe, est lisible et est enregistré sous UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Reduce the template size, or upload it and pass an OSS/HTTP TemplateURL "
+"instead."
+msgstr ""
+"Réduisez la taille du modèle, ou téléversez-le et passez plutôt une "
+"TemplateURL OSS/HTTP."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Save the template as UTF-8 text before validating it again."
+msgstr "Enregistrez le modèle en texte UTF-8 avant de le valider à nouveau."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6419,10 +6463,6 @@ msgid ""
 msgstr ""
 "TemplateURL/local TemplateBody a échoué avant d'entrer dans l'analyseur; "
 "le ROS API n'a pas été appelé."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "Confirmer que le fichier existe, est lisible et est enregistré sous UTF-8."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12678,3 +12718,4 @@ msgstr "Autoriser Bash ?"
 #~ msgstr ""
 #~ "Approuver l'appel d'outil : {tool}\n"
 #~ "Résumé de l'entrée : {summary}"
+

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -6052,8 +6052,20 @@ msgstr ""
 "params.TemplateURL として渡してください。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file does not exist."
+msgstr "ローカルの ROS テンプレートファイルが存在しません。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template path is not a regular file."
+msgstr "ローカルの ROS テンプレートパスが通常ファイルではありません。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "ローカルROSテンプレートファイルは読みません。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the 32 MiB limit."
+msgstr "ローカルの ROS テンプレートファイルが 32 MiB の上限を超えています。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file is not valid UTF-8."
@@ -6061,13 +6073,35 @@ msgstr "ローカルROSテンプレートファイルはUTF-8では有効では�
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
-"TemplateURL/local TemplateBody failed before entering the Parser; the ROS"
-" API was not called."
-msgstr "TemplateURL/local TemplateBodyは、パーサを入力する前に失敗しました。 ROS APIは呼びませんでした。"
+"Check the template path for typos and write the template to that path "
+"before validating it again."
+msgstr "テンプレートパスの入力ミスを確認し、そのパスにテンプレートを書き込んでから再度検証してください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Point TemplateURL at the template file itself rather than a directory or "
+"device."
+msgstr "TemplateURL はディレクトリやデバイスではなく、テンプレートファイル自体を指定してください。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
 msgstr "ファイルが読みやすく、UTF-8として保存されていることを確認してください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Reduce the template size, or upload it and pass an OSS/HTTP TemplateURL "
+"instead."
+msgstr "テンプレートのサイズを小さくするか、アップロードして OSS/HTTP の TemplateURL を渡してください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Save the template as UTF-8 text before validating it again."
+msgstr "テンプレートを UTF-8 テキストとして保存してから再度検証してください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"TemplateURL/local TemplateBody failed before entering the Parser; the ROS"
+" API was not called."
+msgstr "TemplateURL/local TemplateBodyは、パーサを入力する前に失敗しました。 ROS APIは呼びませんでした。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -11706,3 +11740,4 @@ msgstr "Bash を許可しますか？"
 #~ msgstr ""
 #~ "ツール呼び出しを承認: {tool}\n"
 #~ "入力サマリー: {summary}"
+

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6341,12 +6341,56 @@ msgstr ""
 "OSS/HTTP."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file does not exist."
+msgstr "O arquivo de modelo ROS local não existe."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template path is not a regular file."
+msgstr "O caminho do modelo ROS local não é um arquivo regular."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "O arquivo de modelo ROS local não pode ser lido."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the 32 MiB limit."
+msgstr "O arquivo de modelo ROS local excede o limite de 32 MiB."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file is not valid UTF-8."
 msgstr "O arquivo de modelo ROS local não é válido UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Check the template path for typos and write the template to that path "
+"before validating it again."
+msgstr ""
+"Verifique se há erros de digitação no caminho do modelo e grave o modelo "
+"nesse caminho antes de validá-lo novamente."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Point TemplateURL at the template file itself rather than a directory or "
+"device."
+msgstr ""
+"Aponte TemplateURL para o próprio arquivo de modelo, e não para um "
+"diretório ou dispositivo."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "Confirme que o arquivo existe, é legível e é salvo como UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Reduce the template size, or upload it and pass an OSS/HTTP TemplateURL "
+"instead."
+msgstr ""
+"Reduza o tamanho do modelo, ou faça o upload e passe uma TemplateURL de "
+"OSS/HTTP em vez disso."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Save the template as UTF-8 text before validating it again."
+msgstr "Salve o modelo como texto UTF-8 antes de validá-lo novamente."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6355,10 +6399,6 @@ msgid ""
 msgstr ""
 "O TemplateURL/local TemplateBody falhou antes de entrar no Parser; o ROS "
 "API não foi chamado."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "Confirme que o arquivo existe, é legível e é salvo como UTF-8."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12506,3 +12546,4 @@ msgstr "Permitir Bash?"
 #~ msgstr ""
 #~ "Aprovar chamada de ferramenta: {tool}\n"
 #~ "Resumo da entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -5901,8 +5901,20 @@ msgstr ""
 "params.TemplateURL，例如本地文件路径或 OSS/HTTP URL。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file does not exist."
+msgstr "本地 ROS 模板文件不存在。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template path is not a regular file."
+msgstr "本地 ROS 模板路径不是常规文件。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "本地 ROS 模板文件无法读取。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the 32 MiB limit."
+msgstr "本地 ROS 模板文件超过 32 MiB 限制。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file is not valid UTF-8."
@@ -5910,13 +5922,35 @@ msgstr "本地 ROS 模板文件不是有效 UTF-8。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
-"TemplateURL/local TemplateBody failed before entering the Parser; the ROS"
-" API was not called."
-msgstr "TemplateURL/本地 TemplateBody 在进入 Parser 前失败；未调用 ROS API。"
+"Check the template path for typos and write the template to that path "
+"before validating it again."
+msgstr "请检查模板路径是否有拼写错误，并先把模板写入该路径，然后重新校验。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Point TemplateURL at the template file itself rather than a directory or "
+"device."
+msgstr "请把 TemplateURL 指向模板文件本身，而不是目录或设备。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
 msgstr "确认文件存在、可读，并使用 UTF-8 编码保存。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"Reduce the template size, or upload it and pass an OSS/HTTP TemplateURL "
+"instead."
+msgstr "请减小模板体积，或先上传模板并改用 OSS/HTTP 的 TemplateURL。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Save the template as UTF-8 text before validating it again."
+msgstr "请先将模板保存为 UTF-8 文本，然后重新校验。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid ""
+"TemplateURL/local TemplateBody failed before entering the Parser; the ROS"
+" API was not called."
+msgstr "TemplateURL/本地 TemplateBody 在进入 Parser 前失败；未调用 ROS API。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -11493,3 +11527,4 @@ msgstr "允许 Bash?"
 #~ msgstr ""
 #~ "批准工具调用：{tool}\n"
 #~ "输入摘要：{summary}"
+

--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -72,11 +72,13 @@ from iac_code.tools.cloud.aliyun.runtime import (
 )
 from iac_code.tools.cloud.aliyun.template_source import (
     check_local_template_url_read_permission,
+    check_local_template_url_source,
     is_local_template_url,
     read_local_template_url,
     reject_pipeline_dedicated_ros_deployment_action,
     reject_pipeline_dedicated_ros_template_action,
     reject_pipeline_template_source_params,
+    resolve_template_url_for_api,
 )
 from iac_code.tools.cloud.aliyun.user_agent import build_user_agent
 from iac_code.tools.cloud.base_api import BaseCloudApi
@@ -1678,6 +1680,36 @@ class AliyunApi(BaseCloudApi):
             return None
         return check_local_template_url_read_permission(template_url, context)
 
+    def _local_template_source_gate(
+        self,
+        input: Mapping[str, Any],
+        context: ToolContext,
+    ) -> ToolResult | None:
+        """Reject an unusable local template before any request is assembled.
+
+        Without this gate a missing or non-regular template only fails while the
+        wire layer materializes the body, which reports it as an invalid
+        ``body_file`` even though the caller passed a template path. That message
+        names a parameter the caller never sent, so it cannot be acted on.
+        """
+        template_url = self._local_template_url(dict(input))
+        if template_url is None:
+            return None
+        problem = check_local_template_url_source(
+            template_url,
+            None,
+            cwd=context.cwd,
+            relative_read_directories=list(context.relative_read_directories),
+        )
+        if problem is None:
+            return None
+        from iac_code.tools.cloud.aliyun.hooks.ros_validate import local_template_source_error
+
+        outcome = local_template_source_error(problem)
+        context.ros_preflight_outcome = outcome
+        assert outcome.blocking_result is not None
+        return outcome.blocking_result
+
     @property
     def input_schema(self) -> dict[str, Any]:
         region_desc = "The region to call the action in."
@@ -2193,6 +2225,8 @@ class AliyunApi(BaseCloudApi):
                 for result in self._runtime_file_permission_results(normalized, context):
                     if result.behavior in {"ask", "deny"}:
                         raise ApiContractError(result.message or "aliyun_file_permission_required")
+            if blocking := self._local_template_source_gate(normalized, context):
+                return blocking
 
             observe("contract")
             recovery_metadata_contract: CanonicalWireContract | None = None
@@ -2281,10 +2315,10 @@ class AliyunApi(BaseCloudApi):
                 try:
                     template_bytes = await asyncio.to_thread(_read_body_file, resolved_template)
                     params["TemplateBody"] = template_bytes.decode("utf-8")
-                except (OSError, UnicodeError) as error:
+                except (ApiContractError, OSError, UnicodeError) as error:
                     from iac_code.tools.cloud.aliyun.hooks.ros_validate import local_template_source_error
 
-                    outcome = local_template_source_error(error)
+                    outcome = local_template_source_error(error, path=resolved_template)
                     context.ros_preflight_outcome = outcome
                     assert outcome.blocking_result is not None
                     return outcome.blocking_result
@@ -2552,10 +2586,13 @@ class AliyunApi(BaseCloudApi):
                         return ToolResult.error(path_result.message)
                 try:
                     params["TemplateBody"] = read_local_template_url(template_url, context)
-                except (OSError, UnicodeError) as error:
+                except (ApiContractError, OSError, UnicodeError) as error:
                     from iac_code.tools.cloud.aliyun.hooks.ros_validate import local_template_source_error
 
-                    outcome = local_template_source_error(error)
+                    outcome = local_template_source_error(
+                        error,
+                        path=resolve_template_url_for_api(template_url, context),
+                    )
                     context.ros_preflight_outcome = outcome
                     assert outcome.blocking_result is not None
                     return outcome.blocking_result

--- a/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+++ b/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -30,25 +31,72 @@ from iac_code.tools.cloud.aliyun.ros_validation.outcome import (
 )
 from iac_code.tools.cloud.aliyun.ros_validation.parser import parse_template_source
 from iac_code.tools.cloud.aliyun.ros_validation.validator import validate_ros_template
+from iac_code.tools.cloud.aliyun.template_source import classify_local_template_source
 
 _FLAT_PARAMETER = re.compile(r"^Parameters\.(\d+)\.(ParameterKey|ParameterValue)$")
 
+_TEMPLATE_SOURCE_SUMMARIES: dict[str, Callable[[], str]] = {
+    "MISSING": lambda: _("The local ROS template file does not exist."),
+    "NOT_REGULAR": lambda: _("The local ROS template path is not a regular file."),
+    "UNREADABLE": lambda: _("The local ROS template file cannot be read."),
+    "TOO_LARGE": lambda: _("The local ROS template file exceeds the 32 MiB limit."),
+    "UTF-8": lambda: _("The local ROS template file is not valid UTF-8."),
+    "READ": lambda: _("The local ROS template file cannot be read."),
+}
 
-def local_template_source_error(error: BaseException) -> RosPreflightOutcome:
-    """Convert an allowed local-file read/decode failure into a normal ROS report."""
+_TEMPLATE_SOURCE_SUGGESTIONS: dict[str, Callable[[], str]] = {
+    "MISSING": lambda: _(
+        "Check the template path for typos and write the template to that path before validating it again."
+    ),
+    "NOT_REGULAR": lambda: _("Point TemplateURL at the template file itself rather than a directory or device."),
+    "UNREADABLE": lambda: _("Confirm that the file exists, is readable, and is saved as UTF-8."),
+    "TOO_LARGE": lambda: _("Reduce the template size, or upload it and pass an OSS/HTTP TemplateURL instead."),
+    "UTF-8": lambda: _("Save the template as UTF-8 text before validating it again."),
+    "READ": lambda: _("Confirm that the file exists, is readable, and is saved as UTF-8."),
+}
 
-    kind = "UTF-8" if isinstance(error, UnicodeError) else "READ"
+
+def _template_source_diagnostic_kind(error: BaseException | str) -> str:
+    if isinstance(error, str):
+        return error
+    if isinstance(error, UnicodeError):
+        return "UTF-8"
+    if isinstance(error, FileNotFoundError):
+        return "MISSING"
+    if isinstance(error, IsADirectoryError):
+        return "NOT_REGULAR"
+    return "READ"
+
+
+def local_template_source_error(
+    error: BaseException | str,
+    *,
+    path: str | Path | None = None,
+) -> RosPreflightOutcome:
+    """Convert a local template read/decode failure into a normal ROS report.
+
+    ``error`` may be the raised exception or a problem already classified by
+    ``classify_local_template_source``. Pass ``path`` when the exception itself
+    carries no filesystem cause -- ``_read_body_file`` raises a generic
+    ``ApiContractError``, so the path has to be re-inspected to report why the
+    template was unusable rather than emitting an unactionable message.
+    """
+
+    if path is not None and not isinstance(error, (str, OSError, UnicodeError)):
+        error = classify_local_template_source(path) or error
+    kind = _template_source_diagnostic_kind(error)
+    detail_arg = kind if isinstance(error, str) else type(error).__name__
+    summary = _TEMPLATE_SOURCE_SUMMARIES.get(kind, _TEMPLATE_SOURCE_SUMMARIES["READ"])()
+    suggestion = _TEMPLATE_SOURCE_SUGGESTIONS.get(kind, _TEMPLATE_SOURCE_SUGGESTIONS["READ"])()
     diagnostic = make_diagnostic(
         code="ROS1202",
         severity=Severity.ERROR,
         category=Category.COMPATIBILITY,
-        summary=_("The local ROS template file cannot be read.")
-        if kind == "READ"
-        else _("The local ROS template file is not valid UTF-8."),
+        summary=summary,
         detail=_("TemplateURL/local TemplateBody failed before entering the Parser; the ROS API was not called."),
         subject="local-template-source",
-        stable_args=(kind, type(error).__name__),
-        suggestion=_("Confirm that the file exists, is readable, and is saved as UTF-8."),
+        stable_args=(kind, detail_arg),
+        suggestion=suggestion,
     )
     return outcome_from_report(ValidationReport.build([diagnostic], analysis_incomplete=False))
 

--- a/src/iac_code/tools/cloud/aliyun/ros_stack.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_stack.py
@@ -22,6 +22,7 @@ from iac_code.services.telemetry.sanitize import (
     sanitize_terraform_provider,
 )
 from iac_code.tools.base import ToolContext, ToolResult
+from iac_code.tools.cloud.aliyun.api_contract import ApiContractError
 from iac_code.tools.cloud.aliyun.ros_client import RosClientFactory
 from iac_code.tools.cloud.aliyun.template_source import (
     check_local_template_url_read_permission,
@@ -29,6 +30,7 @@ from iac_code.tools.cloud.aliyun.template_source import (
     read_local_template_url,
     reject_pipeline_dedicated_ros_deployment_action,
     reject_pipeline_template_source_params,
+    resolve_template_url_for_api,
 )
 from iac_code.tools.cloud.base_stack import BaseCloudStack
 from iac_code.tools.cloud.types import ResourceStatus, StackStatus
@@ -278,10 +280,18 @@ class RosStack(BaseCloudStack):
                         cwd=context.cwd,
                         relative_read_directories=context.relative_read_directories,
                     )
-                except (OSError, UnicodeError) as error:
+                except (ApiContractError, OSError, UnicodeError) as error:
                     from iac_code.tools.cloud.aliyun.hooks.ros_validate import local_template_source_error
 
-                    outcome = local_template_source_error(error)
+                    outcome = local_template_source_error(
+                        error,
+                        path=resolve_template_url_for_api(
+                            template_url,
+                            None,
+                            cwd=context.cwd,
+                            relative_read_directories=context.relative_read_directories,
+                        ),
+                    )
                     context.ros_preflight_outcome = outcome
                     assert outcome.blocking_result is not None
                     return outcome.blocking_result
@@ -614,10 +624,18 @@ class RosStack(BaseCloudStack):
                     cwd=cwd,
                     relative_read_directories=relative_read_directories,
                 )
-            except (OSError, UnicodeError) as error:
+            except (ApiContractError, OSError, UnicodeError) as error:
                 from iac_code.tools.cloud.aliyun.hooks.ros_validate import local_template_source_error
 
-                outcome = local_template_source_error(error)
+                outcome = local_template_source_error(
+                    error,
+                    path=resolve_template_url_for_api(
+                        template_url,
+                        None,
+                        cwd=cwd,
+                        relative_read_directories=relative_read_directories,
+                    ),
+                )
                 if tool_context is not None:
                     tool_context.ros_preflight_outcome = outcome
                 assert outcome.blocking_result is not None

--- a/src/iac_code/tools/cloud/aliyun/template_source.py
+++ b/src/iac_code/tools/cloud/aliyun/template_source.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
+import os
+import stat
 from pathlib import Path
 from typing import Any, Literal
 
 from iac_code.i18n import _
+from iac_code.tools.cloud.aliyun.api_contract import _MAX_BODY_BYTES
 from iac_code.tools.path_safety import check_read_path, resolve_read_path
 from iac_code.types.permissions import PermissionResult
 
 REMOTE_TEMPLATE_URL_PREFIXES = ("http://", "https://", "oss://")
+
+# Reuse the wire-layer request-body ceiling so this gate and the transport can
+# never disagree about which templates are too large.
+MAX_LOCAL_TEMPLATE_BYTES = _MAX_BODY_BYTES
+
+LocalTemplateSourceProblem = Literal["MISSING", "NOT_REGULAR", "UNREADABLE", "TOO_LARGE"]
 
 PIPELINE_TEMPLATE_URL_ACTIONS = frozenset(
     {
@@ -130,6 +139,48 @@ def read_local_template_url(
         relative_read_directories=relative_read_directories,
     )
     return Path(resolved).read_text(encoding="utf-8")
+
+
+def classify_local_template_source(path: str | Path) -> LocalTemplateSourceProblem | None:
+    """Return why a resolved local template cannot be read, or None when usable.
+
+    Runs before credentials, endpoints, and any network call so the first failed
+    attempt already tells the caller what to fix instead of surfacing a generic
+    wire-layer error after the request was assembled.
+    """
+    try:
+        info = os.stat(path)
+    except FileNotFoundError:
+        return "MISSING"
+    except OSError:
+        return "UNREADABLE"
+    if not stat.S_ISREG(info.st_mode):
+        return "NOT_REGULAR"
+    if info.st_size > MAX_LOCAL_TEMPLATE_BYTES:
+        return "TOO_LARGE"
+    if not os.access(path, os.R_OK):
+        return "UNREADABLE"
+    return None
+
+
+def check_local_template_url_source(
+    template_url: str,
+    context: Any,
+    *,
+    cwd: str | None = None,
+    relative_read_directories: list[str] | None = None,
+) -> LocalTemplateSourceProblem | None:
+    """Classify a local TemplateURL using the same resolution as the read path."""
+    if not template_url or not is_local_template_url(template_url):
+        return None
+    return classify_local_template_source(
+        resolve_template_url_for_api(
+            template_url,
+            context,
+            cwd=cwd,
+            relative_read_directories=relative_read_directories,
+        )
+    )
 
 
 def reject_pipeline_dedicated_ros_template_action(action: str, *, pipeline_mode: bool) -> str | None:

--- a/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
@@ -2088,9 +2088,11 @@ async def test_delegated_local_template_rejects_parent_symlink_swap_at_materiali
     runtime.execution_stage_observer = swap_parent
     result = await delegated.execute(outer_input, _execution_context(permission_context, permission))
 
-    assert result == ToolResult.error(
-        _expected_public_error("invalid_body_file", {"region_id": "cn-hangzhou"}, contract=contract)
-    )
+    assert result.is_error
+    # The caller passed template_url, so the failure must be reported against the
+    # template source rather than as an invalid body_file it never sent.
+    assert "body_file" not in result.content
+    assert (result.metadata or {}).get("ros_validation") is not None
     assert runtime.request_builder.inputs == []
 
 
@@ -3253,3 +3255,112 @@ async def test_runtime_services_own_one_delegated_factory_and_bound_internal_cal
         assert isinstance(services.internal_caller, AliyunInternalCaller)
     finally:
         await services.aclose()
+
+
+def _unusable_local_template(tmp_path: Path, kind: str) -> Path:
+    if kind == "missing":
+        return tmp_path / "absent.yml"
+    if kind == "directory":
+        directory = tmp_path / "template-dir"
+        directory.mkdir()
+        return directory
+    template = tmp_path / "bad.yml"
+    template.write_bytes(b"\xff\xfe\x00not-utf8")
+    return template
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ("missing", "directory", "not_utf8"))
+async def test_unusable_local_template_is_rejected_before_any_request(tmp_path: Path, kind: str) -> None:
+    """An unusable template must fail once, with a fix, and without a request.
+
+    Previously only the wire layer noticed, and it reported an invalid
+    ``body_file`` -- a parameter the caller never sent -- so the same template
+    input was retried across tools instead of being corrected.
+    """
+
+    template = _unusable_local_template(tmp_path, kind)
+    contract = _canonical_contract(product="ROS", version="2019-09-10", action="ValidateTemplate")
+    tool, runtime = _execution_runtime(contract)
+    tool_input = {
+        "product": "ros",
+        "version": contract.version,
+        "action": "ValidateTemplate",
+        "region_id": "cn-hangzhou",
+        "params": {"TemplateURL": str(template)},
+    }
+    permission_context = _bound_context(tool_input, cwd=str(tmp_path))
+    permission = await tool.check_permissions(tool_input, permission_context)
+
+    result = await tool.execute(tool_input=tool_input, context=_execution_context(permission_context, permission))
+
+    assert result.is_error
+    assert "body_file" not in result.content
+    report = (result.metadata or {}).get("ros_validation")
+    assert report is not None
+    assert report["counts_by_code"] == {"ROS1202": 1}
+    assert runtime.request_builder.inputs == []
+    assert runtime.transport_router.requests == []
+    assert "credential_network" not in runtime.transport_router.calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "action", "extra_input"),
+    [
+        ("ros_validate_template", "ValidateTemplate", {}),
+        ("ros_preview_template", "PreviewStack", {"stack_name": "preview", "parameters": {}}),
+    ],
+)
+async def test_dedicated_ros_tools_report_the_template_source_not_body_file(
+    tmp_path: Path,
+    tool_name: str,
+    action: str,
+    extra_input: dict,
+) -> None:
+    from iac_code.tools.cloud.aliyun.runtime import AliyunDelegatedExecutor
+
+    template = tmp_path / "absent.yml"
+    contract = _canonical_contract(product="ROS", version="2019-09-10", action=action)
+    tool, runtime = _execution_runtime(contract)
+    delegated = AliyunDelegatedExecutor(tool, action=action)
+    outer_input = {"template_url": str(template), "region_id": "cn-hangzhou", **extra_input}
+    permission_context = _bound_context(
+        outer_input,
+        tool_name=tool_name,
+        cwd=str(tmp_path),
+        pipeline_mode=True,
+    )
+    permission = await delegated.check_permissions(outer_input, permission_context)
+
+    result = await delegated.execute(outer_input, _execution_context(permission_context, permission))
+
+    assert result.is_error
+    assert "body_file" not in result.content
+    assert (result.metadata or {}).get("ros_validation") is not None
+    assert runtime.request_builder.inputs == []
+
+
+@pytest.mark.asyncio
+async def test_binary_body_file_still_reports_invalid_body_file(tmp_path: Path) -> None:
+    """The template diagnostics must not leak into genuine body_file inputs."""
+
+    contract = _canonical_contract(request_body_type="byte")
+    tool, runtime = _execution_runtime(contract)
+    body_file = tmp_path / "payload.bin"
+    body_file.write_bytes(b"payload")
+    tool_input = {
+        "product": "ecs",
+        "version": contract.version,
+        "action": contract.action,
+        "region_id": "cn-hangzhou",
+        "body_file": str(body_file),
+    }
+    permission_context = _bound_context(tool_input, cwd=str(tmp_path))
+    permission = await tool.check_permissions(tool_input, permission_context)
+    body_file.unlink()
+
+    result = await tool.execute(tool_input=tool_input, context=_execution_context(permission_context, permission))
+
+    assert result == ToolResult.error(_expected_public_error("invalid_body_file", tool_input, contract=contract))
+    assert runtime.request_builder.inputs == []

--- a/tests/tools/cloud/aliyun/test_ros_validate_hook.py
+++ b/tests/tools/cloud/aliyun/test_ros_validate_hook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from iac_code.tools.cloud.aliyun import template_source
 from iac_code.tools.cloud.aliyun.hooks.ros_validate import (
     _format_json_error,
     _format_yaml_error,
@@ -9,6 +10,10 @@ from iac_code.tools.cloud.aliyun.hooks.ros_validate import (
     _validate_structure,
     check_template,
     local_template_source_error,
+)
+from iac_code.tools.cloud.aliyun.template_source import (
+    check_local_template_url_source,
+    classify_local_template_source,
 )
 
 
@@ -348,3 +353,50 @@ class TestCheckTemplate:
 
         assert result is not None and result.blocking_result is None
         assert params == {"TemplateBody": body}
+
+
+class TestLocalTemplateSourceClassification:
+    """Every unusable local template must name its cause and its fix.
+
+    Regression guard: a generic report gives the model nothing to correct, which
+    is what previously drove repeated retries of the same template input.
+    """
+
+    def test_missing_file_is_classified_and_actionable(self, tmp_path) -> None:
+        assert classify_local_template_source(tmp_path / "absent.yml") == "MISSING"
+        diagnostic = local_template_source_error("MISSING").report.diagnostics[0]
+        assert diagnostic.code == "ROS1202"
+        assert "does not exist" in diagnostic.summary
+        assert diagnostic.suggestion
+
+    def test_directory_is_not_a_usable_template_source(self, tmp_path) -> None:
+        assert classify_local_template_source(tmp_path) == "NOT_REGULAR"
+        diagnostic = local_template_source_error("NOT_REGULAR").report.diagnostics[0]
+        assert "not a regular file" in diagnostic.summary
+
+    def test_oversized_template_is_rejected_before_the_wire_limit(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(template_source, "MAX_LOCAL_TEMPLATE_BYTES", 4)
+        template = tmp_path / "big.yml"
+        template.write_text("Resources: {}\n", encoding="utf-8")
+        assert classify_local_template_source(template) == "TOO_LARGE"
+        diagnostic = local_template_source_error("TOO_LARGE").report.diagnostics[0]
+        assert "32 MiB" in diagnostic.summary
+
+    def test_readable_template_has_no_problem(self, tmp_path) -> None:
+        template = tmp_path / "ok.yml"
+        template.write_text("Resources: {}\n", encoding="utf-8")
+        assert classify_local_template_source(template) is None
+
+    def test_remote_template_url_is_never_classified_locally(self) -> None:
+        assert check_local_template_url_source("oss://bucket/template.yml", None, cwd=".") is None
+        assert check_local_template_url_source("https://example.com/template.yml", None, cwd=".") is None
+
+    def test_each_problem_maps_to_a_distinct_actionable_diagnostic(self) -> None:
+        summaries = {
+            problem: local_template_source_error(problem).report.diagnostics[0].summary
+            for problem in ("MISSING", "NOT_REGULAR", "UNREADABLE", "TOO_LARGE", "UTF-8")
+        }
+        assert len(set(summaries.values())) == len(summaries)
+        for problem, summary in summaries.items():
+            # The caller supplies a template path, never a body_file.
+            assert "body_file" not in summary, problem


### PR DESCRIPTION
## Problem

ROS template tools reported an unusable local template as an invalid `body_file` — a parameter the caller never sent. Callers passing `template_url` therefore could not tell what to fix from the first failure, and retried the same template input across `ros_validate_template`, `aliyun_api ValidateTemplate`, and `ros_preview_template` before resorting to `bash` to inspect the file.

Two defects produced that message:

- **No pre-call readability gate.** Permission checks only *authorized* the template path, so a missing or non-regular template still returned `allow` and only failed later, while the wire layer materialized the request body.
- **A swallowed error type.** `_read_body_file` converts read failures into `ApiContractError("invalid_body_file")`, but the local-template branches caught only `(OSError, UnicodeError)`. The error escaped to the generic handler and lost both its template-source context and its structured report.

Observed before the fix — the most common failure mode returned the *least* diagnostic information:

| Local template state | Permission stage | Final error | Structured report |
| --- | --- | --- | --- |
| missing | `allow` | `body_file is invalid` | none |
| path is a directory | `allow` | `body_file is invalid` | none |
| not UTF-8 | `allow` | `ROS1202` report | `ros_validation` |

## Change

Classify local templates (missing / not-regular / unreadable / too-large) before credentials, endpoints, and any request, and report every failure as a `ROS1202` diagnostic carrying `metadata.ros_validation` plus a specific corrective action. The size ceiling is derived from the wire-layer limit so the gate and the transport cannot disagree.

Applied consistently to the runtime, legacy, and `ros_stack` read paths so the dedicated ROS tools and `ros_deploy` all fail the same way.

Genuine `body_file` inputs keep reporting `invalid_body_file`, and the success path is unchanged.

## Verification

- `make test`: 13282 passed, 4 skipped. Two failures are pre-existing and unrelated — verified failing identically on the untouched base commit `d470b40` (a urllib error-class difference and an mtime-granularity ordering assumption).
- `make lint` (`ruff` + `ty`): clean.
- `make translate` run for the `messages` domain; the 7 new user-facing strings are translated across `zh es fr de ja pt`.
- The 6 new regression tests were confirmed to fail when the fix is reverted, so they are not vacuous. They assert the failure names the template source and never `body_file`, and that no request is assembled (`request_builder.inputs == []`).
