### PR TITLE
fix: block bare-zero cost and undeclared preview failures at candidate finalization

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -3879,6 +3879,30 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"monthly_estimate must not be a bare zero amount. For pay-as-you-go "
+"resources (such as OSS storage or CDN traffic), report a usage-based "
+"range estimate labeled as pay-as-you-go, or report the pricing failure as"
+" \"询价失败\"; never present ¥0/月 as a comparable monthly cost."
+msgstr ""
+"monthly_estimate darf kein bloßer Nullbetrag sein. Für nutzungsbasierte "
+"Ressourcen (wie OSS-Speicher oder CDN-Traffic) geben Sie eine "
+"nutzungsbasierte Bereichsschätzung mit Pay-as-you-go-Kennzeichnung an "
+"oder melden Sie den Preisabruf-Fehler als \"询价失败\"; präsentieren Sie "
+"niemals ¥0/月 als vergleichbare Monatskosten."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"preview_validation.succeeded is false, so the conclusion must declare the"
+" parameter gaps in missing_deployment_parameters or explain the failure "
+"in error before completing this step."
+msgstr ""
+"preview_validation.succeeded ist false; die Schlussfolgerung muss vor "
+"Abschluss dieses Schritts die Parameterlücken in "
+"missing_deployment_parameters deklarieren oder den Fehler in error "
+"erläutern."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3947,6 +3971,14 @@ msgstr "<gemäß den Anforderungen des aktuellen Schritts ausfüllen>"
 #: src/iac_code/ui/renderer.py
 msgid "complete_step validation failed."
 msgstr "Die Validierung von complete_step ist fehlgeschlagen."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"The current conclusion is not allowed to complete this step; fix it and "
+"retry."
+msgstr ""
+"Die aktuelle Schlussfolgerung darf diesen Schritt nicht abschließen; "
+"korrigieren Sie sie und versuchen Sie es erneut."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
@@ -12695,3 +12727,4 @@ msgstr "Bash zulassen?"
 #~ msgstr ""
 #~ "Tool-Aufruf genehmigen: {tool}\n"
 #~ "Eingabezusammenfassung: {summary}"
+

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -3859,6 +3859,29 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"monthly_estimate must not be a bare zero amount. For pay-as-you-go "
+"resources (such as OSS storage or CDN traffic), report a usage-based "
+"range estimate labeled as pay-as-you-go, or report the pricing failure as"
+" \"询价失败\"; never present ¥0/月 as a comparable monthly cost."
+msgstr ""
+"monthly_estimate no debe ser un importe cero sin más. Para recursos de "
+"pago por uso (como almacenamiento OSS o tráfico CDN), informe una "
+"estimación por rangos basada en el uso etiquetada como pago por uso, o "
+"informe el fallo de tarificación como \"询价失败\"; nunca presente ¥0/月 como "
+"un coste mensual comparable."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"preview_validation.succeeded is false, so the conclusion must declare the"
+" parameter gaps in missing_deployment_parameters or explain the failure "
+"in error before completing this step."
+msgstr ""
+"preview_validation.succeeded es false, por lo que la conclusión debe "
+"declarar las brechas de parámetros en missing_deployment_parameters o "
+"explicar el fallo en error antes de completar este paso."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3924,6 +3947,14 @@ msgstr "<rellenar según los requisitos del paso actual>"
 #: src/iac_code/ui/renderer.py
 msgid "complete_step validation failed."
 msgstr "La validación de complete_step falló."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"The current conclusion is not allowed to complete this step; fix it and "
+"retry."
+msgstr ""
+"La conclusión actual no permite completar este paso; corríjala y vuelva a"
+" intentarlo."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
@@ -12612,3 +12643,4 @@ msgstr "¿Permitir Bash?"
 #~ msgstr ""
 #~ "Aprobar llamada de herramienta: {tool}\n"
 #~ "Resumen de entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -3873,6 +3873,29 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"monthly_estimate must not be a bare zero amount. For pay-as-you-go "
