### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 __release_date__ = ""

--- a/src/iac_code/a2a/events.py
+++ b/src/iac_code/a2a/events.py
@@ -206,9 +206,7 @@ def _tool_result_metadata_value(value: Any, *, _depth: int = 0, _artifact_scope:
             )
         return output
     if isinstance(value, list | tuple):
-        return [
-            _tool_result_metadata_value(item, _depth=_depth + 1, _artifact_scope=_artifact_scope) for item in value
-        ]
+        return [_tool_result_metadata_value(item, _depth=_depth + 1, _artifact_scope=_artifact_scope) for item in value]
     if value is None or isinstance(value, bool | int | float):
         return value
     return str(value)[:_METADATA_MAX_CHARS]

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -110,6 +110,8 @@ _CONTEXT_LOCK_ACQUIRE_TIMEOUT_SECONDS = 1
 _CANCEL_ACTIVE_TASK_DRAIN_TIMEOUT_SECONDS = 30
 _ERROR_TEXT_MAX_CHARS = 1000
 _DEFERRED_CLEANUP_PROMPTS_FILENAME = "cleanup-deferred-prompts.json"
+
+
 def _format_exception(exc: BaseException) -> str:
     message = str(exc)
     raw = type(exc).__name__ if not message else f"{type(exc).__name__}: {message}"

--- a/src/iac_code/a2a/pipeline_stream.py
+++ b/src/iac_code/a2a/pipeline_stream.py
@@ -101,6 +101,8 @@ _EXTREME_DEFERRED_EVENT_TYPES = {"text_delta", "thinking_delta"}
 _EXTREME_JOURNAL_FLUSH_EVENTS = 512
 _RECOVERY_STATE_SCOPES = {"step", "candidate", "candidateStep", "candidate_step"}
 _RECOVERY_STATE_STATUSES = {"working"}
+
+
 def backup_committed_delivery_envelope(
     ack_envelope: dict[str, Any],
     committed_envelope: dict[str, Any],
@@ -1034,10 +1036,10 @@ class PipelineA2AEventPublisher:
 
     async def _enqueue_artifact_update(self, envelope: dict[str, Any], artifact_metadata: dict[str, Any]) -> None:
         event = _artifact_update_event(
-                task_id=self._delivery_task_id(envelope),
-                context_id=self._delivery_context_id(envelope),
-                metadata=artifact_metadata,
-            )
+            task_id=self._delivery_task_id(envelope),
+            context_id=self._delivery_context_id(envelope),
+            metadata=artifact_metadata,
+        )
         await self.event_queue.enqueue_event(event)
 
     async def _apply_permission_metadata(

--- a/src/iac_code/a2a/projection.py
+++ b/src/iac_code/a2a/projection.py
@@ -386,9 +386,7 @@ def _project_mapping(
     public_path_roots: Iterable[Mapping[str, str]] | None,
 ) -> dict[Any, Any]:
     unchanged_keys = {
-        key
-        for key in value
-        if not isinstance(key, str) or redact_known_public_paths(key, public_path_roots) == key
+        key for key in value if not isinstance(key, str) or redact_known_public_paths(key, public_path_roots) == key
     }
     used_keys: set[Any] = set()
     projected: dict[Any, Any] = {}

--- a/src/iac_code/acp/session.py
+++ b/src/iac_code/acp/session.py
@@ -95,16 +95,12 @@ def _history_tool_input_text(tool_name: str, tool_input: dict[str, Any]) -> str:
     del tool_name
     if not tool_input:
         return ""
-    return _("Input: {input}").format(
-        input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
-    )
+    return _("Input: {input}").format(input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str))
 
 
 def _display_tool_input_text(tool_name: str, tool_input: dict[str, Any]) -> str:
     del tool_name
