### PR TITLE
fix(pipeline): re-emit step_started when resuming a waiting-input step

### DIFF
--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -2669,6 +2669,7 @@ class PipelineRunner:
         async for event in self._continue_from_current(
             **self._continue_input_kwargs(pipeline_input),
             resume_waiting_step=True,
+            reemit_step_started=True,
         ):
             if (
                 not selection_observed
@@ -3698,6 +3699,7 @@ class PipelineRunner:
         precompleted_tools: dict[str, dict[str, Any]] | None = None,
         resume_waiting_step: bool = False,
         resume_running_step: bool = False,
+        reemit_step_started: bool = False,
     ) -> AsyncGenerator[StreamEvent | PipelineEvent | StepResult, None]:
         is_first_step = True
         terminal_pipeline_telemetry_emitted = False
@@ -3766,6 +3768,28 @@ class PipelineRunner:
                 except PipelineStatePersistenceError as exc:
                     yield self._persistence_failure_event(exc)
                     return
+                if reemit_step_started:
+                    # A waiting-input step (auto_advance=false, e.g. confirm_and_select)
+                    # already emitted STEP_COMPLETED before pausing, and this resume run
+                    # will emit STEP_COMPLETED again after processing the user's answer.
+                    # Re-emit STEP_STARTED for the same attempt so aggregated run-event
+                    # counts keep parent step started/completed strictly paired.
+                    yield PipelineEvent(
+                        type=PipelineEventType.STEP_STARTED,
+                        step_id=step.step_id,
+                        timestamp=step_start,
+                        data={
+                            "index": step_index,
+                            "attempt": step_attempt,
+                            "total": self.state_machine.total_steps,
+                            "name": step.step_id,
+                            "step_type": step.step_type,
+                            "ui_mode": step.ui_mode,
+                            "active_attempt_id": attempt["attempt_id"],
+                            "transcript_id": attempt["transcript_id"],
+                            "resumed": True,
+                        },
+                    )
             else:
                 step_attempt = self._next_step_attempt(step.step_id)
                 try:

--- a/tests/pipeline/engine/test_pipeline_observability.py
+++ b/tests/pipeline/engine/test_pipeline_observability.py
@@ -1581,7 +1581,7 @@ async def test_runner_resume_emits_user_input_received_and_selection_telemetry(r
     runner._observability.selection_made = MagicMock()
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 
@@ -1744,7 +1744,7 @@ async def test_runner_does_not_emit_selection_made_for_unmatched_or_ambiguous_ca
     runner._observability.selection_made = MagicMock()
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -1554,6 +1554,74 @@ async def test_resume_input_save_failure_stops_before_input_received_event(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_resume_waiting_step_reemits_step_started_so_counts_stay_paired(tmp_path):
+    """A waiting-input step emits STEP_COMPLETED before pausing and again after the
+    user answers; the resume must re-emit STEP_STARTED for the same attempt so
+    aggregated run-event counts keep started/completed strictly paired."""
+    runner = _build_two_step_runner(tmp_path, auto_advance_first=False)
+
+    async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+        yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"ok": True})
+
+    runner._step_executor.execute = fake_execute
+
+    events = [event async for event in runner.run("start")]
+    events += [event async for event in runner.resume("continue")]
+
+    def _step_events(event_type, step_id):
+        return [
+            event
+            for event in events
+            if isinstance(event, PipelineEvent) and event.type == event_type and event.step_id == step_id
+        ]
+
+    started_a = _step_events(PipelineEventType.STEP_STARTED, "a")
+    completed_a = _step_events(PipelineEventType.STEP_COMPLETED, "a")
+    assert len(started_a) == len(completed_a) == 2
+    resumed_started = started_a[1]
+    assert resumed_started.data["resumed"] is True
+    assert resumed_started.data["attempt"] == started_a[0].data["attempt"]
+
+    total_started = sum(
+        1 for event in events if isinstance(event, PipelineEvent) and event.type == PipelineEventType.STEP_STARTED
+    )
+    total_completed = sum(
+        1 for event in events if isinstance(event, PipelineEvent) and event.type == PipelineEventType.STEP_COMPLETED
+    )
+    assert total_started == total_completed
+
+
+@pytest.mark.asyncio
+async def test_resume_ask_user_question_does_not_reemit_step_started(tmp_path):
+    """resume_ask_user_question resumes a step that never emitted STEP_COMPLETED
+    before pausing, so re-emitting STEP_STARTED there would create the opposite
+    imbalance; the continue path must not re-emit for that flow."""
+    runner = _build_two_step_runner(tmp_path, auto_advance_first=False)
+
+    async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+        yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"ok": True})
+
+    runner._step_executor.execute = fake_execute
+    runner._ensure_parent_attempt("a")
+    runner._resume_messages_for_current_parent_step = lambda step_id: []
+
+    events = [
+        event
+        async for event in runner.resume_ask_user_question(
+            {"selected_id": "opt-1", "selected_label": "Option 1", "free_text": ""},
+            tool_use_id="tool-1",
+        )
+    ]
+
+    started_a = [
+        event
+        for event in events
+        if isinstance(event, PipelineEvent) and event.type == PipelineEventType.STEP_STARTED and event.step_id == "a"
+    ]
+    assert not any(event.data.get("resumed") for event in started_a)
+
+
+@pytest.mark.asyncio
 async def test_pause_confirmation_save_failure_stops_before_input_received_event(tmp_path):
     runner = _build_two_step_runner(tmp_path)
     runner.session = FailingUserInputCheckpointPipelineSession()

