### PR TITLE
fix: improve pipeline safety and ROS nested stack validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test coverage lint format translate run dev clean publish
+.PHONY: help install test coverage lint format translate run dev web pipeline clean publish
 
 .DEFAULT_GOAL := help
 
@@ -79,6 +79,14 @@ run: ## Run iac-code
 
 dev: ## Run iac-code in debug mode
 	IAC_CODE_INSTRUCTION_MEMORY_FILE=IAC-CODE.md uv run iac-code --debug
+
+web: ## Run iac-code as a local Web app
+	IAC_CODE_INSTRUCTION_MEMORY_FILE=IAC-CODE.md uv run iac-code web
+
+PIPELINE_NAME ?= selling
+
+pipeline: ## Run iac-code in pipeline mode (PIPELINE_NAME=selling by default)
+	IAC_CODE_INSTRUCTION_MEMORY_FILE=IAC-CODE.md IAC_CODE_MODE=pipeline IAC_CODE_PIPELINE_NAME=$(PIPELINE_NAME) uv run iac-code
 
 clean: ## Clean build artifacts
 	rm -rf .ruff_cache .pytest_cache dist build htmlcov .coverage coverage.xml

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -7696,6 +7696,33 @@ msgstr "Der logische Ressourcenname oder Count-Instanzname ist ungültig."
 #: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
 #, python-brace-format
 msgid ""
+"Fn::GetAtt for nested stack {} must use "
+"Outputs.<nested_stack_output_name>."
+msgstr ""
+"Fn::GetAtt für den verschachtelten Stack {} muss "
+"Outputs.<nested_stack_output_name> verwenden."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid ""
+"ALIYUN::ROS::Stack exposes child stack outputs only through the fixed "
+"Outputs. prefix, followed by a non-empty output name."
+msgstr ""
+"ALIYUN::ROS::Stack stellt Ausgaben des untergeordneten Stacks nur über "
+"das feste Präfix Outputs. bereit, gefolgt von einem nicht leeren "
+"Ausgabenamen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
+"Change the second argument to Outputs.<nested_stack_output_name>, for "
+"example Fn::GetAtt: [{}, Outputs.MyOutput]."
+msgstr ""
+"Ändern Sie das zweite Argument in Outputs.<nested_stack_output_name>, zum"
+" Beispiel Fn::GetAtt: [{}, Outputs.MyOutput]."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
 "Count resource {} expands into multiple instances, but this Fn::GetAtt "
 "cannot be automatically rewritten into an attribute list."
 msgstr ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -7649,6 +7649,33 @@ msgstr "El nombre lógico de recurso o el nombre de instancia Count es inválido
 #: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
 #, python-brace-format
 msgid ""
+"Fn::GetAtt for nested stack {} must use "
+"Outputs.<nested_stack_output_name>."
+msgstr ""
+"Fn::GetAtt para la pila anidada {} debe usar "
+"Outputs.<nested_stack_output_name>."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid ""
+"ALIYUN::ROS::Stack exposes child stack outputs only through the fixed "
+"Outputs. prefix, followed by a non-empty output name."
+msgstr ""
+"ALIYUN::ROS::Stack expone las salidas de la pila secundaria únicamente "
+"mediante el prefijo fijo Outputs., seguido de un nombre de salida no "
+"vacío."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
+"Change the second argument to Outputs.<nested_stack_output_name>, for "
+"example Fn::GetAtt: [{}, Outputs.MyOutput]."
+msgstr ""
+"Cambie el segundo argumento a Outputs.<nested_stack_output_name>, por "
+"ejemplo Fn::GetAtt: [{}, Outputs.MyOutput]."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
 "Count resource {} expands into multiple instances, but this Fn::GetAtt "
 "cannot be automatically rewritten into an attribute list."
 msgstr ""

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -7687,6 +7687,32 @@ msgstr "Le nom logique de la ressource ou le nom d'instance Count est invalide."
 #: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
 #, python-brace-format
 msgid ""
