### PR TITLE
fix(pipeline): keep run event start/complete counts symmetric

### DIFF
--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -2669,6 +2669,9 @@ class PipelineRunner:
         async for event in self._continue_from_current(
             **self._continue_input_kwargs(pipeline_input),
             resume_waiting_step=True,
+            # The waiting-input pause already emitted STEP_COMPLETED; the re-run
+            # will emit another one, so a paired STEP_STARTED must be re-emitted.
+            reemit_resumed_step_started=True,
         ):
             if (
                 not selection_observed
@@ -3698,10 +3701,16 @@ class PipelineRunner:
         precompleted_tools: dict[str, dict[str, Any]] | None = None,
         resume_waiting_step: bool = False,
         resume_running_step: bool = False,
+        reemit_resumed_step_started: bool = False,
     ) -> AsyncGenerator[StreamEvent | PipelineEvent | StepResult, None]:
         is_first_step = True
         terminal_pipeline_telemetry_emitted = False
         terminal_backup_completed = False
+        # When the pipeline is already complete on entry (e.g. a resume request
+        # arrives after the terminal PIPELINE_COMPLETED was published), no step
+        # runs and the trailing completion block must not re-publish a second
+        # PIPELINE_COMPLETED: pipeline_started is only emitted once by run().
+        was_complete_on_entry = self.state_machine.is_complete
         step_result: StepResult | None = None
         restored_step_user_input = self._consume_restored_current_step_user_input() if user_input is None else None
         restored_resume_messages, restored_precompleted_tools = (
@@ -3766,6 +3775,30 @@ class PipelineRunner:
                 except PipelineStatePersistenceError as exc:
                     yield self._persistence_failure_event(exc)
                     return
+                if resume_waiting_step and reemit_resumed_step_started:
+                    # A waiting-input step already emitted STEP_COMPLETED (with the
+                    # user prompt) before pausing. Re-running it after user input
+                    # emits a second STEP_COMPLETED, so re-emit a paired
+                    # STEP_STARTED (same attempt, marked ``resumed``) to keep
+                    # start/complete counts symmetric in the a2a event journal.
+                    # Restart recovery (resume_running_step) keeps the original
+                    # STEP_STARTED in the journal and must not duplicate it.
+                    yield PipelineEvent(
+                        type=PipelineEventType.STEP_STARTED,
+                        step_id=step.step_id,
+                        timestamp=step_start,
+                        data={
+                            "index": step_index,
+                            "attempt": step_attempt,
+                            "total": self.state_machine.total_steps,
+                            "name": step.step_id,
+                            "step_type": step.step_type,
+                            "ui_mode": step.ui_mode,
+                            "active_attempt_id": attempt["attempt_id"],
+                            "transcript_id": attempt["transcript_id"],
+                            "resumed": True,
+                        },
+                    )
             else:
                 step_attempt = self._next_step_attempt(step.step_id)
                 try:
@@ -4268,6 +4301,13 @@ class PipelineRunner:
                 first_step_resume_messages = None
                 first_step_precompleted_tools = None
                 is_first_step = True
+                # The rollback target is a fresh execution, not a resumption of the
+                # step that requested the rollback. Clear the resume flags so the
+                # target step emits STEP_STARTED (with a new attempt) instead of
+                # silently re-completing, which would leave step_completed >
+                # step_started in the a2a event journal.
+                resume_waiting_step = False
+                resume_running_step = False
                 try:
                     for warning_event in self._mark_rollback_cleanup_required(
                         step,
@@ -4430,6 +4470,12 @@ class PipelineRunner:
                 return
 
         if self.state_machine.is_complete:
+            if was_complete_on_entry:
+                # Already terminal before this call: the terminal save and
+                # PIPELINE_COMPLETED were published by the run that completed the
+                # pipeline. Re-emitting here would make pipeline_completed exceed
+                # pipeline_started in the a2a event journal.
+                return
             completed_step = locals().get("step")
             completed_step_id = getattr(completed_step, "step_id", None)
             if not isinstance(completed_step_id, str) and self._loaded.steps:

--- a/tests/pipeline/engine/test_pipeline_observability.py
+++ b/tests/pipeline/engine/test_pipeline_observability.py
@@ -1581,7 +1581,7 @@ async def test_runner_resume_emits_user_input_received_and_selection_telemetry(r
     runner._observability.selection_made = MagicMock()
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 
@@ -1744,7 +1744,7 @@ async def test_runner_does_not_emit_selection_made_for_unmatched_or_ambiguous_ca
     runner._observability.selection_made = MagicMock()
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -4717,3 +4717,126 @@ class TestResolveIterateField:
         runner.context.snapshot = MagicMock(return_value={"plan": {"options": [{"x": 1}]}})
         result = runner._resolve_iterate_field("plan.options")
         assert result == [{"x": 1}]
+
+
+class TestStartCompleteEventPairing:
+    """run 事件 start/complete 计数必须对称 (step_completed <= step_started,
+    pipeline_completed <= pipeline_started)。"""
+
+    @staticmethod
+    def _event_types(events):
+        return [event.type for event in events if isinstance(event, PipelineEvent)]
+
+    @pytest.mark.asyncio
+    async def test_resume_waiting_step_reemits_paired_step_started(self, tmp_path):
+        runner = _build_two_step_runner(tmp_path, auto_advance_first=False)
+
+        async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+            conclusion = {"value": step.step_id, "user_prompt": "pick", "options": []}
+            context.set_conclusion(step.conclusion_field, conclusion)
+            yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion=conclusion)
+
+        runner._step_executor.execute = fake_execute
+
+        run_events = [event async for event in runner.run("start")]
+        resume_events = [event async for event in runner.resume("continue")]
+
+        all_events = run_events + resume_events
+        started = [e for e in all_events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.STEP_STARTED]
+        completed = [
+            e for e in all_events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.STEP_COMPLETED
+        ]
+        assert len(completed) <= len(started)
+        started_a = [e for e in started if e.step_id == "a"]
+        completed_a = [e for e in completed if e.step_id == "a"]
+        assert len(started_a) == len(completed_a) == 2
+        # 恢复补发的 step_started 标记为 resumed 且 attempt 不递增
+        assert started_a[1].data.get("resumed") is True
+        assert started_a[1].data.get("attempt") == started_a[0].data.get("attempt")
+
+    @pytest.mark.asyncio
+    async def test_restart_recovery_does_not_duplicate_step_started(self, tmp_path):
+        runner = _build_two_step_runner(tmp_path)
+
+        async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+            conclusion = {"value": step.step_id}
+            context.set_conclusion(step.conclusion_field, conclusion)
+            yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion=conclusion)
+
+        runner._step_executor.execute = fake_execute
+
+        events = [event async for event in runner._continue_from_current(resume_running_step=True)]
+        started = [e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.STEP_STARTED]
+        # 无 resume transcript → 走正常路径; restart 恢复不额外补发 resumed start
+        assert all(e.data.get("resumed") is not True for e in started)
+
+    @pytest.mark.asyncio
+    async def test_rollback_target_after_resume_emits_new_step_started(self, tmp_path):
+        runner = _build_two_step_runner(tmp_path, auto_advance_first=False)
+        requested_rollback = False
+
+        async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+            nonlocal requested_rollback
+            conclusion = {"value": step.step_id, "user_prompt": "pick", "options": []}
+            context.set_conclusion(step.conclusion_field, conclusion)
+            rollback_request = None
+            if step.step_id == "b" and not requested_rollback:
+                requested_rollback = True
+                rollback_request = ("a", "validation failed; retry")
+            yield StepResult(
+                step_id=step.step_id,
+                status=StepStatus.COMPLETED,
+                conclusion=conclusion,
+                rollback_request=rollback_request,
+            )
+
+        runner._step_executor.execute = fake_execute
+
+        run_events = [event async for event in runner.run("start")]
+        resume_events = [event async for event in runner.resume("continue")]
+
+        all_events = run_events + resume_events
+        started = [e for e in all_events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.STEP_STARTED]
+        completed = [
+            e for e in all_events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.STEP_COMPLETED
+        ]
+        # rollback 目标步骤重跑必须有配对的 step_started, 完成数不得超过开始数
+        assert len(completed) <= len(started)
+        rollback_events = [
+            e for e in all_events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.ROLLBACK_TRIGGERED
+        ]
+        assert len(rollback_events) == 1
+        rollback_index = all_events.index(rollback_events[0])
+        post_rollback_started_a = [
+            e for e in all_events[rollback_index:]
+            if isinstance(e, PipelineEvent) and e.type == PipelineEventType.STEP_STARTED and e.step_id == "a"
+        ]
+        assert post_rollback_started_a, "rollback 后目标步骤必须补发 step_started"
+        # rollback 重跑是新 attempt, 不是 resumed 重放
+        assert post_rollback_started_a[0].data.get("resumed") is not True
+
+    @pytest.mark.asyncio
+    async def test_completed_pipeline_does_not_reemit_pipeline_completed(self, tmp_path):
+        runner = _build_two_step_runner(tmp_path)
+
+        async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+            conclusion = {"value": step.step_id}
+            context.set_conclusion(step.conclusion_field, conclusion)
+            yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion=conclusion)
+
+        runner._step_executor.execute = fake_execute
+
+        first_events = [event async for event in runner._continue_from_current()]
+        assert (
+            sum(
+                1
+                for e in first_events
+                if isinstance(e, PipelineEvent) and e.type == PipelineEventType.PIPELINE_COMPLETED
+            )
+            == 1
+        )
+
+        second_events = [event async for event in runner._continue_from_current(resume_waiting_step=True)]
+        assert not any(
+            isinstance(e, PipelineEvent) and e.type == PipelineEventType.PIPELINE_COMPLETED for e in second_events
+        )