-    return _("Input: {input}").format(
-        input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
-    )
+    return _("Input: {input}").format(input=json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str))
 
 
 def _permission_request_event(event: Any) -> PermissionRequestEvent | None:

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.0\n"
+"Project-Id-Version: iac-code 0.11.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/webui.po
@@ -3629,7 +3629,9 @@ msgstr "Entwicklermodus"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "When enabled, a Developer settings tab appears with additional tools."
-msgstr "Wenn aktiviert, erscheint ein Entwickler-Einstellungstab mit zusätzlichen Werkzeugen."
+msgstr ""
+"Wenn aktiviert, erscheint ein Entwickler-Einstellungstab mit zusätzlichen"
+" Werkzeugen."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Enable developer mode"
@@ -3637,7 +3639,9 @@ msgstr "Entwicklermodus aktivieren"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Reveals the Developer settings tab. Turning it off hides that tab again."
-msgstr "Zeigt den Entwickler-Einstellungstab an. Beim Deaktivieren wird dieser Tab wieder ausgeblendet."
+msgstr ""
+"Zeigt den Entwickler-Einstellungstab an. Beim Deaktivieren wird dieser "
+"Tab wieder ausgeblendet."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid ""
@@ -3788,7 +3792,9 @@ msgstr "Fehlgeschlagene Tool-Aufrufe rot hervorheben"
 msgid ""
 "When enabled, failed tool calls are painted red. When disabled, they look"
 " like any other tool call."
-msgstr "Wenn aktiviert, werden fehlgeschlagene Tool-Aufrufe rot dargestellt. Wenn deaktiviert, sehen sie aus wie jeder andere Tool-Aufruf."
+msgstr ""
+"Wenn aktiviert, werden fehlgeschlagene Tool-Aufrufe rot dargestellt. Wenn"
+" deaktiviert, sehen sie aus wie jeder andere Tool-Aufruf."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Restart service"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.0\n"
+"Project-Id-Version: iac-code 0.11.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/webui.po
@@ -3617,7 +3617,9 @@ msgstr "Modo de desarrollador"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "When enabled, a Developer settings tab appears with additional tools."
-msgstr "Cuando se activa, aparece una pestaña de ajustes de Desarrollador con herramientas adicionales."
+msgstr ""
+"Cuando se activa, aparece una pestaña de ajustes de Desarrollador con "
+"herramientas adicionales."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Enable developer mode"
@@ -3625,7 +3627,9 @@ msgstr "Activar el modo de desarrollador"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Reveals the Developer settings tab. Turning it off hides that tab again."
-msgstr "Muestra la pestaña de ajustes de Desarrollador. Al desactivarlo, esa pestaña se oculta de nuevo."
+msgstr ""
+"Muestra la pestaña de ajustes de Desarrollador. Al desactivarlo, esa "
+"pestaña se oculta de nuevo."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid ""
@@ -3763,7 +3767,9 @@ msgstr "Llamadas a herramientas fallidas"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Control how failed tool calls are shown in the transcript."
-msgstr "Controla cómo se muestran en la transcripción las llamadas a herramientas fallidas."
+msgstr ""
+"Controla cómo se muestran en la transcripción las llamadas a herramientas"
+" fallidas."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Highlight failed tool calls in red"
@@ -3773,7 +3779,10 @@ msgstr "Resaltar en rojo las llamadas a herramientas fallidas"
 msgid ""
 "When enabled, failed tool calls are painted red. When disabled, they look"
 " like any other tool call."
-msgstr "Cuando se activa, las llamadas a herramientas fallidas se muestran en rojo. Cuando se desactiva, se ven como cualquier otra llamada a herramientas."
+msgstr ""
+"Cuando se activa, las llamadas a herramientas fallidas se muestran en "
+"rojo. Cuando se desactiva, se ven como cualquier otra llamada a "
+"herramientas."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Restart service"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.0\n"
+"Project-Id-Version: iac-code 0.11.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/webui.po
@@ -3631,7 +3631,9 @@ msgstr "Mode développeur"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "When enabled, a Developer settings tab appears with additional tools."
-msgstr "Lorsqu’il est activé, un onglet de paramètres Développeur apparaît avec des outils supplémentaires."
+msgstr ""
+"Lorsqu’il est activé, un onglet de paramètres Développeur apparaît avec "
+"des outils supplémentaires."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Enable developer mode"
@@ -3639,7 +3641,9 @@ msgstr "Activer le mode développeur"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Reveals the Developer settings tab. Turning it off hides that tab again."
-msgstr "Affiche l’onglet de paramètres Développeur. Le désactiver masque à nouveau cet onglet."
+msgstr ""
+"Affiche l’onglet de paramètres Développeur. Le désactiver masque à "
+"nouveau cet onglet."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid ""
@@ -3780,7 +3784,9 @@ msgstr "Appels d’outils en échec"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Control how failed tool calls are shown in the transcript."
-msgstr "Contrôle la façon dont les appels d’outils en échec sont affichés dans la transcription."
+msgstr ""
+"Contrôle la façon dont les appels d’outils en échec sont affichés dans la"
+" transcription."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Highlight failed tool calls in red"
@@ -3790,7 +3796,10 @@ msgstr "Surligner en rouge les appels d’outils en échec"
 msgid ""
 "When enabled, failed tool calls are painted red. When disabled, they look"
 " like any other tool call."