+"Fn::GetAtt for nested stack {} must use "
+"Outputs.<nested_stack_output_name>."
+msgstr ""
+"Fn::GetAtt pour la pile imbriquée {} doit utiliser "
+"Outputs.<nested_stack_output_name>."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid ""
+"ALIYUN::ROS::Stack exposes child stack outputs only through the fixed "
+"Outputs. prefix, followed by a non-empty output name."
+msgstr ""
+"ALIYUN::ROS::Stack expose les sorties de la pile enfant uniquement via le"
+" préfixe fixe Outputs., suivi d’un nom de sortie non vide."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
+"Change the second argument to Outputs.<nested_stack_output_name>, for "
+"example Fn::GetAtt: [{}, Outputs.MyOutput]."
+msgstr ""
+"Remplacez le deuxième argument par Outputs.<nested_stack_output_name>, "
+"par exemple Fn::GetAtt: [{}, Outputs.MyOutput]."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
 "Count resource {} expands into multiple instances, but this Fn::GetAtt "
 "cannot be automatically rewritten into an attribute list."
 msgstr ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -7159,6 +7159,32 @@ msgstr "リソース論理名またはCountインスタンス名は無効です�
 #: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
 #, python-brace-format
 msgid ""
+"Fn::GetAtt for nested stack {} must use "
+"Outputs.<nested_stack_output_name>."
+msgstr ""
+"ネストされたスタック {} の Fn::GetAtt では Outputs.<nested_stack_output_name> "
+"を使用する必要があります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid ""
+"ALIYUN::ROS::Stack exposes child stack outputs only through the fixed "
+"Outputs. prefix, followed by a non-empty output name."
+msgstr ""
+"ALIYUN::ROS::Stack では、固定プレフィックス Outputs. "
+"の後に空でない出力名を指定した場合にのみ、子スタックの出力を参照できます。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
+"Change the second argument to Outputs.<nested_stack_output_name>, for "
+"example Fn::GetAtt: [{}, Outputs.MyOutput]."
+msgstr ""
+"2 番目の引数を Outputs.<nested_stack_output_name> に変更してください。例: Fn::GetAtt: [{},"
+" Outputs.MyOutput]。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
 "Count resource {} expands into multiple instances, but this Fn::GetAtt "
 "cannot be automatically rewritten into an attribute list."
 msgstr "Countリソース{}は複数のインスタンスに展開しますが、このFn::GetAttは属性リストに自動的に書き込まれることはできません。"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -7574,6 +7574,32 @@ msgstr "O nome lógico do recurso ou o nome da instância Count é inválido."
 #: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
 #, python-brace-format
 msgid ""
+"Fn::GetAtt for nested stack {} must use "
+"Outputs.<nested_stack_output_name>."
+msgstr ""
+"Fn::GetAtt para a pilha aninhada {} deve usar "
+"Outputs.<nested_stack_output_name>."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid ""
+"ALIYUN::ROS::Stack exposes child stack outputs only through the fixed "
+"Outputs. prefix, followed by a non-empty output name."
+msgstr ""
+"ALIYUN::ROS::Stack expõe as saídas da pilha filha somente por meio do "
+"prefixo fixo Outputs., seguido de um nome de saída não vazio."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
+"Change the second argument to Outputs.<nested_stack_output_name>, for "
+"example Fn::GetAtt: [{}, Outputs.MyOutput]."
+msgstr ""
+"Altere o segundo argumento para Outputs.<nested_stack_output_name>, por "
+"exemplo, Fn::GetAtt: [{}, Outputs.MyOutput]."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
 "Count resource {} expands into multiple instances, but this Fn::GetAtt "
 "cannot be automatically rewritten into an attribute list."
 msgstr ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -6996,6 +6996,28 @@ msgstr "资源逻辑名或 Count 实例名无效。"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
 #, python-brace-format
 msgid ""
+"Fn::GetAtt for nested stack {} must use "
+"Outputs.<nested_stack_output_name>."
+msgstr "嵌套资源栈 {} 的 Fn::GetAtt 必须使用 Outputs.<nested_stack_output_name>。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid ""
+"ALIYUN::ROS::Stack exposes child stack outputs only through the fixed "
+"Outputs. prefix, followed by a non-empty output name."
+msgstr "ALIYUN::ROS::Stack 只能通过固定的 Outputs. 前缀访问子资源栈输出，前缀后必须跟一个非空的输出名称。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
+"Change the second argument to Outputs.<nested_stack_output_name>, for "
+"example Fn::GetAtt: [{}, Outputs.MyOutput]."
+msgstr ""
+"请将第二个参数改为 Outputs.<nested_stack_output_name>，例如 Fn::GetAtt: [{}, "
+"Outputs.MyOutput]。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid ""
 "Count resource {} expands into multiple instances, but this Fn::GetAtt "
 "cannot be automatically rewritten into an attribute list."
 msgstr "Count 资源 {} 会展开为多个实例，但此处的 Fn::GetAtt 不能自动改写成属性列表。"

