### PR TITLE
fix(a2a): queue selection during input backup

### DIFF
--- a/scripts/a2a/e2e/README.md
+++ b/scripts/a2a/e2e/README.md
@@ -91,6 +91,26 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1-performance-backup
 ```
 
+To reproduce the race where the candidate page is already visible while the
+post-`input_required` backup is still running on slow storage:
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
+  --allow-real-cloud \
+  --provider dashscope \
+  --stream-timeout 2400 \
+  --event-timeout 300 \
+  --preflight-timeout 60 \
+  --scenario selection-during-backup
+```
+
+An E2E-only fixture delays the Step 4 `input_required` backup by at least 10
+seconds. The client submits its selection as soon as the event arrives. The
+scenario proves that dispatch happened inside the backup started/finished
+window, the message was consumed as candidate input, and no
+`interrupt_received` / `interrupt_classified` event was emitted.
+
 Run the full real E2E matrix:
 
 ```bash
@@ -103,6 +123,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --preflight-timeout 60 \
   --scenario scenario1 \
   --scenario scenario1-performance-backup \
+  --scenario selection-during-backup \
   --scenario redaction-step4 \
   --scenario selection-waiting \
   --scenario ask-waiting \
@@ -149,6 +170,7 @@ the rest of the tests.
 | `redaction-step4` | Force A2A safe mode and stop when the real mini-app backend/database task reaches step 4 candidate selection | None; no candidate selection is submitted | Canonical password parameters are not placeholders; public A2A passwords equal canonical values; token counters stay numeric when present; known server paths become `[PATH]` only in the public copy; deployment never starts. |
 | `scenario1` | After pipeline completion and one normal-chat follow-up | Ask what the previous normal-chat question was | Normal-chat history survives restart; VSwitch evidence exists. |
 | `scenario1-performance-backup` | Full `scenario1` with `IAC_CODE_A2A_EXTREME_PERFORMANCE=true` and `IAC_CODE_CONFIG_BACKUP_DIR=<run-dir>/session-backup` | After the Step4 backup is durable, stop the server, remove the matching primary session under `projects`, restart, and select without `taskId`; later normal-chat recovery also omits `taskId` | Only the backup session exists before restart; restart alone does not recreate the primary session; selection without `taskId` restores the primary session from backup and hydrates the recovered task; full scenario1 passes. |
+| `selection-during-backup` | Step 4 `input_required` is published, then an E2E fixture blocks its backup for at least 10 seconds | Immediately send `你随便选一个方案。` with the active pipeline `taskId` while backup is running | Dispatch falls inside the backup started/finished window; the request is queued and consumed as candidate input; no interrupt events are emitted; the pipeline completes. |
 | `selection-waiting` | Step 4 waits for candidate selection | `你随便选一个方案。` without `taskId` | Waiting step4 task is recovered and selected; VSwitch evidence exists. |
 | `ask-waiting` | `ask_user_question` waits for user input | Clarification answers without `taskId` | Pending ask input is recovered and pipeline completes; VSwitch evidence exists. |
 | `image-initial` | Initial user message is the static `initial.png` image fixture | Candidate selection text | The image starts the pipeline, reaches step4 selection, completes, and produces VSwitch evidence. |
@@ -221,15 +243,16 @@ When stabilizing changes, run the smaller or more diagnostic cases first:
 2. `fault-after-snapshot`
 3. `scenario1`
 4. `scenario1-performance-backup`
-5. `selection-waiting`
-6. `ask-waiting`
-7. `image-initial`, `image-ask-waiting`, and `image-selection-waiting`
-8. `image-normal-handoff` and `image-interrupt`
-9. `step1-running` through `step5-running`
-10. `normal-running`
-11. `cancel-step1` through `cancel-step5`
-12. `rollback-step1` through `rollback-step5`
-13. `rollback-step5-cleanup`, then `rollback-step5-cleanup-recovery`
+5. `selection-during-backup`
+6. `selection-waiting`
+7. `ask-waiting`
+8. `image-initial`, `image-ask-waiting`, and `image-selection-waiting`
+9. `image-normal-handoff` and `image-interrupt`
+10. `step1-running` through `step5-running`
+11. `normal-running`
+12. `cancel-step1` through `cancel-step5`
+13. `rollback-step1` through `rollback-step5`
+14. `rollback-step5-cleanup`, then `rollback-step5-cleanup-recovery`
 
 ## Preflight
 

--- a/scripts/a2a/e2e/README.zh-CN.md
+++ b/scripts/a2a/e2e/README.zh-CN.md
@@ -99,6 +99,23 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --scenario scenario1-performance-backup
 ```
 
