### PR TITLE
fix(a2a): mark deployedBeforeCancel on pipeline cancel after deploy activity

### DIFF
--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -561,8 +561,16 @@ class IacCodeA2APipelineExecutor:
             except asyncio.CancelledError:
                 try:
                     task.state = TASK_STATE_CANCELED
-                    cancel_data = {"source": "executor", "reason": _("Task canceled.")}
-                    cancel_handoff_data = {"canceled": True, "reason": _("Task canceled.")}
+                    cancel_data: dict[str, Any] = {"source": "executor", "reason": _("Task canceled.")}
+                    cancel_handoff_data: dict[str, Any] = {"canceled": True, "reason": _("Task canceled.")}
+                    cancel_snapshot = publisher.snapshot_store.load() if publisher is not None else None
+                    deploy_evidence = _deployed_before_cancel_evidence(
+                        cancel_snapshot,
+                        cancel_snapshot.get("cleanup") if isinstance(cancel_snapshot, dict) else None,
+                    )
+                    if deploy_evidence is not None:
+                        cancel_data.update(deploy_evidence)
+                        cancel_handoff_data.update(deploy_evidence)
 
                     async def publish_cancel_terminal() -> bool:
                         if pipeline is not None:
@@ -2511,7 +2519,14 @@ class IacCodeA2APipelineExecutor:
             "outcome": outcome,
             "summary": summary,
         }
+        for evidence_key in ("deployedBeforeCancel", "deployedStackIds"):
+            if evidence_key in event_data:
+                data[evidence_key] = copy.deepcopy(event_data[evidence_key])
         cleanup = _pipeline_cleanup_handoff_data(pipeline)
