### PR TITLE
fix(a2a): validate ask recovery deployment

### DIFF
--- a/scripts/a2a/e2e/run_recovery_scenarios.py
+++ b/scripts/a2a/e2e/run_recovery_scenarios.py
@@ -925,8 +925,7 @@ def _run_scenario1(
             backup_restore["primaryAbsentAfterRestart"] = not primary_session_dir.exists()
             backup_restore["primarySessionFileAbsentAfterRestart"] = not primary_session_file.exists()
             h.checks["primary session stayed absent after restart"] = (
-                backup_restore["primaryAbsentAfterRestart"]
-                and backup_restore["primarySessionFileAbsentAfterRestart"]
+                backup_restore["primaryAbsentAfterRestart"] and backup_restore["primarySessionFileAbsentAfterRestart"]
             )
             _write_json(h.run_dir / "step4.backup-only-restore.json", backup_restore)
         selection = h.stream(
@@ -988,9 +987,7 @@ def _run_scenario1(
         h.checks["normal follow-up persisted in session"] = _a2a_session_contains_user_message(
             h, args.normal_followup_prompt
         )
-        h.checks["recovery question persisted in session"] = _a2a_session_contains_user_message(
-            h, args.recovery_prompt
-        )
+        h.checks["recovery question persisted in session"] = _a2a_session_contains_user_message(h, args.recovery_prompt)
         h.checks["VSwitch evidence found"] = _has_any_marker(_all_evidence(h), VSWITCH_MARKERS)
         h.checks["scenario1 emitted no cleanup events"] = not _run_dir_has_cleanup_events(h.run_dir)
         h.checks["scenario1 persisted no cleanup prompt"] = not _session_has_cleanup_prompt(h)
@@ -1078,7 +1075,7 @@ def run_ask_waiting(args: argparse.Namespace, scenario: str) -> int:
         answer = h.stream(prompt=ASK_FIRST_ANSWER, name="02-answer-first-ask", task_id="")
         _add_hydrated_task_checks(h, answer, "first ask answer")
         final_summary = answer
-        if answer.last_input_required_step_id:
+        if _waiting_for_followup_ask(h, answer):
             second = h.stream(prompt=ASK_SECOND_ANSWER, name="03-answer-second-ask")
             _add_same_task_checks(h, second, "second ask answer")
             _finish_pipeline_after_possible_input(h, second, args)
@@ -1086,6 +1083,7 @@ def run_ask_waiting(args: argparse.Namespace, scenario: str) -> int:
         else:
             _finish_pipeline_after_possible_input(h, answer, args)
         h.checks["pipeline completed after ask recovery"] = _completed_snapshot_or_stream(h, final_summary)
+        h.checks["deployment succeeded with Stack ID"] = _deployment_succeeded_with_stack_id(h.run_dir)
         h.checks["VSwitch evidence found"] = _has_any_marker(_all_evidence(h), VSWITCH_MARKERS)
 
     return _run_with_harness(args, scenario, callback)
@@ -1190,7 +1188,7 @@ def run_image_ask_waiting(args: argparse.Namespace, scenario: str) -> int:
         )
         _add_hydrated_task_checks(h, answer, "first ask image answer")
         final_summary = answer
-        if answer.last_input_required_step_id:
+        if _waiting_for_followup_ask(h, answer):
             second = h.stream_image_text(
                 text=ASK_SECOND_ANSWER,
                 image_key="ask-second-answer",
@@ -1202,6 +1200,7 @@ def run_image_ask_waiting(args: argparse.Namespace, scenario: str) -> int:
         else:
             _finish_pipeline_after_possible_input(h, answer, args)
         h.checks["pipeline completed after ask image recovery"] = _completed_snapshot_or_stream(h, final_summary)
+        h.checks["deployment succeeded with Stack ID"] = _deployment_succeeded_with_stack_id(h.run_dir)
         h.checks["VSwitch evidence found"] = _has_any_marker(_all_evidence(h), VSWITCH_MARKERS)
 
     return _run_with_harness(args, scenario, callback)
@@ -1966,6 +1965,13 @@ def _answer_intervening_ask_inputs(
     return current
 
 
+def _waiting_for_followup_ask(h: ScenarioHarness, summary: StreamSummary) -> bool:
+    if not summary.last_input_required_step_id:
+        return False
+    events_path = h.run_dir / f"{summary.name}.events.jsonl"
+    return _latest_pending_kind(events_path) == "ask_user_question"
+
+
 def _join_after_kill(stream: BackgroundStream, h: ScenarioHarness) -> None:
     try:
         stream.join(timeout=10)
@@ -2359,9 +2365,7 @@ def _known_server_path_occurrences(value: Any, known_server_paths: Iterable[str]
 
     def visit(item: Any) -> int:
         if isinstance(item, dict):
-            return sum(
-                (count_text(key) if isinstance(key, str) else 0) + visit(child) for key, child in item.items()
-            )
+            return sum((count_text(key) if isinstance(key, str) else 0) + visit(child) for key, child in item.items())
         if isinstance(item, (list, tuple)):
             return sum(visit(child) for child in item)
         if isinstance(item, str):
@@ -2596,10 +2600,7 @@ def _a2a_session_contains_user_message(h: Any, text: str) -> bool:
     except Exception as exc:
         _append_harness_note(h, f"cannot inspect A2A session: {type(exc).__name__} loading {session_id}")
         return False
-    return any(
-        getattr(message, "role", "") == "user" and text in _agent_message_text(message)
-        for message in messages
-    )
+    return any(getattr(message, "role", "") == "user" and text in _agent_message_text(message) for message in messages)
 
 
 def _agent_message_text(message: Any) -> str:
@@ -2687,6 +2688,49 @@ def _latest_input_required_step_id_from_events(events: Iterable[Any]) -> str:
             if isinstance(data, dict) and data.get("stepId"):
                 step_id = str(data.get("stepId") or "")
     return step_id
+
+
+def _deployment_succeeded_with_stack_id(run_dir: Path) -> bool:
+    latest_rank: tuple[float, int] | None = None
+    latest_conclusion: dict[str, Any] = {}
+    event_order = 0
+    for path in sorted(run_dir.glob("*.events.jsonl")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            for envelope in _extract_pipeline_envelopes(value):
+                event_order += 1
+                step = envelope.get("step")
+                if envelope.get("eventType") != "step_completed" or not isinstance(step, dict):
+                    continue
+                if step.get("id") != "deploying":
+                    continue
+                data = envelope.get("data")
+                conclusion = data.get("conclusion") if isinstance(data, dict) else None
+                if not isinstance(conclusion, dict):
+                    continue
+                try:
+                    sequence = float(envelope.get("sequence"))
+                except (TypeError, ValueError):
+                    sequence = float("-inf")
+                rank = (sequence, event_order)
+                if latest_rank is None or rank > latest_rank:
+                    latest_rank = rank
+                    latest_conclusion = conclusion
+
+    if str(latest_conclusion.get("status") or "").casefold() != "success":
+        return False
+    stack_id = latest_conclusion.get("stack_id") or latest_conclusion.get("stackId")
+    outputs = latest_conclusion.get("outputs")
+    if not stack_id and isinstance(outputs, dict):
+        stack_id = outputs.get("StackId") or outputs.get("stackId") or outputs.get("stack_id")
+    return isinstance(stack_id, str) and bool(stack_id.strip())
 
 
 def _all_evidence(h: ScenarioHarness) -> str:
@@ -2838,11 +2882,14 @@ def _created_stack_event(
     expected_stack_name: str | None = None,
 ) -> Callable[[Any, StreamSummary], bool]:
     def predicate(event: Any, _summary: StreamSummary) -> bool:
-        return _created_stack_id_from_event(
-            event,
-            exclude=exclude,
-            expected_stack_name=expected_stack_name,
-        ) is not None
+        return (
+            _created_stack_id_from_event(
+                event,
+                exclude=exclude,
+                expected_stack_name=expected_stack_name,
+            )
+            is not None
+        )
 
     return predicate
 

--- a/scripts/a2a/e2e/run_recovery_scenarios.py
+++ b/scripts/a2a/e2e/run_recovery_scenarios.py
@@ -925,7 +925,8 @@ def _run_scenario1(
             backup_restore["primaryAbsentAfterRestart"] = not primary_session_dir.exists()
             backup_restore["primarySessionFileAbsentAfterRestart"] = not primary_session_file.exists()
             h.checks["primary session stayed absent after restart"] = (
-                backup_restore["primaryAbsentAfterRestart"] and backup_restore["primarySessionFileAbsentAfterRestart"]
+                backup_restore["primaryAbsentAfterRestart"]
+                and backup_restore["primarySessionFileAbsentAfterRestart"]
             )
             _write_json(h.run_dir / "step4.backup-only-restore.json", backup_restore)
         selection = h.stream(
@@ -987,7 +988,9 @@ def _run_scenario1(
         h.checks["normal follow-up persisted in session"] = _a2a_session_contains_user_message(
             h, args.normal_followup_prompt
         )
-        h.checks["recovery question persisted in session"] = _a2a_session_contains_user_message(h, args.recovery_prompt)
+        h.checks["recovery question persisted in session"] = _a2a_session_contains_user_message(
+            h, args.recovery_prompt
+        )
         h.checks["VSwitch evidence found"] = _has_any_marker(_all_evidence(h), VSWITCH_MARKERS)
         h.checks["scenario1 emitted no cleanup events"] = not _run_dir_has_cleanup_events(h.run_dir)
         h.checks["scenario1 persisted no cleanup prompt"] = not _session_has_cleanup_prompt(h)
@@ -2365,7 +2368,9 @@ def _known_server_path_occurrences(value: Any, known_server_paths: Iterable[str]
 
     def visit(item: Any) -> int:
         if isinstance(item, dict):
-            return sum((count_text(key) if isinstance(key, str) else 0) + visit(child) for key, child in item.items())
+            return sum(
+                (count_text(key) if isinstance(key, str) else 0) + visit(child) for key, child in item.items()
+            )
         if isinstance(item, (list, tuple)):
             return sum(visit(child) for child in item)
         if isinstance(item, str):
@@ -2600,7 +2605,10 @@ def _a2a_session_contains_user_message(h: Any, text: str) -> bool:
     except Exception as exc:
         _append_harness_note(h, f"cannot inspect A2A session: {type(exc).__name__} loading {session_id}")
         return False
-    return any(getattr(message, "role", "") == "user" and text in _agent_message_text(message) for message in messages)
+    return any(
+        getattr(message, "role", "") == "user" and text in _agent_message_text(message)
+        for message in messages
+    )
 
 
 def _agent_message_text(message: Any) -> str:
@@ -2882,14 +2890,11 @@ def _created_stack_event(
     expected_stack_name: str | None = None,
 ) -> Callable[[Any, StreamSummary], bool]:
     def predicate(event: Any, _summary: StreamSummary) -> bool:
-        return (
-            _created_stack_id_from_event(
-                event,
-                exclude=exclude,
-                expected_stack_name=expected_stack_name,
-            )
-            is not None
-        )
+        return _created_stack_id_from_event(
+            event,
+            exclude=exclude,
+            expected_stack_name=expected_stack_name,
+        ) is not None
 
     return predicate
 

--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 __release_date__ = ""

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.1\n"
+"Project-Id-Version: iac-code 0.11.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.1\n"
+"Project-Id-Version: iac-code 0.11.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.1\n"
+"Project-Id-Version: iac-code 0.11.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.1\n"
+"Project-Id-Version: iac-code 0.11.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.1\n"
+"Project-Id-Version: iac-code 0.11.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.1\n"
+"Project-Id-Version: iac-code 0.11.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"

--- a/src/iac_code/pipeline/engine/handoff.py
+++ b/src/iac_code/pipeline/engine/handoff.py
@@ -52,10 +52,7 @@ def build_handoff_summary(
                 "obtain a fresh, explicit confirmation from the user in normal chat. Any confirmation given "
                 "during the pipeline does not count."
             ),
-            (
-                "- Exception: pipeline-managed automatic cleanup may proceed without this additional "
-                "confirmation."
-            ),
+            ("- Exception: pipeline-managed automatic cleanup may proceed without this additional confirmation."),
             "",
             "Use this context when answering follow-up questions after the pipeline handoff.",
         ]

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
@@ -3082,9 +3082,9 @@ class ExpressionAnalyzer:
             if semantic_reachable:
                 self.diagnostic(
                     "ROS4005",
-                    _(
-                        "Fn::GetAtt for nested stack {} must use Outputs.<nested_stack_output_name>."
-                    ).format(resource_name),
+                    _("Fn::GetAtt for nested stack {} must use Outputs.<nested_stack_output_name>.").format(
+                        resource_name
+                    ),
                     _(
                         "ALIYUN::ROS::Stack exposes child stack outputs only through the fixed Outputs. prefix, "
                         "followed by a non-empty output name."

--- a/tests/a2a_e2e/test_run_recovery_scenarios.py
+++ b/tests/a2a_e2e/test_run_recovery_scenarios.py
@@ -70,6 +70,61 @@ def test_latest_input_required_kind_from_events_uses_latest_kind() -> None:
     assert kind == "candidate_selection"
 
 
+def test_waiting_for_followup_ask_distinguishes_candidate_selection(tmp_path: Path) -> None:
+    runner = _load_runner()
+    summary = runner.StreamSummary(
+        name="02-answer-first-ask",
+        prompt=runner.ASK_FIRST_ANSWER,
+        pipeline_event_types=["input_required"],
+        last_input_required_step_id="confirm_and_select",
+    )
+    events_path = tmp_path / "02-answer-first-ask.events.jsonl"
+    events_path.write_text(
+        json.dumps(_input_required_event("candidate_selection", step_id="confirm_and_select")) + "\n",
+        encoding="utf-8",
+    )
+    harness = SimpleNamespace(run_dir=tmp_path)
+
+    assert runner._waiting_for_followup_ask(harness, summary) is False
+
+    events_path.write_text(
+        json.dumps(_input_required_event("ask_user_question", step_id="intent_parsing")) + "\n",
+        encoding="utf-8",
+    )
+    assert runner._waiting_for_followup_ask(harness, summary) is True
+
+
+def test_deployment_success_requires_latest_success_and_stack_id(tmp_path: Path) -> None:
+    runner = _load_runner()
+    events_path = tmp_path / "02-answer.events.jsonl"
+
+    def completed(sequence: int, conclusion: dict) -> dict:
+        return _pipeline_batch(
+            {
+                "eventType": "step_completed",
+                "sequence": sequence,
+                "step": {"id": "deploying"},
+                "data": {"conclusion": conclusion},
+            }
+        )
+
+    events_path.write_text(
+        "\n".join(
+            [
+                json.dumps(completed(1, {"status": "success", "stack_id": "stack-1"})),
+                json.dumps(completed(2, {"status": "failed", "resources_created": []})),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert runner._deployment_succeeded_with_stack_id(tmp_path) is False
+
+    with events_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(completed(3, {"status": "success", "outputs": {"StackId": "stack-2"}})) + "\n")
+    assert runner._deployment_succeeded_with_stack_id(tmp_path) is True
+
+
 def test_recovery_predicates_and_evidence_inspect_every_batched_event() -> None:
     runner = _load_runner()
     event = _pipeline_batch(

--- a/tests/pipeline/engine/test_pipeline_handoff.py
+++ b/tests/pipeline/engine/test_pipeline_handoff.py
@@ -89,10 +89,8 @@ def test_build_handoff_summary_includes_only_configured_fields_and_deterministic
         "- Exception: pipeline-managed automatic cleanup may proceed without this additional confirmation."
     )
 
-    assert (
-        summary
-        == dedent(
-            """\
+    assert summary == dedent(
+        """\
         [Pipeline Handoff Context]
         This is injected context for the assistant, not a user request.
         Pipeline: selling
@@ -115,10 +113,8 @@ def test_build_handoff_summary_includes_only_configured_fields_and_deterministic
 
         Use this context when answering follow-up questions after the pipeline handoff.
         """
-        )
-        .strip()
-        .replace("RESOURCE_RELEASE_REQUIREMENT", resource_release_requirement)
-        .replace("AUTOMATIC_CLEANUP_EXCEPTION", automatic_cleanup_exception)
+    ).strip().replace("RESOURCE_RELEASE_REQUIREMENT", resource_release_requirement).replace(
+        "AUTOMATIC_CLEANUP_EXCEPTION", automatic_cleanup_exception
     )
     assert "architecture" not in summary
     assert "deployment" not in summary

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -118,7 +118,7 @@ def test_legacy_setup_declares_package_metadata(monkeypatch):
     kwargs = setup_module._TEST_SETUP_KWARGS
 
     assert kwargs["name"] == "iac_code"
-    assert kwargs["version"] == "0.11.1"
+    assert kwargs["version"] == "0.11.2"
     assert kwargs["package_dir"] == {"": "src"}
     assert "iac_code.pipeline.selling.tools" in kwargs["packages"]
     assert "iac_code.pipeline.selling.hooks" in kwargs["packages"]


### PR DESCRIPTION
## Summary

- distinguish a follow-up `ask_user_question` from `confirm_and_select` after A2A recovery
- send the candidate selection prompt when the recovered stream is already waiting at step 4
- require the latest deployment conclusion to be successful and contain a Stack ID before ask-recovery scenarios pass
- add focused regression tests for both the input-kind routing and deployment-success check

## Root cause

The real `ask-waiting` scenario treated any second `input_required` response as another clarification request. When the first answer had already advanced to candidate selection, the runner sent another requirements sentence instead of a selection. The pipeline eventually completed with a failed deployment conclusion, while the runner still reported PASS because it only checked for `pipeline_completed` and generic VSwitch text.

## Impact

The A2A real-cloud regression now exercises the intended recovery path and can no longer report a false positive when step 5 fails or omits a real Stack ID.

## Validation

- `make lint`
- `make test` — 13,339 passed, 2 skipped
- real `dashscope/qwen3.8-max` `ask-waiting` scenario — PASS with successful deployment and Stack ID
- real test Stack was identity-checked and deleted after the run