+"resources (such as OSS storage or CDN traffic), report a usage-based "
+"range estimate labeled as pay-as-you-go, or report the pricing failure as"
+" \"询价失败\"; never present ¥0/月 as a comparable monthly cost."
+msgstr ""
+"monthly_estimate ne doit pas être un montant nul brut. Pour les "
+"ressources facturées à l'usage (stockage OSS, trafic CDN), fournissez une"
+" estimation par fourchette basée sur l'usage et étiquetée comme "
+"facturation à l'usage, ou signalez l'échec de tarification par \"询价失败\" ;"
+" ne présentez jamais ¥0/月 comme un coût mensuel comparable."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"preview_validation.succeeded is false, so the conclusion must declare the"
+" parameter gaps in missing_deployment_parameters or explain the failure "
+"in error before completing this step."
+msgstr ""
+"preview_validation.succeeded est false ; la conclusion doit déclarer les "
+"paramètres manquants dans missing_deployment_parameters ou expliquer "
+"l'échec dans error avant de terminer cette étape."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3936,6 +3959,14 @@ msgstr "<renseigner selon les exigences de l’étape actuelle>"
 #: src/iac_code/ui/renderer.py
 msgid "complete_step validation failed."
 msgstr "La validation de complete_step a échoué."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"The current conclusion is not allowed to complete this step; fix it and "
+"retry."
+msgstr ""
+"La conclusion actuelle ne permet pas de terminer cette étape ; corrigez-"
+"la et réessayez."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
@@ -12678,3 +12709,4 @@ msgstr "Autoriser Bash ?"
 #~ msgstr ""
 #~ "Approuver l'appel d'outil : {tool}\n"
 #~ "Résumé de l'entrée : {summary}"
+

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3682,6 +3682,26 @@ msgstr "デプロイ成功には、ros_deploy が CREATE_COMPLETE を返すま�
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"monthly_estimate must not be a bare zero amount. For pay-as-you-go "
+"resources (such as OSS storage or CDN traffic), report a usage-based "
+"range estimate labeled as pay-as-you-go, or report the pricing failure as"
+" \"询价失败\"; never present ¥0/月 as a comparable monthly cost."
+msgstr ""
+"monthly_estimate をゼロ金額のみで出力してはいけません。OSS ストレージや CDN "
+"トラフィックなどの従量課金リソースは、従量課金と明記した使用量ベースのレンジ見積もりを出力するか、見積もり失敗を「询价失败」として報告してください。¥0/月"
+" を比較可能な月額費用として提示しないでください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"preview_validation.succeeded is false, so the conclusion must declare the"
+" parameter gaps in missing_deployment_parameters or explain the failure "
+"in error before completing this step."
+msgstr ""
+"preview_validation.succeeded が false のため、このステップを完了する前に "
+"missing_deployment_parameters でパラメータ不足を宣言するか、error で失敗理由を説明する必要があります。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3741,6 +3761,12 @@ msgstr "<現在のステップ要件に従って入力>"
 #: src/iac_code/ui/renderer.py
 msgid "complete_step validation failed."
 msgstr "complete_step の検証に失敗しました。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"The current conclusion is not allowed to complete this step; fix it and "
+"retry."
+msgstr "現在の結論ではこのステップを完了できません。修正して再試行してください。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
@@ -11706,3 +11732,4 @@ msgstr "Bash を許可しますか？"
 #~ msgstr ""
 #~ "ツール呼び出しを承認: {tool}\n"
 #~ "入力サマリー: {summary}"