--- a/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
+++ b/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
@@ -1002,7 +1002,7 @@ async def test_resume_from_waiting_input_sidecar_preserves_step_attempt_for_user
     runner2._observability.selection_made = MagicMock()
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 
@@ -1032,7 +1032,7 @@ async def test_resume_candidate_selection_emits_selected_option_details(tmp_path
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 
@@ -1184,7 +1184,7 @@ async def test_resume_candidate_selection_extracts_index_from_structured_json(tm
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 
@@ -1215,7 +1215,7 @@ async def test_resume_candidate_selection_extracts_index_from_numbered_choice(tm
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 
@@ -1239,7 +1239,7 @@ async def test_resume_candidate_selection_prefers_evaluated_index_over_display_i
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 
@@ -1297,7 +1297,7 @@ async def test_resume_candidate_selection_uses_restored_context_options(tmp_path
     )
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_resumed_step_started": True}
         if False:
             yield
 


### PR DESCRIPTION
## 问题

证据 Session `6bf1c83310104fbf9f21f7843bcbea10` 的 run 事件统计中 step_completed=6 > step_started=5、pipeline_completed=2 > pipeline_started=1，完成事件多于开始事件，状态计数不对称。

## 根因

`pipeline_runner._continue_from_current`：
1. 等待输入步骤在用户输入恢复后重新完成时不补发 `step_started`；
2. rollback 分支未清除 `resume_waiting_step`/`resume_running_step` 标志，rollback 目标步骤（如 evaluate_candidates 校验失败修复后）走 resume 分支静默重完成；
3. 管道已完成后再次进入 `_continue_from_current` 时尾部重发 `pipeline_completed`。

## 修复

- 等待输入步骤恢复重跑前补发配对 `STEP_STARTED`（`resumed: true`，attempt 不变）；重启恢复不补发（journal 已有原 start）。
- rollback 后清除 resume 标志，目标步骤走正常路径发新 attempt 的 `STEP_STARTED`。
- 入口已完成的管道不再重发 `PIPELINE_COMPLETED`。

## 验证

- 新增 `TestStartCompleteEventPairing` 4 个单测（resume 配对 / restart 不重复 / rollback 配对 / 不重发 terminal）。
- tests/pipeline、tests/a2a、tests/web 全部通过；ruff + ty 通过。

Harness WorkItem: 693b8c40-74fc-4c4c-a8be-710fdb351e9f