--- a/src/iac_code/pipeline/engine/handoff.py
+++ b/src/iac_code/pipeline/engine/handoff.py
@@ -43,5 +43,21 @@ def build_handoff_summary(
     if missing:
         lines.extend(["", "Missing context fields:"])
         lines.extend(f"- {field_name}" for field_name in missing)
-    lines.extend(["", "Use this context when answering follow-up questions after the pipeline handoff."])
+    lines.extend(
+        [
+            "",
+            "Safety requirements for normal chat:",
+            (
+                "- Before performing any operation that releases, deletes, or otherwise destroys a resource, "
+                "obtain a fresh, explicit confirmation from the user in normal chat. Any confirmation given "
+                "during the pipeline does not count."
+            ),
+            (
+                "- Exception: pipeline-managed automatic cleanup may proceed without this additional "
+                "confirmation."
+            ),
+            "",
+            "Use this context when answering follow-up questions after the pipeline handoff.",
+        ]
+    )
     return "\n".join(lines)

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
@@ -3074,6 +3074,31 @@ class ExpressionAnalyzer:
                     )
                 return InferredValue.invalid()
             expanded_instance = True
+        if (
+            symbol.resource_type == "ALIYUN::ROS::Stack"
+            and attribute is not None
+            and (not attribute.startswith("Outputs.") or not attribute[len("Outputs.") :].strip())
+        ):
+            if semantic_reachable:
+                self.diagnostic(
+                    "ROS4005",
+                    _(
+                        "Fn::GetAtt for nested stack {} must use Outputs.<nested_stack_output_name>."
+                    ).format(resource_name),
+                    _(
+                        "ALIYUN::ROS::Stack exposes child stack outputs only through the fixed Outputs. prefix, "
+                        "followed by a non-empty output name."
+                    ),
+                    _index(path, 1),
+                    stable_args=(resource_name, attribute, "nested-stack-output"),
+                    expected="Outputs.<nested_stack_output_name>",
+                    actual=attribute,
+                    suggestion=_(
+                        "Change the second argument to Outputs.<nested_stack_output_name>, for example "
+                        "Fn::GetAtt: [{}, Outputs.MyOutput]."
+                    ).format(resource_name),
+                )
+            return InferredValue.invalid()
         base_type = (
             self.resource_specs.attribute_type(symbol.resource_type, attribute) if attribute is not None else ANY_VALUE
         )

--- a/tests/pipeline/engine/test_pipeline_handoff.py
+++ b/tests/pipeline/engine/test_pipeline_handoff.py
@@ -80,6 +80,14 @@ def test_build_handoff_summary_includes_only_configured_fields_and_deterministic
         },
         include_fields=["intent", "missing_field"],
     )
