### PR TITLE
feat(providers): add DeepSeek V4 Flash 0731 and Claude Opus 5

### DIFF
--- a/src/iac_code/a2a/transports/dispatcher.py
+++ b/src/iac_code/a2a/transports/dispatcher.py
@@ -795,10 +795,22 @@ class IacCodeRequestHandler(DefaultRequestHandler):
             raise TaskNotFoundError(f"Task {params.id} not found")
         if isinstance(self.task_store, A2ATaskStore) and not await self.task_store.is_task_active(params.id):
             raise TaskNotFoundError(f"Task {params.id} is not active")
+        terminal_state_seen = False
         async for event in super().on_subscribe_to_task(params, context):
+            event_state = _task_event_state(event)
+            terminal_state_seen = terminal_state_seen or event_state in TERMINAL_TASK_STATES
             yield event
-            if _task_event_state(event) in INTERRUPTED_TASK_STATES:
+            if event_state in INTERRUPTED_TASK_STATES:
                 return
+        if terminal_state_seen:
+            return
+
+        # a2a-sdk 1.1 can close its subscriber queue after the producer finishes but
+        # before the consumer publishes the last update. Recover the persisted terminal
+        # snapshot so subscribers do not observe a silent, non-terminal stream ending.
+        final_task = await self.task_store.get(params.id, context)
+        if final_task is not None and final_task.status.state in TERMINAL_TASK_STATES:
+            yield final_task
 
     async def on_create_task_push_notification_config(
         self, params: TaskPushNotificationConfig, context

--- a/src/iac_code/providers/anthropic_provider.py
+++ b/src/iac_code/providers/anthropic_provider.py
@@ -144,7 +144,12 @@ class AnthropicProvider(Provider):
 
         kwargs: dict[str, Any] = {}
         if self._thinking_disabled():
-            if not spec.adaptive_always_on:
+            forbidden_disable_efforts = {item.value for item in spec.disable_forbidden_efforts}
+            if effort in forbidden_disable_efforts:
+                raise ValueError(
+                    f"Anthropic thinking cannot be disabled for {self._model} at {effort} effort; use high or lower"
+                )
+            if spec.supports_disable:
                 kwargs["thinking"] = {"type": "disabled"}
         elif not spec.adaptive_always_on and (effort is not None or self._thinking_forced()):
             kwargs["thinking"] = {"type": "adaptive"}

--- a/src/iac_code/providers/manager.py
+++ b/src/iac_code/providers/manager.py
@@ -304,6 +304,7 @@ def _error_event_from_exception(exc: BaseException) -> ErrorEvent:
 
 MODEL_FALLBACK_MAP = {
     "claude-fable-5": "claude-opus-4-8",
+    "claude-opus-5": "claude-opus-4-8",
     "claude-opus-4-8": "claude-sonnet-5",
     "claude-opus-4-7": "claude-haiku-4-5-20251001",
     "claude-opus-4-6": "claude-haiku-4-5-20251001",
@@ -322,10 +323,12 @@ MODEL_FALLBACK_MAP = {
     "glm-5.2-fast-preview": "glm-5.2",
     "glm-5.2": "glm-5.1",
     "deepseek-v4-pro": "deepseek-v4-flash",
+    "deepseek-v4-flash-0731": "deepseek-v4-flash",
 }
 
 _MODEL_REFUSAL_FALLBACK_MAP = {
     "claude-fable-5": "claude-opus-4-8",
+    "claude-opus-5": "claude-opus-4-8",
 }
 
 _PROVIDER_MODEL_FALLBACK_MAP = {

--- a/src/iac_code/providers/registry.py
+++ b/src/iac_code/providers/registry.py
@@ -65,6 +65,7 @@ PROVIDER_REGISTRY: dict[str, ProviderDescriptor] = {
             ModelEntry("kimi-k2.6", support_multimodal=True),
             ModelEntry("kimi-k2.5", support_multimodal=True),
             ModelEntry("deepseek-v4-pro"),
+            ModelEntry("deepseek-v4-flash-0731"),
             ModelEntry("deepseek-v4-flash"),
             ModelEntry("glm-5.2-fast-preview"),
             ModelEntry("glm-5.2"),
@@ -129,6 +130,7 @@ PROVIDER_REGISTRY: dict[str, ProviderDescriptor] = {
         base_url=None,
         models=[
             ModelEntry("claude-fable-5", is_default=True, support_multimodal=True),
+            ModelEntry("claude-opus-5", support_multimodal=True),
             ModelEntry("claude-opus-4-8", support_multimodal=True),
             ModelEntry("claude-sonnet-5", support_multimodal=True),
             ModelEntry("claude-opus-4-7", support_multimodal=True),

--- a/src/iac_code/providers/thinking.py
+++ b/src/iac_code/providers/thinking.py
@@ -77,6 +77,8 @@ class ThinkingSpec:
     uses_reasoning_effort_param: bool = False
     adaptive_always_on: bool = False
     supports_disable: bool = True
+    thinking_enabled_by_default: bool = False
+    disable_forbidden_efforts: tuple[EffortLevel, ...] = ()
 
     @property
     def supports_effort(self) -> bool:
@@ -155,8 +157,19 @@ _ANTHROPIC_46_EFFORTS: tuple[EffortLevel, ...] = (
     EffortLevel.AUTO,
 )
 
-# DeepSeek V4 accepts only high/max — XHIGH is intentionally skipped.
+# The official DeepSeek endpoint exposes only high/max — XHIGH is intentionally skipped.
 _DEEPSEEK_EFFORTS: tuple[EffortLevel, ...] = (EffortLevel.HIGH, EffortLevel.MAX)
+
+# DashScope accepts the full effort vocabulary for its hosted DeepSeek V4
+# models. Low/medium currently map to high and xhigh maps to max server-side,
+# but keeping the accepted wire values lets callers migrate without a 400.
+_DASHSCOPE_DEEPSEEK_EFFORTS: tuple[EffortLevel, ...] = (
+    EffortLevel.LOW,
+    EffortLevel.MEDIUM,
+    EffortLevel.HIGH,
+    EffortLevel.XHIGH,
+    EffortLevel.MAX,
+)
 
 _GLM_EFFORTS: tuple[EffortLevel, ...] = (
     EffortLevel.NONE,
@@ -230,6 +243,14 @@ _ANTHROPIC_ADAPTIVE_SPEC = ThinkingSpec(
     EffortLevel.HIGH,
 )
 
+_ANTHROPIC_OPUS5_SPEC = ThinkingSpec(
+    ThinkingFamily.ANTHROPIC_ADAPTIVE,
+    _ANTHROPIC_MODERN_EFFORTS,
+    EffortLevel.HIGH,
+    thinking_enabled_by_default=True,
+    disable_forbidden_efforts=(EffortLevel.XHIGH, EffortLevel.MAX),
+)
+
 _ANTHROPIC_46_ADAPTIVE_SPEC = ThinkingSpec(
     ThinkingFamily.ANTHROPIC_ADAPTIVE,
     _ANTHROPIC_46_EFFORTS,
@@ -262,6 +283,7 @@ _ZHIPU_GLM52_SPEC = ThinkingSpec(
 MODEL_THINKING: dict[str, dict[str, ThinkingSpec]] = {
     "anthropic": {
         "claude-fable-5": _ANTHROPIC_ADAPTIVE_ALWAYS_ON_SPEC,
+        "claude-opus-5": _ANTHROPIC_OPUS5_SPEC,
         "claude-sonnet-5": _ANTHROPIC_ADAPTIVE_SPEC,
         "claude-opus-4-8": _ANTHROPIC_ADAPTIVE_SPEC,
         "claude-opus-4-7": _ANTHROPIC_ADAPTIVE_SPEC,
@@ -314,8 +336,24 @@ MODEL_THINKING: dict[str, dict[str, ThinkingSpec]] = {
         "glm-5.1": _DASHSCOPE_GLM51_SPEC,
         "MiniMax-M2.5": ThinkingSpec(ThinkingFamily.DASHSCOPE),
         "MiniMax/MiniMax-M3": ThinkingSpec(ThinkingFamily.MINIMAX),
-        "deepseek-v4-pro": ThinkingSpec(ThinkingFamily.DASHSCOPE, _DEEPSEEK_EFFORTS, EffortLevel.HIGH),
-        "deepseek-v4-flash": ThinkingSpec(ThinkingFamily.DASHSCOPE, _DEEPSEEK_EFFORTS, EffortLevel.HIGH),
+        "deepseek-v4-pro": ThinkingSpec(
+            ThinkingFamily.DASHSCOPE,
+            _DASHSCOPE_DEEPSEEK_EFFORTS,
+            EffortLevel.HIGH,
+            uses_reasoning_effort_param=True,
+        ),
+        "deepseek-v4-flash-0731": ThinkingSpec(
+            ThinkingFamily.DASHSCOPE,
+            _DASHSCOPE_DEEPSEEK_EFFORTS,
+            EffortLevel.HIGH,
+            uses_reasoning_effort_param=True,
+        ),
+        "deepseek-v4-flash": ThinkingSpec(
+            ThinkingFamily.DASHSCOPE,
+            _DASHSCOPE_DEEPSEEK_EFFORTS,
+            EffortLevel.HIGH,
+            uses_reasoning_effort_param=True,
+        ),
     },
     "dashscope_token_plan": {
         "qwen3.8-max-preview": _DASHSCOPE_QWEN38_SPEC,
@@ -473,9 +511,9 @@ _THINKING_DISABLE_EFFORTS: frozenset[str] = frozenset({"none", "off", "disable",
 # Families whose providers emit an explicit "thinking on" directive by default
 # when the user has NOT configured ``thinkingEnabled`` (DashScope
 # ``enable_thinking=True``, Kimi/Zhipu ``thinking.type=enabled``). For these an
-# unset config still means the next turn thinks. Reasoning-effort families
-# (OpenAI/Anthropic/Gemini) instead emit nothing when unset and let the server
-# decide — unobservable here, so they resolve to off.
+# unset config still means the next turn thinks. Most reasoning-effort models
+# (OpenAI/Anthropic/Gemini) instead emit nothing when unset and resolve to off;
+# models with a documented server-side thinking default opt in explicitly.
 _DEFAULT_ON_FAMILIES: frozenset[ThinkingFamily] = frozenset(
     {ThinkingFamily.DASHSCOPE, ThinkingFamily.KIMI, ThinkingFamily.ZHIPU}
 )
@@ -498,15 +536,19 @@ def resolve_thinking_active(
     spec = get_thinking_spec(provider_key or "", model or "")
     if spec.family is ThinkingFamily.NONE:
         return False
+    normalized_effort = normalize_effort(effort)
     if thinking_enabled is False:
-        return False
+        if not spec.supports_disable:
+            return True
+        forbidden = {item.value for item in spec.disable_forbidden_efforts}
+        return normalized_effort in forbidden
     # DashScope disable-effort tokens force thinking off even when configured on.
-    if spec.family is ThinkingFamily.DASHSCOPE and normalize_effort(effort) in _THINKING_DISABLE_EFFORTS:
+    if spec.family is ThinkingFamily.DASHSCOPE and normalized_effort in _THINKING_DISABLE_EFFORTS:
         return False
     if thinking_enabled is True:
         return True
     # thinking_enabled is None (not configured): use the family default.
-    return spec.family in _DEFAULT_ON_FAMILIES
+    return spec.thinking_enabled_by_default or spec.adaptive_always_on or spec.family in _DEFAULT_ON_FAMILIES
 
 
 # Anthropic extended-thinking budget tokens per effort level.

--- a/src/iac_code/services/context_manager.py
+++ b/src/iac_code/services/context_manager.py
@@ -50,6 +50,7 @@ def _context_config(context_window: int, max_output_tokens: int = 8_192) -> Cont
 
 _MODEL_EXACT_CONFIGS: dict[str, ContextWindowConfig] = {
     "claude-fable-5": _context_config(1_000_000, 128_000),
+    "claude-opus-5": _context_config(1_000_000, 128_000),
     "claude-opus-4-8": _context_config(1_000_000, 128_000),
     "claude-sonnet-5": _context_config(1_000_000, 128_000),
     "claude-sonnet-4-6-1m": _context_config(1_000_000, 64_000),
@@ -91,6 +92,7 @@ _MODEL_EXACT_CONFIGS: dict[str, ContextWindowConfig] = {
     "qwen3-max": _context_config(262_144),
     "qwen3-coder-next": _context_config(262_144),
     "deepseek-v4-pro": _context_config(1_000_000),
+    "deepseek-v4-flash-0731": _context_config(1_000_000, 393_216),
     "deepseek-v4-flash": _context_config(1_000_000),
     "glm-5.2-fast-preview": _context_config(1_048_576, 131_072),
     "glm-5.2": _context_config(1_000_000, 128_000),

--- a/src/iac_code/services/telemetry/constants.py
+++ b/src/iac_code/services/telemetry/constants.py
@@ -44,6 +44,7 @@ KNOWN_MODELS: frozenset[str] = frozenset(
     {
         # Anthropic
         "claude-fable-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-sonnet-5",
         "claude-opus-4-7",
@@ -130,6 +131,7 @@ KNOWN_MODELS: frozenset[str] = frozenset(
         "gemini-2.5-flash-lite",
         # DeepSeek / MiniMax / Volcengine
         "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
         "deepseek-v4-flash",
         "deepseek-v3.2",
         "MiniMax/MiniMax-M3",

--- a/tests/a2a/test_transport_dispatcher.py
+++ b/tests/a2a/test_transport_dispatcher.py
@@ -694,6 +694,78 @@ async def test_subscribe_to_task_stops_after_input_required_status(monkeypatch) 
 
 
 @pytest.mark.asyncio
+async def test_subscribe_to_task_recovers_terminal_snapshot_when_sdk_stream_ends_early(monkeypatch) -> None:
+    task = Task(
+        id="task-1",
+        context_id="ctx-1",
+        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+    )
+    store = A2ATaskStore()
+    call_context = ServerCallContext()
+    await store.save(task, call_context)
+    record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    record.active_task = asyncio.current_task()
+
+    async def truncated_sdk_subscription(self, params, context):
+        yield TaskStatusUpdateEvent(
+            task_id="task-1",
+            context_id="ctx-1",
+            status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+        )
+        final_task = Task(
+            id="task-1",
+            context_id="ctx-1",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+        )
+        await store.save(final_task, context)
+
+    monkeypatch.setattr(DefaultRequestHandler, "on_subscribe_to_task", truncated_sdk_subscription)
+    handler = IacCodeRequestHandler.__new__(IacCodeRequestHandler)
+    handler.task_store = store
+    handler._validate_extensions = lambda context: None
+
+    events = await _collect_async(handler.on_subscribe_to_task(SubscribeToTaskRequest(id="task-1"), call_context))
+
+    assert [event.status.state for event in events] == [
+        TaskState.TASK_STATE_WORKING,
+        TaskState.TASK_STATE_COMPLETED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_to_task_does_not_duplicate_terminal_sdk_event(monkeypatch) -> None:
+    task = Task(
+        id="task-1",
+        context_id="ctx-1",
+        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+    )
+    store = A2ATaskStore()
+    call_context = ServerCallContext()
+    await store.save(task, call_context)
+    record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    record.active_task = asyncio.current_task()
+
+    async def complete_sdk_subscription(self, params, context):
+        final_task = Task(
+            id="task-1",
+            context_id="ctx-1",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+        )
+        await store.save(final_task, context)
+        yield final_task
+
+    monkeypatch.setattr(DefaultRequestHandler, "on_subscribe_to_task", complete_sdk_subscription)
+    handler = IacCodeRequestHandler.__new__(IacCodeRequestHandler)
+    handler.task_store = store
+    handler._validate_extensions = lambda context: None
+
+    events = await _collect_async(handler.on_subscribe_to_task(SubscribeToTaskRequest(id="task-1"), call_context))
+
+    assert len(events) == 1
+    assert events[0].status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
 async def test_create_runtime_components_returns_shared_objects() -> None:
     components = create_runtime_components(model="qwen3.6-plus", host="127.0.0.1", port=41242)
 

--- a/tests/providers/test_anthropic_provider.py
+++ b/tests/providers/test_anthropic_provider.py
@@ -271,6 +271,39 @@ class TestAnthropicProvider:
 
 
 class TestAnthropicBuildThinkingKwargs:
+    def test_opus5_defaults_to_server_managed_thinking(self):
+        from iac_code.providers.anthropic_provider import AnthropicProvider
+
+        p = AnthropicProvider(model="claude-opus-5", api_key="k")
+        assert p._build_thinking_kwargs() == {}
+
+    def test_opus5_can_disable_thinking_at_high_or_lower_effort(self):
+        from iac_code.providers.anthropic_provider import AnthropicProvider
+
+        p = AnthropicProvider(
+            model="claude-opus-5",
+            api_key="k",
+            effort="high",
+            thinking_enabled=False,
+        )
+        assert p._build_thinking_kwargs() == {
+            "thinking": {"type": "disabled"},
+            "output_config": {"effort": "high"},
+        }
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    def test_opus5_rejects_disabling_thinking_at_highest_efforts(self, effort):
+        from iac_code.providers.anthropic_provider import AnthropicProvider
+
+        p = AnthropicProvider(
+            model="claude-opus-5",
+            api_key="k",
+            effort=effort,
+            thinking_enabled=False,
+        )
+        with pytest.raises(ValueError, match="cannot be disabled.*use high or lower"):
+            p._build_thinking_kwargs()
+
     def test_high_returns_adaptive_thinking_and_effort(self):
         from iac_code.providers.anthropic_provider import AnthropicProvider
 

--- a/tests/providers/test_dashscope_provider.py
+++ b/tests/providers/test_dashscope_provider.py
@@ -109,12 +109,14 @@ class TestDashScopeBuildThinkingKwargs:
         p = DashScopeProvider(model="glm-5.1", api_key="k")
         assert p._build_thinking_kwargs() == {"extra_body": {"enable_thinking": True}}
 
-    def test_bailian_deepseek_does_not_emit_reasoning_effort(self):
-        # Bailian-hosted DeepSeek uses the BAILIAN wire format, not OpenAI's.
-        p = DashScopeProvider(model="deepseek-v4-pro", api_key="k", effort="high")
+    @pytest.mark.parametrize("model", ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v4-flash-0731"])
+    def test_bailian_deepseek_emits_enable_thinking_and_reasoning_effort(self, model):
+        p = DashScopeProvider(model=model, api_key="k", effort="xhigh")
         kwargs = p._build_thinking_kwargs()
-        assert kwargs == {"extra_body": {"enable_thinking": True}}
-        assert "reasoning_effort" not in kwargs
+        assert kwargs == {
+            "extra_body": {"enable_thinking": True},
+            "reasoning_effort": "xhigh",
+        }
 
     def test_unknown_model_returns_empty(self):
         p = DashScopeProvider(model="not-real", api_key="k")

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -373,6 +373,13 @@ class TestProviderManager:
 
         assert manager._get_fallback_model() == "claude-opus-4-8"
 
+    def test_opus5_falls_back_to_opus48_for_errors_and_refusals(self, monkeypatch):
+        monkeypatch.setattr("iac_code.config.get_active_provider_key", lambda: "anthropic")
+        manager = ProviderManager(model="claude-opus-5", credentials={})
+
+        assert manager._get_fallback_model() == "claude-opus-4-8"
+        assert manager._get_refusal_fallback_model("claude-opus-5", "anthropic") == "claude-opus-4-8"
+
     def test_no_fallback_cheapest(self, monkeypatch):
         monkeypatch.setattr("iac_code.config.get_active_provider_key", lambda: "anthropic")
         m = ProviderManager(model="claude-haiku-4-5-20251001", credentials={})

--- a/tests/providers/test_provider_model_research_updates.py
+++ b/tests/providers/test_provider_model_research_updates.py
@@ -33,6 +33,7 @@ def test_dashscope_models_match_researched_bailian_catalog() -> None:
         "qwen-plus",
         "qwen-flash",
         "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
         "deepseek-v4-flash",
         "kimi/kimi-k3",
         "kimi-k2.7-code",
@@ -54,6 +55,7 @@ def test_dashscope_models_match_researched_bailian_catalog() -> None:
     assert PROVIDER_REGISTRY["dashscope"].default_model == "qwen3.7-max"
     assert not _model_entry("dashscope", "glm-5.2-fast-preview").support_multimodal
     assert "glm-5.2-fast-preview" not in _model_ids("dashscope_token_plan")
+    assert "deepseek-v4-flash-0731" not in _model_ids("dashscope_token_plan")
     assert not _model_entry("dashscope", "qwen3.7-max").support_multimodal
     for model_id in (
         "qwen3.7-plus",
@@ -124,6 +126,9 @@ def test_openai_azure_anthropic_and_gemini_models_are_updated() -> None:
 
     assert PROVIDER_REGISTRY["anthropic"].default_model == "claude-fable-5"
     assert get_thinking_spec("anthropic", "claude-fable-5").family is ThinkingFamily.ANTHROPIC_ADAPTIVE
+    assert "claude-opus-5" in _model_ids("anthropic")
+    assert _model_entry("anthropic", "claude-opus-5").support_multimodal
+    assert get_thinking_spec("anthropic", "claude-opus-5").family is ThinkingFamily.ANTHROPIC_ADAPTIVE
     assert get_thinking_spec("anthropic", "claude-opus-4-8").family is ThinkingFamily.ANTHROPIC_ADAPTIVE
     assert get_thinking_spec("anthropic", "claude-sonnet-5").family is ThinkingFamily.ANTHROPIC_ADAPTIVE
 
@@ -258,6 +263,11 @@ def test_gemini_thinking_rules_match_each_model_generation() -> None:
 def test_anthropic_effort_and_disable_rules_are_model_specific() -> None:
     from iac_code.providers.anthropic_provider import AnthropicProvider
 
+    opus_5 = get_thinking_spec("anthropic", "claude-opus-5")
+    assert opus_5.thinking_enabled_by_default is True
+    assert opus_5.default_effort is EffortLevel.HIGH
+    assert opus_5.disable_forbidden_efforts == (EffortLevel.XHIGH, EffortLevel.MAX)
+
     sonnet_5 = get_thinking_spec("anthropic", "claude-sonnet-5")
     assert sonnet_5.adaptive_always_on is False
     assert AnthropicProvider(
@@ -274,6 +284,17 @@ def test_anthropic_effort_and_disable_rules_are_model_specific() -> None:
 
 def test_dashscope_new_model_protocols_are_not_flattened() -> None:
     from iac_code.providers.dashscope_provider import DashScopeProvider
+
+    deepseek = get_thinking_spec("dashscope", "deepseek-v4-flash-0731")
+    assert deepseek.allowed_efforts == (
+        EffortLevel.LOW,
+        EffortLevel.MEDIUM,
+        EffortLevel.HIGH,
+        EffortLevel.XHIGH,
+        EffortLevel.MAX,
+    )
+    assert deepseek.default_effort is EffortLevel.HIGH
+    assert deepseek.uses_reasoning_effort_param is True
 
     qwen = get_thinking_spec("dashscope_token_plan", "qwen3.8-max-preview")
     assert qwen.allowed_efforts == (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.XHIGH)

--- a/tests/providers/test_thinking_registry.py
+++ b/tests/providers/test_thinking_registry.py
@@ -17,6 +17,21 @@ class TestGetThinkingSpec:
         assert spec.supports_effort is True
         assert spec.default_effort is EffortLevel.HIGH
 
+    def test_anthropic_opus5_defaults_on_and_limits_disable_efforts(self):
+        spec = get_thinking_spec("anthropic", "claude-opus-5")
+        assert spec.family is ThinkingFamily.ANTHROPIC_ADAPTIVE
+        assert spec.allowed_efforts == (
+            EffortLevel.LOW,
+            EffortLevel.MEDIUM,
+            EffortLevel.HIGH,
+            EffortLevel.XHIGH,
+            EffortLevel.MAX,
+            EffortLevel.AUTO,
+        )
+        assert spec.default_effort is EffortLevel.HIGH
+        assert spec.thinking_enabled_by_default is True
+        assert spec.disable_forbidden_efforts == (EffortLevel.XHIGH, EffortLevel.MAX)
+
     def test_anthropic_haiku_supports_manual_thinking_budget(self):
         spec = get_thinking_spec("anthropic", "claude-haiku-4-5-20251001")
         assert spec.family is ThinkingFamily.ANTHROPIC
@@ -184,11 +199,19 @@ class TestGetThinkingSpec:
             assert spec.use_max_completion_tokens is False, (provider_key, model)
             assert spec.default_thinking_budget is None, (provider_key, model)
 
-    def test_dashscope_deepseek_supports_high_max(self):
-        spec = get_thinking_spec("dashscope", "deepseek-v4-pro")
-        assert spec.family is ThinkingFamily.DASHSCOPE
-        assert spec.allowed_efforts == (EffortLevel.HIGH, EffortLevel.MAX)
-        assert spec.default_effort is EffortLevel.HIGH
+    def test_dashscope_deepseek_supports_documented_efforts(self):
+        for model in ("deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v4-flash-0731"):
+            spec = get_thinking_spec("dashscope", model)
+            assert spec.family is ThinkingFamily.DASHSCOPE
+            assert spec.allowed_efforts == (
+                EffortLevel.LOW,
+                EffortLevel.MEDIUM,
+                EffortLevel.HIGH,
+                EffortLevel.XHIGH,
+                EffortLevel.MAX,
+            )
+            assert spec.default_effort is EffortLevel.HIGH
+            assert spec.uses_reasoning_effort_param is True
 
     def test_dashscope_qwen36_max_preview(self):
         spec = get_thinking_spec("dashscope", "qwen3.6-max-preview")
@@ -267,6 +290,13 @@ class TestResolveThinkingActive:
         assert resolve_thinking_active("openai", "gpt-5.5", None) is False
         assert resolve_thinking_active("anthropic", "claude-opus-4-8", None) is False
         assert resolve_thinking_active("gemini", "gemini-3.5-flash", None) is False
+
+    def test_anthropic_default_on_and_disable_constraints_are_reflected(self):
+        assert resolve_thinking_active("anthropic", "claude-fable-5", None) is True
+        assert resolve_thinking_active("anthropic", "claude-opus-5", None) is True
+        assert resolve_thinking_active("anthropic", "claude-opus-5", False, effort="high") is False
+        assert resolve_thinking_active("anthropic", "claude-opus-5", False, effort="xhigh") is True
+        assert resolve_thinking_active("anthropic", "claude-opus-5", False, effort="max") is True
 
     def test_explicit_true_forces_on_across_families(self):
         assert resolve_thinking_active("openai", "gpt-5.5", True) is True

--- a/tests/services/test_context_manager.py
+++ b/tests/services/test_context_manager.py
@@ -59,7 +59,7 @@ class TestContextWindowConfig:
         assert config.context_window == 1_000_000
         assert config.max_output_tokens == 128_000
 
-    @pytest.mark.parametrize("model", ["claude-opus-4-8", "gpt-5.5", "gpt-5.4"])
+    @pytest.mark.parametrize("model", ["claude-opus-5", "claude-opus-4-8", "gpt-5.5", "gpt-5.4"])
     def test_new_frontier_models_use_documented_long_context_capacity(self, model):
         config = get_context_window_config(model)
         assert config.context_window in {1_000_000, 1_050_000}
@@ -103,6 +103,7 @@ class TestContextWindowConfig:
             ("qwen3.7-plus", 1_000_000),
             ("qwen3.6-flash", 1_000_000),
             ("deepseek-v4-pro", 1_000_000),
+            ("deepseek-v4-flash-0731", 1_000_000),
             ("deepseek-v4-flash", 1_000_000),
             ("glm-5.1", 202_752),
             ("MiniMax-M3", 1_000_000),
@@ -111,6 +112,10 @@ class TestContextWindowConfig:
     )
     def test_current_dashscope_models_use_documented_context_capacity(self, model, context_window):
         assert get_context_window_config(model).context_window == context_window
+
+    def test_dashscope_deepseek_v4_flash_0731_uses_documented_output_capacity(self):
+        config = get_context_window_config("deepseek-v4-flash-0731")
+        assert config.max_output_tokens == 393_216
 
     def test_direct_glm52_uses_documented_context_and_output_capacity(self):
         config = get_context_window_config("glm-5.2")

--- a/tests/test_services/test_telemetry/test_constants.py
+++ b/tests/test_services/test_telemetry/test_constants.py
@@ -30,6 +30,7 @@ def test_known_models_contains_claude_and_openai():
 def test_known_models_contains_researched_provider_updates():
     for model in (
         "claude-fable-5",
+        "claude-opus-5",
         "gpt-5.6-sol",
         "qwen3.8-max-preview",
         "kimi-k3",
@@ -40,6 +41,7 @@ def test_known_models_contains_researched_provider_updates():
         "gemini-3.5-flash-lite",
         "gemini-2.5-pro",
         "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
         "MiniMax-M3",
         "doubao-seed-2-0-pro-260215",
     ):


### PR DESCRIPTION
## Summary

- add Alibaba Cloud Bailian `deepseek-v4-flash-0731` to the standard DashScope catalog
- add Anthropic `claude-opus-5` with multimodal, context-window, thinking, and refusal behavior
- update model fallback, telemetry allowlists, and focused regression coverage

## Why

Both providers published new model IDs and model-specific protocol constraints. The registry and request capability tables need exact entries so model selection, thinking controls, context compaction, fallbacks, and telemetry remain consistent.

## Behavior

- `deepseek-v4-flash-0731` is scoped to standard Bailian, not Token Plan, with a 1M context window and 393,216 maximum output tokens
- Bailian DeepSeek V4 requests accept `low/medium/high/xhigh/max` reasoning efforts and send both `enable_thinking` and `reasoning_effort`
- `claude-opus-5` uses a 1M context window, 128K maximum output, vision input, and thinking enabled by default
- disabling Opus 5 thinking at `xhigh` or `max` is rejected locally before the API call
- Opus 5 errors and classifier refusals fall back to `claude-opus-4-8`

## Validation

- `make test`: 13,324 passed, 2 skipped
- `make lint`: Ruff and ty passed
- focused provider tests: 397 passed
