### PR TITLE
feat(ros): block repeat validation of unchanged templates

### DIFF
--- a/src/iac_code/a2a/events.py
+++ b/src/iac_code/a2a/events.py
@@ -206,9 +206,7 @@ def _tool_result_metadata_value(value: Any, *, _depth: int = 0, _artifact_scope:
             )
         return output
     if isinstance(value, list | tuple):
-        return [
-            _tool_result_metadata_value(item, _depth=_depth + 1, _artifact_scope=_artifact_scope) for item in value
-        ]
+        return [_tool_result_metadata_value(item, _depth=_depth + 1, _artifact_scope=_artifact_scope) for item in value]
     if value is None or isinstance(value, bool | int | float):
         return value
     return str(value)[:_METADATA_MAX_CHARS]

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -110,6 +110,8 @@ _CONTEXT_LOCK_ACQUIRE_TIMEOUT_SECONDS = 1
 _CANCEL_ACTIVE_TASK_DRAIN_TIMEOUT_SECONDS = 30
 _ERROR_TEXT_MAX_CHARS = 1000
 _DEFERRED_CLEANUP_PROMPTS_FILENAME = "cleanup-deferred-prompts.json"
+
+
 def _format_exception(exc: BaseException) -> str:
     message = str(exc)
     raw = type(exc).__name__ if not message else f"{type(exc).__name__}: {message}"

--- a/src/iac_code/a2a/pipeline_stream.py
+++ b/src/iac_code/a2a/pipeline_stream.py
@@ -101,6 +101,8 @@ _EXTREME_DEFERRED_EVENT_TYPES = {"text_delta", "thinking_delta"}
 _EXTREME_JOURNAL_FLUSH_EVENTS = 512
 _RECOVERY_STATE_SCOPES = {"step", "candidate", "candidateStep", "candidate_step"}
 _RECOVERY_STATE_STATUSES = {"working"}
+
+
 def backup_committed_delivery_envelope(
     ack_envelope: dict[str, Any],
     committed_envelope: dict[str, Any],
@@ -1034,10 +1036,10 @@ class PipelineA2AEventPublisher:
 
     async def _enqueue_artifact_update(self, envelope: dict[str, Any], artifact_metadata: dict[str, Any]) -> None:
         event = _artifact_update_event(
-                task_id=self._delivery_task_id(envelope),
-                context_id=self._delivery_context_id(envelope),
-                metadata=artifact_metadata,
-            )
+            task_id=self._delivery_task_id(envelope),
+            context_id=self._delivery_context_id(envelope),
+            metadata=artifact_metadata,
+        )
         await self.event_queue.enqueue_event(event)
 
     async def _apply_permission_metadata(

--- a/src/iac_code/a2a/projection.py
+++ b/src/iac_code/a2a/projection.py
@@ -386,9 +386,7 @@ def _project_mapping(
     public_path_roots: Iterable[Mapping[str, str]] | None,
 ) -> dict[Any, Any]:
     unchanged_keys = {
-        key
-        for key in value
-        if not isinstance(key, str) or redact_known_public_paths(key, public_path_roots) == key
+        key for key in value if not isinstance(key, str) or redact_known_public_paths(key, public_path_roots) == key
     }
     used_keys: set[Any] = set()
     projected: dict[Any, Any] = {}

--- a/src/iac_code/acp/session.py
+++ b/src/iac_code/acp/session.py
@@ -95,16 +95,12 @@ def _history_tool_input_text(tool_name: str, tool_input: dict[str, Any]) -> str:
     del tool_name
     if not tool_input:
         return ""
-    return _("Input: {input}").format(
-        input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
-    )
+    return _("Input: {input}").format(input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str))
 
 
 def _display_tool_input_text(tool_name: str, tool_input: dict[str, Any]) -> str:
     del tool_name
-    return _("Input: {input}").format(
-        input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
-    )
+    return _("Input: {input}").format(input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str))
 
 
 def _permission_request_event(event: Any) -> PermissionRequestEvent | None:

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -6368,6 +6368,44 @@ msgstr "CloudStackInstances"
 msgid "Calling ROS template tool for {template_url}..."
 msgstr "Rufe das ROS-Vorlagenwerkzeug für {template_url} auf..."
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"Repeated ROS validation blocked: the template at {template_url} has not "
+"changed since the last failed validation (result_digest={digest}, failed "
+"attempts={count}). Calling ros_validate_template again would return the "
+"same error. Diagnose the template syntax root cause from the error below,"
+" fix the template file first, and only revalidate after the file content "
+"changed.\n"
+"Last validation error:\n"
+"{error}"
+msgstr ""
+"Wiederholte ROS-Validierung blockiert: Die Vorlage unter {template_url} "
+"hat sich seit der letzten fehlgeschlagenen Validierung nicht geändert "
+"(result_digest={digest}, fehlgeschlagene Versuche={count}). Ein erneuter "
+"Aufruf von ros_validate_template würde denselben Fehler zurückgeben. "
+"Diagnostizieren Sie die Ursache des Vorlagensyntaxfehlers anhand des "
+"folgenden Fehlers, korrigieren Sie zuerst die Vorlagendatei und "
+"validieren Sie erst erneut, nachdem sich der Dateiinhalt geändert hat.\n"
+"Letzter Validierungsfehler:\n"
+"{error}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"\n"
+"\n"
+"ros_validate_template failure result_digest={digest}. Locate and fix the "
+"template syntax root cause before revalidating; revalidating the "
+"unchanged template will be blocked."
+msgstr ""
+"\n"
+"\n"
+"ros_validate_template-Fehler result_digest={digest}. Lokalisieren und "
+"beheben Sie die Ursache des Vorlagensyntaxfehlers vor der erneuten "
+"Validierung; die erneute Validierung der unveränderten Vorlage wird "
+"blockiert."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 #, python-brace-format
 msgid ""
