### PR TITLE
fix(aliyun): give ROS template tools actionable input errors

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -6355,6 +6355,28 @@ msgstr ""
 "Die Alibaba-Cloud-API {operation} konnte nicht sicher vorbereitet werden."
 " Prüfen Sie die Anfrage und versuchen Sie es erneut."
 
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide parameters as a key/value object; use "
+"ros_get_template_parameter_constraints to resolve allowed values first."
+msgstr " Geben Sie parameters als Schlüssel/Wert-Objekt an; verwenden Sie zuerst ros_get_template_parameter_constraints, um erlaubte Werte zu ermitteln."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide a unique stack_name; it is a tool argument, not a template "
+"parameter."
+msgstr " Geben Sie einen eindeutigen stack_name an; er ist ein Tool-Argument, kein Vorlagenparameter."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide template_url as a readable local template file path, OSS URL, or"
+" HTTP(S) URL."
+msgstr " Geben Sie template_url als lesbaren lokalen Vorlagendateipfad, OSS-URL oder HTTP(S)-URL an."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid " Fix the input before calling again instead of repeating the same call."
+msgstr " Korrigieren Sie die Eingabe vor dem erneuten Aufruf, anstatt denselben Aufruf zu wiederholen."
+
 #: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
@@ -6412,12 +6434,32 @@ msgstr ""
 "/HTTP-URL."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file is not valid UTF-8."
+msgstr "Die lokale ROS Vorlagendatei ist nicht gültig UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr ""
+"Bestätigen Sie, dass die Datei vorhanden ist, lesbar ist und als UTF-8 "
+"gespeichert ist."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the maximum supported size."
+msgstr "Die lokale ROS-Vorlagendatei überschreitet die maximal unterstützte Größe."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Use a smaller regular template file within the 32 MiB limit."
+msgstr "Verwenden Sie eine kleinere reguläre Vorlagendatei innerhalb der Grenze von 32 MiB."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "Die lokale ROS Template-Datei kann nicht gelesen werden."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "The local ROS template file is not valid UTF-8."
-msgstr "Die lokale ROS Vorlagendatei ist nicht gültig UTF-8."
+msgid ""
+"Confirm that template_url points to an existing, readable regular file, "
+"then retry with the fixed path."
+msgstr "Stellen Sie sicher, dass template_url auf eine vorhandene, lesbare reguläre Datei verweist, und versuchen Sie es mit dem korrigierten Pfad erneut."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6426,12 +6468,6 @@ msgid ""
 msgstr ""
 "TemplateURL/local TemplateBody scheiterte vor dem Betreten des Parsers; "
 "der ROS API wurde nicht aufgerufen."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr ""
-"Bestätigen Sie, dass die Datei vorhanden ist, lesbar ist und als UTF-8 "
-"gespeichert ist."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12695,3 +12731,4 @@ msgstr "Bash zulassen?"
 #~ msgstr ""
 #~ "Tool-Aufruf genehmigen: {tool}\n"
 #~ "Eingabezusammenfassung: {summary}"
+

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6326,6 +6326,28 @@ msgstr ""
 "La API de Alibaba Cloud {operation} no se pudo preparar de forma segura. "
 "Compruebe la solicitud y vuelva a intentarlo."
 
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide parameters as a key/value object; use "
+"ros_get_template_parameter_constraints to resolve allowed values first."
+msgstr " Proporcione parameters como un objeto clave/valor; use ros_get_template_parameter_constraints para resolver primero los valores permitidos."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide a unique stack_name; it is a tool argument, not a template "
+"parameter."
+msgstr " Proporcione un stack_name único; es un argumento de la herramienta, no un parámetro de plantilla."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide template_url as a readable local template file path, OSS URL, or"
+" HTTP(S) URL."
+msgstr " Proporcione template_url como una ruta de archivo de plantilla local legible, una URL de OSS o una URL HTTP(S)."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid " Fix the input before calling again instead of repeating the same call."
+msgstr " Corrija la entrada antes de volver a llamar en lugar de repetir la misma llamada."
+
 #: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