+

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -3840,6 +3840,29 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"monthly_estimate must not be a bare zero amount. For pay-as-you-go "
+"resources (such as OSS storage or CDN traffic), report a usage-based "
+"range estimate labeled as pay-as-you-go, or report the pricing failure as"
+" \"询价失败\"; never present ¥0/月 as a comparable monthly cost."
+msgstr ""
+"monthly_estimate não deve ser um valor zero puro. Para recursos pagos por"
+" uso (como armazenamento OSS ou tráfego CDN), informe uma estimativa em "
+"faixa baseada no uso rotulada como pagamento por uso, ou informe a falha "
+"de cotação como \"询价失败\"; nunca apresente ¥0/月 como um custo mensal "
+"comparável."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"preview_validation.succeeded is false, so the conclusion must declare the"
+" parameter gaps in missing_deployment_parameters or explain the failure "
+"in error before completing this step."
+msgstr ""
+"preview_validation.succeeded é false, então a conclusão deve declarar as "
+"lacunas de parâmetros em missing_deployment_parameters ou explicar a "
+"falha em error antes de concluir esta etapa."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3902,6 +3925,14 @@ msgstr "<preencher conforme os requisitos da etapa atual>"
 #: src/iac_code/ui/renderer.py
 msgid "complete_step validation failed."
 msgstr "A validação de complete_step falhou."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"The current conclusion is not allowed to complete this step; fix it and "
+"retry."
+msgstr ""
+"A conclusão atual não pode concluir esta etapa; corrija-a e tente "
+"novamente."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
@@ -12506,3 +12537,4 @@ msgstr "Permitir Bash?"
 #~ msgstr ""
 #~ "Aprovar chamada de ferramenta: {tool}\n"
 #~ "Resumo da entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3646,6 +3646,25 @@ msgstr "部署成功必须等待 ros_deploy 返回 CREATE_COMPLETE。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"monthly_estimate must not be a bare zero amount. For pay-as-you-go "
+"resources (such as OSS storage or CDN traffic), report a usage-based "
+"range estimate labeled as pay-as-you-go, or report the pricing failure as"
+" \"询价失败\"; never present ¥0/月 as a comparable monthly cost."
+msgstr ""
+"monthly_estimate 不得为裸零金额。OSS 存储、CDN "
+"流量等按量付费资源应输出标注按量计费口径的用量区间估算，或如实填写“询价失败”；不得把 ¥0/月 作为可对比的月成本。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"preview_validation.succeeded is false, so the conclusion must declare the"
+" parameter gaps in missing_deployment_parameters or explain the failure "
+"in error before completing this step."
+msgstr ""
+"preview_validation.succeeded 为 false，完成本步骤前必须在 "
+"missing_deployment_parameters 中声明参数缺口，或在 error 中说明失败原因。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr "调用此工具提交结论以完成当前步骤。如需回滚到较早步骤，请设置 rollback_request。"
@@ -3703,6 +3722,12 @@ msgstr "<按当前步骤要求填写>"
 #: src/iac_code/ui/renderer.py
 msgid "complete_step validation failed."
 msgstr "complete_step 校验失败。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"The current conclusion is not allowed to complete this step; fix it and "
+"retry."
+msgstr "当前结论不允许完成本步骤；请修正后重试。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
@@ -11493,3 +11518,4 @@ msgstr "允许 Bash?"
 #~ msgstr ""
 #~ "批准工具调用：{tool}\n"
 #~ "输入摘要：{summary}"
+

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -55,6 +55,15 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "or confirm that it should not be handled for now."
     ),
     "deploy_wait_create_complete": ("A successful deployment must wait until ros_deploy returns CREATE_COMPLETE."),
+    "cost_zero_monthly_estimate_forbidden": (
+        "monthly_estimate must not be a bare zero amount. For pay-as-you-go resources (such as OSS storage or "
+        "CDN traffic), report a usage-based range estimate labeled as pay-as-you-go, or report the pricing "
+        'failure as "询价失败"; never present ¥0/月 as a comparable monthly cost.'
+    ),
+    "cost_preview_failed_requires_gap_declaration": (
+        "preview_validation.succeeded is false, so the conclusion must declare the parameter gaps in "
+        "missing_deployment_parameters or explain the failure in error before completing this step."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -91,6 +100,15 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
             "or confirm that it should not be handled for now."
         ),
         _("A successful deployment must wait until ros_deploy returns CREATE_COMPLETE."),