@@ -12695,3 +12733,4 @@ msgstr "Bash zulassen?"
 #~ msgstr ""
 #~ "Tool-Aufruf genehmigen: {tool}\n"
 #~ "Eingabezusammenfassung: {summary}"
+

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6339,6 +6339,43 @@ msgstr "CloudStackInstances"
 msgid "Calling ROS template tool for {template_url}..."
 msgstr "Llamando a la herramienta de plantilla ROS para {template_url}..."
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"Repeated ROS validation blocked: the template at {template_url} has not "
+"changed since the last failed validation (result_digest={digest}, failed "
+"attempts={count}). Calling ros_validate_template again would return the "
+"same error. Diagnose the template syntax root cause from the error below,"
+" fix the template file first, and only revalidate after the file content "
+"changed.\n"
+"Last validation error:\n"
+"{error}"
+msgstr ""
+"Validación ROS repetida bloqueada: la plantilla en {template_url} no ha "
+"cambiado desde la última validación fallida (result_digest={digest}, "
+"intentos fallidos={count}). Volver a llamar a ros_validate_template "
+"devolvería el mismo error. Diagnostique la causa raíz de la sintaxis de "
+"la plantilla a partir del error siguiente, corrija primero el archivo de "
+"la plantilla y solo revalide después de que el contenido del archivo "
+"cambie.\n"
+"Último error de validación:\n"
+"{error}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"\n"
+"\n"
+"ros_validate_template failure result_digest={digest}. Locate and fix the "
+"template syntax root cause before revalidating; revalidating the "
+"unchanged template will be blocked."
+msgstr ""
+"\n"
+"\n"
+"Fallo de ros_validate_template result_digest={digest}. Localice y corrija"
+" la causa raíz de la sintaxis de la plantilla antes de revalidar; la "
+"revalidación de la plantilla sin cambios será bloqueada."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 #, python-brace-format
 msgid ""
@@ -12612,3 +12649,4 @@ msgstr "¿Permitir Bash?"
 #~ msgstr ""
 #~ "Aprobar llamada de herramienta: {tool}\n"
 #~ "Resumen de entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6361,6 +6361,42 @@ msgstr "CloudStackInstances"
 msgid "Calling ROS template tool for {template_url}..."
 msgstr "Appel de l'outil de modèle ROS pour {template_url}..."
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"Repeated ROS validation blocked: the template at {template_url} has not "
+"changed since the last failed validation (result_digest={digest}, failed "
+"attempts={count}). Calling ros_validate_template again would return the "
+"same error. Diagnose the template syntax root cause from the error below,"
+" fix the template file first, and only revalidate after the file content "
+"changed.\n"
+"Last validation error:\n"
+"{error}"
+msgstr ""
+"Validation ROS répétée bloquée : le modèle à {template_url} n'a pas "
+"changé depuis le dernier échec de validation (result_digest={digest}, "
+"tentatives échouées={count}). Rappeler ros_validate_template renverrait "
+"la même erreur. Diagnostiquez la cause racine de la syntaxe du modèle à "
+"partir de l'erreur ci-dessous, corrigez d'abord le fichier du modèle et "
+"ne revalidez qu'après modification du contenu du fichier.\n"
+"Dernière erreur de validation :\n"
+"{error}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"\n"
+"\n"
+"ros_validate_template failure result_digest={digest}. Locate and fix the "
+"template syntax root cause before revalidating; revalidating the "
+"unchanged template will be blocked."
+msgstr ""
+"\n"
+"\n"
+"Échec de ros_validate_template result_digest={digest}. Localisez et "
+"corrigez la cause racine de la syntaxe du modèle avant de revalider ; la "
+"revalidation du modèle inchangé sera bloquée."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 #, python-brace-format
 msgid ""
@@ -12678,3 +12714,4 @@ msgstr "Autoriser Bash ?"
 #~ msgstr ""
 #~ "Approuver l'appel d'outil : {tool}\n"
 #~ "Résumé de l'entrée : {summary}"
