### PR TITLE
fix(a2a): finalize dangling candidate steps in pipeline snapshot

### DIFF
--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -660,9 +660,41 @@ class _PipelineSnapshotReducer:
             step["candidates"].append(candidate)
         self._candidate_parent_step_run_ids[run_id] = step["runId"]
 
+        coordinate_steps = coordinate.get("steps")
+        coordinate = {key: value for key, value in coordinate.items() if key != "steps"}
         _merge_coordinate(candidate, coordinate)
+        self._merge_candidate_skeleton_steps(candidate, coordinate_steps)
         self._apply_candidate_lifecycle(candidate, event)
         return candidate
+
+    def _merge_candidate_skeleton_steps(self, candidate: dict[str, Any], coordinate_steps: Any) -> None:
+        """Merge candidate step skeletons (from ``candidate_started``) without
+        clobbering or duplicating lifecycle-tracked step entries.
+
+        Skeleton entries are registered in ``_candidate_steps_by_run_id`` so that
+        later ``candidate_step_*`` events update the same record instead of
+        appending a second entry with the same runId, which previously left a
+        stale ``pending`` twin next to the real terminal record.
+        """
+        for skeleton in _dict_list(coordinate_steps):
+            step_run_id = _string_or_none(skeleton.get("runId"))
+            if step_run_id is None:
+                continue
+            existing = self._candidate_steps_by_run_id.get(step_run_id)
+            if existing is None:
+                entry = copy.deepcopy(skeleton)
+                entry.setdefault("status", "pending")
+                self._candidate_steps_by_run_id[step_run_id] = entry
+                if entry not in candidate["steps"]:
+                    candidate["steps"].append(entry)
+                continue
+            # Only fill in metadata; never downgrade the tracked status.
+            for key, value in skeleton.items():
+                if key == "status" or value is None:
+                    continue
+                existing.setdefault(key, copy.deepcopy(value))
+            if existing not in candidate["steps"]:
+                candidate["steps"].append(existing)
 
     def _apply_candidate_lifecycle(self, candidate: dict[str, Any], event: dict[str, Any]) -> None:
         event_type = event.get("eventType")
@@ -677,16 +709,35 @@ class _PipelineSnapshotReducer:
             candidate["status"] = "completed"
             _set_time(candidate, "completedAt", created_at)
             _merge_completion_data(candidate, event)
+            self._finalize_pending_candidate_steps(candidate, created_at)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
         elif event_type == "candidate_failed":
             candidate["status"] = "failed"
             _set_time(candidate, "failedAt", created_at)
             _merge_completion_data(candidate, event)
+            self._finalize_pending_candidate_steps(candidate, created_at)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
         elif event_type == "candidate_restart_requested":
             candidate["status"] = "restarting"
             _set_time(candidate, "restartingAt", created_at)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
+
+    @staticmethod
+    def _finalize_pending_candidate_steps(candidate: dict[str, Any], created_at: str | None) -> None:
+        """Force every non-terminal candidate step into a terminal state when
+        its candidate reaches a terminal state.
+
+        Steps that never ran (skipped, or superseded by a retried attempt) are
+        marked ``canceled`` so a completed candidate can no longer carry
+        dangling ``pending``/``working`` sub-steps with a null conclusion.
+        """
+        for candidate_step in _dict_list(candidate.get("steps")):
+            status = _string_or_none(candidate_step.get("status"))
+            if status in {"completed", "failed", "canceled"}:
+                continue
+            candidate_step["status"] = "canceled"
+            _set_time(candidate_step, "canceledAt", created_at)
+            candidate_step.setdefault("cancelReason", "candidate_terminal_without_step_completion")
 
     def _remove_active_candidate_attempts(self, candidate: dict[str, Any]) -> None:
         candidate_id = _string_or_none(candidate.get("id"))

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -733,6 +733,133 @@ def test_reduce_candidate_lifecycle_and_candidate_steps() -> None:
     assert snapshot["control"]["activeCandidateRunIds"] == []
 
 
