### PR TITLE
fix(a2a): merge candidate step skeletons through the run-id index

### DIFF
--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -660,9 +660,47 @@ class _PipelineSnapshotReducer:
             step["candidates"].append(candidate)
         self._candidate_parent_step_run_ids[run_id] = step["runId"]
 
+        # ``candidate_started`` carries a pending skeleton of the candidate's
+        # sub-steps.  It must be merged through the run-id index instead of
+        # overwriting ``candidate["steps"]``, otherwise later
+        # ``candidate_step_*`` events append a second entry with the same runId
+        # and the snapshot ends up with a pending/empty-conclusion duplicate
+        # living next to the completed step.
+        skeletons = _dict_list(coordinate.get("steps"))
+        coordinate = {key: value for key, value in coordinate.items() if key != "steps"}
+
         _merge_coordinate(candidate, coordinate)
+        self._merge_candidate_step_skeletons(candidate, skeletons)
         self._apply_candidate_lifecycle(candidate, event)
         return candidate
+
+    def _merge_candidate_step_skeletons(
+        self,
+        candidate: dict[str, Any],
+        skeletons: list[dict[str, Any]],
+    ) -> None:
+        for skeleton in skeletons:
+            run_id = _string_or_none(skeleton.get("runId"))
+            if run_id is None:
+                continue
+
+            candidate_step = self._candidate_steps_by_run_id.get(run_id)
+            if candidate_step is None:
+                candidate_step = {
+                    "runId": run_id,
+                    "id": _string_or_none(skeleton.get("id")) or run_id,
+                    "attempt": _int_or_none(skeleton.get("attempt")) or 1,
+                    "status": _string_or_none(skeleton.get("status")) or "pending",
+                }
+                self._candidate_steps_by_run_id[run_id] = candidate_step
+
+            if candidate_step not in candidate["steps"]:
+                candidate["steps"].append(candidate_step)
+
+            # The skeleton is always ``pending``; never let it rewind a step
+            # that already reached working/completed/failed.
+            descriptive = {key: value for key, value in skeleton.items() if key != "status"}
+            _merge_coordinate(candidate_step, descriptive)
 
     def _apply_candidate_lifecycle(self, candidate: dict[str, Any], event: dict[str, Any]) -> None:
         event_type = event.get("eventType")

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -825,6 +825,86 @@ def test_reduce_candidate_without_parent_step_does_not_create_none_step() -> Non
     assert snapshot["steps"] == []
 
 