-msgstr "Lorsqu’il est activé, les appels d’outils en échec sont affichés en rouge. Lorsqu’il est désactivé, ils ressemblent à n’importe quel autre appel d’outil."
+msgstr ""
+"Lorsqu’il est activé, les appels d’outils en échec sont affichés en "
+"rouge. Lorsqu’il est désactivé, ils ressemblent à n’importe quel autre "
+"appel d’outil."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Restart service"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.0\n"
+"Project-Id-Version: iac-code 0.11.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.0\n"
+"Project-Id-Version: iac-code 0.11.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/webui.po
@@ -3610,7 +3610,9 @@ msgstr "Modo de desenvolvedor"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "When enabled, a Developer settings tab appears with additional tools."
-msgstr "Quando ativado, uma aba de configurações de Desenvolvedor aparece com ferramentas adicionais."
+msgstr ""
+"Quando ativado, uma aba de configurações de Desenvolvedor aparece com "
+"ferramentas adicionais."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Enable developer mode"
@@ -3618,7 +3620,9 @@ msgstr "Ativar o modo de desenvolvedor"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Reveals the Developer settings tab. Turning it off hides that tab again."
-msgstr "Mostra a aba de configurações de Desenvolvedor. Ao desativá-lo, essa aba é ocultada novamente."
+msgstr ""
+"Mostra a aba de configurações de Desenvolvedor. Ao desativá-lo, essa aba "
+"é ocultada novamente."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid ""
@@ -3755,7 +3759,9 @@ msgstr "Chamadas de ferramenta com falha"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Control how failed tool calls are shown in the transcript."
-msgstr "Controla como as chamadas de ferramenta com falha são exibidas na transcrição."
+msgstr ""
+"Controla como as chamadas de ferramenta com falha são exibidas na "
+"transcrição."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Highlight failed tool calls in red"
@@ -3765,7 +3771,9 @@ msgstr "Destacar em vermelho as chamadas de ferramenta com falha"
 msgid ""
 "When enabled, failed tool calls are painted red. When disabled, they look"
 " like any other tool call."
-msgstr "Quando ativado, as chamadas de ferramenta com falha ficam em vermelho. Quando desativado, elas parecem qualquer outra chamada de ferramenta."
+msgstr ""
+"Quando ativado, as chamadas de ferramenta com falha ficam em vermelho. "
+"Quando desativado, elas parecem qualquer outra chamada de ferramenta."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Restart service"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.0\n"
+"Project-Id-Version: iac-code 0.11.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"

--- a/src/iac_code/services/telemetry/content_serializer.py
+++ b/src/iac_code/services/telemetry/content_serializer.py
@@ -140,9 +140,7 @@ def serialize_input_messages(messages: list) -> str:
             for block in content:
                 btype = getattr(block, "type", "text")
                 if btype == "text":