+def _candidate_skeleton_steps(candidate_run_id: str, step_ids: list[str]) -> list[dict]:
+    total = len(step_ids)
+    return [
+        {
+            "id": step_id,
+            "name": step_id,
+            "runId": f"{candidate_run_id}-{step_id}-1",
+            "attempt": 1,
+            "index": index,
+            "total": total,
+            "status": "pending",
+        }
+        for index, step_id in enumerate(step_ids, start=1)
+    ]
+
+
+def test_reduce_candidate_started_skeleton_steps_do_not_duplicate_lifecycle_entries() -> None:
+    parent = _base("evt-1", 1, "step_started", scope="step")
+    parent["step"] = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    candidate_coordinate = {
+        "runId": "candidate-eval-0-1",
+        "id": "eval",
+        "index": 0,
+        "attempt": 1,
+        "steps": _candidate_skeleton_steps("candidate-eval-0-1", ["template_generating", "cost_estimating"]),
+    }
+    started = _base("evt-2", 2, "candidate_started", scope="candidate")
+    started["step"] = parent["step"]
+    started["candidate"] = candidate_coordinate
+    step_started = _base("evt-3", 3, "candidate_step_started", scope="candidate_step")
+    step_started["step"] = parent["step"]
+    step_started["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}
+    step_started["candidateStep"] = {
+        "runId": "candidate-eval-0-1-template_generating-1",
+        "id": "template_generating",
+        "index": 1,
+        "total": 2,
+        "attempt": 1,
+    }
+    step_completed = _base("evt-4", 4, "candidate_step_completed", scope="candidate_step")
+    step_completed["step"] = parent["step"]
+    step_completed["candidate"] = step_started["candidate"]
+    step_completed["candidateStep"] = step_started["candidateStep"]
+    step_completed["data"] = {"conclusion": {"ok": True}}
+
+    snapshot = reduce_pipeline_events([parent, started, step_started, step_completed])
+
+    steps = snapshot["steps"][0]["candidates"][0]["steps"]
+    run_ids = [entry["runId"] for entry in steps]
+    assert len(run_ids) == len(set(run_ids))
+    by_id = {entry["id"]: entry for entry in steps}
+    assert by_id["template_generating"]["status"] == "completed"
+    assert by_id["template_generating"]["conclusion"] == {"ok": True}
+    assert by_id["cost_estimating"]["status"] == "pending"
+
+
+def test_reduce_candidate_completed_finalizes_dangling_pending_steps() -> None:
+    parent = _base("evt-1", 1, "step_started", scope="step")
+    parent["step"] = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    candidate_run_id = "candidate-eval-0-1"
+    started = _base("evt-2", 2, "candidate_started", scope="candidate")
+    started["step"] = parent["step"]
+    started["candidate"] = {
+        "runId": candidate_run_id,
+        "id": "eval",
+        "index": 0,
+        "attempt": 1,
+        "steps": _candidate_skeleton_steps(candidate_run_id, ["template_generating", "reviewing", "cost_estimating"]),
+    }
+    candidate_coordinate = {"runId": candidate_run_id, "id": "eval", "index": 0, "attempt": 1}
+    step_completed = _base("evt-3", 3, "candidate_step_completed", scope="candidate_step")
+    step_completed["step"] = parent["step"]
+    step_completed["candidate"] = candidate_coordinate
+    step_completed["candidateStep"] = {
+        "runId": f"{candidate_run_id}-reviewing-1",
+        "id": "reviewing",
+        "index": 2,
+        "total": 3,
+        "attempt": 1,
+    }
+    step_completed["data"] = {"conclusion": {"ok": True}}
+    completed = _base("evt-4", 4, "candidate_completed", scope="candidate")
+    completed["step"] = parent["step"]
+    completed["candidate"] = candidate_coordinate
+
+    snapshot = reduce_pipeline_events([parent, started, step_completed, completed])
+
+    candidate = snapshot["steps"][0]["candidates"][0]
+    assert candidate["status"] == "completed"
+    by_id = {entry["id"]: entry for entry in candidate["steps"]}
+    assert by_id["reviewing"]["status"] == "completed"
+    for dangling_id in ("template_generating", "cost_estimating"):
+        assert by_id[dangling_id]["status"] == "canceled"
+        assert by_id[dangling_id]["cancelReason"] == "candidate_terminal_without_step_completion"
+        assert by_id[dangling_id]["canceledAt"] == completed["createdAt"]
+    assert all(entry["status"] in {"completed", "failed", "canceled"} for entry in candidate["steps"])
+
+
+def test_reduce_candidate_failed_finalizes_dangling_working_steps() -> None:
+    parent = _base("evt-1", 1, "step_started", scope="step")
+    parent["step"] = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    candidate_coordinate = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}
+    started = _base("evt-2", 2, "candidate_started", scope="candidate")
+    started["step"] = parent["step"]
+    started["candidate"] = candidate_coordinate
+    step_started = _base("evt-3", 3, "candidate_step_started", scope="candidate_step")
+    step_started["step"] = parent["step"]
+    step_started["candidate"] = candidate_coordinate
+    step_started["candidateStep"] = {
+        "runId": "candidate-eval-0-1-template_generating-1",
+        "id": "template_generating",
+        "index": 1,
+        "total": 1,
+        "attempt": 1,
+    }
+    failed = _base("evt-4", 4, "candidate_failed", scope="candidate", status="working")
+    failed["step"] = parent["step"]
+    failed["candidate"] = candidate_coordinate
+
+    snapshot = reduce_pipeline_events([parent, started, step_started, failed])
+
+    candidate = snapshot["steps"][0]["candidates"][0]
+    assert candidate["status"] == "failed"
+    assert candidate["steps"][0]["status"] == "canceled"
+    assert candidate["steps"][0]["cancelReason"] == "candidate_terminal_without_step_completion"
+
+
 def test_reduce_candidate_failure_keeps_snapshot_working() -> None:
     parent = _base("evt-1", 1, "step_started", scope="step")
     parent["step"] = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}


### PR DESCRIPTION
## 问题
Session `eadbf79d597b4e929827475e01612717` 的 pipeline_snapshot 中，候选 `evaluate_candidate_ea1b4215` 标记 completed，但其子步骤 `template_generating`、`cost_estimating` 仍为 pending 且 conclusion 为 null。

## 根因
`src/iac_code/a2a/pipeline_snapshot.py` 快照 reducer：
1. `candidate_started` 携带的子步骤骨架未按 runId 登记进 `_candidate_steps_by_run_id`，后续 `candidate_step_*` 事件另建条目，留下重复的 pending 骨架；
2. `candidate_completed`/`candidate_failed` 不收尾非终态子步骤。

## 修复
- 骨架子步骤按 runId 去重登记，lifecycle 事件复用同一条记录；
- 候选进入终态时，将仍为 pending/working 的子步骤显式标记 `canceled`（含 canceledAt / cancelReason）。

## 测试
- 新增 3 个回归测试；tests/a2a 全量 1435 通过；下游快照消费方测试 105 通过；ruff/ty 通过。

Aone 需求 #84501215 | Harness WorkItem 219d1d2a