@@ -6383,12 +6405,30 @@ msgstr ""
 "OSS/HTTP."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file is not valid UTF-8."
+msgstr "El archivo de plantilla local ROS no es válido UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "Confirme que el archivo existe, es legible, y se guarda como UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the maximum supported size."
+msgstr "El archivo de plantilla ROS local supera el tamaño máximo admitido."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Use a smaller regular template file within the 32 MiB limit."
+msgstr "Use un archivo de plantilla normal más pequeño, dentro del límite de 32 MiB."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "El archivo de plantilla local ROS no se puede leer."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "The local ROS template file is not valid UTF-8."
-msgstr "El archivo de plantilla local ROS no es válido UTF-8."
+msgid ""
+"Confirm that template_url points to an existing, readable regular file, "
+"then retry with the fixed path."
+msgstr "Confirme que template_url apunta a un archivo normal existente y legible, y vuelva a intentarlo con la ruta corregida."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6397,10 +6437,6 @@ msgid ""
 msgstr ""
 "TemplateURL/local TemplateBody falló antes de entrar en el Parser; el ROS"
 " API no fue llamado."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "Confirme que el archivo existe, es legible, y se guarda como UTF-8."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12612,3 +12648,4 @@ msgstr "¿Permitir Bash?"
 #~ msgstr ""
 #~ "Aprobar llamada de herramienta: {tool}\n"
 #~ "Resumen de entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6348,6 +6348,28 @@ msgstr ""
 "L'API Alibaba Cloud {operation} n'a pas pu être préparée en toute "
 "sécurité. Vérifiez la requête et réessayez."
 
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide parameters as a key/value object; use "
+"ros_get_template_parameter_constraints to resolve allowed values first."
+msgstr " Fournissez parameters sous forme d'objet clé/valeur ; utilisez d'abord ros_get_template_parameter_constraints pour résoudre les valeurs autorisées."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide a unique stack_name; it is a tool argument, not a template "
+"parameter."
+msgstr " Fournissez un stack_name unique ; c'est un argument de l'outil, pas un paramètre de modèle."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide template_url as a readable local template file path, OSS URL, or"
+" HTTP(S) URL."
+msgstr " Fournissez template_url sous forme de chemin de fichier de modèle local lisible, d'URL OSS ou d'URL HTTP(S)."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid " Fix the input before calling again instead of repeating the same call."
+msgstr " Corrigez l'entrée avant de rappeler au lieu de répéter le même appel."
+
 #: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
@@ -6405,12 +6427,30 @@ msgstr ""
 "OSS/HTTP."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file is not valid UTF-8."
+msgstr "Le fichier modèle local ROS n'est pas valide UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "Confirmer que le fichier existe, est lisible et est enregistré sous UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the maximum supported size."
+msgstr "Le fichier modèle ROS local dépasse la taille maximale prise en charge."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Use a smaller regular template file within the 32 MiB limit."
+msgstr "Utilisez un fichier modèle normal plus petit, dans la limite de 32 Mio."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "Le fichier modèle local ROS ne peut pas être lu."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "The local ROS template file is not valid UTF-8."
-msgstr "Le fichier modèle local ROS n'est pas valide UTF-8."
+msgid ""
+"Confirm that template_url points to an existing, readable regular file, "
+"then retry with the fixed path."
+msgstr "Vérifiez que template_url pointe vers un fichier normal existant et lisible, puis réessayez avec le chemin corrigé."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6419,10 +6459,6 @@ msgid ""
 msgstr ""
 "TemplateURL/local TemplateBody a échoué avant d'entrer dans l'analyseur; "
 "le ROS API n'a pas été appelé."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "Confirmer que le fichier existe, est lisible et est enregistré sous UTF-8."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12678,3 +12714,4 @@ msgstr "Autoriser Bash ?"
 #~ msgstr ""
 #~ "Approuver l'appel d'outil : {tool}\n"
 #~ "Résumé de l'entrée : {summary}"