+

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -6012,6 +6012,40 @@ msgstr "CloudStackInstances"
 msgid "Calling ROS template tool for {template_url}..."
 msgstr "{template_url} の ROS テンプレートツールを呼び出しています..."
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"Repeated ROS validation blocked: the template at {template_url} has not "
+"changed since the last failed validation (result_digest={digest}, failed "
+"attempts={count}). Calling ros_validate_template again would return the "
+"same error. Diagnose the template syntax root cause from the error below,"
+" fix the template file first, and only revalidate after the file content "
+"changed.\n"
+"Last validation error:\n"
+"{error}"
+msgstr ""
+"繰り返しの ROS 検証をブロックしました：{template_url} "
+"のテンプレートは前回の検証失敗以降変更されていません（result_digest={digest}、失敗回数={count}）。ros_validate_template"
+" "
+"を再度呼び出しても同じエラーが返されます。以下のエラーからテンプレート構文の根本原因を特定し、先にテンプレートファイルを修正して、ファイル内容が変更された後にのみ再検証してください。"
+"\n"
+"前回の検証エラー：\n"
+"{error}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"\n"
+"\n"
+"ros_validate_template failure result_digest={digest}. Locate and fix the "
+"template syntax root cause before revalidating; revalidating the "
+"unchanged template will be blocked."
+msgstr ""
+"\n"
+"\n"
+"ros_validate_template 失敗 "
+"result_digest={digest}。再検証の前にテンプレート構文の根本原因を特定して修正してください。未変更のテンプレートの再検証はブロックされます。"
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 #, python-brace-format
 msgid ""
@@ -11706,3 +11740,4 @@ msgstr "Bash を許可しますか？"
 #~ msgstr ""
 #~ "ツール呼び出しを承認: {tool}\n"
 #~ "入力サマリー: {summary}"
+

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6298,6 +6298,42 @@ msgstr "CloudStackInstances"
 msgid "Calling ROS template tool for {template_url}..."
 msgstr "Chamando a ferramenta de modelo ROS para {template_url}..."
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"Repeated ROS validation blocked: the template at {template_url} has not "
+"changed since the last failed validation (result_digest={digest}, failed "
+"attempts={count}). Calling ros_validate_template again would return the "
+"same error. Diagnose the template syntax root cause from the error below,"
+" fix the template file first, and only revalidate after the file content "
+"changed.\n"
+"Last validation error:\n"
+"{error}"
+msgstr ""
+"Validação ROS repetida bloqueada: o modelo em {template_url} não mudou "
+"desde a última validação com falha (result_digest={digest}, tentativas "
+"com falha={count}). Chamar ros_validate_template novamente retornaria o "
+"mesmo erro. Diagnostique a causa raiz da sintaxe do modelo a partir do "
+"erro abaixo, corrija primeiro o arquivo do modelo e revalide somente após"
+" o conteúdo do arquivo mudar.\n"
+"Último erro de validação:\n"
+"{error}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"\n"
+"\n"
+"ros_validate_template failure result_digest={digest}. Locate and fix the "
+"template syntax root cause before revalidating; revalidating the "
+"unchanged template will be blocked."
+msgstr ""
+"\n"
+"\n"
+"Falha de ros_validate_template result_digest={digest}. Localize e corrija"
+" a causa raiz da sintaxe do modelo antes de revalidar; a revalidação do "
+"modelo inalterado será bloqueada."
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 #, python-brace-format
 msgid ""
@@ -12506,3 +12542,4 @@ msgstr "Permitir Bash?"
 #~ msgstr ""
 #~ "Aprovar chamada de ferramenta: {tool}\n"
 #~ "Resumo da entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -5863,6 +5863,38 @@ msgstr "云资源栈实例"
 msgid "Calling ROS template tool for {template_url}..."
 msgstr "正在为 {template_url} 调用 ROS 模板工具..."
 
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"Repeated ROS validation blocked: the template at {template_url} has not "
+"changed since the last failed validation (result_digest={digest}, failed "
+"attempts={count}). Calling ros_validate_template again would return the "
+"same error. Diagnose the template syntax root cause from the error below,"
+" fix the template file first, and only revalidate after the file content "
+"changed.\n"
+"Last validation error:\n"
+"{error}"
+msgstr ""
+"重复的 ROS 校验已被拦截：{template_url} "
+"的模板自上次校验失败以来没有变化（result_digest={digest}，失败次数={count}）。再次调用 "
+"ros_validate_template 只会返回相同错误。请根据下方错误定位模板语法根因，先修复模板文件，仅在文件内容变化后再重新校验。\n"
+"上次校验错误：\n"
+"{error}"
+
+#: src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+#, python-brace-format
+msgid ""
+"\n"
+"\n"
+"ros_validate_template failure result_digest={digest}. Locate and fix the "
+"template syntax root cause before revalidating; revalidating the "
+"unchanged template will be blocked."
+msgstr ""
+"\n"
+"\n"
+"ros_validate_template 失败 "
+"result_digest={digest}。请先定位并修复模板语法根因再重新校验；对未修改模板的重复校验将被拦截。"
+
 #: src/iac_code/tools/cloud/aliyun/template_source.py
 #, python-brace-format
 msgid ""
@@ -11493,3 +11525,4 @@ msgstr "允许 Bash?"
 #~ msgstr ""
 #~ "批准工具调用：{tool}\n"
 #~ "输入摘要：{summary}"
+