-                    parts.append(
-                        {"type": "text", "content": _truncate(_strict_text(getattr(block, "text", "") or ""))}
-                    )
+                    parts.append({"type": "text", "content": _truncate(_strict_text(getattr(block, "text", "") or ""))})
                 elif btype == "tool_use":
                     tool_use_id = _tool_call_id(block)
                     tool_name = _strict_text(getattr(block, "name", ""))

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/association_property_specs.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/association_property_specs.py
@@ -252,11 +252,7 @@ def apply_contract_corrections(payload: Mapping[str, Any]) -> dict[str, Any]:
             frozenset({"component", "deprecated", "replacement", "scope"}),
         ),
         "common_metadata": (
-            {
-                field: deepcopy(common[field])
-                for field in ("coverage", "schema", "semantic_rules")
-                if field in common
-            }
+            {field: deepcopy(common[field]) for field in ("coverage", "schema", "semantic_rules") if field in common}
             if isinstance(common, Mapping)
             else deepcopy(common)
         ),

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
@@ -733,9 +733,7 @@ class _ValidationState:
                     "ROS5305",
                     Severity.WARNING,
                     _("AssociationProperty availability depends on the stock form read-only state."),
-                    _(
-                        "The editable form path does not support this value, while the read-only path may bypass it."
-                    ),
+                    _("The editable form path does not support this value, while the read-only path may bypass it."),
                     association_path,
                     subject=normalized_association,
                     stable_args=("excluded-read-only-unknown", normalized_association),
