### PR TITLE
fix(pipeline): bind deploying conclusion to the final ros_deploy result

### DIFF
--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -456,6 +456,14 @@ class CompleteStepTool(Tool):
                 base_message,
                 after_index=after_index,
             )
+        if bool(requirement.get("latest_record_must_match")):
+            return self._validate_final_required_tool_result(
+                records,
+                requirement,
+                conclusion,
+                base_message,
+                after_index=after_index,
+            )
 
         mismatch_message: str | None = None
         field_mismatch_message: str | None = None
@@ -686,6 +694,151 @@ class CompleteStepTool(Tool):
         return _("{message} Call {tool} first and wait for a successful result.").format(
             message=base_message,
             tool=tool_name or _("the required tool"),
+        )
+
+    def _validate_final_required_tool_result(
+        self,
+        records: list[Any],
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        base_message: str,
+        *,
+        after_index: int,
+    ) -> str | None:
+        """Validate only the final matching tool call, so the conclusion tracks the last attempt.
+
+        Unlike the existence-based scan, an earlier satisfying record cannot rescue a
+        conclusion that contradicts the last call — e.g. a deploying conclusion may not
+        pair the stack_id of a superseded CREATE_FAILED stack with ``status: success``.
+        """
+        tool_name = str(requirement.get("tool") or "")
+        actions = self._expected_actions(requirement)
+        expected_product = requirement.get("product")
+        expected_success = requirement.get("is_success")
+        status_in = {str(status) for status in requirement.get("status_in") or [] if status is not None}
+        result_field_equals = requirement.get("result_field_equals") or {}
+        required_result_fields = requirement.get("required_result_fields") or []
+
+        final_index = self._final_matching_tool_result_index(
+            records,
+            tool_name=tool_name,
+            actions=actions,
+            expected_product=expected_product,
+            after_index=after_index,
+        )
+        if final_index is None:
+            return self._missing_final_tool_result_message(
+                base_message,
+                tool_name=tool_name,
+                actions=actions,
+                status_in=status_in,
+                expected_success=expected_success,
+            )
+
+        record = records[final_index]
+        tool_input = self._dict_value(record.get("input"))
+        raw_result = record.get("result")
+        result = self._dict_value(raw_result)
+        if record.get("is_error") or not isinstance(raw_result, dict):
+            return self._final_tool_result_failed_message(base_message, tool_name)
+        if expected_success is not None and self._bool_from_result(result) is not bool(expected_success):
+            return self._final_tool_result_failed_message(base_message, tool_name)
+        if status_in and self._status_from_result(result) not in status_in:
+            return self._final_tool_result_failed_message(base_message, tool_name)
+
+        field_mismatch = self._first_match_field_mismatch(requirement, conclusion, tool_input, result, tool_name)
+        if field_mismatch is not None:
+            return self._format_match_field_mismatch(base_message, field_mismatch)
+        if isinstance(result_field_equals, dict):
+            failed_field = self._first_failed_result_field(result, result_field_equals)
+            if failed_field is not None:
+                field, expected, actual = failed_field
+                return _(
+                    "{message} The final {tool} result field {field} must equal {expected}; actual value was {actual}."
+                ).format(
+                    message=base_message,
+                    tool=tool_name or _("tool"),
+                    field=field,
+                    expected=expected,
+                    actual=actual,
+                )
+        missing_required_field = self._first_missing_result_field(result, required_result_fields)
+        if missing_required_field is not None:
+            return _("{message} The final {tool} result must include non-empty field {field}.").format(
+                message=base_message,
+                tool=tool_name or _("tool"),
+                field=missing_required_field,
+            )
+        return self._validate_no_disallowed_tool_results_after_match(
+            records,
+            requirement,
+            conclusion,
+            base_message,
+            matched_index=final_index,
+        )
+
+    def _final_matching_tool_result_index(
+        self,
+        records: list[Any],
+        *,
+        tool_name: str,
+        actions: set[str],
+        expected_product: Any,
+        after_index: int,
+    ) -> int | None:
+        """Index of the last record matching tool/action/product, regardless of its outcome."""
+        for index in range(len(records) - 1, after_index, -1):
+            record = records[index]
+            if not isinstance(record, dict):
+                continue
+            if tool_name and record.get("tool_name") != tool_name:
+                continue
+            tool_input = self._dict_value(record.get("input"))
+            if expected_product and not self._strings_equal_ignore_case(
+                self._first_string(tool_input, ("product", "Product")),
+                str(expected_product),
+            ):
+                continue
+            if actions and self._first_string(tool_input, ("action", "Action")) not in actions:
+                continue
+            return index
+        return None
+
+    @staticmethod
+    def _final_tool_result_failed_message(base_message: str, tool_name: str) -> str:
+        return _(
+            "{message} The final {tool} result did not succeed; submit the conclusion that matches the final result "
+            "instead of an earlier attempt."
+        ).format(message=base_message, tool=tool_name or _("tool"))
+
+    def _missing_final_tool_result_message(
+        self,
+        base_message: str,
+        *,
+        tool_name: str,
+        actions: set[str],
+        status_in: set[str],
+        expected_success: Any,
+    ) -> str:
+        status_hint = ""
+        if status_in:
+            status_hint = _(" with status {statuses}").format(statuses=", ".join(sorted(status_in)))
+        success_hint = ""
+        if expected_success is not None:
+            success_hint = _(" and is_success={expected}").format(expected=str(bool(expected_success)).lower())
+        action_hint = ""
+        if len(actions) == 1:
+            action_hint = f" {next(iter(actions))}"
+        elif actions:
+            action_hint = _(" one of {actions}").format(actions=", ".join(sorted(actions)))
+        return _(
+            "{message} Call {tool}{action} first and wait for a successful result{status_hint}{success_hint}."
+        ).format(
+            message=base_message,
+            tool=tool_name or _("the required tool"),
+            action=action_hint,
+            status_hint=status_hint,
+            success_hint=success_hint,
         )
 
     def _validate_no_disallowed_tool_results_after_match(

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -510,6 +510,7 @@ steps:
           is_success: true
           status_in: [CREATE_COMPLETE]
           match_conclusion_field: stack_id
+          latest_record_must_match: true
         message_key: deploy_wait_create_complete
     tools:
       include: []

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -146,6 +146,14 @@ conclusion_schema:
 - 工具会先确认替代创建参数和模板可用，再删除旧失败 Stack 后创建新的 Stack
 - 成功后最终结果使用新 Stack 的 `stack_id`，不要把旧 `stack_id` 当成部署成功结果
 
+## 结论必须对齐最终部署结果
+
+`stack_id` 和 `status` 必须来自本步骤**最后一次** `ros_deploy` 部署动作（`create` / `continue_create` / `delete_and_create` / `wait`）的结果：
+
+- 早期 `create` 失败后经 `continue_create` 或 `delete_and_create` 恢复时，结论只能记录最终那次调用返回的 `stack_id` 和状态。
+- 禁止把已被取代的 CREATE_FAILED 栈的 `stack_id` 与 `status: success` 配对提交。
+- 最后一次部署动作未达到 `CREATE_COMPLETE` 时，结论必须是 `status: failed` 并在 `error` 中说明原因，不得沿用更早一次成功结果。
+
 ## 资源和文档搜索
 
 - 不确定的 ROS 资源属性或 Schema → aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<类型>"})

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -568,6 +568,122 @@ class TestCompletionGuards:
 
         assert not result.is_error
 
+    @staticmethod
+    def _final_deploy_tool(result_records: list[dict]) -> CompleteStepTool:
+        config = StepConfig(
+            step_id="deploying",
+            conclusion_field="deployment",
+            forward=None,
+            conclusion_schema={
+                "type": "object",
+                "required": ["status"],
+                "additionalProperties": False,
+                "properties": {
+                    "stack_id": {"type": "string"},
+                    "status": {"type": "string", "enum": ["success", "failed", "cancelled"]},
+                    "error": {"type": "string"},
+                },
+            },
+        )
+        return CompleteStepTool(
+            config,
+            completion_guards=[
+                {
+                    "when_conclusion_field_equals": {"status": "success"},
+                    "required_conclusion_field": "stack_id",
+                    "require_tool_result": {
+                        "tool": "ros_deploy",
+                        "action_in": ["create", "continue_create", "delete_and_create", "wait"],
+                        "is_success": True,
+                        "status_in": ["CREATE_COMPLETE"],
+                        "match_conclusion_field": "stack_id",
+                        "latest_record_must_match": True,
+                    },
+                    "message_key": "deploy_wait_create_complete",
+                }
+            ],
+            completion_guard_state={
+                "successful_tools": {"ros_deploy"},
+                "tool_results": {},
+                "tool_result_records": list(result_records),
+            },
+        )
+
+    @staticmethod
+    def _ros_deploy_record(action: str, stack_id: str, status: str, *, is_success: bool) -> dict:
+        return {
+            "tool_name": "ros_deploy",
+            "input": {"action": action, "stack_id": stack_id},
+            "result": {"stack_id": stack_id, "status": status, "is_success": is_success},
+            "is_error": not is_success,
+        }
+
+    @pytest.mark.asyncio
+    async def test_final_record_guard_rejects_superseded_stack_id_paired_with_success(self):
+        tool = self._final_deploy_tool(
+            [
+                self._ros_deploy_record("create", "stack-old", "CREATE_COMPLETE", is_success=True),
+                self._ros_deploy_record("delete_and_create", "stack-new", "CREATE_COMPLETE", is_success=True),
+            ]
+        )
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"status": "success", "stack_id": "stack-old"}},
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "stack_id" in result.content
+        assert "stack-new" in result.content
+
+    @pytest.mark.asyncio
+    async def test_final_record_guard_accepts_final_stack_id(self):
+        tool = self._final_deploy_tool(
+            [
+                self._ros_deploy_record("create", "stack-old", "CREATE_COMPLETE", is_success=True),
+                self._ros_deploy_record("delete_and_create", "stack-new", "CREATE_COMPLETE", is_success=True),
+            ]
+        )
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"status": "success", "stack_id": "stack-new"}},
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_final_record_guard_rejects_success_when_final_deploy_failed(self):
+        tool = self._final_deploy_tool(
+            [
+                self._ros_deploy_record("create", "stack-old", "CREATE_COMPLETE", is_success=True),
+                self._ros_deploy_record("wait", "stack-old", "CREATE_FAILED", is_success=False),
+            ]
+        )
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"status": "success", "stack_id": "stack-old"}},
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "CREATE_COMPLETE" in result.content
+
+    @pytest.mark.asyncio
+    async def test_final_record_guard_still_allows_failed_conclusion(self):
+        tool = self._final_deploy_tool(
+            [
+                self._ros_deploy_record("create", "stack-old", "CREATE_FAILED", is_success=False),
+            ]
+        )
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"status": "failed", "error": "VPCResourceException"}},
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
     @pytest.mark.asyncio
     async def test_required_tool_result_rejects_non_matching_stack_action(self):
         tool = self._deploying_tool(

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -180,4 +180,5 @@ def test_deploying_success_requires_create_stack_complete_guard():
         "is_success": True,
         "status_in": ["CREATE_COMPLETE"],
         "match_conclusion_field": "stack_id",
+        "latest_record_must_match": True,
     }


### PR DESCRIPTION
## Problem
The selling `deploying` step success guard only checked that *some* `ros_deploy` record satisfied CREATE_COMPLETE, so a conclusion could pair the stack_id of a superseded CREATE_FAILED stack with `status: success` (Session 5bed835ca9c84c7d9e3ec57fbc95c0e9: CREATE_FAILED stack 41aacbd4… recorded as success).

## Fix
- Add `latest_record_must_match` to `require_tool_result` in `complete_step_tool.py`, validating only the final matching tool call (including failed records) so the conclusion tracks the last `ros_deploy` attempt.
- Enable it on the selling deploying guard in `pipeline.yaml`.
- Tighten `iac-aliyun-deploying` SKILL guidance; add engine + contract tests.

## Tests
- `tests/pipeline/engine/test_complete_step_tool.py`, `tests/pipeline/selling/` pass; `ruff check` and `ty check src` green.