+

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -5999,6 +5999,28 @@ msgid ""
 "request and try again."
 msgstr "Alibaba Cloud API {operation} を安全に準備できませんでした。リクエストを確認して再試行してください。"
 
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide parameters as a key/value object; use "
+"ros_get_template_parameter_constraints to resolve allowed values first."
+msgstr " parameters はキー/値オブジェクトで指定してください。まず ros_get_template_parameter_constraints で許可された値を解決してください。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide a unique stack_name; it is a tool argument, not a template "
+"parameter."
+msgstr " 一意の stack_name を指定してください。これはツール引数であり、テンプレートパラメータではありません。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide template_url as a readable local template file path, OSS URL, or"
+" HTTP(S) URL."
+msgstr " template_url には読み取り可能なローカルテンプレートファイルのパス、OSS URL、または HTTP(S) URL を指定してください。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid " Fix the input before calling again instead of repeating the same call."
+msgstr " 同じ呼び出しを繰り返す代わりに、入力を修正してから再度呼び出してください。"
+
 #: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS スタック"
@@ -6052,22 +6074,36 @@ msgstr ""
 "params.TemplateURL として渡してください。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file is not valid UTF-8."
+msgstr "ローカルROSテンプレートファイルはUTF-8では有効ではありません。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "ファイルが読みやすく、UTF-8として保存されていることを確認してください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the maximum supported size."
+msgstr "ローカル ROS テンプレートファイルがサポートされる最大サイズを超えています。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Use a smaller regular template file within the 32 MiB limit."
+msgstr "32 MiB の制限内のより小さい通常のテンプレートファイルを使用してください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "ローカルROSテンプレートファイルは読みません。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "The local ROS template file is not valid UTF-8."
-msgstr "ローカルROSテンプレートファイルはUTF-8では有効ではありません。"
+msgid ""
+"Confirm that template_url points to an existing, readable regular file, "
+"then retry with the fixed path."
+msgstr "template_url が既存かつ読み取り可能な通常ファイルを指していることを確認し、修正したパスで再試行してください。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "TemplateURL/local TemplateBody failed before entering the Parser; the ROS"
 " API was not called."
 msgstr "TemplateURL/local TemplateBodyは、パーサを入力する前に失敗しました。 ROS APIは呼びませんでした。"
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "ファイルが読みやすく、UTF-8として保存されていることを確認してください。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -11706,3 +11742,4 @@ msgstr "Bash を許可しますか？"
 #~ msgstr ""
 #~ "ツール呼び出しを承認: {tool}\n"
 #~ "入力サマリー: {summary}"
+

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6285,6 +6285,28 @@ msgstr ""
 "A API do Alibaba Cloud {operation} não pôde ser preparada com segurança. "
 "Verifique a solicitação e tente novamente."
 
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide parameters as a key/value object; use "
+"ros_get_template_parameter_constraints to resolve allowed values first."
+msgstr " Forneça parameters como um objeto chave/valor; use ros_get_template_parameter_constraints para resolver primeiro os valores permitidos."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide a unique stack_name; it is a tool argument, not a template "
+"parameter."
+msgstr " Forneça um stack_name único; ele é um argumento da ferramenta, não um parâmetro do modelo."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide template_url as a readable local template file path, OSS URL, or"
+" HTTP(S) URL."
+msgstr " Forneça template_url como um caminho de arquivo de modelo local legível, URL do OSS ou URL HTTP(S)."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid " Fix the input before calling again instead of repeating the same call."
+msgstr " Corrija a entrada antes de chamar novamente, em vez de repetir a mesma chamada."
+
 #: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS Stack"
@@ -6341,12 +6363,30 @@ msgstr ""
 "OSS/HTTP."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file is not valid UTF-8."