--- a/src/iac_code/pipeline/selling/prompts/template_generating.md
+++ b/src/iac_code/pipeline/selling/prompts/template_generating.md
@@ -20,6 +20,11 @@
 ## ROS 模板来源
 生成后的模板文件路径就是 `{candidate.output_path}`。调用 `ros_validate_template` 校验时，必须传 `template_url = "{candidate.output_path}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口，不要传 `TemplateBody`、`TemplateId` 或 `TemplateScratchId`。
 
+## 校验重试纪律
+- 校验失败后，先根据错误信息定位模板语法根因并修复 `{candidate.output_path}`，再重新调用 `ros_validate_template`。
+- 禁止对未修改的模板重复调用 `ros_validate_template`：相同内容只会返回相同错误（相同 result_digest），并会被工具拦截。
+- 结论的 `validation_summary` 字段必须记录校验迭代摘要：校验次数、失败次数与首次成功前的失败原因摘要；一次通过时写明一次通过。
+
 ## 输出
 文件写入完成后调用 `complete_step` 提交结论。
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -20,6 +20,9 @@ conclusion_schema:
     description:
       type: string
       description: 模板简要描述
+    validation_summary:
+      type: string
+      description: 校验迭代摘要：校验总次数、失败次数，以及首次成功前的失败原因摘要（含 result_digest）；一次通过时写明一次通过
 ---
 
 # ROS 模板生成
@@ -43,8 +46,8 @@ conclusion_schema:
 4. 生成 ROS YAML 模板（库存相关属性按 [references/cloud-products/](references/cloud-products/) 与 [references/template-parameters.md](references/template-parameters.md) 定义为 Parameters，所有 Parameters 必须添加 AssociationProperty）并写入文件
    - 生成的模板默认放在当前工作目录；仅当用户指定其他路径时才写入该路径，不要默认使用 `/tmp` 等工作目录外路径
 5. 调用 `ros_validate_template` 校验；`template_url` 使用刚写入的模板文件路径，已有具体地域时传 `region_id`，否则使用工具默认地域
-6. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
-7. 校验通过 → 完成
+6. 校验失败 → 先定位模板语法根因（比对错误中的 result_digest，逐条分析错误信息，必要时查 GetResourceType Schema）→ 修复模板文件 → 重试（最多 5 轮）。**禁止在未修改模板文件的情况下重复调用 `ros_validate_template`**：同一失败模板的重复校验只会返回相同错误（相同 result_digest），且会被工具直接拦截
+7. 校验通过 → 完成，并在结论的 `validation_summary` 中记录校验迭代摘要（校验次数、失败原因摘要；一次通过时写明一次通过）
 
 > **模板路径支持本地文件**：`ros_validate_template` 的 `template_url` 可传当前工作目录内的本地文件路径（如 `./template.yml`）。避免将大模板内容直接作为参数传递。
 
@@ -92,7 +95,7 @@ conclusion_schema:
 ## 错误处理
 
 ### 校验失败
-分析错误原因 → 查 GetResourceType Schema（如需）→ 修复 → 重试（最多 5 轮）
+先定位语法根因：逐条阅读错误信息，比对 result_digest 判断是否与上次为同一错误 → 查 GetResourceType Schema（如需）→ 修复模板文件 → 重试（最多 5 轮）。模板文件未修改时不要重复校验：相同内容的重复校验会被拦截并返回上次的失败信息。
 
 ## 参考文件
 

--- a/src/iac_code/services/telemetry/content_serializer.py
+++ b/src/iac_code/services/telemetry/content_serializer.py
@@ -140,9 +140,7 @@ def serialize_input_messages(messages: list) -> str:
             for block in content:
                 btype = getattr(block, "type", "text")
                 if btype == "text":
-                    parts.append(
-                        {"type": "text", "content": _truncate(_strict_text(getattr(block, "text", "") or ""))}
-                    )
+                    parts.append({"type": "text", "content": _truncate(_strict_text(getattr(block, "text", "") or ""))})
                 elif btype == "tool_use":
                     tool_use_id = _tool_call_id(block)
                     tool_name = _strict_text(getattr(block, "name", ""))

--- a/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
+import re
 from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import jsonschema
@@ -17,8 +21,34 @@ from iac_code.tools.cloud.aliyun.aliyun_api import (
     AliyunApi,
 )
 from iac_code.tools.cloud.aliyun.public_errors import public_aliyun_error
-from iac_code.tools.cloud.aliyun.template_source import is_local_template_url
+from iac_code.tools.cloud.aliyun.template_source import (
+    is_local_template_url,
+    resolve_template_url_for_api,
+)
 from iac_code.types.permissions import PermissionResult, ToolPermissionContext
+
+_REQUEST_ID_PATTERN = re.compile(r'"?RequestId"?\s*[:=]\s*"?[0-9A-Fa-f-]+"?')
+
+
+def validation_result_digest(content: str) -> str:
+    """Stable short digest identifying a validation failure payload.
+
+    Request-scoped identifiers are stripped so that the same template error
+    produces the same digest across repeated remote validation calls.
+    """
+
+    normalized = _REQUEST_ID_PATTERN.sub("RequestId=<volatile>", content)
+    return hashlib.sha256(normalized.encode("utf-8", errors="replace")).hexdigest()[:8]
+
+
+@dataclass
+class _FailedValidationRecord:
+    template_fingerprint: str
+    result_digest: str
+    failure_count: int
+    last_error: str
+    blocked_attempts: int = 0
+
 
 _TEMPLATE_URL_PROPERTY = {
     "type": "string",
@@ -213,6 +243,10 @@ class _RosTemplateTool(Tool):
 class RosValidateTemplateTool(_RosTemplateTool):
     action = "ValidateTemplate"
 
+    def __init__(self, *, delegated_executor: Any | None = None) -> None:
+        super().__init__(delegated_executor=delegated_executor)
+        self._failed_validations: dict[tuple[str, str], _FailedValidationRecord] = {}
+
     @property
     def name(self) -> str:
         return "ros_validate_template"
@@ -228,8 +262,72 @@ class RosValidateTemplateTool(_RosTemplateTool):
     def input_schema(self) -> dict[str, Any]:
         return delegated_input_schema(self.action)
 
+    def _template_fingerprint(
+        self,
+        tool_input: Mapping[str, Any],
+        context: ToolContext,
+    ) -> tuple[tuple[str, str], str | None]:
+        template_url = tool_input.get("template_url")
+        key = (str(template_url), str(tool_input.get("region_id") or ""))
+        if not isinstance(template_url, str) or not is_local_template_url(template_url):
+            return key, None
+        try:
+            resolved = resolve_template_url_for_api(template_url, context)
+            content = Path(resolved).read_bytes()
+        except OSError:
+            return key, None
+        return key, hashlib.sha256(content).hexdigest()
+
+    def _repeated_failure_result(self, record: _FailedValidationRecord, template_url: str) -> ToolResult:
+        message = _(
+            "Repeated ROS validation blocked: the template at {template_url} has not changed since the last "
+            "failed validation (result_digest={digest}, failed attempts={count}). Calling ros_validate_template "
+            "again would return the same error. Diagnose the template syntax root cause from the error below, "
+            "fix the template file first, and only revalidate after the file content changed.\n"
+            "Last validation error:\n{error}"
+        ).format(
+            template_url=template_url,
+            digest=record.result_digest,
+            count=record.failure_count,
+            error=record.last_error,
+        )
+        return ToolResult.error(message)
+
     async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
-        return await self._call_ros_api(tool_input=tool_input, context=context)
+        if self._delegated_executor is None:
+            return await self._call_ros_api(tool_input=tool_input, context=context)
+        guard_key, fingerprint = self._template_fingerprint(tool_input, context)
+        if fingerprint is not None:
+            record = self._failed_validations.get(guard_key)
+            if record is not None and record.template_fingerprint == fingerprint:
+                record.blocked_attempts += 1
+                return self._repeated_failure_result(record, str(tool_input.get("template_url")))
+        result = await self._call_ros_api(tool_input=tool_input, context=context)
+        if fingerprint is None:
+            return result
+        if not result.is_error:
+            self._failed_validations.pop(guard_key, None)
+            return result
+        digest = validation_result_digest(result.content)
+        previous = self._failed_validations.get(guard_key)
+        failure_count = previous.failure_count + 1 if previous is not None and previous.result_digest == digest else 1
+        self._failed_validations[guard_key] = _FailedValidationRecord(
+            template_fingerprint=fingerprint,
+            result_digest=digest,
+            failure_count=failure_count,
+            last_error=result.content,
+        )
+        annotation = _(
+            "\n\nros_validate_template failure result_digest={digest}. Locate and fix the template syntax root "
+            "cause before revalidating; revalidating the unchanged template will be blocked."
+        ).format(digest=digest)
+        return ToolResult(
+            content=result.content + annotation,
+            is_error=True,
+            new_messages=list(result.new_messages),
+            context_modifier=result.context_modifier,
+            metadata=result.metadata,
+        )
 
 
 class RosGetTemplateParameterConstraintsTool(_RosTemplateTool):

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/association_property_specs.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/association_property_specs.py
@@ -252,11 +252,7 @@ def apply_contract_corrections(payload: Mapping[str, Any]) -> dict[str, Any]:
             frozenset({"component", "deprecated", "replacement", "scope"}),
         ),
         "common_metadata": (
-            {
-                field: deepcopy(common[field])
-                for field in ("coverage", "schema", "semantic_rules")
-                if field in common
-            }
+            {field: deepcopy(common[field]) for field in ("coverage", "schema", "semantic_rules") if field in common}
             if isinstance(common, Mapping)
             else deepcopy(common)
         ),

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
@@ -733,9 +733,7 @@ class _ValidationState:
                     "ROS5305",
                     Severity.WARNING,
                     _("AssociationProperty availability depends on the stock form read-only state."),
-                    _(
-                        "The editable form path does not support this value, while the read-only path may bypass it."
-                    ),
+                    _("The editable form path does not support this value, while the read-only path may bypass it."),
                     association_path,
                     subject=normalized_association,
                     stable_args=("excluded-read-only-unknown", normalized_association),
@@ -2155,9 +2153,7 @@ class _ValidationState:
             self._emit(
                 "ROS5305",
                 Severity.WARNING,
-                _(
-                    "Metadata reference {} has more than one possible lookup scope."
-                ).format(name),
+                _("Metadata reference {} has more than one possible lookup scope.").format(name),
                 _(
                     "It may resolve from template Parameters or component-local data. The runtime component is "
                     "unknown, so local validation leaves the reference unchecked."

--- a/src/iac_code/utils/public_paths.py
+++ b/src/iac_code/utils/public_paths.py
@@ -181,8 +181,7 @@ def _redact_known_path_token(
 def _path_matches_roots(path: str, roots: list[_NormalizedRoot]) -> bool:
     windows = _is_windows_path(path)
     return any(
-        root.windows == windows
-        and _path_is_under_root(candidate, root.norm_path, windows=windows)
+        root.windows == windows and _path_is_under_root(candidate, root.norm_path, windows=windows)
         for candidate in _candidate_norm_paths(path, windows=windows)
         for root in roots
     )

--- a/tests/a2a/test_grpc_transport.py
+++ b/tests/a2a/test_grpc_transport.py
@@ -191,9 +191,7 @@ async def test_official_grpc_projects_success_and_error_from_new_request_cwd(mon
     ParseDict({"path": server_path, "password": "real-secret"}, response.message.metadata)
 
     projected = await handler._handle_unary(request, object(), None, response)
-    handler.error_to_abort = WireError(
-        message=f"failed token=real-secret at {server_path}", data={"path": server_path}
-    )
+    handler.error_to_abort = WireError(message=f"failed token=real-secret at {server_path}", data={"path": server_path})
     await handler._handle_unary(request, object(), None, a2a_pb2.SendMessageResponse())
 
     assert MessageToDict(projected.message.metadata) == {"path": "[PATH]", "password": "real-secret"}

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -4195,9 +4195,7 @@ async def test_executor_preserves_auth_looking_pipeline_error_without_safe_mode(
 
     final_status = _status_events(queue)[-1]["status"]
     assert final_status["state"] == "TASK_STATE_FAILED"
-    assert final_status["message"]["parts"][0]["text"] == (
-        "ValueError: missing API key: secret-internal-detail"
-    )
+    assert final_status["message"]["parts"][0]["text"] == ("ValueError: missing API key: secret-internal-detail")
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_pipeline_recovery.py
+++ b/tests/a2a/test_pipeline_recovery.py
@@ -92,12 +92,8 @@ async def test_recovery_keeps_pipeline_warning_visible_after_snapshot_sequence(t
     assert state["snapshot"]["lastSequence"] == 2
     assert state["snapshot"]["control"]["warningHistory"][0]["eventId"] == "evt-warning"
     assert state["snapshot"]["control"]["warningHistory"][0]["data"]["reason"] == "cleanup_tracking_unavailable"
-    assert state["snapshot"]["control"]["warningHistory"][0]["data"]["ledger_path"].endswith(
-        "/cleanup.yaml"
-    )
-    assert "while parsing /Users/alice" in state["snapshot"]["control"]["warningHistory"][0]["data"][
-        "load_error"
-    ]
+    assert state["snapshot"]["control"]["warningHistory"][0]["data"]["ledger_path"].endswith("/cleanup.yaml")
+    assert "while parsing /Users/alice" in state["snapshot"]["control"]["warningHistory"][0]["data"]["load_error"]
 
     replay_state = await service.get_state(context_id="ctx-1", after_sequence=1)
 
@@ -336,9 +332,7 @@ async def test_recovery_resolves_cleanup_snapshot_from_normal_delivery_task_id(t
     assert state["snapshot"]["cleanup"]["resources"][0]["resourceId"] == "stack-123"
     assert state["snapshot"]["cleanup"]["prompt"] == "hidden cleanup prompt for stack-123"
     assert state["snapshot"]["cleanup"]["ledgerPath"].endswith("/cleanup.yaml")
-    assert state["snapshot"]["cleanup"]["history"][0]["data"]["prompt"] == (
-        "hidden cleanup prompt for stack-123"
-    )
+    assert state["snapshot"]["cleanup"]["history"][0]["data"]["prompt"] == ("hidden cleanup prompt for stack-123")
     assert state["snapshot"]["cleanup"]["history"][0]["data"]["ledgerPath"].endswith("/cleanup.yaml")
     assert state["snapshot"]["cleanup"]["history"][0]["data"]["lastError"] == raw_error
     assert [event["eventId"] for event in state["events"]] == ["evt-cleanup-started"]

--- a/tests/a2a/test_projection.py
+++ b/tests/a2a/test_projection.py
@@ -227,9 +227,7 @@ def test_http_projection_uses_new_request_cwd_before_task_context_exists(tmp_pat
 def test_http_jsonrpc_task_scoped_error_uses_params_task_workspace(tmp_path, monkeypatch) -> None:
     workspace = tmp_path / "task-workspace"
     server_path = str(workspace / "private" / "result.json")
-    store = _MultiProjectionTaskStore(
-        {"task-1": ("context-1", str(workspace), "session-1")}
-    )
+    store = _MultiProjectionTaskStore({"task-1": ("context-1", str(workspace), "session-1")})
 
     async def fail(_request: Request) -> JSONResponse:
         return JSONResponse({"jsonrpc": "2.0", "id": "request-1", "error": {"message": server_path}})
@@ -325,9 +323,7 @@ def test_http_projection_aggregates_roots_for_list_tasks_response(tmp_path, monk
 @pytest.mark.asyncio
 async def test_task_scoped_request_and_grpc_bare_id_resolve_task_workspace_roots(tmp_path) -> None:
     workspace = tmp_path / "task-workspace"
-    store = _MultiProjectionTaskStore(
-        {"task-1": ("context-1", str(workspace), "session-1")}
-    )
+    store = _MultiProjectionTaskStore({"task-1": ("context-1", str(workspace), "session-1")})
 
     jsonrpc_roots = await resolve_a2a_public_path_roots_for_data(
         store,

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -110,6 +110,19 @@ class TestSkillContentRosOnly:
     def test_contains_error_handling(self, body):
         assert "校验失败" in body
 
+    def test_forbids_repeat_validation_of_unchanged_template(self, body):
+        assert "禁止在未修改模板文件的情况下重复调用" in body
+        assert "result_digest" in body
+        assert "先定位模板语法根因" in body or "先定位语法根因" in body
+
+    def test_requires_validation_summary_in_conclusion(self, body):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        props = fm["conclusion_schema"]["properties"]
+        assert "validation_summary" in props
+        assert "validation_summary" not in fm["conclusion_schema"]["required"]
+        assert "validation_summary" in body
+
     def test_honors_candidate_resource_lifecycle_contract(self, body):
         assert "resource_intents" in body
         assert "action=create" in body

--- a/tests/tools/cloud/aliyun/test_ros_association_property_specs.py
+++ b/tests/tools/cloud/aliyun/test_ros_association_property_specs.py
@@ -102,9 +102,7 @@ def test_vendored_contract_contains_only_supported_public_fields() -> None:
         for spec in payload["association_properties"].values()
     )
     assert all(set(spec) <= {"scope"} for spec in payload["excluded_association_properties"].values())
-    assert all(
-        set(spec) <= {"coverage", "metadata", "semantic_rules"} for spec in payload["components"].values()
-    )
+    assert all(set(spec) <= {"coverage", "metadata", "semantic_rules"} for spec in payload["components"].values())
 
 
 def test_contract_corrections_are_idempotent_and_sanitizing() -> None:
@@ -165,15 +163,9 @@ def test_loader_rejects_unknown_consumer_set_and_semantic_rule() -> None:
     "mutate",
     [
         lambda item: item.__setitem__("unsupported_top_level", {"count": 1}),
-        lambda item: item["association_properties"]["AutoCompleteInput"].__setitem__(
-            "unsupported_detail", "discarded"
-        ),
-        lambda item: item["components"]["AutoCompleteInput"].__setitem__(
-            "unsupported_detail", "discarded"
-        ),
-        lambda item: item["excluded_association_properties"]["Default"].__setitem__(
-            "unsupported_detail", "discarded"
-        ),
+        lambda item: item["association_properties"]["AutoCompleteInput"].__setitem__("unsupported_detail", "discarded"),
+        lambda item: item["components"]["AutoCompleteInput"].__setitem__("unsupported_detail", "discarded"),
+        lambda item: item["excluded_association_properties"]["Default"].__setitem__("unsupported_detail", "discarded"),
     ],
 )
 def test_loader_rejects_fields_outside_public_contract(mutate) -> None:

--- a/tests/tools/cloud/aliyun/test_ros_association_property_validation.py
+++ b/tests/tools/cloud/aliyun/test_ros_association_property_validation.py
@@ -456,9 +456,7 @@ def test_known_unknown_excluded_apsara_and_deprecated_association_properties() -
     excluded = _validate({"Type": "String", "AssociationProperty": "ALIYUN::OOS::Component::ActionChoice"})
     assert _codes(excluded) == ["ROS1302"]
     excluded_diagnostic = next(item for item in excluded.diagnostics if item.code == "ROS1302")
-    assert excluded_diagnostic.detail == (
-        "This AssociationProperty value is available only in the OOS parameter form."
-    )
+    assert excluded_diagnostic.detail == ("This AssociationProperty value is available only in the OOS parameter form.")
 
     for allowed_values in ([], ["a"], {}):
         bypassed = _validate(

--- a/tests/tools/cloud/aliyun/test_ros_template_tools.py
+++ b/tests/tools/cloud/aliyun/test_ros_template_tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from iac_code.tools.base import ToolContext, ToolResult
@@ -330,3 +332,119 @@ async def test_ros_template_tool_preserves_delegated_permission_result() -> None
     result = await tool.check_permissions(tool_input, _permission_context())
 
     assert result is expected
+
+
+class _SequencedDelegatedExecutor:
+    """Delegated executor returning queued results, tracking execution count."""
+
+    def __init__(self, results: list[ToolResult]) -> None:
+        self._results = list(results)
+        self.execution_calls: list[dict] = []
+
+    async def check_permissions(self, tool_input, context):
+        return PermissionResult(behavior="allow", execution_class="concurrent")
+
+    async def execute(self, tool_input, context):
+        self.execution_calls.append(dict(tool_input))
+        return self._results.pop(0)
+
+
+def _write_template(tmp_path, content: str) -> str:
+    template = tmp_path / "template.yml"
+    template.write_text(content, encoding="utf-8")
+    return str(template)
+
+
+@pytest.mark.asyncio
+async def test_ros_validate_template_blocks_repeat_validation_of_unchanged_template(tmp_path) -> None:
+    template_url = _write_template(tmp_path, "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n")
+    failure = ToolResult.error('{"Code":"InvalidTemplate","Message":"bad !Ref","RequestId":"AAA-111"}')
+    delegated = _SequencedDelegatedExecutor([failure])
+    tool = RosValidateTemplateTool(delegated_executor=delegated)
+    context = ToolContext(cwd=str(tmp_path), pipeline_mode=True)
+    tool_input = {"template_url": template_url}
+
+    first = await tool.execute(tool_input=tool_input, context=context)
+    second = await tool.execute(tool_input=tool_input, context=context)
+    third = await tool.execute(tool_input=tool_input, context=context)
+
+    assert first.is_error
+    assert "result_digest=" in first.content
+    assert len(delegated.execution_calls) == 1  # remote validation not repeated
+    for repeated in (second, third):
+        assert repeated.is_error
+        assert "Repeated ROS validation blocked" in repeated.content
+        assert "bad !Ref" in repeated.content  # last error is surfaced for root-cause analysis
+    assert "failed attempts=1" in second.content
+
+
+@pytest.mark.asyncio
+async def test_ros_validate_template_revalidates_after_template_change(tmp_path) -> None:
+    template_url = _write_template(tmp_path, "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n")
+    failure = ToolResult.error('{"Code":"InvalidTemplate","Message":"bad","RequestId":"AAA-111"}')
+    success = ToolResult.success('{"RequestId":"BBB-222"}')
+    delegated = _SequencedDelegatedExecutor([failure, success])
+    tool = RosValidateTemplateTool(delegated_executor=delegated)
+    context = ToolContext(cwd=str(tmp_path), pipeline_mode=True)
+    tool_input = {"template_url": template_url}
+
+    first = await tool.execute(tool_input=tool_input, context=context)
+    Path(template_url).write_text(
+        "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\nOutputs: {}\n",
+        encoding="utf-8",
+    )
+    second = await tool.execute(tool_input=tool_input, context=context)
+
+    assert first.is_error
+    assert not second.is_error
+    assert len(delegated.execution_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_ros_validate_template_clears_failure_state_after_success(tmp_path) -> None:
+    template_url = _write_template(tmp_path, "a: 1\n")
+    failure = ToolResult.error('{"Code":"InvalidTemplate","Message":"bad","RequestId":"AAA-111"}')
+    success = ToolResult.success('{"RequestId":"BBB-222"}')
+    failure_again = ToolResult.error('{"Code":"InvalidTemplate","Message":"other","RequestId":"CCC-333"}')
+    delegated = _SequencedDelegatedExecutor([failure, success, failure_again])
+    tool = RosValidateTemplateTool(delegated_executor=delegated)
+    context = ToolContext(cwd=str(tmp_path), pipeline_mode=True)
+    tool_input = {"template_url": template_url}
+
+    await tool.execute(tool_input=tool_input, context=context)
+    Path(template_url).write_text("a: 2\n", encoding="utf-8")
+    ok = await tool.execute(tool_input=tool_input, context=context)
+    # Same content revalidated after success must reach the remote API again.
+    third = await tool.execute(tool_input=tool_input, context=context)
+
+    assert not ok.is_error
+    assert third.is_error
+    assert len(delegated.execution_calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_ros_validate_template_guard_skips_remote_urls() -> None:
+    failure = ToolResult.error('{"Code":"InvalidTemplate","Message":"bad","RequestId":"AAA-111"}')
+    failure_two = ToolResult.error('{"Code":"InvalidTemplate","Message":"bad","RequestId":"DDD-444"}')
+    delegated = _SequencedDelegatedExecutor([failure, failure_two])
+    tool = RosValidateTemplateTool(delegated_executor=delegated)
+    context = ToolContext(cwd="/tmp", pipeline_mode=True)
+    tool_input = {"template_url": "oss://bucket/template.yml"}
+
+    first = await tool.execute(tool_input=tool_input, context=context)
+    second = await tool.execute(tool_input=tool_input, context=context)
+
+    assert first.is_error and second.is_error
+    assert "Repeated ROS validation blocked" not in second.content
+    assert len(delegated.execution_calls) == 2
+
+
+def test_validation_result_digest_ignores_request_ids() -> None:
+    from iac_code.tools.cloud.aliyun.ros_template_tools import validation_result_digest
+
+    same_a = validation_result_digest('{"Code":"InvalidTemplate","RequestId":"AAA-111","Message":"bad"}')
+    same_b = validation_result_digest('{"Code":"InvalidTemplate","RequestId":"BBB-222","Message":"bad"}')
+    other = validation_result_digest('{"Code":"InvalidTemplate","RequestId":"AAA-111","Message":"other"}')
+
+    assert same_a == same_b
+    assert same_a != other


### PR DESCRIPTION
## 背景
Session f608eb3c/ec63773c/7f7062ed 中 ros_validate_template 在 template_generating 反复以相同 result_digest 失败（如 8d806e2c），未及时定位模板语法根因，远端校验被冗余调用。

## 变更
- `RosValidateTemplateTool` 增加失败去重守卫：本地模板内容 sha256 指纹 + RequestId 归一化的 result_digest；模板未修改时重复校验被直接拦截并返回上次错误与根因定位指引；失败结果尾部附加 result_digest 标注；成功后清除状态；远端 URL 跳过守卫。
- `iac-aliyun-template-generating` SKILL.md / prompts/template_generating.md：加入校验重试纪律（失败先定位语法根因、禁止对未修改模板重复校验），conclusion_schema 新增可选 `validation_summary` 记录校验迭代摘要。
- i18n：新增两条用户可见消息并补全 zh/es/fr/de/ja/pt 翻译。

## 测试
- 新增 6 个单测：重复失败拦截、修改后放行、成功清除状态、远端 URL 跳过、digest 归一化。
- `make lint` 通过；`make test` 13277 passed / 2 failed（两个失败在干净基线同样失败，属环境既有问题）。

Harness WorkItem: 77585667-1c53-4fff-9f77-bd01390e046b