+    resource_release_requirement = (
+        "- Before performing any operation that releases, deletes, or otherwise destroys a resource, "
+        "obtain a fresh, explicit confirmation from the user in normal chat. Any confirmation given "
+        "during the pipeline does not count."
+    )
+    automatic_cleanup_exception = (
+        "- Exception: pipeline-managed automatic cleanup may proceed without this additional confirmation."
+    )
 
     assert (
         summary
@@ -101,12 +109,32 @@ def test_build_handoff_summary_includes_only_configured_fields_and_deterministic
         Missing context fields:
         - missing_field
 
+        Safety requirements for normal chat:
+        RESOURCE_RELEASE_REQUIREMENT
+        AUTOMATIC_CLEANUP_EXCEPTION
+
         Use this context when answering follow-up questions after the pipeline handoff.
         """
-        ).strip()
+        )
+        .strip()
+        .replace("RESOURCE_RELEASE_REQUIREMENT", resource_release_requirement)
+        .replace("AUTOMATIC_CLEANUP_EXCEPTION", automatic_cleanup_exception)
     )
     assert "architecture" not in summary
     assert "deployment" not in summary
+
+
+def test_build_handoff_summary_requires_new_confirmation_for_resource_release_except_automatic_cleanup():
+    summary = build_handoff_summary(
+        pipeline_name="selling",
+        outcome="completed",
+        context_snapshot={},
+        include_fields=[],
+    )
+
+    assert "obtain a fresh, explicit confirmation from the user in normal chat" in summary
+    assert "Any confirmation given during the pipeline does not count" in summary
+    assert "pipeline-managed automatic cleanup may proceed without this additional confirmation" in summary
 
 
 def test_runner_should_switch_to_normal_for_completed_policy(tmp_path):

--- a/tests/tools/cloud/aliyun/test_ros_validate_hook.py
+++ b/tests/tools/cloud/aliyun/test_ros_validate_hook.py
@@ -289,6 +289,34 @@ class TestCheckTemplate:
             "$.Parameters.GeneratedSuffix.AssociationPropertyMetadata.CharacterClasses[0].Class"
         )
 
+    def test_nested_stack_getatt_error_explains_the_required_output_format(self) -> None:
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Resources": {
+                "Nested": {
+                    "Type": "ALIYUN::ROS::Stack",
+                    "Properties": {
+                        "TemplateBody": {
+                            "ROSTemplateFormatVersion": "2015-09-01",
+                            "Outputs": {"Child": {"Value": "ok"}},
+                        }
+                    },
+                }
+            },
+            "Outputs": {"Invalid": {"Value": {"Fn::GetAtt": ["Nested", "Child"]}}},
+        }
+
+        result = check_template("ros", "ValidateTemplate", {"TemplateBody": body})
+
+        assert result is not None and result.blocking_result is not None
+        assert result.template_analyzed
+        assert "ROS4005" in result.blocking_result.content
+        assert "Outputs.<nested_stack_output_name>" in result.blocking_result.content
+        assert "Fn::GetAtt: [Nested, Outputs.MyOutput]" in result.blocking_result.content
+        metadata = result.blocking_result.metadata["ros_validation"]
+        assert metadata["error_count"] == 1
+        assert metadata["diagnostics"][0]["path"] == "$.Outputs.Invalid.Value.Fn::GetAtt[1]"
+
     def test_association_property_rule_is_shared_with_create_stack(self) -> None:
         body = {
             "ROSTemplateFormatVersion": "2015-09-01",

--- a/tests/tools/cloud/aliyun/test_ros_validation_semantics.py
+++ b/tests/tools/cloud/aliyun/test_ros_validation_semantics.py
@@ -147,6 +147,38 @@ Resources:
     assert not any(item.code == "ROS4005" for item in report.diagnostics)
 
 
+def test_nested_stack_getatt_requires_outputs_prefix_and_nonempty_output_name() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Nested:
+    Type: ALIYUN::ROS::Stack
+    Properties:
+      TemplateBody:
+        ROSTemplateFormatVersion: 2015-09-01
+        Outputs:
+          Child: {Value: ok}
+Outputs:
+  Valid: {Value: {Fn::GetAtt: [Nested, Outputs.Child]}}
+  MissingPrefix: {Value: {Fn::GetAtt: [Nested, Child]}}
+  EmptyOutputName: {Value: {Fn::GetAtt: [Nested, Outputs.]}}
+  WrongAttribute: {Value: {Fn::GetAtt: [Nested, StackId]}}
+"""
+    )
+
+    errors = [item for item in report.diagnostics if item.code == "ROS4005"]
+    assert len(errors) == 3
+    assert {display_path(item.path) for item in errors} == {
+        "$.Outputs.MissingPrefix.Value.Fn::GetAtt[1]",
+        "$.Outputs.EmptyOutputName.Value.Fn::GetAtt[1]",
+        "$.Outputs.WrongAttribute.Value.Fn::GetAtt[1]",
+    }
+    assert all("Outputs.<nested_stack_output_name>" in item.summary for item in errors)
+    assert all(item.expected == "Outputs.<nested_stack_output_name>" for item in errors)
+    assert {item.actual for item in errors} == {"Child", "Outputs.", "StackId"}
+    assert all("Fn::GetAtt: [Nested, Outputs.MyOutput]" in (item.suggestion or "") for item in errors)
+
+
 def test_count_ref_is_lifted_once_and_invalid_count_is_independent() -> None:
     report = validate(
         """ROSTemplateFormatVersion: 2015-09-01


### PR DESCRIPTION
## What changed

- require a fresh confirmation in normal chat before resource-release or destructive operations after a pipeline handoff, while exempting pipeline-managed automatic cleanup
- add `make web` and `make pipeline` entry points, with `PIPELINE_NAME` override support
- validate nested-stack `Fn::GetAtt` attributes locally and require the `Outputs.<output-name>` form
- add localized diagnostics in all supported message catalogs and regression coverage

## Why

The handoff prompt did not clearly preserve the confirmation boundary once execution moved from pipeline mode to normal chat. Local startup commands also lacked convenient Makefile targets. In addition, ROS server-side validation reports malformed nested-stack `Fn::GetAtt` attributes with a vague error, so agents could not reliably infer the required repair.

## Impact

Users receive clearer safety behavior after pipeline handoff, simpler local Web/Pipeline startup commands, and actionable local validation errors before calling ROS ValidateTemplate.

## Validation

- `make translate`
- `make lint`
- `make test` — 13,329 passed, 2 skipped
- `make -n web pipeline`
- verified every `origin/main` message-catalog `msgid` remains present after rebase