+如果要复现“候选选择页已出现，但 `input_required` backup 仍在慢速 OSS 上执行”的竞态，运行：
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
+  --allow-real-cloud \
+  --provider dashscope \
+  --stream-timeout 2400 \
+  --event-timeout 300 \
+  --preflight-timeout 60 \
+  --scenario selection-during-backup
+```
+
+该场景通过仅注入 server 子进程的 E2E fixture，把 step4 `input_required` backup 至少阻塞 10 秒；
+客户端收到候选选择事件后立即提交方案。场景会验证选择请求确实在 backup 的 started/finished 窗口内发出、
+最终被消费为 candidate selection，并且没有产生 `interrupt_received` / `interrupt_classified`。
+
 如果要跑完整真实 E2E 矩阵：
 
 ```bash
@@ -111,6 +128,7 @@ uv run python scripts/a2a/e2e/run_recovery_scenarios.py \
   --preflight-timeout 60 \
   --scenario scenario1 \
   --scenario scenario1-performance-backup \
+  --scenario selection-during-backup \
   --scenario redaction-step4 \
   --scenario selection-waiting \
   --scenario ask-waiting \
@@ -154,6 +172,7 @@ provider、tool、真实云调用场景默认会被保护住。只有确认要�
 | `redaction-step4` | 强制 A2A safe mode，真实小程序后端/数据库需求到达 step4 候选方案选择即停止 | 无；不提交方案选择 | canonical 密码参数不是脱敏占位符；A2A 密码值与 canonical 一致；存在的 token 统计仍为数字；已知服务器路径只在 A2A 副本中变成 `[PATH]`；不进入部署。 |
 | `scenario1` | pipeline 完成并完成一轮 normal-chat follow-up 后 | 询问上一条 normal-chat 问题是什么 | normal-chat 历史重启后仍可用；存在 VSwitch 证据。 |
 | `scenario1-performance-backup` | 完整 `scenario1`，并强制 `IAC_CODE_A2A_EXTREME_PERFORMANCE=true`、`IAC_CODE_CONFIG_BACKUP_DIR=<run-dir>/session-backup` | step4 backup 落盘后停服并删除主 `projects` 下对应 session，重启后不带 `taskId` 选择；后续 normal-chat 恢复也不带 `taskId` | 重启前只有 backup session；重启本身不会重建主 session；省略 `taskId` 的选择会从 backup restore 主 session 并 hydrate 到恢复 task；完整 scenario1 通过。 |
+| `selection-during-backup` | step4 `input_required` 已发出，E2E fixture 将随后执行的 backup 至少阻塞 10 秒 | backup 仍在执行时，携带原 task 的 `taskId` 立即发送 `你随便选一个方案。` | 请求时间落在 backup started/finished 窗口内；选择被排队并作为 candidate input 消费；不产生 interrupt 事件；pipeline 完成。 |
 | `selection-waiting` | step4 等待候选方案选择时 | 不带 `taskId` 发送 `你随便选一个方案。` | 能恢复等待中的 step4 task 并完成选择；存在 VSwitch 证据。 |
 | `ask-waiting` | `ask_user_question` 等待用户输入时 | 不带 `taskId` 发送澄清回答 | 能恢复 pending ask 输入并完成 pipeline；存在 VSwitch 证据。 |
 | `image-initial` | 首轮用户消息就是静态 `initial.png` 图片 fixture | 文本选择候选方案 | 图片能启动 pipeline，进入 step4 选择，最终完成并产生 VSwitch 证据。 |