--- a/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
+++ b/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
@@ -1002,7 +1002,7 @@ async def test_resume_from_waiting_input_sidecar_preserves_step_attempt_for_user
     runner2._observability.selection_made = MagicMock()
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 
@@ -1032,7 +1032,7 @@ async def test_resume_candidate_selection_emits_selected_option_details(tmp_path
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 
@@ -1184,7 +1184,7 @@ async def test_resume_candidate_selection_extracts_index_from_structured_json(tm
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 
@@ -1215,7 +1215,7 @@ async def test_resume_candidate_selection_extracts_index_from_numbered_choice(tm
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 
@@ -1239,7 +1239,7 @@ async def test_resume_candidate_selection_prefers_evaluated_index_over_display_i
     ]
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 
@@ -1297,7 +1297,7 @@ async def test_resume_candidate_selection_uses_restored_context_options(tmp_path
     )
 
     async def fake_continue(user_input=None, **kwargs):
-        assert kwargs == {"resume_waiting_step": True}
+        assert kwargs == {"resume_waiting_step": True, "reemit_step_started": True}
         if False:
             yield
 


### PR DESCRIPTION
## 问题
证据 Session `eadbf79d597b4e929827475e01612717` 的 run 事件聚合计中 `step_completed=6` 而 `step_started=5`，主步骤 started/completed 不配对。

## 根因
等待输入步骤（`auto_advance=false`，如 `confirm_and_select`）在暂停前已 yield `STEP_COMPLETED`；用户回复后 `resume()` 走 `resume_waiting_step` 路径重入该步骤，恢复分支不再发 `STEP_STARTED`，但处理完用户输入后又会再次 yield `STEP_COMPLETED`，导致同一步骤 1 个 started 对应 2 个 completed。候选子步骤 `candidate_*` 事件计数不受影响。

## 修复
- `resume()` 传入 `reemit_step_started=True`；`_continue_from_current` 的 `resume_current_step` 分支据此补发与原步骤同 step_id/attempt 的 `STEP_STARTED`（`data.resumed=true`）。
- `resume_ask_user_question`（暂停前未发 `STEP_COMPLETED`）保持默认不补发，避免反向不配对。
- 同 runId 的补发事件对 A2A translator / snapshot / web transcript 是幂等的原位更新。

## 测试
- 新增 `test_resume_waiting_step_reemits_step_started_so_counts_stay_paired`、`test_resume_ask_user_question_does_not_reemit_step_started`。
- tests/pipeline + tests/a2a + web transcript 套件 3051 passed（唯一失败的 `test_prerequisites` 用例在未修改基线上同样失败，环境相关）。
- ruff 通过。

Harness WorkItem: 72e769e3-f852-4006-ac2a-ee04a6fd2d55