+def _candidate_skeleton_events() -> tuple[dict, dict, dict, dict]:
+    run_id = "candidate-selling_candidate-0-1"
+    parent = _base("evt-1", 1, "step_started", scope="step")
+    parent["step"] = {"runId": "step-evaluate_candidates-1", "id": "evaluate_candidates", "index": 3, "attempt": 1}
+    started = _base("evt-2", 2, "candidate_started", scope="candidate")
+    started["step"] = parent["step"]
+    started["candidate"] = {
+        "runId": run_id,
+        "id": "selling_candidate",
+        "index": 0,
+        "attempt": 1,
+        "steps": [
+            {
+                "runId": f"{run_id}-template_generating-1",
+                "id": "template_generating",
+                "name": "template_generating",
+                "index": 1,
+                "total": 2,
+                "attempt": 1,
+                "status": "pending",
+            },
+            {
+                "runId": f"{run_id}-cost_estimating-1",
+                "id": "cost_estimating",
+                "name": "cost_estimating",
+                "index": 2,
+                "total": 2,
+                "attempt": 1,
+                "status": "pending",
+            },
+        ],
+    }
+    step_started = _base("evt-3", 3, "candidate_step_started", scope="candidate_step")
+    step_started["step"] = parent["step"]
+    step_started["candidate"] = {"runId": run_id, "id": "selling_candidate", "index": 0, "attempt": 1}
+    step_started["candidateStep"] = {
+        "runId": f"{run_id}-template_generating-1",
+        "id": "template_generating",
+        "index": 1,
+        "total": 2,
+        "attempt": 1,
+    }
+    step_completed = _base("evt-4", 4, "candidate_step_completed", scope="candidate_step")
+    step_completed["step"] = parent["step"]
+    step_completed["candidate"] = step_started["candidate"]
+    step_completed["candidateStep"] = step_started["candidateStep"]
+    step_completed["data"] = {"conclusion": {"template": "ros"}}
+    return parent, started, step_started, step_completed
+
+
+def test_reduce_candidate_step_skeleton_does_not_duplicate_completed_step() -> None:
+    parent, started, step_started, step_completed = _candidate_skeleton_events()
+
+    snapshot = reduce_pipeline_events([parent, started, step_started, step_completed])
+
+    steps = snapshot["steps"][0]["candidates"][0]["steps"]
+    assert [step["id"] for step in steps] == ["template_generating", "cost_estimating"]
+    assert steps[0]["status"] == "completed"
+    assert steps[0]["conclusion"] == {"template": "ros"}
+    # Descriptive skeleton fields still land on the tracked step.
+    assert steps[0]["name"] == "template_generating"
+    assert steps[1]["status"] == "pending"
+
+
+def test_reduce_candidate_step_skeleton_does_not_rewind_finished_step() -> None:
+    parent, started, step_started, step_completed = _candidate_skeleton_events()
+    existing = reduce_pipeline_events([parent, started, step_started, step_completed])
+
+    resent_skeleton = _base("evt-5", 5, "candidate_started", scope="candidate")
+    resent_skeleton["step"] = parent["step"]
+    resent_skeleton["candidate"] = started["candidate"]
+
+    snapshot = reduce_pipeline_events([resent_skeleton], existing)
+
+    steps = snapshot["steps"][0]["candidates"][0]["steps"]
+    assert [step["id"] for step in steps] == ["template_generating", "cost_estimating"]
+    assert steps[0]["status"] == "completed"
+    assert steps[0]["conclusion"] == {"template": "ros"}
+
+
 def test_reduce_display_items_and_rollback_are_deduplicated() -> None:
     detail = _base("evt-1", 1, "candidate_detail_shown", scope="candidate")
     detail["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}


### PR DESCRIPTION
修正 `pipeline_snapshot.py` reducer 合并候选子步骤骨架的方式，消除「候选下同 id 子步骤 pending（空结论）与 completed 并存」的状态歧义。

## 问题

`candidate_started` 事件携带候选子步骤的 pending 骨架（`status=pending`、无 `conclusion`）。reducer 把这个列表当作普通坐标字段直接写进 `candidate["steps"]`，却没有把骨架项登记到 `_candidate_steps_by_run_id` 索引。

因此后续 `candidate_step_started` / `candidate_step_completed` 在 `_upsert_candidate_step` 查索引时查不到，会再新建一个同 `runId` 的 dict 并 append。同一个候选子步骤在 snapshot 里出现两份：

- 骨架副本：`status=pending`，`conclusion` 缺失
- 生命周期副本：`status=completed`，带 `conclusion`

这正是 pipeline snapshot 中 `steps.*.candidates.*.steps.0` 的状态歧义（`template_generating`、`cost_estimating` 各出现 pending 空结论 + completed 两份）。

同一缺陷在候选重启时还会丢弃已跟踪的子步骤状态，因为骨架列表每次都被整体替换。

## 改动

- 把 `steps` 从候选坐标中分离，骨架改为经 run-id 索引做 upsert 合并，生命周期事件复用同一 dict，不再产生同 id 副本。
- 骨架的 `status` 仅作首次创建时的初始值：重复投递的骨架（候选重启、snapshot 重新水合）不会把已进入 working/completed/failed 的子步骤打回 pending，也不会清空其 `conclusion`。
- 骨架的展示性字段（`name`/`index`/`total`）仍会补齐到已跟踪的条目。

公开 snapshot schema 不变，`SNAPSHOT_SCHEMA_VERSION` 未改动。

## 验证

- 新增 2 条回归用例：骨架 + 生命周期事件不产生同 id 重复项；重复投递骨架不回退已完成子步骤。
- `tests/a2a` 全量 1434 通过。
- `ruff check` 与 `ty check src/` 全通过。