+        if cleanup is None and event_data.get("deployedBeforeCancel") is True:
+            # 部署证据存在但 cleanup 台账没有可展示的 pending 资源:显式回退到
+            # unavailable,提示下游按 stack 证据对账,避免云资源孤儿。
+            cleanup = _cleanup_state_unavailable_payload()
         if cleanup is not None:
             data["cleanup"] = cleanup
         return _NormalHandoffPublication(
@@ -3293,11 +3308,18 @@ def _cancel_waiting_input_task_from_sidecar_locked(
     )
     translator = PipelineEventTranslator(context)
     translator.hydrate_from_events(events)
+    waiting_cancel_data: dict[str, Any] = {"source": "a2a_cancel", "reason": reason}
+    waiting_deploy_evidence = _deployed_before_cancel_evidence(
+        snapshot,
+        snapshot.get("cleanup") if isinstance(snapshot, dict) else None,
+    )
+    if waiting_deploy_evidence is not None:
+        waiting_cancel_data.update(waiting_deploy_evidence)
     envelope = translator.manual_event(
         "pipeline_canceled",
         "pipeline",
         status="canceled",
-        data={"source": "a2a_cancel", "reason": reason},
+        data=waiting_cancel_data,
     )
     high_water_sequence = max(
         [int(event.get("sequence") or 0) for event in events if isinstance(event, dict)]
@@ -3671,7 +3693,17 @@ def _waiting_input_cancel_handoff_event(
         "summary": summary,
         "reason": reason,
     }
+    deploy_evidence = _deployed_before_cancel_evidence(
+        snapshot,
+        snapshot.get("cleanup") if isinstance(snapshot, dict) else None,
+    )
+    if deploy_evidence is not None:
+        data.update(deploy_evidence)
     cleanup = _pipeline_cleanup_handoff_data_from_session(cwd=cwd, session_id=session_id, public_snapshot=snapshot)
+    if cleanup is None and deploy_evidence is not None:
+        # 部署证据存在但 cleanup 台账没有可展示的 pending 资源:显式回退到
+        # unavailable,提示下游按 stack 证据对账,避免云资源孤儿。
+        cleanup = _cleanup_state_unavailable_payload()
     if cleanup is not None:
         data["cleanup"] = cleanup
     return translator.manual_event(
@@ -3850,6 +3882,48 @@ def _persist_normal_handoff_summary(pipeline: Any, summary: str) -> None:
         append(cwd, session_id, AgentMessage(role="user", content=summary))
     except Exception:
         logger.warning("Failed to persist A2A pipeline normal handoff summary", exc_info=True)
+
+
+def _deployed_before_cancel_evidence(
+    snapshot: dict[str, Any] | None,
+    cleanup: Any,
+) -> dict[str, Any] | None:
+    """在取消发布前核对本轮是否已发生部署动作。
+
+    证据来源:
+    - snapshot ``stacks``(CreateStack 已返回 stack_id 即视为已发起部署);
+    - cleanup 数据中存在 pending/unavailable 资源。
+
+    命中时返回 ``{"deployedBeforeCancel": True, "deployedStackIds": [...]}``,
+    供 ``pipeline_canceled`` / ``pipeline_handoff_ready`` 持久化到
+    ``pendingTerminal`` / ``pendingNormalHandoff``,触发下游对账;未命中返回 None。
+    该函数只做只读检测,任何异常都不阻断取消发布。
+    """
+    try:
+        stack_ids: list[str] = []
+        stacks = snapshot.get("stacks") if isinstance(snapshot, dict) else None
+        if isinstance(stacks, dict):
+            candidates: list[Any] = []
+            current = stacks.get("current")
+            if isinstance(current, dict):
+                candidates.append(current)
+            by_id = stacks.get("byId")
+            if isinstance(by_id, dict):
+                candidates.extend(value for value in by_id.values() if isinstance(value, dict))
+            for stack in candidates:
+                stack_id = stack.get("stackId") or stack.get("id")
+                if isinstance(stack_id, str) and stack_id and stack_id not in stack_ids:
+                    stack_ids.append(stack_id)
+        has_cleanup_evidence = _public_cleanup_snapshot_has_pending_evidence(cleanup)
+        if not stack_ids and not has_cleanup_evidence:
+            return None
+        evidence: dict[str, Any] = {"deployedBeforeCancel": True}
+        if stack_ids:
+            evidence["deployedStackIds"] = stack_ids
+        return evidence
+    except Exception:
+        logger.warning("Failed to inspect deploy evidence before pipeline cancel", exc_info=True)
+        return None
 
 
 def _pipeline_cleanup_handoff_data(pipeline: Any) -> dict[str, Any] | None:

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -10386,3 +10386,204 @@ async def test_pending_ask_user_question_resume_preserves_image_input(tmp_path: 
 
     assert events
     assert received["supplemental_input"] == pipeline_input
+
+
+def test_deployed_before_cancel_evidence_detects_snapshot_stacks() -> None:
+    from iac_code.a2a.pipeline_executor import _deployed_before_cancel_evidence
+
+    snapshot = {
+        "stacks": {
+            "current": {"stackId": "stack-current", "status": "CREATE_IN_PROGRESS"},
+            "byId": {
+                "stack-current": {"stackId": "stack-current"},
+                "stack-old": {"stackId": "stack-old", "status": "CREATE_COMPLETE"},
+            },
+            "history": [],
+        },
+    }
+
+    evidence = _deployed_before_cancel_evidence(snapshot, snapshot.get("cleanup"))
+
+    assert evidence is not None
+    assert evidence["deployedBeforeCancel"] is True
+    assert set(evidence["deployedStackIds"]) == {"stack-current", "stack-old"}
+
+
+def test_deployed_before_cancel_evidence_detects_cleanup_pending_resources() -> None:
+    from iac_code.a2a.pipeline_executor import _deployed_before_cancel_evidence
+
+    cleanup = {"status": "pending", "resourceCount": 1, "resources": [{"resourceId": "i-123"}]}
+
+    evidence = _deployed_before_cancel_evidence({"stacks": {"current": None, "byId": {}, "history": []}}, cleanup)
+
+    assert evidence == {"deployedBeforeCancel": True}
+
+
+def test_deployed_before_cancel_evidence_absent_without_deploy_activity() -> None:
+    from iac_code.a2a.pipeline_executor import _deployed_before_cancel_evidence
+
+    snapshot = {"stacks": {"current": None, "byId": {}, "history": []}, "cleanup": {"status": "none"}}
+
+    assert _deployed_before_cancel_evidence(snapshot, snapshot.get("cleanup")) is None
+    assert _deployed_before_cancel_evidence(None, None) is None
+
+
+def test_cancel_waiting_input_after_deploy_marks_deployed_before_cancel(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import (
+        WaitingInputCancelResult,
+        cancel_waiting_input_task_from_sidecar,
+    )
+    from iac_code.a2a.pipeline_paths import a2a_pipeline_dir_for_session
+
+    cwd = tmp_path / "workspace"
+    session_id = "session-deployed-cancel"
+    context_id = "ctx-1"
+    pipeline_dir = a2a_pipeline_dir_for_session(cwd=str(cwd), session_id=session_id)
+    base = {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "pipelineRunId": context_id,
+        "taskId": "task-1",
+        "contextId": context_id,
+        "pipelineName": "selling",
+    }
+    stack_event = {
+        **base,
+        "eventId": "evt-stack",
+        "sequence": 1,
+        "createdAt": "2026-07-14T05:10:00Z",
+        "eventType": "stack_current_changed",
+        "scope": "stack",
+        "status": "working",
+        "data": {"stackId": "stack-deployed-1", "status": "CREATE_COMPLETE"},
+    }
+    pending = {
+        **base,
+        "eventId": "evt-input",
+        "sequence": 2,
+        "createdAt": "2026-07-14T05:10:10Z",
+        "eventType": "input_required",
+        "scope": "step",
+        "status": "input_required",
+        "step": {"runId": "step-deploying-1", "id": "deploying", "attempt": 1},
+        "input": {
+            "inputId": "input-deploying-1",
+            "kind": "candidate_selection",
+            "prompt": "confirm",
+            "options": [{"name": "A", "candidate_index": 0}],
+        },
+    }
+    journal = A2APipelineJournal(pipeline_dir)
+    journal.append(stack_event)
+    journal.append(pending)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([stack_event, pending]))
+
+    canceled = cancel_waiting_input_task_from_sidecar(
+        cwd=str(cwd),
+        session_id=session_id,
+        context_id=context_id,
+        task_id="task-1",
+        reason="user canceled",
+    )
+
+    assert canceled == WaitingInputCancelResult.CANCELED
+    events = A2APipelineJournal(pipeline_dir).read_all()
+    canceled_events = [event for event in events if event["eventType"] == "pipeline_canceled"]
+    assert canceled_events
+    for event in canceled_events:
+        assert event["data"]["deployedBeforeCancel"] is True
+        assert event["data"]["deployedStackIds"] == ["stack-deployed-1"]
+
+    snapshot = A2APipelineSnapshotStore(pipeline_dir).load()
+    assert snapshot is not None
+    normal_handoff = snapshot.get("normalHandoff") or {}
+    handoff_data = normal_handoff.get("data") or {}
+    assert handoff_data.get("deployedBeforeCancel") is True
+    assert handoff_data.get("deployedStackIds") == ["stack-deployed-1"]
+    assert (handoff_data.get("cleanup") or {}).get("status") == "unavailable"
+
+
+def test_cancel_waiting_input_without_deploy_keeps_payload_unchanged(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import (
+        WaitingInputCancelResult,
+        cancel_waiting_input_task_from_sidecar,
+    )
+    from iac_code.a2a.pipeline_paths import a2a_pipeline_dir_for_session
+
+    cwd = tmp_path / "workspace"
+    session_id = "session-clean-cancel"
+    context_id = "ctx-1"
+    pipeline_dir = a2a_pipeline_dir_for_session(cwd=str(cwd), session_id=session_id)
+    pending = {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "eventId": "evt-input",
+        "sequence": 1,
+        "createdAt": "2026-07-14T05:10:10Z",
+        "eventType": "input_required",
+        "scope": "step",
+        "pipelineRunId": context_id,
+        "taskId": "task-1",
+        "contextId": context_id,
+        "pipelineName": "selling",
+        "status": "input_required",
+        "step": {"runId": "step-confirm-1", "id": "confirm", "attempt": 1},
+        "input": {
+            "inputId": "input-confirm-1",
+            "kind": "candidate_selection",
+            "prompt": "confirm",
+            "options": [{"name": "A", "candidate_index": 0}],
+        },
+    }
+    A2APipelineJournal(pipeline_dir).append(pending)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([pending]))
+
+    canceled = cancel_waiting_input_task_from_sidecar(
+        cwd=str(cwd),
+        session_id=session_id,
+        context_id=context_id,
+        task_id="task-1",
+        reason="user canceled",
+    )
+
+    assert canceled == WaitingInputCancelResult.CANCELED
+    events = A2APipelineJournal(pipeline_dir).read_all()
+    canceled_events = [event for event in events if event["eventType"] == "pipeline_canceled"]
+    assert canceled_events
+    for event in canceled_events:
+        assert "deployedBeforeCancel" not in event["data"]
+        assert "deployedStackIds" not in event["data"]
+
+
+def test_normal_handoff_publication_carries_deploy_evidence_and_unavailable_cleanup(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import IacCodeA2APipelineExecutor
+
+    executor = IacCodeA2APipelineExecutor(
+        task_store=A2ATaskStore(metrics=NoOpA2AMetrics()),
+        model="test-model",
+        metrics=NoOpA2AMetrics(),
+        artifact_store=None,
+        push_notifier=None,
+        permission_resolver=None,
+        auto_approve_permissions=True,
+        thinking_exposure_types=set(),
+    )
+    pipeline = FakePipeline([], session_dir=tmp_path / "missing-session")
+    pipeline.handoff_enabled = True
+
+    publication = executor._normal_handoff_publication(
+        pipeline,
+        {
+            "canceled": True,
+            "reason": "Task canceled.",
+            "deployedBeforeCancel": True,
+            "deployedStackIds": ["stack-deployed-1"],
+        },
+    )
+
+    assert publication is not None
+    assert publication.status == "canceled"
+    assert publication.data["outcome"] == "canceled"
+    assert publication.data["deployedBeforeCancel"] is True
+    assert publication.data["deployedStackIds"] == ["stack-deployed-1"]
+    assert publication.data["cleanup"]["status"] == "unavailable"


### PR DESCRIPTION
## 问题

Aone 需求 #84289704：Session `8fde0f19425b4a06b1473a9aeec63223` / `02b02665f3ff410d9c8d8df9f9e2addb` 中，deploying 步骤已输出“部署成功/开始执行部署”后 17s~2min 内触发 `pipeline_canceled`，`pendingNormalHandoff.Outcome` 仅记录 `canceled`，未区分“部署前取消”与“部署后取消”，存在云资源孤儿风险。

## 方案

取消发布前增加只读部署证据核对钩子 `_deployed_before_cancel_evidence`：

- 证据来源：snapshot `stacks`（CreateStack 已返回 stack_id 即视为已发起部署）+ cleanup 数据中的 pending/unavailable 资源。
- 命中时在两条取消路径（executor `CancelledError` 分支、waiting-input sidecar cancel）的 `pipeline_canceled` terminal data 与 `pipeline_handoff_ready` handoff data 写入 `deployedBeforeCancel: true` 与 `deployedStackIds`，随 `pendingTerminal` / `pendingNormalHandoff` / `normalHandoff` 持久化，触发下游按 stack 证据对账。
- 部署证据存在但 cleanup 台账无 pending 资源时，回退 `cleanup.status=unavailable`，避免下游误认为干净取消。
- 不在取消路径自动 DeleteStack，避免误删用户资源；证据检测异常不阻断取消发布。

## 测试

- 新增 6 个单测：证据检测（stacks/cleanup/无证据）、部署后取消端到端标注、部署前取消 payload 不变、handoff publication 携带证据并回退 unavailable cleanup。
- `tests/a2a` 全量 1438 通过；`ruff check` / `ty check` 通过；全量 pytest 13259 通过（18 个失败项在基线 d470b40 上同样失败，属沙箱环境问题）。
