### PR TITLE
Release v0.11.3

### DIFF
--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 __release_date__ = ""

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.2\n"
+"Project-Id-Version: iac-code 0.11.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.2\n"
+"Project-Id-Version: iac-code 0.11.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.2\n"
+"Project-Id-Version: iac-code 0.11.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.2\n"
+"Project-Id-Version: iac-code 0.11.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.2\n"
+"Project-Id-Version: iac-code 0.11.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.2\n"
+"Project-Id-Version: iac-code 0.11.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"

--- a/src/iac_code/web/token_transport.py
+++ b/src/iac_code/web/token_transport.py
@@ -235,9 +235,7 @@ class TokenTransport:
             origins and not _origin_matches(origins[0], hosts[0], str(scope.get("scheme") or "http"))
         ):
             return False
-        return len(fetch_sites) <= 1 and (
-            not fetch_sites or fetch_sites[0].lower() in {"same-origin", "none"}
-        )
+        return len(fetch_sites) <= 1 and (not fetch_sites or fetch_sites[0].lower() in {"same-origin", "none"})
 
     async def _challenge(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         await _read_body(receive)

--- a/tests/cli/test_web_command.py
+++ b/tests/cli/test_web_command.py
@@ -7,9 +7,7 @@ def test_web_command_runs_local_server_with_safe_defaults(monkeypatch) -> None:
     calls: list[dict] = []
 
     def fake_run_web_server(*, host: str, port: int, open_browser: bool, access_token_file: str | None) -> None:
-        calls.append(
-            {"host": host, "port": port, "open_browser": open_browser, "access_token_file": access_token_file}
-        )
+        calls.append({"host": host, "port": port, "open_browser": open_browser, "access_token_file": access_token_file})
 
     monkeypatch.setattr("iac_code.web.server.run_web_server", fake_run_web_server)
 
@@ -23,9 +21,7 @@ def test_web_command_accepts_host_port_and_open_browser(monkeypatch) -> None:
     calls: list[dict] = []
 
     def fake_run_web_server(*, host: str, port: int, open_browser: bool, access_token_file: str | None) -> None:
-        calls.append(
-            {"host": host, "port": port, "open_browser": open_browser, "access_token_file": access_token_file}
-        )
+        calls.append({"host": host, "port": port, "open_browser": open_browser, "access_token_file": access_token_file})
 
     monkeypatch.setattr("iac_code.web.server.run_web_server", fake_run_web_server)
 
@@ -39,9 +35,7 @@ def test_web_command_no_open_disables_browser(monkeypatch) -> None:
     calls: list[dict] = []
 
     def fake_run_web_server(*, host: str, port: int, open_browser: bool, access_token_file: str | None) -> None:
-        calls.append(
-            {"host": host, "port": port, "open_browser": open_browser, "access_token_file": access_token_file}
-        )
+        calls.append({"host": host, "port": port, "open_browser": open_browser, "access_token_file": access_token_file})
 
     monkeypatch.setattr("iac_code.web.server.run_web_server", fake_run_web_server)
 

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -115,7 +115,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
     assert "--host 0.0.0.0 --port 8766 --access-token-file" in script
     assert "Restart=on-failure" in script
     assert "secrets.token_urlsafe(32)" in script
-    assert "exec >>\"$LOG\" 2>&1" in script
+    assert 'exec >>"$LOG" 2>&1' in script
     assert "printf '%s' \"$TOKEN\" >&3" in script
     assert set(re.findall(r"\$\{([^}]+)\}", script)) == {
         "IacCodeVersion",
@@ -141,9 +141,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
     assert set(outputs) == {"PublicUrl", "WebAccessToken", "InstanceId", "EipAddress", "IacCodeVersion"}
     assert all(set(output["Label"]) == {"en", "zh-cn"} for output in outputs.values())
     assert outputs["WebAccessToken"]["Value"] == {
-        "Fn::Base64Decode": {
-            "Fn::Jq": ["First", ".[0].Output", {"Fn::GetAtt": ["Bootstrap", "InvokeResults"]}]
-        }
+        "Fn::Base64Decode": {"Fn::Jq": ["First", ".[0].Output", {"Fn::GetAtt": ["Bootstrap", "InvokeResults"]}]}
     }
     assert "ApiKey" not in outputs
 

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -128,7 +128,7 @@ def test_legacy_setup_declares_package_metadata(monkeypatch):
     kwargs = setup_module._TEST_SETUP_KWARGS
 
     assert kwargs["name"] == "iac_code"
-    assert kwargs["version"] == "0.11.2"
+    assert kwargs["version"] == "0.11.3"
     assert kwargs["package_dir"] == {"": "src"}
     assert "iac_code.pipeline.selling.tools" in kwargs["packages"]
     assert "iac_code.pipeline.selling.hooks" in kwargs["packages"]

--- a/tests/web/test_token_transport.py
+++ b/tests/web/test_token_transport.py
@@ -179,14 +179,20 @@ def test_ping_request_replay_and_internal_denials(client: TestClient, token: str
     out_of_order = client.post("/api/token/request", json=browser.request_envelope(2, "/api/echo"))
     assert out_of_order.status_code == 200
     assert client.post("/api/token/request", json=request).status_code == 401
-    assert client.post(
-        "/api/token/request",
-        json=browser.request_envelope(5, "/api/token/challenge"),
-    ).status_code == 401
-    assert client.post(
-        "/api/token/request",
-        json=browser.request_envelope(6, "/api/cloud/aliyun/oauth-login"),
-    ).status_code == 401
+    assert (
+        client.post(
+            "/api/token/request",
+            json=browser.request_envelope(5, "/api/token/challenge"),
+        ).status_code
+        == 401
+    )
+    assert (
+        client.post(
+            "/api/token/request",
+            json=browser.request_envelope(6, "/api/cloud/aliyun/oauth-login"),
+        ).status_code
+        == 401
+    )
 
 
 def test_wrong_token_cannot_validate_ping(client: TestClient) -> None:
@@ -215,8 +221,7 @@ def test_stream_metadata_body_and_end_are_encrypted(client: TestClient, token: s
     start = json.loads(browser.decrypt(envelopes[0], "stream-start"))
     assert start["status"] == 200
     body = b"".join(
-        _decode(json.loads(browser.decrypt(envelope, "stream-body"))["body"])
-        for envelope in envelopes[1:-1]
+        _decode(json.loads(browser.decrypt(envelope, "stream-body"))["body"]) for envelope in envelopes[1:-1]
     )
     assert body == b'data: {"value":1}\n\ndata: {"value":2}\n\n'
     assert json.loads(browser.decrypt(envelopes[-1], "stream-end")) == {}


### PR DESCRIPTION
## Summary

- Bump the package version to 0.11.3.
- Refresh translation catalog metadata for the new release version.
- Include the `ruff format` normalization produced by the requested release checklist.

## Validation

- `make format`
- `make lint` (rerun after `uv sync --all-extras` populated optional A2A dependencies for `ty`)
- `make translate`
- `make test` (`13450 passed, 2 skipped`)