+msgstr "O arquivo de modelo ROS local não é válido UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "Confirme que o arquivo existe, é legível e é salvo como UTF-8."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the maximum supported size."
+msgstr "O arquivo de modelo ROS local excede o tamanho máximo suportado."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Use a smaller regular template file within the 32 MiB limit."
+msgstr "Use um arquivo de modelo comum menor, dentro do limite de 32 MiB."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "O arquivo de modelo ROS local não pode ser lido."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "The local ROS template file is not valid UTF-8."
-msgstr "O arquivo de modelo ROS local não é válido UTF-8."
+msgid ""
+"Confirm that template_url points to an existing, readable regular file, "
+"then retry with the fixed path."
+msgstr "Confirme que template_url aponta para um arquivo comum existente e legível, e tente novamente com o caminho corrigido."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
@@ -6355,10 +6395,6 @@ msgid ""
 msgstr ""
 "O TemplateURL/local TemplateBody falhou antes de entrar no Parser; o ROS "
 "API não foi chamado."
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "Confirme que o arquivo existe, é legível e é salvo como UTF-8."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -12506,3 +12542,4 @@ msgstr "Permitir Bash?"
 #~ msgstr ""
 #~ "Aprovar chamada de ferramenta: {tool}\n"
 #~ "Resumo da entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -5850,6 +5850,28 @@ msgid ""
 "request and try again."
 msgstr "无法安全准备阿里云 API {operation}。请检查请求后重试。"
 
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide parameters as a key/value object; use "
+"ros_get_template_parameter_constraints to resolve allowed values first."
+msgstr " 请以键值对象形式提供 parameters；可先用 ros_get_template_parameter_constraints 求解合法取值。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide a unique stack_name; it is a tool argument, not a template "
+"parameter."
+msgstr " 请提供唯一的 stack_name；它是工具参数，不是模板参数。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid ""
+" Provide template_url as a readable local template file path, OSS URL, or"
+" HTTP(S) URL."
+msgstr " 请将 template_url 设为可读的本地模板文件路径、OSS URL 或 HTTP(S) URL。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+msgid " Fix the input before calling again instead of repeating the same call."
+msgstr " 请先修复输入再重新调用，不要重复相同调用。"
+
 #: src/iac_code/tools/cloud/aliyun/ros_stack.py
 msgid "ROS Stack"
 msgstr "ROS 资源栈"
@@ -5901,22 +5923,36 @@ msgstr ""
 "params.TemplateURL，例如本地文件路径或 OSS/HTTP URL。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file is not valid UTF-8."
+msgstr "本地 ROS 模板文件不是有效 UTF-8。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
+msgstr "确认文件存在、可读，并使用 UTF-8 编码保存。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "The local ROS template file exceeds the maximum supported size."
+msgstr "本地 ROS 模板文件超过支持的最大大小。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+msgid "Use a smaller regular template file within the 32 MiB limit."
+msgstr "请使用 32 MiB 限制内更小的常规模板文件。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."
 msgstr "本地 ROS 模板文件无法读取。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "The local ROS template file is not valid UTF-8."
-msgstr "本地 ROS 模板文件不是有效 UTF-8。"
+msgid ""
+"Confirm that template_url points to an existing, readable regular file, "
+"then retry with the fixed path."
+msgstr "确认 template_url 指向存在且可读的常规文件，修正路径后重试。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid ""
 "TemplateURL/local TemplateBody failed before entering the Parser; the ROS"
 " API was not called."
 msgstr "TemplateURL/本地 TemplateBody 在进入 Parser 前失败；未调用 ROS API。"
-
-#: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
-msgid "Confirm that the file exists, is readable, and is saved as UTF-8."
-msgstr "确认文件存在、可读，并使用 UTF-8 编码保存。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 #, python-brace-format
@@ -11493,3 +11529,4 @@ msgstr "允许 Bash?"
 #~ msgstr ""
 #~ "批准工具调用：{tool}\n"
 #~ "输入摘要：{summary}"
+

--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -2042,13 +2042,13 @@ class AliyunApi(BaseCloudApi):
                     region_id=shape.get("region_id"),
                 )
             )
-        from iac_code.tools.cloud.aliyun.ros_template_tools import validate_delegated_tool_input
+        from iac_code.tools.cloud.aliyun.ros_template_tools import delegated_tool_input_error
 