@@ -225,15 +244,16 @@ CLI 覆盖后的文本，才会回退到运行时渲染图片。
 2. `fault-after-snapshot`
 3. `scenario1`
 4. `scenario1-performance-backup`
-5. `selection-waiting`
-6. `ask-waiting`
-7. `image-initial`、`image-ask-waiting` 和 `image-selection-waiting`
-8. `image-normal-handoff` 和 `image-interrupt`
-9. `step1-running` 到 `step5-running`
-10. `normal-running`
-11. `cancel-step1` 到 `cancel-step5`
-12. `rollback-step1` 到 `rollback-step5`
-13. `rollback-step5-cleanup`，再跑 `rollback-step5-cleanup-recovery`
+5. `selection-during-backup`
+6. `selection-waiting`
+7. `ask-waiting`
+8. `image-initial`、`image-ask-waiting` 和 `image-selection-waiting`
+9. `image-normal-handoff` 和 `image-interrupt`
+10. `step1-running` 到 `step5-running`
+11. `normal-running`
+12. `cancel-step1` 到 `cancel-step5`
+13. `rollback-step1` 到 `rollback-step5`
+14. `rollback-step5-cleanup`，再跑 `rollback-step5-cleanup-recovery`
 
 ## Preflight
 

--- a/scripts/a2a/e2e/fixtures/backup-delay-sitecustomize/sitecustomize.py
+++ b/scripts/a2a/e2e/fixtures/backup-delay-sitecustomize/sitecustomize.py
@@ -1,0 +1,114 @@
+"""Inject a controllable backup delay into the A2A E2E server process."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from functools import wraps
+from pathlib import Path
+from typing import Any
+
+from iac_code.services import session_backup
+
+_DELAY_SECONDS_ENV = "IAC_CODE_E2E_BACKUP_DELAY_SECONDS"
+_CONTROL_ENV = "IAC_CODE_E2E_BACKUP_DELAY_CONTROL"
+_ARM_WAIT_SECONDS = 5.0
+_claim_lock = threading.Lock()
+_claimed = False
+
+
+def _marker_path(control: Path, marker: str) -> Path:
+    return control.with_name(f"{control.name}.{marker}.json")
+
+
+def _write_marker(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _claim_delay(reason: Any) -> tuple[Path, float, float] | None:
+    global _claimed
+
+    reason_value = getattr(reason, "value", reason)
+    if reason_value != session_backup.BackupReason.INPUT_REQUIRED.value:
+        return None
+    control_value = os.environ.get(_CONTROL_ENV, "")
+    try:
+        delay_seconds = float(os.environ.get(_DELAY_SECONDS_ENV, ""))
+    except ValueError:
+        return None
+    if not control_value or delay_seconds <= 0:
+        return None
+
+    control = Path(control_value)
+    arm_path = _marker_path(control, "arm")
+    with _claim_lock:
+        if _claimed:
+            return None
+        deadline = time.monotonic() + _ARM_WAIT_SECONDS
+        while not arm_path.is_file() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        if not arm_path.is_file():
+            return None
+        _claimed = True
+
+    started_at = time.time()
+    started_monotonic = time.monotonic()
+    _write_marker(
+        _marker_path(control, "started"),
+        {
+            "startedAt": started_at,
+            "startedMonotonic": started_monotonic,
+            "delaySeconds": delay_seconds,
+            "reason": str(reason_value),
+        },
+    )
+    time.sleep(delay_seconds)
+    return control, started_at, started_monotonic
+
+
+def _finish_delay(state: tuple[Path, float, float], *, succeeded: bool) -> None:
+    control, started_at, started_monotonic = state
+    finished_at = time.time()
+    finished_monotonic = time.monotonic()
+    _write_marker(
+        _marker_path(control, "finished"),
+        {
+            "startedAt": started_at,
+            "finishedAt": finished_at,
+            "startedMonotonic": started_monotonic,
+            "finishedMonotonic": finished_monotonic,
+            "elapsedSeconds": finished_monotonic - started_monotonic,
+            "succeeded": succeeded,
+        },
+    )
+
+
+def _install() -> None:
+    original = session_backup.SessionBackupService.backup_session
+    original_body = getattr(original, "__wrapped__", None)
+    if original_body is None or getattr(original, "__e2e_backup_delay__", False):
+        return
+
+    @session_backup._log_backup_session_elapsed
+    @wraps(original_body)
+    def delayed_backup(self: Any, *args: Any, **kwargs: Any) -> Any:
+        delay_state = _claim_delay(kwargs.get("reason"))
+        succeeded = False
+        try:
+            result = original_body(self, *args, **kwargs)
+            succeeded = bool(getattr(result, "succeeded", True))
+            return result
+        finally:
+            if delay_state is not None:
+                _finish_delay(delay_state, succeeded=succeeded)
+
+    delayed_backup.__e2e_backup_delay__ = True
+    session_backup.SessionBackupService.backup_session = delayed_backup
+
+
+_install()

--- a/scripts/a2a/e2e/run_recovery_scenarios.py
+++ b/scripts/a2a/e2e/run_recovery_scenarios.py
@@ -110,7 +110,10 @@ CLEANUP_EVENT_TYPES = frozenset(
 )
 CLEANUP_ACTIVE_STATUSES = frozenset({"pending", "started", "in_progress", "failed"})
 FAULT_AFTER_SNAPSHOT_POINT = "after_a2a_pipeline_snapshot_saved"
-PERFORMANCE_BACKUP_SCENARIOS = frozenset({"scenario1-performance-backup"})
+SELECTION_DURING_BACKUP_SCENARIO = "selection-during-backup"
+BACKUP_DELAY_SECONDS = 10.0
+BACKUP_DELAY_FIXTURE_ROOT = E2E_SCRIPTS_DIR / "fixtures" / "backup-delay-sitecustomize"
+PERFORMANCE_BACKUP_SCENARIOS = frozenset({"scenario1-performance-backup", SELECTION_DURING_BACKUP_SCENARIO})
 DEFAULT_TEXT_MODEL = "deepseek-v4-flash-0731"
 DEFAULT_MULTIMODAL_MODEL = "qwen3.8-max"
 MULTIMODAL_SCENARIOS = frozenset(
@@ -401,6 +404,8 @@ class BackgroundStream:
         self.summary = StreamSummary(name=name, prompt=prompt, request_task_id=task_id)
         self.events: list[Any] = []
         self.exception: BaseException | None = None
+        self.request_started_at: float | None = None
+        self.request_started_monotonic: float | None = None
         self._condition = threading.Condition()
         self._done = False
         self._thread = threading.Thread(target=self._run, name=f"a2a-e2e-{name}", daemon=True)
@@ -457,6 +462,8 @@ class BackgroundStream:
             message_id=str(uuid.uuid4()),
             images=self.images,
         )
+        self.request_started_at = time.time()
+        self.request_started_monotonic = time.monotonic()
         _append_jsonl(
             self.run_dir / "requests.jsonl",
             {"name": self.name, "payload": payload, "at": _utc_now()},
@@ -533,6 +540,17 @@ class ScenarioHarness:
             self.server_env["IAC_CODE_A2A_EXTREME_PERFORMANCE"] = "true"
             self.server_env["IAC_CODE_CONFIG_BACKUP_DIR"] = str(self.backup_root)
             self.notes.append(f"enabled A2A extreme performance and backup dir {self.backup_root}")
+        if scenario == SELECTION_DURING_BACKUP_SCENARIO:
+            fixture_path = str(BACKUP_DELAY_FIXTURE_ROOT.resolve())
+            existing_pythonpath = self.server_env.get("PYTHONPATH", "")
+            self.server_env["PYTHONPATH"] = os.pathsep.join(
+                value for value in (fixture_path, existing_pythonpath) if value
+            )
+            self.server_env["IAC_CODE_E2E_BACKUP_DELAY_SECONDS"] = str(BACKUP_DELAY_SECONDS)
+            self.server_env["IAC_CODE_E2E_BACKUP_DELAY_CONTROL"] = str(
+                (self.run_dir / "selection-backup-delay").resolve()
+            )
+            self.notes.append(f"armed E2E-only input_required backup delay fixture for {BACKUP_DELAY_SECONDS:.0f}s")
         if args.deterministic:
             self.server_env["IAC_CODE_A2A_DETERMINISTIC_RECOVERY"] = "1"
             self.server_env["IAC_CODE_TEST_FAULT_INJECTION"] = "1"
@@ -1121,6 +1139,78 @@ def run_selection_waiting(args: argparse.Namespace, scenario: str) -> int:
         selection = h.stream(prompt=args.selection_prompt, name="02-select-after-restart", task_id="")
         _add_hydrated_task_checks(h, selection, "selection answer")
         h.checks["selection accepted and advanced past waiting step"] = _selection_advanced_past_waiting_step(selection)
+        h.checks["VSwitch evidence found"] = _has_any_marker(_all_evidence(h), VSWITCH_MARKERS)
+
+    return _run_with_harness(args, scenario, callback)
+
+
+def run_selection_during_backup(args: argparse.Namespace, scenario: str) -> int:
+    def callback(h: ScenarioHarness) -> None:
+        initial_streams = _wait_for_with_intervening_ask_inputs(
+            h,
+            [h.start_stream(prompt=args.initial_prompt, name="01-initial", context_id="", task_id="")],
+            _input_required_step("confirm_and_select"),
+            description="step4 candidate selection input_required",
+            timeout=args.event_timeout,
+            name_prefix="01-initial",
+        )
+        h.checks["initial reached step4 input_required before stream completed"] = any(
+            stream.summary.last_input_required_step_id == "confirm_and_select" and not stream.done
+            for stream in initial_streams
+        )
+
+        control = _backup_delay_control_path(h)
+        arm_path = _backup_delay_marker_path(control, "arm")
+        _write_json(
+            arm_path,
+            {
+                "armedAt": time.time(),
+                "scenario": scenario,
+                "delaySeconds": BACKUP_DELAY_SECONDS,
+            },
+        )
+        started = _wait_for_backup_delay_marker(control, "started", timeout=min(10.0, args.event_timeout))
+        h.snapshots["backup_delay_started"] = started
+        h.checks["input_required backup delay started"] = started.get("delaySeconds") == BACKUP_DELAY_SECONDS
+
+        h.checks["backup was unfinished when selection request was dispatched"] = not _backup_delay_marker_path(
+            control, "finished"
+        ).exists()
+        selection_stream = h.start_stream(prompt=args.selection_prompt, name="02-select-during-backup")
+
+        for stream in initial_streams:
+            stream.join(timeout=args.stream_timeout)
+        selection = selection_stream.join(timeout=args.stream_timeout)
+        finished = _wait_for_backup_delay_marker(control, "finished", timeout=min(10.0, args.event_timeout))
+        h.snapshots["backup_delay_finished"] = finished
+        h.snapshots["selection_dispatch"] = {
+            "dispatchedAt": selection_stream.request_started_at,
+            "dispatchedMonotonic": selection_stream.request_started_monotonic,
+        }
+
+        started_monotonic = _float_value(started.get("startedMonotonic"))
+        finished_monotonic = _float_value(finished.get("finishedMonotonic"))
+        selection_dispatched_monotonic = selection_stream.request_started_monotonic
+        delay_elapsed = _float_value(finished.get("elapsedSeconds"))
+        h.checks["selection request was dispatched during backup delay"] = (
+            started_monotonic is not None
+            and finished_monotonic is not None
+            and selection_dispatched_monotonic is not None
+            and started_monotonic <= selection_dispatched_monotonic < finished_monotonic
+        )
+        h.checks["backup delay lasted at least 10 seconds"] = (
+            delay_elapsed is not None and delay_elapsed >= BACKUP_DELAY_SECONDS
+        )
+        h.checks["selection stayed on pipeline task"] = selection.task_id == h.pipeline_task_id
+        h.checks["selection was consumed as candidate input"] = _selection_advanced_past_waiting_step(selection)
+        observed_event_types = set(selection.pipeline_event_types)
+        for stream in initial_streams:
+            observed_event_types.update(stream.summary.pipeline_event_types)
+        h.checks["selection did not enter interrupt routing"] = not {
+            "interrupt_received",
+            "interrupt_classified",
+        }.intersection(observed_event_types)
+        h.checks["selection completed pipeline"] = _pipeline_completed(selection)
         h.checks["VSwitch evidence found"] = _has_any_marker(_all_evidence(h), VSWITCH_MARKERS)
 
     return _run_with_harness(args, scenario, callback)
@@ -2015,6 +2105,42 @@ def _selection_advanced_past_waiting_step(summary: StreamSummary) -> bool:
     except ValueError:
         return False
     return "step_started" in event_types[completed_index + 1 :] or _pipeline_completed(summary)
+
+
+def _backup_delay_control_path(h: ScenarioHarness) -> Path:
+    raw = h.server_env.get("IAC_CODE_E2E_BACKUP_DELAY_CONTROL", "")
+    if not raw:
+        raise RuntimeError("backup delay control path is not configured")
+    return Path(raw)
+
+
+def _backup_delay_marker_path(control: Path, marker: str) -> Path:
+    return control.with_name(f"{control.name}.{marker}.json")
+
+
+def _wait_for_backup_delay_marker(control: Path, marker: str, *, timeout: float) -> dict[str, Any]:
+    path = _backup_delay_marker_path(control, marker)
+    deadline = time.monotonic() + timeout
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            last_error = str(exc)
+            time.sleep(0.05)
+            continue
+        if isinstance(value, dict):
+            return value
+        last_error = "marker was not a JSON object"
+        time.sleep(0.05)
+    raise TimeoutError(f"Timed out waiting for backup delay marker {path}: {last_error}")
+
+
+def _float_value(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _add_same_task_checks(h: ScenarioHarness, summary: StreamSummary, prefix: str) -> None:
@@ -3537,6 +3663,7 @@ _REAL_CLOUD_SCENARIOS = {
     "image-selection-waiting",
     "scenario1",
     "scenario1-performance-backup",
+    SELECTION_DURING_BACKUP_SCENARIO,
     "normal-running",
     "ask-waiting",
     REDACTION_STEP4_SCENARIO,
@@ -3557,6 +3684,7 @@ _SCENARIOS: dict[str, Callable[[argparse.Namespace, str], int]] = {
     "image-selection-waiting": run_image_selection_waiting,
     "scenario1": run_scenario1,
     "scenario1-performance-backup": run_scenario1_performance_backup,
+    SELECTION_DURING_BACKUP_SCENARIO: run_selection_during_backup,
     "normal-running": run_normal_running,
     "ask-waiting": run_ask_waiting,
     REDACTION_STEP4_SCENARIO: run_redaction_step4,

--- a/src/iac_code/a2a/transports/dispatcher.py
+++ b/src/iac_code/a2a/transports/dispatcher.py
@@ -472,7 +472,11 @@ class IacCodeRequestHandler(DefaultRequestHandler):
         if task_id and isinstance(self.task_store, A2ATaskStore) and await self.task_store.is_task_active(task_id):
             task = await self.task_store.get(task_id, context)
             active_task = await self._active_task_registry.get(task_id)
-            if task is not None and active_task is not None and task.status.state not in TERMINAL_TASK_STATES:
+            if (
+                task is not None
+                and active_task is not None
+                and task.status.state not in TERMINAL_TASK_STATES | INTERRUPTED_TASK_STATES
+            ):
                 active_stream = self._on_active_message_send_stream(
                     params,
                     context,

--- a/tests/a2a/test_transport_dispatcher.py
+++ b/tests/a2a/test_transport_dispatcher.py
@@ -421,6 +421,63 @@ async def test_message_stream_does_not_acknowledge_transport_delivery_when_close
 
 
 @pytest.mark.asyncio
+async def test_message_stream_queues_input_required_followup_instead_of_routing_as_interrupt(monkeypatch) -> None:
+    call_context = ServerCallContext()
+    store = A2ATaskStore()
+    await store.save(
+        Task(
+            id="task-1",
+            context_id="ctx-1",
+            status=TaskStatus(state=TaskState.TASK_STATE_INPUT_REQUIRED),
+        ),
+        call_context,
+    )
+    record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    record.active_task = asyncio.current_task()
+    update = TaskStatusUpdateEvent(
+        task_id="task-1",
+        context_id="ctx-1",
+        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+    )
+    sdk_stream_called = False
+
+    async def sdk_stream(_handler, _params, _context):
+        nonlocal sdk_stream_called
+        sdk_stream_called = True
+        yield update
+
+    async def hydrate(_params) -> None:
+        return None
+
+    async def reconcile(_params, _context) -> None:
+        return None
+
+    class ActiveTaskRegistry:
+        async def get(self, _task_id):
+            return object()
+
+    async def fail_active_stream(*_args, **_kwargs):
+        raise AssertionError("input-required follow-up must not use the active interrupt route")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(DefaultRequestHandler, "on_message_send_stream", sdk_stream)
+    handler = IacCodeRequestHandler.__new__(IacCodeRequestHandler)
+    handler.task_store = store
+    handler._active_task_registry = ActiveTaskRegistry()
+    handler._validate_extensions = lambda _context: None
+    handler._validate_pipeline_message_request = lambda _params: None
+    handler._hydrate_recoverable_pipeline_task_id = hydrate
+    handler._reconcile_recoverable_pipeline_task = reconcile
+    handler._on_active_message_send_stream = fail_active_stream
+    params = SimpleNamespace(message=SimpleNamespace(task_id="task-1", context_id="ctx-1"))
+
+    events = await _collect_async(handler.on_message_send_stream(params, call_context))
+
+    assert events == [update]
+    assert sdk_stream_called is True
+
+
+@pytest.mark.asyncio
 async def test_dispatcher_stream_preserves_message_metadata_echo_without_safe_mode(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("IAC_CODE_A2A_SAFE_MODE", raising=False)
     loop = FakeAgentLoop([TextDeltaEvent(text="streamed")])

--- a/tests/a2a_e2e/test_run_recovery_scenarios.py
+++ b/tests/a2a_e2e/test_run_recovery_scenarios.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import base64
 import importlib.util
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -329,6 +331,20 @@ def test_scenario1_performance_backup_is_registered_and_requires_real_cloud() ->
         assert "--allow-real-cloud" in str(exc)
     else:
         raise AssertionError("scenario1-performance-backup should require --allow-real-cloud")
+
+
+def test_selection_during_backup_is_registered_and_requires_real_cloud() -> None:
+    runner = _load_runner()
+
+    scenario = runner.SELECTION_DURING_BACKUP_SCENARIO
+    assert runner._SCENARIOS[scenario] is runner.run_selection_during_backup
+    args = SimpleNamespace(allow_real_cloud=False, deterministic=False)
+    try:
+        runner._validate_scenario_execution(args, scenario)
+    except SystemExit as exc:
+        assert "--allow-real-cloud" in str(exc)
+    else:
+        raise AssertionError(f"{scenario} should require --allow-real-cloud")
 
 
 def test_redaction_step4_is_registered_requires_real_cloud_and_forces_safe_mode(tmp_path: Path) -> None:
@@ -889,6 +905,66 @@ def test_scenario1_performance_backup_configures_server_env(tmp_path: Path) -> N
     assert harness.server_env["IAC_CODE_A2A_EXTREME_PERFORMANCE"] == "true"
     assert harness.server_env["IAC_CODE_CONFIG_BACKUP_DIR"] == str((tmp_path / "run" / "session-backup").resolve())
     assert harness.backup_root == (tmp_path / "run" / "session-backup").resolve()
+
+
+def test_selection_during_backup_configures_e2e_only_delay(tmp_path: Path) -> None:
+    runner = _load_runner()
+    args = SimpleNamespace(
+        server_cwd=str(tmp_path),
+        run_dir=str(tmp_path / "run"),
+        run_root=str(tmp_path),
+        cwd="",
+        host="127.0.0.1",
+        port=0,
+        no_auto_approve_permissions=False,
+        provider="",
+        model="",
+        api_base="",
+        deterministic=False,
+        fault_at="",
+    )
+
+    harness = runner.ScenarioHarness(args, scenario=runner.SELECTION_DURING_BACKUP_SCENARIO)
+
+    assert harness.server_env["IAC_CODE_A2A_EXTREME_PERFORMANCE"] == "true"
+    assert harness.server_env["IAC_CODE_E2E_BACKUP_DELAY_SECONDS"] == "10.0"
+    assert harness.server_env["IAC_CODE_E2E_BACKUP_DELAY_CONTROL"] == str(
+        (tmp_path / "run" / "selection-backup-delay").resolve()
+    )
+    assert str(runner.BACKUP_DELAY_FIXTURE_ROOT.resolve()) == harness.server_env["PYTHONPATH"].split(os.pathsep)[0]
+
+
+def test_backup_delay_sitecustomize_delays_armed_input_required_backup(tmp_path: Path) -> None:
+    runner = _load_runner()
+    control = tmp_path / "backup-delay"
+    runner._write_json(runner._backup_delay_marker_path(control, "arm"), {"armed": True})
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        value for value in (str(runner.BACKUP_DELAY_FIXTURE_ROOT.resolve()), env.get("PYTHONPATH", "")) if value
+    )
+    env["IAC_CODE_E2E_BACKUP_DELAY_SECONDS"] = "0.05"
+    env["IAC_CODE_E2E_BACKUP_DELAY_CONTROL"] = str(control)
+    script = "\n".join(
+        [
+            "from iac_code.services.session_backup import BackupReason, SessionBackupService",
+            "service = SessionBackupService()",
+            "service.backup_session('', 'session-1', reason=BackupReason.INPUT_REQUIRED, critical=False)",
+        ]
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    finished = runner._wait_for_backup_delay_marker(control, "finished", timeout=1)
+    assert finished["elapsedSeconds"] >= 0.05
+    assert finished["succeeded"] is True
 
 
 def test_scenario1_performance_backup_omits_selection_task_id_and_checks_backup(


### PR DESCRIPTION
## Summary

- route follow-up messages for active `input-required` / `auth-required` tasks through the SDK request queue
- prevent an immediate Step 4 candidate selection from being misclassified as an active pipeline interrupt while post-publication backup is still running
- add a dedicated `selection-during-backup` real A2A E2E scenario with an E2E-only 10-second backup delay fixture
- document the new scenario in both A2A E2E READMEs

## Root cause

The original request remains active while the post-`input_required` session backup runs. During that window, the transport dispatcher treated the follow-up selection as an active interrupt. Candidate selection is not handled by that route, so it could reach interrupt classification with no supplement target instead of being consumed as the pending Step 4 input.

## Impact

Selections submitted as soon as the candidate page appears are queued behind the current request and processed after backup finishes. Existing active interrupt routing remains unchanged for working tasks.

## Validation

- `uv run pytest tests/a2a_e2e/test_run_recovery_scenarios.py tests/a2a/test_transport_dispatcher.py tests/a2a/test_pipeline_events.py -q` (`170 passed`)
- `make lint`
- real `selection-during-backup` E2E passed with backup elapsed `10.111s`; selection dispatch started about `28.6ms` after backup began and no interrupt events were emitted
- rebased onto current `origin/main`; subagent and Claude Code compatibility reviews found no functional incompatibility