### PR TITLE
fix(pipeline): make pipeline_init idempotent per session and emit pipeline_restarted on re-run

### DIFF
--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -1818,6 +1818,38 @@ class PipelineRunner:
             exc_info=True,
         )
 
+    def _session_has_pipeline_init_meta(self) -> bool:
+        """Best-effort check whether this session already recorded a ``pipeline_init`` meta row.
+
+        Used to keep pipeline startup idempotent per session: a second ``run()``
+        against the same session (contextId) must not append a duplicate
+        ``pipeline_init``; it records an explicit ``pipeline_restarted`` instead.
+        Any read failure is treated as "not present" so startup never breaks.
+        """
+        try:
+            path = self._session_storage.session_path(self._cwd, self._session_id)
+            if not isinstance(path, Path) or not _is_regular_file_entry(path):
+                return False
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        value = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(value, dict) and "role" not in value and value.get("type") == "pipeline_init":
+                        return True
+        except Exception:
+            logger.debug(
+                "Failed to check existing pipeline_init meta (pipeline=%s, session_id=%s)",
+                getattr(getattr(self, "_loaded", None), "name", ""),
+                getattr(self, "_session_id", ""),
+                exc_info=True,
+            )
+        return False
+
     def _append_pipeline_session_meta_best_effort(self, meta: dict[str, Any], *, operation: str) -> None:
         try:
             self._session_storage.append_meta(self._cwd, self._session_id, meta)
@@ -2540,10 +2572,20 @@ class PipelineRunner:
         except PipelineStatePersistenceError as exc:
             yield self._persistence_failure_event(exc)
             return
-        self._append_pipeline_session_meta_best_effort(
-            {"type": "pipeline_init", "pipeline_type": self._loaded.name},
-            operation="pipeline_init",
-        )
+        if self._session_has_pipeline_init_meta():
+            self._append_pipeline_session_meta_best_effort(
+                {
+                    "type": "pipeline_restarted",
+                    "pipeline_type": self._loaded.name,
+                    "reason": "duplicate_pipeline_init_suppressed",
+                },
+                operation="pipeline_restarted",
+            )
+        else:
+            self._append_pipeline_session_meta_best_effort(
+                {"type": "pipeline_init", "pipeline_type": self._loaded.name},
+                operation="pipeline_init",
+            )
         self._observability.pipeline_started(
             total_steps=self.state_machine.total_steps,
             step_names=list(self.state_machine._order),

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -1753,6 +1753,91 @@ async def test_session_meta_append_failure_is_best_effort_for_completed_pipeline
     assert "Failed to append pipeline session metadata" in caplog.text
 
 
+class JsonlFileSessionStorage(FakeSessionStorage):
+    """Fake storage backed by a real session.jsonl file for idempotency tests."""
+
+    def __init__(self, root: Path):
+        super().__init__()
+        self._root = root
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def session_path(self, cwd, session_id):
+        return self._root / f"{session_id}.jsonl"
+
+    def append_meta(self, cwd, session_id, meta):
+        super().append_meta(cwd, session_id, meta)
+        entry = dict(meta)
+        entry["session_id"] = session_id
+        with self.session_path(cwd, session_id).open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+class RaisingSessionPathStorage(FakeSessionStorage):
+    def session_path(self, cwd, session_id):
+        raise OSError("session path unavailable")
+
+
+def _completing_fake_execute(step, context, session_id, user_message=None, **kwargs):
+    async def _gen():
+        conclusion = {"value": step.step_id}
+        context.set_conclusion(step.conclusion_field, conclusion)
+        yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion=conclusion)
+
+    return _gen()
+
+
+@pytest.mark.asyncio
+async def test_second_run_for_same_session_emits_pipeline_restarted_instead_of_duplicate_init(tmp_path):
+    storage = JsonlFileSessionStorage(tmp_path / "sessions")
+
+    first_runner = _build_two_step_runner(tmp_path, storage=storage)
+    first_runner._step_executor.execute = _completing_fake_execute
+    async for _ in first_runner.run("start"):
+        pass
+
+    second_runner = _build_two_step_runner(tmp_path, storage=storage)
+    second_runner._step_executor.execute = _completing_fake_execute
+    async for _ in second_runner.run("start again"):
+        pass
+
+    init_metas = [meta for meta in storage.meta_entries if meta["type"] == "pipeline_init"]
+    restarted_metas = [meta for meta in storage.meta_entries if meta["type"] == "pipeline_restarted"]
+    assert len(init_metas) == 1
+    assert len(restarted_metas) == 1
+    assert restarted_metas[0]["pipeline_type"] == "test"
+    assert restarted_metas[0]["reason"] == "duplicate_pipeline_init_suppressed"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_restarted_detects_preexisting_init_meta_in_session_jsonl(tmp_path):
+    storage = JsonlFileSessionStorage(tmp_path / "sessions")
+    storage.session_path(str(tmp_path), "test").write_text(
+        '{"type": "pipeline_init", "pipeline_type": "test", "session_id": "test"}\n',
+        encoding="utf-8",
+    )
+
+    runner = _build_two_step_runner(tmp_path, storage=storage)
+    runner._step_executor.execute = _completing_fake_execute
+    async for _ in runner.run("start"):
+        pass
+
+    assert not any(meta["type"] == "pipeline_init" for meta in storage.meta_entries)
+    assert any(meta["type"] == "pipeline_restarted" for meta in storage.meta_entries)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_init_check_read_failure_falls_back_to_init(tmp_path):
+    storage = RaisingSessionPathStorage()
+
+    runner = _build_two_step_runner(tmp_path, storage=storage)
+    runner._step_executor.execute = _completing_fake_execute
+    async for _ in runner.run("start"):
+        pass
+
+    assert any(meta["type"] == "pipeline_init" for meta in storage.meta_entries)
+    assert not any(meta["type"] == "pipeline_restarted" for meta in storage.meta_entries)
+
+
 @pytest.mark.asyncio
 async def test_rollback_session_meta_append_failure_is_best_effort(tmp_path, caplog):
     storage = FailingAppendMetaSessionStorage(fail_types={"pipeline_rollback"})


### PR DESCRIPTION
## 问题
同一会话（contextId）出现重复 `pipeline_init` 与重复 `intent_parsing` step_complete 记录（证据 Session：`b0963f5a432c4f60ac357fbb36c8b8ef`、`2253e91dc0c84b678d96e15d88868d90`）。

## 根因
`PipelineRunner.run()` 每次被调用都无条件向 session.jsonl 追加 `pipeline_init` lite-meta；A2A 侧 sidecar 状态不匹配后的 fresh-run 及兜底路径会对同一 contextId 再次调用 `run()`，导致重复。

## 修复
- `run()` 写 `pipeline_init` 前 best-effort 检查 session.jsonl 是否已有 `pipeline_init` meta；
- 已存在时改写显式 `pipeline_restarted` meta（`reason=duplicate_pipeline_init_suppressed`）；
- 读取失败按首次启动处理，不影响主流程。

预期：每条会话 `pipeline_init` 计数 ≤ 1，重启被 `pipeline_restarted` 显式标注。

## 测试
- 新增 3 个单测（重复 run、预存 init meta、读取失败回退）
- tests/pipeline 1531 passed（1 个 test_prerequisites 失败为预存问题，干净树复现）
- tests/a2a 1432 passed；ruff + ty 通过

Ref: Aone #84289723 / Harness a6b029db