### PR TITLE
fix(a2a): export real cleanup state instead of unavailable placeholder

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -79,6 +79,7 @@ from iac_code.pipeline.engine.cleanup import (
     CleanupLedger,
     CleanupObserver,
     cleanup_prompt_ledger_path,
+    cleanup_state_unavailable_message,
     create_cleanup_prompt_message,
     is_active_cleanup_prompt_message,
     mark_cleanup_prompt_message_completed,
@@ -162,14 +163,32 @@ def _cleanup_payload_from_private_ledger_or_unavailable(
         ledger_exists = ledger_path.exists()
     except OSError:
         ledger_exists = False
-    if not ledger_exists or ledger.load_failed():
+    if not ledger_exists:
         return {
             "status": "unavailable",
-            "statusMessage": _("Cleanup state unavailable. Inspect the session file and cloud resources manually."),
+            "unavailableReason": "ledger_missing",
+            "statusMessage": cleanup_state_unavailable_message(reason="ledger_missing"),
+        }
+    if ledger.load_failed():
+        return {
+            "status": "unavailable",
+            "unavailableReason": "load_failed",
+            "statusMessage": cleanup_state_unavailable_message(
+                reason="load_failed",
+                load_error=ledger.load_error(),
+            ),
         }
     prompt = ledger.build_pending_prompt()
     if prompt is None:
-        return {"status": "completed", "resourceCount": 0}
+        summary = ledger.build_state_summary()
+        payload: dict[str, Any] = {
+            "status": summary.status,
+            "statusMessage": summary.status_message,
+            "resourceCount": summary.resource_count,
+        }
+        if summary.skipped:
+            payload["skipped"] = True
+        return payload
     return {
         "status": "pending",
         "resourceCount": len(prompt.resources),

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -56,7 +56,7 @@ from iac_code.agent.message import Message as AgentMessage
 from iac_code.i18n import _
 from iac_code.pipeline import create_pipeline, discover_pipelines
 from iac_code.pipeline.config import get_pipeline_name, is_selling_review_step_enabled
-from iac_code.pipeline.engine.cleanup import CleanupLedger
+from iac_code.pipeline.engine.cleanup import CleanupLedger, cleanup_state_unavailable_message
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_outcome_from_completed_event
 from iac_code.pipeline.engine.loader import _resolve_feature_flags, load_pipeline_dir
@@ -3878,7 +3878,7 @@ def _pipeline_cleanup_handoff_data_from_session(
     if not ledger_path.exists():
         snapshot_cleanup = public_snapshot.get("cleanup") if isinstance(public_snapshot, dict) else None
         if _public_cleanup_snapshot_has_pending_evidence(snapshot_cleanup):
-            return _cleanup_state_unavailable_payload()
+            return _cleanup_state_unavailable_payload(reason="ledger_missing")
         return None
     return _pipeline_cleanup_handoff_data_from_ledger(CleanupLedger(ledger_path))
 
@@ -3887,36 +3887,80 @@ def _pipeline_cleanup_handoff_data_from_ledger(ledger: Any) -> dict[str, Any] | 
     try:
         ledger_path = getattr(ledger, "path", None)
         if ledger_path is not None and not Path(ledger_path).exists():
-            return _cleanup_state_unavailable_payload()
+            return _cleanup_state_unavailable_payload(reason="ledger_missing")
         load_failed = getattr(ledger, "load_failed", None)
         if callable(load_failed) and load_failed():
-            return _cleanup_state_unavailable_payload()
+            return _cleanup_state_unavailable_payload(
+                reason="load_failed",
+                load_error=_cleanup_ledger_load_error(ledger),
+            )
         build_pending_prompt = getattr(ledger, "build_pending_prompt", None)
         if not callable(build_pending_prompt):
             return None
         prompt = build_pending_prompt()
+        summary = _cleanup_state_summary(ledger)
     except Exception:
         logger.warning("Failed to build A2A pipeline cleanup handoff data", exc_info=True)
-        return _cleanup_state_unavailable_payload()
-    if prompt is None:
-        return None
+        return _cleanup_state_unavailable_payload(reason="build_failed")
 
-    resources = list(getattr(prompt, "resources", []) or [])
+    resources = list(getattr(prompt, "resources", []) or []) if prompt is not None else []
     if not resources:
-        return None
+        return _cleanup_state_payload_from_summary(summary)
     return {
-        "status": "pending",
+        "status": _cleanup_pending_status(summary),
         "resourceCount": len(resources),
-        "statusMessage": str(getattr(prompt, "status_message", "") or ""),
+        "statusMessage": _cleanup_pending_status_message(summary, prompt),
         "resources": [_cleanup_resource_handoff_data(resource) for resource in resources],
     }
 
 
-def _cleanup_state_unavailable_payload() -> dict[str, Any]:
+def _cleanup_pending_status(summary: Any) -> str:
+    status = str(getattr(summary, "status", "") or "") if summary is not None else ""
+    return status or "pending"
+
+
+def _cleanup_pending_status_message(summary: Any, prompt: Any) -> str:
+    if _cleanup_pending_status(summary) == "pending":
+        return str(getattr(prompt, "status_message", "") or "")
+    return str(getattr(summary, "status_message", "") or "")
+
+
+def _cleanup_state_summary(ledger: Any) -> Any:
+    build_state_summary = getattr(ledger, "build_state_summary", None)
+    return build_state_summary() if callable(build_state_summary) else None
+
+
+def _cleanup_state_payload_from_summary(summary: Any) -> dict[str, Any] | None:
+    if summary is None:
+        return None
+    payload: dict[str, Any] = {
+        "status": str(getattr(summary, "status", "") or "skipped"),
+        "statusMessage": str(getattr(summary, "status_message", "") or ""),
+        "resourceCount": int(getattr(summary, "resource_count", 0) or 0),
+    }
+    if bool(getattr(summary, "skipped", False)):
+        payload["skipped"] = True
+    return payload
+
+
+def _cleanup_ledger_load_error(ledger: Any) -> str | None:
+    load_error = getattr(ledger, "load_error", None)
+    if not callable(load_error):
+        return None
+    try:
+        return load_error()
+    except Exception:
+        logger.warning("Failed to read A2A pipeline cleanup ledger load error", exc_info=True)
+        return None
+
+
+def _cleanup_state_unavailable_payload(*, reason: str, load_error: str | None = None) -> dict[str, Any]:
     return {
         "status": "unavailable",
-        "statusMessage": _("Cleanup state unavailable. Inspect the session file and cloud resources manually."),
+        "unavailableReason": reason,
+        "statusMessage": cleanup_state_unavailable_message(reason=reason, load_error=load_error),
     }
+
 
 
 def _public_cleanup_snapshot_has_pending_evidence(cleanup: Any) -> bool:

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -74,14 +74,6 @@ msgstr "MCP-Warnung: {message}"
 msgid "A temporary error occurred. Please retry."
 msgstr "Ein temporärer Fehler ist aufgetreten. Bitte erneut versuchen."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-msgid ""
-"Cleanup state unavailable. Inspect the session file and cloud resources "
-"manually."
-msgstr ""
-"Bereinigungsstatus nicht verfügbar. Prüfen Sie die Sitzungsdatei und "
-"Cloud-Ressourcen manuell."
-
 #: src/iac_code/a2a/executor.py
 msgid ""
 "Rollback cleanup deferred prompt state is unavailable. Please repair it "
@@ -3796,6 +3788,65 @@ msgid "Detected {count} rollback cleanup resources; starting cleanup."
 msgstr ""
 "{count} Rollback-Bereinigungsressourcen erkannt; Bereinigung wird "
 "gestartet."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger is missing, so cleanup state cannot be audited."
+msgstr ""
+"Das Cleanup-Ledger fehlt, daher kann der Cleanup-Status nicht geprueft "
+"werden."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup ledger could not be read ({error}), so cleanup state cannot be "
+"audited."
+msgstr ""
+"Das Cleanup-Ledger konnte nicht gelesen werden ({error}), daher kann der "
+"Cleanup-Status nicht geprueft werden."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger could not be read, so cleanup state cannot be audited."
+msgstr ""
+"Das Cleanup-Ledger konnte nicht gelesen werden, daher kann der Cleanup-"
+"Status nicht geprueft werden."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "No cloud resources required cleanup."
+msgstr "Keine Cloud-Ressourcen mussten bereinigt werden."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup skipped for {count} tracked resources."
+msgstr "Bereinigung fuer {count} verfolgte Ressourcen uebersprungen."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup completed for {count} resources."
+msgstr "Bereinigung fuer {count} Ressourcen abgeschlossen."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup failed for {failed} of {count} resources."
+msgstr "Bereinigung fuer {failed} von {count} Ressourcen fehlgeschlagen."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup partially completed: {completed} done, {failed} failed, {pending}"
+" still pending out of {count} resources."
+msgstr ""
+"Bereinigung teilweise abgeschlossen: {completed} erledigt, {failed} "
+"fehlgeschlagen, {pending} noch offen von {count} Ressourcen."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup pending for {count} resources."
+msgstr "Bereinigung fuer {count} Ressourcen ausstehend."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup in progress for {pending} of {count} resources."
+msgstr "Bereinigung fuer {pending} von {count} Ressourcen laeuft."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -12695,3 +12746,13 @@ msgstr "Bash zulassen?"
 #~ msgstr ""
 #~ "Tool-Aufruf genehmigen: {tool}\n"
 #~ "Eingabezusammenfassung: {summary}"
+
+#~ msgid ""
+#~ "Cleanup state unavailable. Inspect the "
+#~ "session file and cloud resources "
+#~ "manually."
+#~ msgstr ""
+#~ "Bereinigungsstatus nicht verfügbar. Prüfen Sie"
+#~ " die Sitzungsdatei und Cloud-Ressourcen "
+#~ "manuell."
+

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -75,14 +75,6 @@ msgstr "Advertencia MCP: {message}"
 msgid "A temporary error occurred. Please retry."
 msgstr "Se produjo un error temporal. Inténtalo de nuevo."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-msgid ""
-"Cleanup state unavailable. Inspect the session file and cloud resources "
-"manually."
-msgstr ""
-"Estado de limpieza no disponible. Inspeccione manualmente el archivo de "
-"sesión y los recursos en la nube."
-
 #: src/iac_code/a2a/executor.py
 msgid ""
 "Rollback cleanup deferred prompt state is unavailable. Please repair it "
@@ -3777,6 +3769,65 @@ msgid "Detected {count} rollback cleanup resources; starting cleanup."
 msgstr ""
 "Se detectaron {count} recursos de limpieza de rollback; iniciando "
 "limpieza."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger is missing, so cleanup state cannot be audited."
+msgstr ""
+"Falta el registro de limpieza, por lo que no se puede auditar el estado "
+"de limpieza."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup ledger could not be read ({error}), so cleanup state cannot be "
+"audited."
+msgstr ""
+"No se pudo leer el registro de limpieza ({error}), por lo que no se puede"
+" auditar el estado de limpieza."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger could not be read, so cleanup state cannot be audited."
+msgstr ""
+"No se pudo leer el registro de limpieza, por lo que no se puede auditar "
+"el estado de limpieza."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "No cloud resources required cleanup."
+msgstr "Ningún recurso en la nube requirió limpieza."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup skipped for {count} tracked resources."
+msgstr "Limpieza omitida para {count} recursos rastreados."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup completed for {count} resources."
+msgstr "Limpieza completada para {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup failed for {failed} of {count} resources."
+msgstr "La limpieza falló en {failed} de {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup partially completed: {completed} done, {failed} failed, {pending}"
+" still pending out of {count} resources."
+msgstr ""
+"Limpieza parcialmente completada: {completed} listos, {failed} fallidos, "
+"{pending} pendientes de {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup pending for {count} resources."
+msgstr "Limpieza pendiente para {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup in progress for {pending} of {count} resources."
+msgstr "Limpieza en curso para {pending} de {count} recursos."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -12612,3 +12663,13 @@ msgstr "¿Permitir Bash?"
 #~ msgstr ""
 #~ "Aprobar llamada de herramienta: {tool}\n"
 #~ "Resumen de entrada: {summary}"
+
+#~ msgid ""
+#~ "Cleanup state unavailable. Inspect the "
+#~ "session file and cloud resources "
+#~ "manually."
+#~ msgstr ""
+#~ "Estado de limpieza no disponible. "
+#~ "Inspeccione manualmente el archivo de "
+#~ "sesión y los recursos en la nube."
+

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -75,14 +75,6 @@ msgstr "Avertissement MCP : {message}"
 msgid "A temporary error occurred. Please retry."
 msgstr "Une erreur temporaire s’est produite. Veuillez réessayer."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-msgid ""
-"Cleanup state unavailable. Inspect the session file and cloud resources "
-"manually."
-msgstr ""
-"État de nettoyage indisponible. Inspectez manuellement le fichier de "
-"session et les ressources cloud."
-
 #: src/iac_code/a2a/executor.py
 msgid ""
 "Rollback cleanup deferred prompt state is unavailable. Please repair it "
@@ -3791,6 +3783,65 @@ msgid "Detected {count} rollback cleanup resources; starting cleanup."
 msgstr ""
 "{count} ressources de nettoyage du rollback détectées ; démarrage du "
 "nettoyage."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger is missing, so cleanup state cannot be audited."
+msgstr ""
+"Le registre de nettoyage est absent, l'état du nettoyage ne peut donc pas"
+" être audité."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup ledger could not be read ({error}), so cleanup state cannot be "
+"audited."
+msgstr ""
+"Le registre de nettoyage n'a pas pu être lu ({error}), l'état du "
+"nettoyage ne peut donc pas être audité."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger could not be read, so cleanup state cannot be audited."
+msgstr ""
+"Le registre de nettoyage n'a pas pu être lu, l'état du nettoyage ne peut "
+"donc pas être audité."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "No cloud resources required cleanup."
+msgstr "Aucune ressource cloud n'a nécessité de nettoyage."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup skipped for {count} tracked resources."
+msgstr "Nettoyage ignoré pour {count} ressources suivies."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup completed for {count} resources."
+msgstr "Nettoyage terminé pour {count} ressources."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup failed for {failed} of {count} resources."
+msgstr "Le nettoyage a échoué pour {failed} ressources sur {count}."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup partially completed: {completed} done, {failed} failed, {pending}"
+" still pending out of {count} resources."
+msgstr ""
+"Nettoyage partiellement terminé : {completed} effectués, {failed} en "
+"échec, {pending} encore en attente sur {count} ressources."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup pending for {count} resources."
+msgstr "Nettoyage en attente pour {count} ressources."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup in progress for {pending} of {count} resources."
+msgstr "Nettoyage en cours pour {pending} ressources sur {count}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -12678,3 +12729,13 @@ msgstr "Autoriser Bash ?"
 #~ msgstr ""
 #~ "Approuver l'appel d'outil : {tool}\n"
 #~ "Résumé de l'entrée : {summary}"
+
+#~ msgid ""
+#~ "Cleanup state unavailable. Inspect the "
+#~ "session file and cloud resources "
+#~ "manually."
+#~ msgstr ""
+#~ "État de nettoyage indisponible. Inspectez "
+#~ "manuellement le fichier de session et"
+#~ " les ressources cloud."
+

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -68,12 +68,6 @@ msgstr "MCP 警告: {message}"
 msgid "A temporary error occurred. Please retry."
 msgstr "一時的なエラーが発生しました。再試行してください。"
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-msgid ""
-"Cleanup state unavailable. Inspect the session file and cloud resources "
-"manually."
-msgstr "クリーンアップ状態を利用できません。セッションファイルとクラウドリソースを手動で確認してください。"
-
 #: src/iac_code/a2a/executor.py
 msgid ""
 "Rollback cleanup deferred prompt state is unavailable. Please repair it "
@@ -3617,6 +3611,59 @@ msgstr ""
 #, python-brace-format
 msgid "Detected {count} rollback cleanup resources; starting cleanup."
 msgstr "{count} 件のロールバッククリーンアップリソースを検出しました。クリーンアップを開始します。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger is missing, so cleanup state cannot be audited."
+msgstr "クリーンアップ台帳が存在しないため、クリーンアップ状態を監査できません。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup ledger could not be read ({error}), so cleanup state cannot be "
+"audited."
+msgstr "クリーンアップ台帳を読み取れませんでした（{error}）。クリーンアップ状態を監査できません。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger could not be read, so cleanup state cannot be audited."
+msgstr "クリーンアップ台帳を読み取れませんでした。クリーンアップ状態を監査できません。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "No cloud resources required cleanup."
+msgstr "クリーンアップが必要なクラウドリソースはありませんでした。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup skipped for {count} tracked resources."
+msgstr "追跡中の {count} 件のリソースのクリーンアップをスキップしました。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup completed for {count} resources."
+msgstr "{count} 件のリソースのクリーンアップが完了しました。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup failed for {failed} of {count} resources."
+msgstr "{count} 件のうち {failed} 件のリソースのクリーンアップが失敗しました。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup partially completed: {completed} done, {failed} failed, {pending}"
+" still pending out of {count} resources."
+msgstr ""
+"クリーンアップは部分的に完了しました：{count} 件のうち {completed} 件完了、{failed} 件失敗、{pending} "
+"件が未処理です。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup pending for {count} resources."
+msgstr "{count} 件のリソースのクリーンアップが保留中です。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup in progress for {pending} of {count} resources."
+msgstr "{count} 件のうち {pending} 件のリソースのクリーンアップが進行中です。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -11706,3 +11753,10 @@ msgstr "Bash を許可しますか？"
 #~ msgstr ""
 #~ "ツール呼び出しを承認: {tool}\n"
 #~ "入力サマリー: {summary}"
+
+#~ msgid ""
+#~ "Cleanup state unavailable. Inspect the "
+#~ "session file and cloud resources "
+#~ "manually."
+#~ msgstr "クリーンアップ状態を利用できません。セッションファイルとクラウドリソースを手動で確認してください。"
+

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -74,14 +74,6 @@ msgstr "Aviso MCP: {message}"
 msgid "A temporary error occurred. Please retry."
 msgstr "Ocorreu um erro temporário. Tente novamente."
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-msgid ""
-"Cleanup state unavailable. Inspect the session file and cloud resources "
-"manually."
-msgstr ""
-"Estado de limpeza indisponível. Inspecione manualmente o arquivo de "
-"sessão e os recursos de nuvem."
-
 #: src/iac_code/a2a/executor.py
 msgid ""
 "Rollback cleanup deferred prompt state is unavailable. Please repair it "
@@ -3759,6 +3751,65 @@ msgstr ""
 #, python-brace-format
 msgid "Detected {count} rollback cleanup resources; starting cleanup."
 msgstr "{count} recursos de limpeza de rollback detectados; iniciando limpeza."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger is missing, so cleanup state cannot be audited."
+msgstr ""
+"O registro de limpeza está ausente, portanto o estado de limpeza não pode"
+" ser auditado."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup ledger could not be read ({error}), so cleanup state cannot be "
+"audited."
+msgstr ""
+"Não foi possível ler o registro de limpeza ({error}), portanto o estado "
+"de limpeza não pode ser auditado."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger could not be read, so cleanup state cannot be audited."
+msgstr ""
+"Não foi possível ler o registro de limpeza, portanto o estado de limpeza "
+"não pode ser auditado."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "No cloud resources required cleanup."
+msgstr "Nenhum recurso de nuvem exigiu limpeza."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup skipped for {count} tracked resources."
+msgstr "Limpeza ignorada para {count} recursos rastreados."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup completed for {count} resources."
+msgstr "Limpeza concluída para {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup failed for {failed} of {count} resources."
+msgstr "A limpeza falhou em {failed} de {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup partially completed: {completed} done, {failed} failed, {pending}"
+" still pending out of {count} resources."
+msgstr ""
+"Limpeza parcialmente concluída: {completed} concluídos, {failed} com "
+"falha, {pending} ainda pendentes de {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup pending for {count} resources."
+msgstr "Limpeza pendente para {count} recursos."
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup in progress for {pending} of {count} resources."
+msgstr "Limpeza em andamento para {pending} de {count} recursos."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -12506,3 +12557,13 @@ msgstr "Permitir Bash?"
 #~ msgstr ""
 #~ "Aprovar chamada de ferramenta: {tool}\n"
 #~ "Resumo da entrada: {summary}"
+
+#~ msgid ""
+#~ "Cleanup state unavailable. Inspect the "
+#~ "session file and cloud resources "
+#~ "manually."
+#~ msgstr ""
+#~ "Estado de limpeza indisponível. Inspecione "
+#~ "manualmente o arquivo de sessão e "
+#~ "os recursos de nuvem."
+

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -68,12 +68,6 @@ msgstr "MCP 警告：{message}"
 msgid "A temporary error occurred. Please retry."
 msgstr "发生临时错误，请重试。"
 
-#: src/iac_code/a2a/executor.py src/iac_code/a2a/pipeline_executor.py
-msgid ""
-"Cleanup state unavailable. Inspect the session file and cloud resources "
-"manually."
-msgstr "清理状态不可用。请手动检查会话文件和云资源。"
-
 #: src/iac_code/a2a/executor.py
 msgid ""
 "Rollback cleanup deferred prompt state is unavailable. Please repair it "
@@ -3583,6 +3577,57 @@ msgstr ""
 #, python-brace-format
 msgid "Detected {count} rollback cleanup resources; starting cleanup."
 msgstr "检测到 {count} 个回滚清理资源；开始清理。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger is missing, so cleanup state cannot be audited."
+msgstr "清理台账缺失，无法审计清理状态。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup ledger could not be read ({error}), so cleanup state cannot be "
+"audited."
+msgstr "清理台账读取失败（{error}），无法审计清理状态。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "Cleanup ledger could not be read, so cleanup state cannot be audited."
+msgstr "清理台账读取失败，无法审计清理状态。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+msgid "No cloud resources required cleanup."
+msgstr "没有云资源需要清理。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup skipped for {count} tracked resources."
+msgstr "已跳过 {count} 个跟踪资源的清理。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup completed for {count} resources."
+msgstr "已完成 {count} 个资源的清理。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup failed for {failed} of {count} resources."
+msgstr "{count} 个资源中有 {failed} 个清理失败。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid ""
+"Cleanup partially completed: {completed} done, {failed} failed, {pending}"
+" still pending out of {count} resources."
+msgstr "清理部分完成：共 {count} 个资源，{completed} 个已完成，{failed} 个失败，{pending} 个仍待处理。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup pending for {count} resources."
+msgstr "有 {count} 个资源等待清理。"
+
+#: src/iac_code/pipeline/engine/cleanup.py
+#, python-brace-format
+msgid "Cleanup in progress for {pending} of {count} resources."
+msgstr "{count} 个资源中有 {pending} 个正在清理。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -11493,3 +11538,10 @@ msgstr "允许 Bash?"
 #~ msgstr ""
 #~ "批准工具调用：{tool}\n"
 #~ "输入摘要：{summary}"
+
+#~ msgid ""
+#~ "Cleanup state unavailable. Inspect the "
+#~ "session file and cloud resources "
+#~ "manually."
+#~ msgstr "清理状态不可用。请手动检查会话文件和云资源。"
+

--- a/src/iac_code/pipeline/engine/cleanup.py
+++ b/src/iac_code/pipeline/engine/cleanup.py
@@ -28,6 +28,15 @@ from iac_code.utils.state_io import atomic_write_text
 logger = logging.getLogger(__name__)
 
 CleanupStatus = Literal["pending", "started", "in_progress", "completed", "failed", "skipped"]
+CleanupAggregateStatus = Literal[
+    "pending",
+    "started",
+    "in_progress",
+    "completed",
+    "failed",
+    "skipped",
+    "partial",
+]
 _LOAD_FAILED_KEY = "_load_failed"
 _LOAD_ERROR_KEY = "_load_error"
 _RETRYABLE_CLEANUP_STATUSES = {"pending", "failed"}
@@ -152,6 +161,24 @@ class CleanupPrompt:
     resources: list[CleanupResource]
     prompt: str
     status_message: str
+
+
+@dataclass(frozen=True)
+class CleanupStateSummary:
+    """Auditable cleanup state derived from the ledger.
+
+    The summary reports the real cleanup outcome (``skipped`` / ``completed`` /
+    ``partial`` / ``failed`` / active statuses) so exporters never have to fall
+    back to a static placeholder message.
+    """
+
+    status: CleanupAggregateStatus
+    status_message: str
+    resource_count: int
+    pending_count: int
+    failed_count: int
+    completed_count: int
+    skipped: bool
 
 
 @dataclass(frozen=True)
@@ -535,6 +562,31 @@ class CleanupLedger:
             status_message=_("Detected {count} rollback cleanup resources; starting cleanup.").format(count=count),
         )
 
+    def build_state_summary(self) -> CleanupStateSummary:
+        """Summarize the real cleanup state so exporters can publish it verbatim."""
+
+        resources = [resource for resource in self.cleanup_resources() if resource.cleanup_required]
+        statuses = [resource.cleanup_status for resource in resources]
+        pending_count = sum(1 for status in statuses if status in _FOLLOWUP_CLEANUP_STATUSES)
+        failed_count = sum(1 for status in statuses if status == "failed")
+        completed_count = sum(1 for status in statuses if status in _TERMINAL_CLEANUP_STATUSES)
+        status = _aggregate_ledger_cleanup_status(statuses)
+        return CleanupStateSummary(
+            status=status,
+            status_message=_cleanup_state_message(
+                status,
+                resource_count=len(resources),
+                failed_count=failed_count,
+                completed_count=completed_count,
+                pending_count=pending_count,
+            ),
+            resource_count=len(resources),
+            pending_count=pending_count,
+            failed_count=failed_count,
+            completed_count=completed_count,
+            skipped=status == "skipped",
+        )
+
     def _load(self) -> dict[str, Any]:
         if not self.path.exists():
             return _empty_ledger_data()
@@ -910,6 +962,69 @@ def _cleanup_tool_input_summary(
 
 def _is_cleanup_stack_tool_name(tool_name: str) -> bool:
     return tool_name.lower() in {"ros_stack", "aliyun_api"}
+
+
+def cleanup_state_unavailable_message(*, reason: str, load_error: str | None = None) -> str:
+    """Auditable message for the only case where cleanup state is truly unknown."""
+
+    if reason == "ledger_missing":
+        return _("Cleanup ledger is missing, so cleanup state cannot be audited.")
+    if load_error:
+        return _("Cleanup ledger could not be read ({error}), so cleanup state cannot be audited.").format(
+            error=sanitize_strict_text(load_error),
+        )
+    return _("Cleanup ledger could not be read, so cleanup state cannot be audited.")
+
+
+def _aggregate_ledger_cleanup_status(statuses: list[CleanupStatus]) -> CleanupAggregateStatus:
+    if not statuses:
+        return "skipped"
+    if "failed" in statuses:
+        return "failed" if all(status == "failed" for status in statuses) else "partial"
+    if any(status in _ACTIVE_CLEANUP_STATUSES for status in statuses):
+        return "in_progress" if "in_progress" in statuses else "started"
+    if all(status in _TERMINAL_CLEANUP_STATUSES for status in statuses):
+        return "skipped" if all(status == "skipped" for status in statuses) else "completed"
+    if all(status == "pending" for status in statuses):
+        return "pending"
+    return "partial"
+
+
+def _cleanup_state_message(
+    status: CleanupAggregateStatus,
+    *,
+    resource_count: int,
+    failed_count: int,
+    completed_count: int,
+    pending_count: int,
+) -> str:
+    if status == "skipped":
+        if resource_count == 0:
+            return _("No cloud resources required cleanup.")
+        return _("Cleanup skipped for {count} tracked resources.").format(count=resource_count)
+    if status == "completed":
+        return _("Cleanup completed for {count} resources.").format(count=resource_count)
+    if status == "failed":
+        return _("Cleanup failed for {failed} of {count} resources.").format(
+            failed=failed_count,
+            count=resource_count,
+        )
+    if status == "partial":
+        return _(
+            "Cleanup partially completed: {completed} done, {failed} failed, {pending} still pending "
+            "out of {count} resources."
+        ).format(
+            completed=completed_count,
+            failed=failed_count,
+            pending=pending_count,
+            count=resource_count,
+        )
+    if status == "pending":
+        return _("Cleanup pending for {count} resources.").format(count=pending_count)
+    return _("Cleanup in progress for {pending} of {count} resources.").format(
+        pending=pending_count,
+        count=resource_count,
+    )
 
 
 def _cleanup_status_from_stack_status(status: str | None, is_error: bool) -> CleanupStatus:

--- a/tests/a2a/test_executor_cleanup.py
+++ b/tests/a2a/test_executor_cleanup.py
@@ -67,6 +67,81 @@ def test_a2a_handoff_does_not_reconstruct_cleanup_prompt_from_public_snapshot(tm
     assert "resources" not in cleanup
 
 
+def test_missing_cleanup_ledger_reports_auditable_unavailable_reason(tmp_path: Path) -> None:
+    cleanup = _cleanup_payload_from_private_ledger_or_unavailable(
+        ledger_path=tmp_path / "missing-cleanup.yaml",
+    )
+
+    assert cleanup["status"] == "unavailable"
+    assert cleanup["unavailableReason"] == "ledger_missing"
+    assert "unavailable" not in cleanup["statusMessage"].lower()
+
+
+def test_corrupt_cleanup_ledger_reports_load_failure_reason(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "cleanup.yaml"
+    ledger_path.write_text("::: not yaml :::\n\t- broken", encoding="utf-8")
+
+    cleanup = _cleanup_payload_from_private_ledger_or_unavailable(ledger_path=ledger_path)
+
+    assert cleanup["status"] == "unavailable"
+    assert cleanup["unavailableReason"] == "load_failed"
+    assert "unavailable" not in cleanup["statusMessage"].lower()
+
+
+def test_cleanup_payload_reports_skipped_when_no_cleanup_was_required(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "cleanup.yaml"
+    ledger = CleanupLedger(ledger_path)
+    ledger.record_observed(
+        ObservedResource(
+            provider="ros",
+            resource_type="stack",
+            resource_id="stack-delivered",
+            region_id="cn-hangzhou",
+            observed_action="CreateStack",
+            source_step_id="deploying",
+        )
+    )
+
+    cleanup = _cleanup_payload_from_private_ledger_or_unavailable(ledger_path=ledger_path)
+
+    assert cleanup["status"] == "skipped"
+    assert cleanup["skipped"] is True
+    assert cleanup["resourceCount"] == 0
+    assert "unavailable" not in cleanup["statusMessage"].lower()
+
+
+def test_cleanup_payload_reports_completed_after_cleanup_finished(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "cleanup.yaml"
+    ledger = CleanupLedger(ledger_path)
+    ledger.mark_cleanup_required(
+        [
+            CleanupResource(
+                provider="ros",
+                resource_type="stack",
+                resource_id="stack-leftover",
+                region_id="cn-hangzhou",
+                source_step_id="deploying",
+            )
+        ],
+        source_step_id="deploying",
+        reason="rollback",
+    )
+    ledger.update_resource(
+        provider="ros",
+        resource_type="stack",
+        resource_id="stack-leftover",
+        region_id="cn-hangzhou",
+        cleanup_status="completed",
+    )
+
+    cleanup = _cleanup_payload_from_private_ledger_or_unavailable(ledger_path=ledger_path)
+
+    assert cleanup["status"] == "completed"
+    assert cleanup["resourceCount"] == 1
+    assert "skipped" not in cleanup
+    assert "unavailable" not in cleanup["statusMessage"].lower()
+
+
 def test_normal_chat_cleanup_ledger_ignores_observed_only_ledger(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -6137,6 +6137,81 @@ def test_cleanup_handoff_missing_ledger_does_not_reconstruct_prompt_from_public_
     assert "prompt" not in cleanup
     assert "resources" not in cleanup
     assert "stack-public-only" not in repr(cleanup)
+    assert cleanup["unavailableReason"] == "ledger_missing"
+    assert "unavailable" not in cleanup["statusMessage"].lower()
+
+
+def test_cleanup_handoff_from_ledger_reports_skipped_when_nothing_needed_cleanup(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import _pipeline_cleanup_handoff_data_from_ledger
+    from iac_code.pipeline.engine.cleanup import CleanupLedger, ObservedResource
+
+    ledger = CleanupLedger(tmp_path / "cleanup.yaml")
+    ledger.record_observed(
+        ObservedResource(
+            provider="ros",
+            resource_type="stack",
+            resource_id="stack-delivered",
+            region_id="cn-hangzhou",
+            observed_action="CreateStack",
+            source_step_id="deploying",
+        )
+    )
+
+    cleanup = _pipeline_cleanup_handoff_data_from_ledger(ledger)
+
+    assert cleanup is not None
+    assert cleanup["status"] == "skipped"
+    assert cleanup["skipped"] is True
+    assert "unavailable" not in cleanup["statusMessage"].lower()
+
+
+def test_cleanup_handoff_from_ledger_reports_partial_state(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import _pipeline_cleanup_handoff_data_from_ledger
+    from iac_code.pipeline.engine.cleanup import CleanupLedger, CleanupResource
+
+    ledger = CleanupLedger(tmp_path / "cleanup.yaml")
+    ledger.mark_cleanup_required(
+        [
+            CleanupResource(
+                provider="ros",
+                resource_type="stack",
+                resource_id="stack-done",
+                region_id="cn-hangzhou",
+                source_step_id="deploying",
+            ),
+            CleanupResource(
+                provider="ros",
+                resource_type="stack",
+                resource_id="stack-broken",
+                region_id="cn-hangzhou",
+                source_step_id="deploying",
+            ),
+        ],
+        source_step_id="deploying",
+        reason="rollback",
+    )
+    ledger.update_resource(
+        provider="ros",
+        resource_type="stack",
+        resource_id="stack-done",
+        region_id="cn-hangzhou",
+        cleanup_status="completed",
+    )
+    ledger.update_resource(
+        provider="ros",
+        resource_type="stack",
+        resource_id="stack-broken",
+        region_id="cn-hangzhou",
+        cleanup_status="failed",
+        last_error="DELETE_FAILED",
+    )
+
+    cleanup = _pipeline_cleanup_handoff_data_from_ledger(ledger)
+
+    assert cleanup is not None
+    assert cleanup["status"] == "partial"
+    assert cleanup["resourceCount"] == 1
+    assert "unavailable" not in cleanup["statusMessage"].lower()
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -160,6 +160,50 @@ def test_reduce_cleanup_handoff_updates_snapshot_cleanup() -> None:
     assert snapshot["normalHandoff"]["data"]["cleanup"]["resourceCount"] == 1
 
 
+def test_reduce_cleanup_handoff_keeps_real_terminal_cleanup_status_auditable() -> None:
+    handoff = _base("evt-cleanup-skipped", 1, "pipeline_handoff_ready", status="completed")
+    handoff["data"] = {
+        "action": "switch_to_normal",
+        "targetMode": "normal",
+        "outcome": "completed",
+        "summary": "[Pipeline Handoff Context]",
+        "cleanup": {
+            "status": "skipped",
+            "skipped": True,
+            "resourceCount": 0,
+            "statusMessage": "No cloud resources required cleanup.",
+        },
+    }
+
+    snapshot = reduce_pipeline_events([handoff])
+
+    assert snapshot["cleanup"]["status"] == "skipped"
+    assert snapshot["cleanup"]["skipped"] is True
+    assert "unavailable" not in snapshot["cleanup"]["statusMessage"].lower()
+    assert snapshot["cleanup"]["history"][-1]["status"] == "skipped"
+
+
+def test_reduce_cleanup_handoff_preserves_partial_cleanup_status() -> None:
+    handoff = _base("evt-cleanup-partial", 1, "pipeline_handoff_ready", status="completed")
+    handoff["data"] = {
+        "action": "switch_to_normal",
+        "targetMode": "normal",
+        "outcome": "completed",
+        "summary": "[Pipeline Handoff Context]",
+        "cleanup": {
+            "status": "partial",
+            "resourceCount": 2,
+            "statusMessage": "Cleanup partially completed: 1 done, 1 failed, 0 still pending out of 2 resources.",
+        },
+    }
+
+    snapshot = reduce_pipeline_events([handoff])
+
+    assert snapshot["cleanup"]["status"] == "partial"
+    assert snapshot["cleanup"]["history"][-1]["status"] == "partial"
+    assert "unavailable" not in snapshot["cleanup"]["statusMessage"].lower()
+
+
 def test_reduce_cleanup_progress_events_update_snapshot_cleanup() -> None:
     started = _base("evt-cleanup-started", 1, "cleanup_started", scope="cleanup")
     started["data"] = {


### PR DESCRIPTION
## Why

`pipeline_snapshot.cleanup.statusMessage` always showed the static placeholder `Cleanup state unavailable. Inspect the session file and cloud resources manually.` and `cleanup.history[].status` was recorded as `unavailable`, so cleanup outcomes were not auditable (evidence sessions b16facddf1324814bdf2e13d1ecedf8b etc., 2026-07-14).

## Root cause

The A2A cleanup exporters (`_pipeline_cleanup_handoff_data_from_ledger` / `_pipeline_cleanup_handoff_data_from_session` in `a2a/pipeline_executor.py`, `_cleanup_payload_from_private_ledger_or_unavailable` in `a2a/executor.py`) only distinguished "has a pending cleanup prompt" from "no prompt". Every other path either emitted the placeholder payload or dropped `data.cleanup` entirely, so the snapshot reducer kept stale/placeholder state.

## What changed

- `pipeline/engine/cleanup.py`: new `CleanupLedger.build_state_summary()` + `CleanupStateSummary` deriving an auditable aggregate status (`skipped` / `completed` / `partial` / `failed` / `pending` / `in_progress`) with a human-readable, translatable status message; `cleanup_state_unavailable_message()` carries the actual reason (`ledger_missing` / `load_failed` + load error).
- `a2a/pipeline_executor.py` / `a2a/executor.py`: exporters now publish the real cleanup state in `pipeline_handoff_ready.data.cleanup` (with `skipped: true` when nothing needed cleanup); `unavailable` is reserved for a genuinely missing/unreadable ledger and includes `unavailableReason`.
- Removed the old placeholder string; updated `messages` catalogs for zh/es/fr/de/ja/pt.
- Tests: new/updated cases in `tests/a2a/test_executor_cleanup.py`, `tests/a2a/test_pipeline_executor.py`, `tests/a2a/test_pipeline_snapshot.py` asserting `statusMessage` no longer contains `unavailable` for real states and `cleanup.history[].status` reflects the ledger.

## Verification

- `tests/a2a + tests/pipeline + tests/i18n + tests/test_i18n.py`: 3034 passed
- `tests/web + tests/services`: 2132 passed, 2 skipped
- `ruff check` / `ty check`: pass
- Only deselected test `tests/pipeline/engine/test_prerequisites.py::test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` also fails on the unmodified baseline (sandbox proxy changes the HTTPError text) — unrelated.

Harness WorkItem: ced39a2e-3a62-4d8c-87ad-0b2c13c60803