+        _(
+            "monthly_estimate must not be a bare zero amount. For pay-as-you-go resources (such as OSS storage or "
+            "CDN traffic), report a usage-based range estimate labeled as pay-as-you-go, or report the pricing "
+            'failure as "询价失败"; never present ¥0/月 as a comparable monthly cost.'
+        ),
+        _(
+            "preview_validation.succeeded is false, so the conclusion must declare the parameter gaps in "
+            "missing_deployment_parameters or explain the failure in error before completing this step."
+        ),
     )
 
 
@@ -317,6 +335,11 @@ class CompleteStepTool(Tool):
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
+            if guard.get("forbid_completion"):
+                return self._completion_guard_message(
+                    guard,
+                    _("The current conclusion is not allowed to complete this step; fix it and retry."),
+                )
             if required_tool and required_tool not in successful_tools:
                 message = self._completion_guard_message(
                     guard,
@@ -906,9 +929,14 @@ class CompleteStepTool(Tool):
 
         user_patterns = guard.get("when_user_message_matches_any") or []
         conclusion_equals = guard.get("when_conclusion_field_equals") or {}
+        conclusion_matches = guard.get("when_conclusion_field_matches") or {}
         applies = bool(user_patterns and any(self._matches(pattern, self._user_message) for pattern in user_patterns))
         applies = applies or any(
             self._resolve_dotted(conclusion, field) == value for field, value in conclusion_equals.items()
+        )
+        applies = applies or any(
+            self._conclusion_field_matches(conclusion, field, pattern)
+            for field, pattern in conclusion_matches.items()
         )
         if not applies:
             return False
@@ -972,6 +1000,13 @@ class CompleteStepTool(Tool):
             return re.search(pattern, value, flags=re.IGNORECASE) is not None
         except re.error:
             return pattern in value
+
+    @classmethod
+    def _conclusion_field_matches(cls, conclusion: dict, field: str, pattern: Any) -> bool:
+        value = cls._resolve_dotted(conclusion, field)
+        if not isinstance(value, str) or not isinstance(pattern, str) or not pattern:
+            return False
+        return cls._matches(pattern, value)
 
     @staticmethod
     def _resolve_dotted(value: dict, path: str) -> Any:

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -338,6 +338,17 @@ sub_pipelines:
         skill: iac-aliyun-cost
         prompt: prompts/cost_estimating.md
         context_fields: [template]
+        completion_guards:
+          # 零金额不得作为月成本对比口径：按量付费资源须给区间估算或如实报告询价失败。
+          - when_conclusion_field_matches:
+              monthly_estimate: '^[^0-9]*0(?:[.,]0+)?(?![0-9])[^1-9]*$'
+            forbid_completion: true
+            message_key: cost_zero_monthly_estimate_forbidden
+          # PreviewStack 保持软门禁，但失败时必须在结论中显式声明参数缺口或失败原因。
+          - when_conclusion_field_equals:
+              preview_validation.succeeded: false
+            required_conclusion_any_of: [missing_deployment_parameters, error]
+            message_key: cost_preview_failed_requires_gap_declaration
         tools:
           include: []
           exclude: [bash, write_memory, ros_stack, ros_stack_instances]

--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
@@ -50,6 +50,15 @@
 
 不要使用 `evaluated_candidates[i].candidate.monthly_estimate`，该字段是架构规划阶段的粗略估算。不要重新询价，也不要重新估算价格。
 
+### 预览与成本状态警示（必须透传）
+
+对每个展示的方案检查 `evaluated_candidates[i].cost`：
+
+- `preview_validation.succeeded` 不为 `true` 时，`show_candidate_detail` 的 `summary` 和 `complete_step.conclusion.options[].summary` 必须以「⚠️ 预览未通过」开头并简述原因（取 `preview_validation.error`）。
+- `missing_deployment_parameters` 非空时，`summary` 必须标注「⚠️ 部署参数不完整」并列出缺失参数名。
+- `monthly_estimate` 为 `"询价失败"` 或为零金额（如 `¥0/月`）时，`total_monthly_cost` 不得展示为确定的 ¥0/月：如实展示「询价失败」或带假设用量说明的按量计费区间；`summary` 同步标注「成本为按量估算/询价失败，不可与包月列表价直接对比」。
+- 上述警示不得省略或弱化；带警示的方案仍可进入 `options` 供用户选择，但用户必须能看到这些状态。
+
 如果多个方案都需要展示，必须对每个方案都调用一次“架构图 + 方案详情”的并行展示；不要为了架构图优化额外阻塞方案详情展示。
 
 - 不要用文字输出对比表格或方案信息 — 所有展示数据通过上述工具传递

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -29,8 +29,11 @@ API 调用完成后调用 `complete_step` 提交费用预估。
 - `TradeAmount` 是合同优惠后的最终价，按与原价相同的月度周期换算并汇总。
 - 两个字段都存在时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
 - 任一字段缺失时只展示可用价格，并在 `api_raw_summary` 中说明缺失字段；询价失败时仍填写 `"询价失败"`。
+- `monthly_estimate` 不得为裸零金额（如 `¥0/月`）。OSS 存储、CDN 流量等按量付费资源询价返回 0 或不支持询价时，基于典型用量假设输出区间估算并标注按量计费口径（如 `约¥10~¥60/月（按量计费，按 50GB 存储 + 100GB CDN 流量估算）`）；无法形成合理假设时填 `"询价失败"` 并在 `error` 说明原因。
 
 若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。
+
+若 `ros_preview_template` 因参数缺失失败（如 `CdnDomainName` 等外部输入无法补齐），必须先尽量补齐可生成参数并重试预览；仍无法通过时，除 `preview_validation.succeeded: false` 外，必须把缺失参数逐项写入 `missing_deployment_parameters`（或在 `error` 说明失败原因），不得在预览失败且缺口未声明的情况下提交结论。
 
 ## 注意事项
 - 不要读取项目文件或记忆，所需的上下文已在上方提供。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -10,7 +10,7 @@ conclusion_schema:
   properties:
     monthly_estimate:
       type: string
-      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"
+      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"；按量付费资源询价为 0 或不支持询价时填基于假设用量的区间估算并标注按量计费口径，禁止输出裸 ¥0/月
     currency:
       type: string
       enum: [CNY]
@@ -140,6 +140,15 @@ PreviewStack 不是硬门禁。它要求完整部署参数，常比询价工具�
 - `PreviewStack` 因候选组合不可行失败时，按 reference 的回溯规则更换候选；因外部输入缺失失败时，记录缺口，不用占位值伪造，并按上方软门禁规则决定是否继续询价。
 - 最终得到的参数集不写入模板 `Default`；将当前已选、已验证或已用于询价的参数作为结构化数据放入 `complete_step.conclusion.deployment_parameters`，传递给 deploying。`ros_preview_template` 成功时，还必须把 `succeeded: true`、同一个 `template_url` 和预览时使用的 `parameters` 写入 `complete_step.conclusion.preview_validation`；deploying 用它判断同一模板是否已完成预览验证，实际部署参数由 `ros_deploy` 做最终校验。模板 Default 只是参数求解的输入来源之一，不是跨步骤传参介质。
 - PreviewStack 成功但询价失败时，不要丢弃 Preview-Validated Pricing Parameter Set；仍在 `deployment_parameters` 输出该参数集，同时如实报告询价失败原因。
+- PreviewStack 失败（如外部输入缺失导致 `CdnDomainName` 等参数无法补齐）时，`preview_validation` 必须填 `{"succeeded": false, "error": "<原因>"}`，并把仍缺的参数写入 `missing_deployment_parameters`；不得在预览失败、缺口未声明的情况下直接定稿。
+
+## 按量付费资源的成本口径
+
+OSS 存储、CDN 流量、日志服务等按量付费资源没有固定包月价，`ros_estimate_template_cost` 常返回 0 元或不支持询价。此时**禁止把 ¥0/月作为月成本输出**——零金额会在方案对比中严重误导用户：
+
+- 询价返回 0 元或资源不支持询价时，基于典型用量假设给出**区间估算**并标注口径，例如：`约¥10~¥60/月（按量计费，按 50GB 存储 + 100GB CDN 流量估算）`；对应 `resources[].cost` 也写区间与假设，不写 `¥0`。
+- 无法形成合理用量假设时，`monthly_estimate` 填 `"询价失败"` 并在 `error` 说明原因；不要用 ¥0 兜底。
+- 固定计费资源与按量付费资源混合时，汇总口径需说明哪部分是列表价、哪部分是按量估算区间。
 
 ## 调用询价 API
 
@@ -194,10 +203,11 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 调用 `complete_step` 提交结论。字段定义见 tool schema。
 
 补充说明：
-- `cost` 字段为字符串，包含金额和计费周期（如 "¥800/月"、"¥0.5/小时"、"¥0"）
+- `cost` 字段为字符串，包含金额和计费周期（如 "¥800/月"、"¥0.5/小时"）；按量付费资源填区间估算并标注假设用量，不填 "¥0"
 - 若修复了模板，设置 `template_fixed: true` 并在 `fix_summary` 中说明修复内容；仅形成或输出 `deployment_parameters` 不算模板修复
 - `deployment_parameters` 填当前已选、已验证或已用于 `ros_estimate_template_cost` 的参数字典；PreviewStack 成功但询价失败时仍填该参数集；没有任何可用参数时填 `{}`
 - `preview_validation` 填 `ros_preview_template` 的结构化状态：成功时填 `{"succeeded": true, "template_url": "<当前模板文件路径>", "parameters": <预览通过的同一参数字典>}`；失败或未执行时填 `{"succeeded": false, "error": "<原因>"}`
 - `missing_deployment_parameters` 填完整部署或 PreviewStack 仍缺少的参数及原因；没有缺口时可省略或填 `[]`
 - `parameter_set_summary` 可简要说明参数来源、可用性筛选、PreviewStack 验证结果以及是否使用软门禁继续询价
 - 询价失败时 `monthly_estimate` 填 "询价失败"，`resources` 为空数组，`error` 说明原因
+- `monthly_estimate` 不得为裸零金额（如 "¥0/月"、"¥0"）；按量付费资源按「按量付费资源的成本口径」输出区间估算，否则填 "询价失败"

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1537,3 +1537,215 @@ class TestNullNormalization:
         valid, error = tool.validate_input(tool_input)
         assert not valid
         assert "name" in error
+
+
+class TestCostEstimatingGuards:
+    """Guards for the selling cost_estimating step: forbid bare-zero cost and undeclared preview failures."""
+
+    ZERO_AMOUNT_PATTERN = r"^[^0-9]*0(?:[.,]0+)?(?![0-9])[^1-9]*$"
+
+    def _cost_tool(self) -> CompleteStepTool:
+        config = StepConfig(step_id="cost_estimating", conclusion_field="cost", forward=None)
+        return CompleteStepTool(
+            config,
+            completion_guards=[
+                {
+                    "when_conclusion_field_matches": {"monthly_estimate": self.ZERO_AMOUNT_PATTERN},
+                    "forbid_completion": True,
+                    "message_key": "cost_zero_monthly_estimate_forbidden",
+                },
+                {
+                    "when_conclusion_field_equals": {"preview_validation.succeeded": False},
+                    "required_conclusion_any_of": ["missing_deployment_parameters", "error"],
+                    "message_key": "cost_preview_failed_requires_gap_declaration",
+                },
+            ],
+            completion_guard_state={"successful_tools": set(), "tool_results": {}},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "monthly_estimate",
+        ["¥0/月", "¥0", "¥0.00/月", "0元/月", "¥0,00/月", "CNY 0/month"],
+    )
+    async def test_rejects_bare_zero_monthly_estimate(self, monthly_estimate):
+        tool = self._cost_tool()
+
+        result = await tool.execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": monthly_estimate,
+                    "currency": "CNY",
+                    "resources": [],
+                    "template_fixed": False,
+                    "deployment_parameters": {},
+                    "preview_validation": {"succeeded": True, "template_url": "./t.yml", "parameters": {}},
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "pay-as-you-go" in result.content
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "monthly_estimate",
+        [
+            "¥96.80/月（列表价，合同优惠后约¥13.76/月）",
+            "约¥10~¥60/月（按量计费，按 50GB 存储 + 100GB CDN 流量估算）",
+            "询价失败",
+            "¥800/月",
+            "¥0.5/小时",
+            "¥1,024/月",
+        ],
+    )
+    async def test_accepts_non_zero_or_declared_estimates(self, monthly_estimate):
+        tool = self._cost_tool()
+
+        result = await tool.execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": monthly_estimate,
+                    "currency": "CNY",
+                    "resources": [],
+                    "template_fixed": False,
+                    "deployment_parameters": {},
+                    "preview_validation": {"succeeded": True, "template_url": "./t.yml", "parameters": {}},
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_rejects_preview_failure_without_gap_declaration(self):
+        tool = self._cost_tool()
+
+        result = await tool.execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": "¥58.00/月",
+                    "currency": "CNY",
+                    "resources": [],
+                    "template_fixed": False,
+                    "deployment_parameters": {},
+                    "preview_validation": {"succeeded": False},
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "missing_deployment_parameters" in result.content
+
+    @pytest.mark.asyncio
+    async def test_accepts_preview_failure_with_missing_parameters_declared(self):
+        tool = self._cost_tool()
+
+        result = await tool.execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": "约¥10~¥60/月（按量计费，按 50GB 存储 + 100GB CDN 流量估算）",
+                    "currency": "CNY",
+                    "resources": [],
+                    "template_fixed": False,
+                    "deployment_parameters": {},
+                    "preview_validation": {"succeeded": False, "error": "CdnDomainName 缺失"},
+                    "missing_deployment_parameters": [
+                        {"name": "CdnDomainName", "reason": "需要用户提供已备案域名"}
+                    ],
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_accepts_preview_failure_with_error_declared(self):
+        tool = self._cost_tool()
+
+        result = await tool.execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": "询价失败",
+                    "currency": "CNY",
+                    "resources": [],
+                    "template_fixed": False,
+                    "deployment_parameters": {},
+                    "preview_validation": {"succeeded": False, "error": "CdnDomainName 缺失"},
+                    "error": "PreviewStack 因 CdnDomainName 缺失失败",
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_preview_success_not_affected_by_gap_guard(self):
+        tool = self._cost_tool()
+
+        result = await tool.execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": "¥96.80/月",
+                    "currency": "CNY",
+                    "resources": [{"type": "ALIYUN::ECS::Instance", "cost": "¥96.80/月"}],
+                    "template_fixed": False,
+                    "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+                    "preview_validation": {
+                        "succeeded": True,
+                        "template_url": "./t.yml",
+                        "parameters": {"ZoneId": "cn-hangzhou-k"},
+                    },
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_when_conclusion_field_matches_ignores_non_string_values(self):
+        config = StepConfig(step_id="cost_estimating", conclusion_field="cost", forward=None)
+        tool = CompleteStepTool(
+            config,
+            completion_guards=[
+                {
+                    "when_conclusion_field_matches": {"monthly_estimate": self.ZERO_AMOUNT_PATTERN},
+                    "forbid_completion": True,
+                    "message_key": "cost_zero_monthly_estimate_forbidden",
+                }
+            ],
+        )
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"monthly_estimate": 0}},
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_forbid_completion_uses_default_message_without_key(self):
+        config = StepConfig(step_id="cost_estimating", conclusion_field="cost", forward=None)
+        tool = CompleteStepTool(
+            config,
+            completion_guards=[
+                {
+                    "when_conclusion_field_matches": {"monthly_estimate": self.ZERO_AMOUNT_PATTERN},
+                    "forbid_completion": True,
+                }
+            ],
+        )
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"monthly_estimate": "¥0/月"}},
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "not allowed to complete" in result.content