@@ -2155,9 +2153,7 @@ class _ValidationState:
             self._emit(
                 "ROS5305",
                 Severity.WARNING,
-                _(
-                    "Metadata reference {} has more than one possible lookup scope."
-                ).format(name),
+                _("Metadata reference {} has more than one possible lookup scope.").format(name),
                 _(
                     "It may resolve from template Parameters or component-local data. The runtime component is "
                     "unknown, so local validation leaves the reference unchecked."

--- a/src/iac_code/utils/public_paths.py
+++ b/src/iac_code/utils/public_paths.py
@@ -181,8 +181,7 @@ def _redact_known_path_token(
 def _path_matches_roots(path: str, roots: list[_NormalizedRoot]) -> bool:
     windows = _is_windows_path(path)
     return any(
-        root.windows == windows
-        and _path_is_under_root(candidate, root.norm_path, windows=windows)
+        root.windows == windows and _path_is_under_root(candidate, root.norm_path, windows=windows)
         for candidate in _candidate_norm_paths(path, windows=windows)
         for root in roots
     )

--- a/src/iac_code/web/runtime.py
+++ b/src/iac_code/web/runtime.py
@@ -471,9 +471,7 @@ class WebSessionRuntime:
                         "user.message", _user_message_payload(request, turn_id=turn_id)
                     )
                     input_consumed = True
-                    self.manager.schedule_llm_title(
-                        self.session, text=request.text, image_ids=request.image_ids
-                    )
+                    self.manager.schedule_llm_title(self.session, text=request.text, image_ids=request.image_ids)
                     # 记录本轮“回放下界”:重载进行中会话时只回放本轮事件(尚未持久化),已完成
                     # 轮次由存储转录提供,避免完成轮次被回放而重复渲染。
                     self.session.active_turn_floor_sequence = int(user_event["sequence"]) - 1

--- a/src/iac_code/web/session_manager.py
+++ b/src/iac_code/web/session_manager.py
@@ -2455,9 +2455,7 @@ class WebSessionManager:
                         img = load_cached_image(image_id, cwd=session.cwd, session_id=session.session_id)
                     except Exception:  # noqa: BLE001 - 图片缺失不应中断标题生成
                         continue
-                    image_blocks.append(
-                        ContentBlock(type="image", media_type=img.media_type, data=img.base64_data)
-                    )
+                    image_blocks.append(ContentBlock(type="image", media_type=img.media_type, data=img.base64_data))
                 title = await session_titler.generate_session_title(
                     text=text,
                     image_blocks=image_blocks,

--- a/src/iac_code/web/session_titler.py
+++ b/src/iac_code/web/session_titler.py
@@ -51,9 +51,7 @@ def _build_manager(selection: WebModelSelection) -> ProviderManager:
     return ProviderManager(
         model=selection.model,
         credentials=credentials,
-        effort_override=_title_effort_override(
-            selection.provider or get_active_provider_key(), selection.model
-        ),
+        effort_override=_title_effort_override(selection.provider or get_active_provider_key(), selection.model),
         **overrides,
     )
 

--- a/tests/a2a/test_grpc_transport.py
+++ b/tests/a2a/test_grpc_transport.py
@@ -191,9 +191,7 @@ async def test_official_grpc_projects_success_and_error_from_new_request_cwd(mon
     ParseDict({"path": server_path, "password": "real-secret"}, response.message.metadata)
 
     projected = await handler._handle_unary(request, object(), None, response)
-    handler.error_to_abort = WireError(
-        message=f"failed token=real-secret at {server_path}", data={"path": server_path}
-    )
+    handler.error_to_abort = WireError(message=f"failed token=real-secret at {server_path}", data={"path": server_path})
     await handler._handle_unary(request, object(), None, a2a_pb2.SendMessageResponse())
 
     assert MessageToDict(projected.message.metadata) == {"path": "[PATH]", "password": "real-secret"}

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -4195,9 +4195,7 @@ async def test_executor_preserves_auth_looking_pipeline_error_without_safe_mode(
 
     final_status = _status_events(queue)[-1]["status"]
     assert final_status["state"] == "TASK_STATE_FAILED"
-    assert final_status["message"]["parts"][0]["text"] == (
-        "ValueError: missing API key: secret-internal-detail"
-    )
+    assert final_status["message"]["parts"][0]["text"] == ("ValueError: missing API key: secret-internal-detail")
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_pipeline_recovery.py
+++ b/tests/a2a/test_pipeline_recovery.py
@@ -92,12 +92,8 @@ async def test_recovery_keeps_pipeline_warning_visible_after_snapshot_sequence(t
     assert state["snapshot"]["lastSequence"] == 2
     assert state["snapshot"]["control"]["warningHistory"][0]["eventId"] == "evt-warning"
     assert state["snapshot"]["control"]["warningHistory"][0]["data"]["reason"] == "cleanup_tracking_unavailable"
-    assert state["snapshot"]["control"]["warningHistory"][0]["data"]["ledger_path"].endswith(
-        "/cleanup.yaml"
-    )
-    assert "while parsing /Users/alice" in state["snapshot"]["control"]["warningHistory"][0]["data"][
-        "load_error"
-    ]
+    assert state["snapshot"]["control"]["warningHistory"][0]["data"]["ledger_path"].endswith("/cleanup.yaml")
+    assert "while parsing /Users/alice" in state["snapshot"]["control"]["warningHistory"][0]["data"]["load_error"]
 
     replay_state = await service.get_state(context_id="ctx-1", after_sequence=1)
 
@@ -336,9 +332,7 @@ async def test_recovery_resolves_cleanup_snapshot_from_normal_delivery_task_id(t
     assert state["snapshot"]["cleanup"]["resources"][0]["resourceId"] == "stack-123"
     assert state["snapshot"]["cleanup"]["prompt"] == "hidden cleanup prompt for stack-123"
     assert state["snapshot"]["cleanup"]["ledgerPath"].endswith("/cleanup.yaml")
-    assert state["snapshot"]["cleanup"]["history"][0]["data"]["prompt"] == (
-        "hidden cleanup prompt for stack-123"
-    )
+    assert state["snapshot"]["cleanup"]["history"][0]["data"]["prompt"] == ("hidden cleanup prompt for stack-123")
     assert state["snapshot"]["cleanup"]["history"][0]["data"]["ledgerPath"].endswith("/cleanup.yaml")
     assert state["snapshot"]["cleanup"]["history"][0]["data"]["lastError"] == raw_error
     assert [event["eventId"] for event in state["events"]] == ["evt-cleanup-started"]

--- a/tests/a2a/test_projection.py
+++ b/tests/a2a/test_projection.py
@@ -227,9 +227,7 @@ def test_http_projection_uses_new_request_cwd_before_task_context_exists(tmp_pat
 def test_http_jsonrpc_task_scoped_error_uses_params_task_workspace(tmp_path, monkeypatch) -> None:
     workspace = tmp_path / "task-workspace"
     server_path = str(workspace / "private" / "result.json")
-    store = _MultiProjectionTaskStore(
-        {"task-1": ("context-1", str(workspace), "session-1")}
-    )
+    store = _MultiProjectionTaskStore({"task-1": ("context-1", str(workspace), "session-1")})
 
     async def fail(_request: Request) -> JSONResponse:
         return JSONResponse({"jsonrpc": "2.0", "id": "request-1", "error": {"message": server_path}})
@@ -325,9 +323,7 @@ def test_http_projection_aggregates_roots_for_list_tasks_response(tmp_path, monk
 @pytest.mark.asyncio
 async def test_task_scoped_request_and_grpc_bare_id_resolve_task_workspace_roots(tmp_path) -> None:
     workspace = tmp_path / "task-workspace"
-    store = _MultiProjectionTaskStore(
-        {"task-1": ("context-1", str(workspace), "session-1")}
-    )
+    store = _MultiProjectionTaskStore({"task-1": ("context-1", str(workspace), "session-1")})
 
     jsonrpc_roots = await resolve_a2a_public_path_roots_for_data(
         store,

--- a/tests/cli/test_mcp_command.py
+++ b/tests/cli/test_mcp_command.py
@@ -3000,8 +3000,7 @@ def test_mcp_add_direct_client_secret_is_available_to_env_expanded_auth(monkeypa
     expanded_config = load_result.servers[0].config
     storage = MCPSecretStorage()
     assert (
-        get_oauth_storage_secret(expanded_config, storage, "client_secret", scope=MCPConfigScope.USER)
-        == "super-secret"
+        get_oauth_storage_secret(expanded_config, storage, "client_secret", scope=MCPConfigScope.USER) == "super-secret"
     )
     captured: list[str | None] = []
 

--- a/tests/mcp/test_e2e.py
+++ b/tests/mcp/test_e2e.py
@@ -333,9 +333,7 @@ async def test_remote_mcp_server_e2e_oauth_bearer_token_connect(monkeypatch, tmp
             },
         )
         storage = MCPSecretStorage()
-        set_oauth_storage_secret(
-            scoped.config, storage, "access_token", "access-token", scope=MCPConfigScope.SESSION
-        )
+        set_oauth_storage_secret(scoped.config, storage, "access_token", "access-token", scope=MCPConfigScope.SESSION)
         manager = MCPManager([scoped], roots=[tmp_path])
 
         await manager.connect_all()

--- a/tests/mcp/test_oauth.py
+++ b/tests/mcp/test_oauth.py
@@ -1653,8 +1653,7 @@ def test_oauth_token_storage_stores_registered_client_information_by_scope() -> 
     )
 
     assert (
-        get_oauth_storage_secret(config, storage, "client_id", scope="project:/repo/.mcp.json")
-        == "registered-client"
+        get_oauth_storage_secret(config, storage, "client_id", scope="project:/repo/.mcp.json") == "registered-client"
     )
     assert (
         get_oauth_storage_secret(config, storage, "client_secret", scope="project:/repo/.mcp.json")

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -118,7 +118,7 @@ def test_legacy_setup_declares_package_metadata(monkeypatch):
     kwargs = setup_module._TEST_SETUP_KWARGS
 
     assert kwargs["name"] == "iac_code"
-    assert kwargs["version"] == "0.11.0"
+    assert kwargs["version"] == "0.11.1"
     assert kwargs["package_dir"] == {"": "src"}
     assert "iac_code.pipeline.selling.tools" in kwargs["packages"]
     assert "iac_code.pipeline.selling.hooks" in kwargs["packages"]

--- a/tests/tools/cloud/aliyun/test_ros_association_property_specs.py
+++ b/tests/tools/cloud/aliyun/test_ros_association_property_specs.py
@@ -102,9 +102,7 @@ def test_vendored_contract_contains_only_supported_public_fields() -> None:
         for spec in payload["association_properties"].values()
     )
     assert all(set(spec) <= {"scope"} for spec in payload["excluded_association_properties"].values())
-    assert all(
-        set(spec) <= {"coverage", "metadata", "semantic_rules"} for spec in payload["components"].values()
-    )
+    assert all(set(spec) <= {"coverage", "metadata", "semantic_rules"} for spec in payload["components"].values())
 
 
 def test_contract_corrections_are_idempotent_and_sanitizing() -> None:
@@ -165,15 +163,9 @@ def test_loader_rejects_unknown_consumer_set_and_semantic_rule() -> None:
     "mutate",
     [
         lambda item: item.__setitem__("unsupported_top_level", {"count": 1}),
-        lambda item: item["association_properties"]["AutoCompleteInput"].__setitem__(
-            "unsupported_detail", "discarded"
-        ),
-        lambda item: item["components"]["AutoCompleteInput"].__setitem__(
-            "unsupported_detail", "discarded"
-        ),
-        lambda item: item["excluded_association_properties"]["Default"].__setitem__(
-            "unsupported_detail", "discarded"
-        ),
+        lambda item: item["association_properties"]["AutoCompleteInput"].__setitem__("unsupported_detail", "discarded"),
+        lambda item: item["components"]["AutoCompleteInput"].__setitem__("unsupported_detail", "discarded"),
+        lambda item: item["excluded_association_properties"]["Default"].__setitem__("unsupported_detail", "discarded"),
     ],
 )
 def test_loader_rejects_fields_outside_public_contract(mutate) -> None:

--- a/tests/tools/cloud/aliyun/test_ros_association_property_validation.py
+++ b/tests/tools/cloud/aliyun/test_ros_association_property_validation.py
@@ -456,9 +456,7 @@ def test_known_unknown_excluded_apsara_and_deprecated_association_properties() -
     excluded = _validate({"Type": "String", "AssociationProperty": "ALIYUN::OOS::Component::ActionChoice"})
     assert _codes(excluded) == ["ROS1302"]
     excluded_diagnostic = next(item for item in excluded.diagnostics if item.code == "ROS1302")
-    assert excluded_diagnostic.detail == (
-        "This AssociationProperty value is available only in the OOS parameter form."
-    )
+    assert excluded_diagnostic.detail == ("This AssociationProperty value is available only in the OOS parameter form.")
 
     for allowed_values in ([], ["a"], {}):
         bypassed = _validate(

--- a/tests/web/test_developer_settings.py
+++ b/tests/web/test_developer_settings.py
@@ -61,7 +61,8 @@ def test_developer_settings_api_rejects_non_bool(tmp_path):
     with TestClient(app) as client:
         # 缺字段 / 非布尔都应被 required_bool 拒绝(400),不落库。
         assert client.put("/api/settings/developer", json={"mode": True}).status_code == 400
-        assert client.put(
-            "/api/settings/developer", json={"mode": "yes", "highlightFailedTools": False}
-        ).status_code == 400
+        assert (
+            client.put("/api/settings/developer", json={"mode": "yes", "highlightFailedTools": False}).status_code
+            == 400
+        )
         assert settings.developer_settings() == {"mode": False, "highlightFailedTools": False}

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -1384,7 +1384,7 @@ def test_sidebar_defers_repaint_while_pointer_inside() -> None:
     # 稳定容器 .session-rail 绑定进出边界探测(只一次);容器不被 replaceChildren 重建,监听长期有效。
     assert "function ensureSidebarHoverGuard()" in app_source
     guard_body = app_source.split("function ensureSidebarHoverGuard()", 1)[1].split("\n}\n", 1)[0]
-    assert '.session-rail' in guard_body
+    assert ".session-rail" in guard_body
     assert 'addEventListener("pointerenter"' in guard_body
     assert 'addEventListener("pointerleave"' in guard_body
     # pointerleave 时若有挂起重绘则追平一次。
@@ -6635,10 +6635,7 @@ def test_plugins_panel_hosts_skills_and_mcp_subtabs() -> None:
     assert 'data-workspace-panel="mcp"' not in html
     # NAV_GROUPS 不再含独立 MCP 项(改用逐字段核对,避免与 PLUGINS_SUBTABS 里同样的
     # `{ id: "mcp", label: "MCP" }` 字面量冲突)。skills 之后是 devOnly 的 developer 项。
-    assert (
-        '{ id: "memory", label: t("Memory") },\n'
-        '      { id: "skills", label: t("Plugins") },\n'
-    ) in source
+    assert ('{ id: "memory", label: t("Memory") },\n      { id: "skills", label: t("Plugins") },\n') in source
     assert '{ id: "mcp", label: "MCP" },\n    ],' not in source
 
     # 「插件」容器包住两个子面板,并注册为唯一的 skills 面板控制器。

--- a/tests/web/test_session_manager.py
+++ b/tests/web/test_session_manager.py
@@ -1847,9 +1847,7 @@ async def test_schedule_llm_title_falls_back_to_image_name(tmp_path, monkeypatch
         return None  # 两次都失败
 
     monkeypatch.setattr(sm.session_titler, "generate_session_title", fake_generate)
-    monkeypatch.setattr(
-        sm, "load_cached_image", lambda image_id, *, cwd, session_id: _FakeImg()
-    )
+    monkeypatch.setattr(sm, "load_cached_image", lambda image_id, *, cwd, session_id: _FakeImg())
     manager = WebSessionManager(projects_dir=tmp_path / "projects")
     session = manager.create_session(cwd=str(tmp_path / "project"), session_id="llm-4")
 
@@ -1882,9 +1880,7 @@ def test_apply_pipeline_auto_title_marks_title_provisional(tmp_path) -> None:
 def test_apply_llm_auto_title_overwrites_provisional_pipeline_title(tmp_path) -> None:
     cwd = str(tmp_path / "project")
     manager = WebSessionManager(projects_dir=tmp_path / "projects")
-    session = manager.create_session(
-        cwd=cwd, mode="pipeline", pipeline_name="selling", session_id="pipe-prov-2"
-    )
+    session = manager.create_session(cwd=cwd, mode="pipeline", pipeline_name="selling", session_id="pipe-prov-2")
     manager.apply_pipeline_auto_title(session, "帮我搭一条售卖流水线")
 
     changed = manager.apply_llm_auto_title(session, "售卖流水线搭建")

--- a/tests/web/test_session_titler.py
+++ b/tests/web/test_session_titler.py
@@ -62,27 +62,21 @@ async def test_generate_title_from_text_success():
 @pytest.mark.asyncio
 async def test_generate_title_retries_once_then_succeeds():
     _SCRIPT.extend([("raise", "boom"), ("ok", "重试成功标题")])
-    title = await session_titler.generate_session_title(
-        text="第一条", image_blocks=[], selection=_selection()
-    )
+    title = await session_titler.generate_session_title(text="第一条", image_blocks=[], selection=_selection())
     assert title == "重试成功标题"
 
 
 @pytest.mark.asyncio
 async def test_generate_title_returns_none_after_two_failures():
     _SCRIPT.extend([("raise", "boom1"), ("raise", "boom2")])
-    title = await session_titler.generate_session_title(
-        text="第一条", image_blocks=[], selection=_selection()
-    )
+    title = await session_titler.generate_session_title(text="第一条", image_blocks=[], selection=_selection())
     assert title is None
 
 
 @pytest.mark.asyncio
 async def test_generate_title_returns_none_for_blank_response():
     _SCRIPT.append(("ok", "   "))
-    title = await session_titler.generate_session_title(
-        text="第一条", image_blocks=[], selection=_selection()
-    )
+    title = await session_titler.generate_session_title(text="第一条", image_blocks=[], selection=_selection())
     assert title is None
 
 
@@ -90,7 +84,5 @@ async def test_generate_title_returns_none_for_blank_response():
 async def test_generate_title_from_image_only_builds_image_message():
     _SCRIPT.append(("ok", "架构图会话"))
     block = ContentBlock(type="image", media_type="image/png", data="AAAA")
-    title = await session_titler.generate_session_title(
-        text=None, image_blocks=[block], selection=_selection()
-    )
+    title = await session_titler.generate_session_title(text=None, image_blocks=[block], selection=_selection())
     assert title == "架构图会话"


### PR DESCRIPTION
## Summary

- bump the Python package version from `0.11.0` to `0.11.1`
- update the packaging assertion for the new version
- apply the repository formatter and refresh translation catalogs

## Why

Prepare the next patch release from the current `main` branch.

## Impact

The published package and CLI report version `0.11.1`. The remaining source and test changes are formatter-only; translation changes refresh catalog metadata and wrapping.

## Validation

- `make format`
- `make lint`
- `make translate`
- `make test` (`13312 passed, 2 skipped`)