-        if not validate_delegated_tool_input(tool_input, action=action):
+        if input_error := delegated_tool_input_error(tool_input, action=action):
             self._invalidate_runtime_handoff(context)
             return ToolResult.error(
                 public_aliyun_error(
-                    "invalid_tool_input",
+                    input_error,
                     product=shape.get("product"),
                     version=shape.get("version"),
                     action=shape.get("action"),
@@ -2281,7 +2281,10 @@ class AliyunApi(BaseCloudApi):
                 try:
                     template_bytes = await asyncio.to_thread(_read_body_file, resolved_template)
                     params["TemplateBody"] = template_bytes.decode("utf-8")
-                except (OSError, UnicodeError) as error:
+                except (OSError, UnicodeError, ApiContractError) as error:
+                    # _read_body_file reports unreadable, non-regular, or oversized
+                    # files as ApiContractError; ROS template callers pass template_url
+                    # and must not receive a body_file error they cannot act on.
                     from iac_code.tools.cloud.aliyun.hooks.ros_validate import local_template_source_error
 
                     outcome = local_template_source_error(error)

--- a/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+++ b/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
@@ -37,18 +37,29 @@ _FLAT_PARAMETER = re.compile(r"^Parameters\.(\d+)\.(ParameterKey|ParameterValue)
 def local_template_source_error(error: BaseException) -> RosPreflightOutcome:
     """Convert an allowed local-file read/decode failure into a normal ROS report."""
 
-    kind = "UTF-8" if isinstance(error, UnicodeError) else "READ"
+    if isinstance(error, UnicodeError):
+        kind = "UTF-8"
+        summary = _("The local ROS template file is not valid UTF-8.")
+        suggestion = _("Confirm that the file exists, is readable, and is saved as UTF-8.")
+    elif str(error) == "body_file_too_large":
+        kind = "SIZE"
+        summary = _("The local ROS template file exceeds the maximum supported size.")
+        suggestion = _("Use a smaller regular template file within the 32 MiB limit.")
+    else:
+        kind = "READ"
+        summary = _("The local ROS template file cannot be read.")
+        suggestion = _(
+            "Confirm that template_url points to an existing, readable regular file, then retry with the fixed path."
+        )
     diagnostic = make_diagnostic(
         code="ROS1202",
         severity=Severity.ERROR,
         category=Category.COMPATIBILITY,
-        summary=_("The local ROS template file cannot be read.")
-        if kind == "READ"
-        else _("The local ROS template file is not valid UTF-8."),
+        summary=summary,
         detail=_("TemplateURL/local TemplateBody failed before entering the Parser; the ROS API was not called."),
         subject="local-template-source",
         stable_args=(kind, type(error).__name__),
-        suggestion=_("Confirm that the file exists, is readable, and is saved as UTF-8."),
+        suggestion=suggestion,
     )
     return outcome_from_report(ValidationReport.build([diagnostic], analysis_incomplete=False))
 

--- a/src/iac_code/tools/cloud/aliyun/public_errors.py
+++ b/src/iac_code/tools/cloud/aliyun/public_errors.py
@@ -158,15 +158,22 @@ def public_aliyun_error(
             return _("Alibaba Cloud API {operation} requires body_file for its binary request body.").format(
                 operation=operation
             )
+        guidance = _ros_template_input_guidance(parameter)
         if parameter is not None and "," not in parameter:
-            return _("Alibaba Cloud API {operation} requires parameter {parameter}.").format(
-                operation=operation,
-                parameter=parameter,
+            return (
+                _("Alibaba Cloud API {operation} requires parameter {parameter}.").format(
+                    operation=operation,
+                    parameter=parameter,
+                )
+                + guidance
             )
         if parameter is not None:
-            return _("Alibaba Cloud API {operation} requires parameters {parameters}.").format(
-                operation=operation,
-                parameters=parameter,
+            return (
+                _("Alibaba Cloud API {operation} requires parameters {parameters}.").format(
+                    operation=operation,
+                    parameters=parameter,
+                )
+                + guidance
             )
         return _("Alibaba Cloud API {operation} is missing required parameters.").format(operation=operation)
     if code.startswith("invalid_parameter_type:"):
@@ -455,6 +462,27 @@ def public_aliyun_unsupported_reasons(
 
     messages = [public_aliyun_error(reason, product=product, action=action) for reason in reasons]
     return list(dict.fromkeys(messages))
+
+
+def _ros_template_input_guidance(parameter: str | None) -> str:
+    """Return actionable guidance for missing ROS template tool inputs."""
+
+    if parameter is None:
+        return ""
+    names = set(parameter.split(","))
+    guidance = ""
+    if "parameters" in names:
+        guidance += _(
+            " Provide parameters as a key/value object; use ros_get_template_parameter_constraints to resolve"
+            " allowed values first."
+        )
+    if "stack_name" in names:
+        guidance += _(" Provide a unique stack_name; it is a tool argument, not a template parameter.")
+    if "template_url" in names:
+        guidance += _(" Provide template_url as a readable local template file path, OSS URL, or HTTP(S) URL.")
+    if guidance:
+        guidance += _(" Fix the input before calling again instead of repeating the same call.")
+    return guidance
 
 
 def _is_oss_unsupported_reason(code: str) -> bool:

--- a/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_template_tools.py
@@ -118,12 +118,30 @@ def delegated_input_schema(action: str) -> dict[str, Any]:
     raise ValueError("unsupported_delegated_action")
 
 
-def validate_delegated_tool_input(tool_input: Mapping[str, Any], *, action: str) -> bool:
+def delegated_tool_input_error(tool_input: Mapping[str, Any], *, action: str) -> str | None:
+    """Return a stable error code naming the offending fields, or None when valid.
+
+    Missing required fields become ``missing_required_parameters:<names>`` so the
+    public error message can name them and the caller can fix the input on the
+    next call instead of repeating the same failing call.
+    """
+
     try:
-        jsonschema.validate(instance=dict(tool_input), schema=delegated_input_schema(action))
-    except (jsonschema.ValidationError, ValueError):
-        return False
-    return True
+        schema = delegated_input_schema(action)
+    except ValueError:
+        return "invalid_tool_input"
+    try:
+        jsonschema.validate(instance=dict(tool_input), schema=schema)
+    except jsonschema.ValidationError:
+        missing = [name for name in schema["required"] if name not in tool_input]
+        if missing:
+            return "missing_required_parameters:" + ",".join(missing)
+        return "invalid_tool_input"
+    return None
+
+
+def validate_delegated_tool_input(tool_input: Mapping[str, Any], *, action: str) -> bool:
+    return delegated_tool_input_error(tool_input, action=action) is None
 
 
 def render_ros_template_tool_result_message(

--- a/src/iac_code/tools/cloud/aliyun/runtime.py
+++ b/src/iac_code/tools/cloud/aliyun/runtime.py
@@ -216,11 +216,11 @@ class AliyunDelegatedExecutor:
             )
         from iac_code.tools.cloud.aliyun.ros_template_tools import (
             build_delegated_call_shape,
-            validate_delegated_tool_input,
+            delegated_tool_input_error,
         )
 
-        if not validate_delegated_tool_input(tool_input, action=self._action):
-            return PermissionResult(behavior="deny", message=self._public_error("invalid_tool_input", tool_input))
+        if input_error := delegated_tool_input_error(tool_input, action=self._action):
+            return PermissionResult(behavior="deny", message=self._public_error(input_error, tool_input))
         shape = build_delegated_call_shape(tool_input, action=self._action)
         return await self._public_tool.check_shape_permissions(shape, replace(context, pipeline_mode=False))
 
@@ -230,11 +230,11 @@ class AliyunDelegatedExecutor:
                 return ToolResult.error(self._public_error("aliyun_delegated_outer_binding_required", tool_input))
             from iac_code.tools.cloud.aliyun.ros_template_tools import (
                 build_delegated_call_shape,
-                validate_delegated_tool_input,
+                delegated_tool_input_error,
             )
 
-            if not validate_delegated_tool_input(tool_input, action=self._action):
-                return ToolResult.error(self._public_error("invalid_tool_input", tool_input))
+            if input_error := delegated_tool_input_error(tool_input, action=self._action):
+                return ToolResult.error(self._public_error(input_error, tool_input))
             shape = build_delegated_call_shape(tool_input, action=self._action)
             delegated_context = _delegated_tool_context(context)
             try:

--- a/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api_permissions.py
@@ -2088,10 +2088,107 @@ async def test_delegated_local_template_rejects_parent_symlink_swap_at_materiali
     runtime.execution_stage_observer = swap_parent
     result = await delegated.execute(outer_input, _execution_context(permission_context, permission))
 
-    assert result == ToolResult.error(
-        _expected_public_error("invalid_body_file", {"region_id": "cn-hangzhou"}, contract=contract)
-    )
+    # ROS template callers pass template_url and must not receive a body_file error.
+    assert result.is_error is True
+    assert "body_file" not in result.content
+    assert "ROS1202" in result.content
     assert runtime.request_builder.inputs == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "action"),
+    [
+        ("ros_validate_template", "ValidateTemplate"),
+        ("ros_get_template_parameter_constraints", "GetTemplateParameterConstraints"),
+        ("ros_preview_template", "PreviewStack"),
+        ("ros_estimate_template_cost", "GetTemplateEstimateCost"),
+    ],
+)
+async def test_delegated_unreadable_local_template_reports_template_diagnostic(
+    tmp_path,
+    tool_name: str,
+    action: str,
+) -> None:
+    from iac_code.tools.cloud.aliyun.runtime import AliyunDelegatedExecutor
+
+    template = tmp_path / "template.yml"
+    template.write_text("Resources: {}\n", encoding="utf-8")
+    contract = _canonical_contract(product="ROS", version="2019-09-10", action=action)
+    tool, runtime = _execution_runtime(contract)
+    delegated = AliyunDelegatedExecutor(tool, action=action)
+    outer_input: dict[str, Any] = {"template_url": str(template), "region_id": "cn-hangzhou"}
+    if action in {"PreviewStack", "GetTemplateEstimateCost"}:
+        outer_input["parameters"] = {"Key": "value"}
+    if action == "PreviewStack":
+        outer_input["stack_name"] = "preview-stack"
+    permission_context = _bound_context(
+        outer_input,
+        tool_name=tool_name,
+        cwd=str(tmp_path),
+        pipeline_mode=True,
+    )
+    permission = await delegated.check_permissions(outer_input, permission_context)
+    assert permission.behavior == "allow"
+
+    def remove_template(stage: str) -> None:
+        if stage == "materialize":
+            template.unlink()
+
+    runtime.execution_stage_observer = remove_template
+    result = await delegated.execute(outer_input, _execution_context(permission_context, permission))
+
+    assert result.is_error is True
+    assert "ROS1202" in result.content
+    assert "body_file" not in result.content
+    assert "template_url" in result.content
+    assert runtime.request_builder.inputs == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "action", "outer_input", "missing"),
+    [
+        (
+            "ros_preview_template",
+            "PreviewStack",
+            {"template_url": "https://example.com/template.yml", "stack_name": "preview-stack"},
+            "parameters",
+        ),
+        (
+            "ros_preview_template",
+            "PreviewStack",
+            {"template_url": "https://example.com/template.yml", "parameters": {"Key": "value"}},
+            "stack_name",
+        ),
+        (
+            "ros_estimate_template_cost",
+            "GetTemplateEstimateCost",
+            {"template_url": "https://example.com/template.yml"},
+            "parameters",
+        ),
+    ],
+)
+async def test_delegated_missing_required_input_names_the_field(
+    tool_name: str,
+    action: str,
+    outer_input: dict[str, Any],
+    missing: str,
+) -> None:
+    from iac_code.tools.cloud.aliyun.runtime import AliyunDelegatedExecutor
+
+    contract = _canonical_contract(product="ROS", version="2019-09-10", action=action)
+    tool, runtime = _execution_runtime(contract)
+    delegated = AliyunDelegatedExecutor(tool, action=action)
+    permission_context = _bound_context(outer_input, tool_name=tool_name, pipeline_mode=True)
+
+    permission = await delegated.check_permissions(outer_input, permission_context)
+
+    assert permission.behavior == "deny"
+    assert permission.message is not None
+    assert missing in permission.message
+    assert "repeating the same call" in permission.message
+    assert runtime.contract_store.size == 0
 
 
 @pytest.mark.asyncio

--- a/tests/tools/cloud/aliyun/test_public_errors.py
+++ b/tests/tools/cloud/aliyun/test_public_errors.py
@@ -125,6 +125,11 @@ def test_aliyun_public_error_templates_are_directly_extractable(tmp_path: Path) 
         "Alibaba Cloud API {operation} received multiple template sources. Provide only one.",
         "Alibaba Cloud API {operation} requires a body source compatible with its API contract.",
         "Alibaba Cloud API {operation} requires parameter {parameter}.",
+        " Provide parameters as a key/value object; use ros_get_template_parameter_constraints to resolve"
+        " allowed values first.",
+        " Provide a unique stack_name; it is a tool argument, not a template parameter.",
+        " Provide template_url as a readable local template file path, OSS URL, or HTTP(S) URL.",
+        " Fix the input before calling again instead of repeating the same call.",
         "Alibaba Cloud API {operation} template file is invalid. Use a readable regular template file.",
         "Alibaba Cloud API {operation} template validation failed. Check the template syntax and resource definitions.",
         "Alibaba Cloud API {operation} was not found. Check the product, version, and action.",


### PR DESCRIPTION
## 问题

ROS 模板工具（`ros_validate_template`、`ros_get_template_parameter_constraints`、`ros_preview_template`、`ros_estimate_template_cost`）在输入有缺陷时返回的错误无法指导修复，导致 agent 首次失败后在不同工具上重复相同调用（会话证据：`93851da3d55542baa2684387d4d5fc31`、`f608eb3cc8944c95a81e901db47c1b2a`、`3a0edeb1756b4e4fbf4e40689a1ee928`）。

根因有两点：

1. **本地 `template_url` 读取失败被误报为 `body_file is invalid`**
   `_execute_runtime_unattached` 的 materialize 阶段通过 `_read_body_file` 读取本地模板；该函数把底层 `OSError` 包装成 `ApiContractError("invalid_body_file")`，而调用处只捕获 `(OSError, UnicodeError)`，因此本应产出的 ROS1202 结构化预检诊断永远不会命中，错误最终渲染为 "body_file is invalid"。这些工具的输入 schema 里没有 `body_file` 字段，agent 无法把错误关联到 `template_url`。

2. **必填输入缺失只返回泛化 `invalid_tool_input`**
   `validate_delegated_tool_input` 仅返回 bool，缺 `parameters` / `stack_name` 时错误不指明字段，也不给修复方向。

## 修改

- `aliyun_api.py`：materialize 阶段同时捕获 `ApiContractError`，统一走 `local_template_source_error`，ROS 模板调用不再出现无法处理的 `body_file` 错误。
- `hooks/ros_validate.py`：ROS1202 诊断区分读取失败 / 非 UTF-8 / 超过大小限制三种情形，并给出对应修复建议。
- `ros_template_tools.py`：新增 `delegated_tool_input_error`，返回 `missing_required_parameters:<names>` 以点名缺失字段；`validate_delegated_tool_input` 复用它保持兼容。
- `runtime.py` / `aliyun_api.py`：delegated 授权与执行路径改用带字段信息的错误码。
- `public_errors.py`：缺失字段消息追加可执行指引（`parameters` 提示先用 `ros_get_template_parameter_constraints` 求解合法取值、`stack_name` 说明是工具参数、`template_url` 说明可接受的路径形式），并明确"先修复输入再调用，不要重复相同调用"。
- i18n：6 个语言补齐译文并重新编译。

## 测试

- 新增用例覆盖四个 ROS 工具在本地 `template_url` 不可读时返回 ROS1202（不含 `body_file`），以及缺 `parameters` / `stack_name` 时错误点名字段。
- `tests/tools/cloud/aliyun` + `tests/i18n`：2185 passed。
- 全量 `pytest tests/`：13277 passed, 4 skipped；另有 2 个失败（`test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token`、`test_latest_pipeline_sidecar_reads_nested_session_layout`）在父提交上同样复现，属既有问题。
- `ruff check` 与 `ty check src/` 均通过。