--- a/tests/pipeline/selling/test_cost_estimating_guards.py
+++ b/tests/pipeline/selling/test_cost_estimating_guards.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from iac_code.pipeline.engine.loader import load_pipeline_dir
+
+
+def _selling_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "src" / "iac_code" / "pipeline" / "selling"
+
+
+def _cost_estimating_step():
+    loaded = load_pipeline_dir(_selling_dir())
+    sub_spec = loaded.sub_pipelines["evaluate_candidate"]
+    return next(step for step in sub_spec.steps if step.step_id == "cost_estimating")
+
+
+def _zero_amount_guard() -> dict:
+    step = _cost_estimating_step()
+    return next(
+        guard
+        for guard in step.completion_guards
+        if guard.get("message_key") == "cost_zero_monthly_estimate_forbidden"
+    )
+
+
+def test_cost_estimating_forbids_zero_monthly_estimate():
+    guard = _zero_amount_guard()
+
+    assert guard.get("forbid_completion") is True
+    assert "monthly_estimate" in (guard.get("when_conclusion_field_matches") or {})
+
+
+def test_cost_estimating_requires_gap_declaration_when_preview_fails():
+    step = _cost_estimating_step()
+
+    guard = next(
+        guard
+        for guard in step.completion_guards
+        if guard.get("message_key") == "cost_preview_failed_requires_gap_declaration"
+    )
+    assert guard.get("when_conclusion_field_equals") == {"preview_validation.succeeded": False}
+    assert guard.get("required_conclusion_any_of") == ["missing_deployment_parameters", "error"]
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["¥0/月", "¥0", "¥0.00/月", "0元/月", "¥0,00/月", "CNY 0/month", "0.0"],
+)
+def test_zero_amount_pattern_matches_bare_zero_estimates(value):
+    pattern = _zero_amount_guard()["when_conclusion_field_matches"]["monthly_estimate"]
+
+    assert re.search(pattern, value, flags=re.IGNORECASE) is not None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "¥96.80/月（列表价，合同优惠后约¥13.76/月）",
+        "约¥10~¥60/月（按量计费，按 50GB 存储 + 100GB CDN 流量估算）",
+        "询价失败",
+        "¥800/月",
+        "¥0.5/小时",
+        "¥1,024/月",
+        "¥10/月",
+        "¥0.01/月",
+    ],
+)
+def test_zero_amount_pattern_does_not_match_valid_estimates(value):
+    pattern = _zero_amount_guard()["when_conclusion_field_matches"]["monthly_estimate"]
+
+    assert re.search(pattern, value, flags=re.IGNORECASE) is None


### PR DESCRIPTION
## 背景

Session `62a1cae4e5524c1492d28c152809e8a0` 中，OSS+CDN 候选在 `preview_validation.succeeded=false`（CdnDomainName 缺失）的情况下仍以 ¥0/月 的月成本定稿完成并进入用户选择，与 ECS+SLB 候选形成误导性成本对比。

## 改动

- **complete_step 守卫增强**：新增 `when_conclusion_field_matches` 正则谓词与 `forbid_completion` 动作，及两个 message key（零成本禁止 / preview 失败须声明缺口）
- **selling pipeline**：`cost_estimating` 新增 completion_guards——裸零金额 `monthly_estimate` 拒绝定稿；`preview_validation.succeeded=false` 时必须提供 `missing_deployment_parameters` 或 `error`（PreviewStack 保持软门禁，不误杀外部输入缺失场景）
- **iac-aliyun-cost skill/prompt**：按量付费资源（OSS 存储/CDN 流量）询价为 0 或不支持询价时，必须输出标注按量计费口径的用量区间估算或"询价失败"，禁止 ¥0/月
- **confirm_and_select prompt**：候选展示必须透传预览未通过/参数缺口/成本口径警示，`total_monthly_cost` 不得展示 ¥0/月 伪确定值
- i18n：新增 3 条可翻译串并补全 6 个 locale 翻译

## 测试

- 新增 `TestCostEstimatingGuards`（引擎层 18 例）与 `tests/pipeline/selling/test_cost_estimating_guards.py`（配置/正则 17 例）
- `make lint` 通过；全量 pytest 13305 passed（2 项 pre-existing 环境相关失败与本改动无关）

Harness WorkItem: bbd3e2d8-028d-409f-b9d7-ca6d688fa480
