### PR TITLE
fix: harden iac-code Web ECS deployment flow

### DIFF
--- a/src/iac_code/a2a/pipeline_events.py
+++ b/src/iac_code/a2a/pipeline_events.py
@@ -14,6 +14,7 @@ from iac_code.a2a.pipeline_journal import to_json_safe
 from iac_code.mcp.progress import mcp_progress_metadata
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.services.permissions.audit import build_input_summary, build_redacted_tool_input, fingerprint_text
+from iac_code.tools.cloud.base_stack import stack_result_from_metadata
 from iac_code.types.stream_events import (
     AskUserQuestionEvent,
     CandidateDetailEvent,
@@ -900,7 +901,7 @@ class PipelineEventTranslator:
         action = operation["action"]
         params = operation["params"]
 
-        result = _json_object_from_string(event.result)
+        result = stack_result_from_metadata(event.metadata) or _json_object_from_string(event.result)
         if result is None:
             return None
         is_success = _bool_or_none(result.get("is_success"))
@@ -1480,12 +1481,15 @@ def _safe_permission_field_name(key: Any) -> str:
 
 
 def _tool_result_data(event: ToolResultEvent) -> dict[str, Any]:
-    return {
+    data = {
         "toolName": event.tool_name,
         "toolUseId": event.tool_use_id,
         "isError": event.is_error,
         "result": to_json_safe(event.result),
     }
+    if stack_result := stack_result_from_metadata(event.metadata):
+        data["stackResult"] = to_json_safe(stack_result)
+    return data
 
 
 def _sanitize_tool_input(tool_input: dict[str, Any]) -> dict[str, Any]:

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
@@ -69,8 +69,8 @@ conclusion_schema:
 
 判断标准：如果你需要添加用户完全没提到的产品来"制造"差异，那就不该有多个方案。
 
-若意图是把 iac-code Web 部署到 ECS，只生成一个候选，并固定
-`candidate.name = iac-code-web-single-ecs`。
+若将 iac-code Web 部署到 ECS，只生成一个单 ECS + EIP 候选，安全组仅开放 8766，不得增加其他入口资源；
+将其 `candidate.name` 固定为 `iac-code-web-single-ecs`。
 
 ## 差异化维度
 

--- a/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.md
@@ -2,7 +2,7 @@
 
 仅当 `candidate.name` 精确等于 `iac-code-web-single-ecs` 时使用本文件。生成 ROS 模板时直接以
 同目录的 `iac-code-web.ros.yml` 为基线，只允许调整可用区、实例规格、系统盘类型、EIP 带宽、
-访问 CIDR 和 iac-code 版本。不得增加 HTTPS、Nginx、域名、SLB、WAF、多实例或已有百炼
+访问 CIDR。不得增加 HTTPS、Nginx、域名、SLB、WAF、多实例或已有百炼
 API Key 参数。
 
 ## 资源与网络
@@ -16,7 +16,7 @@ API Key 参数。
 
 ## Bootstrap
 
-- 使用 Python 3.11 虚拟环境，并从阿里云 PyPI 镜像安装参数指定版本的 `iac-code[http]`。
+- 使用 Python 3.11 虚拟环境，并从阿里云 PyPI 镜像安装部署时最新的 `iac-code[http]`。
 - 生成 Web 访问 Token 并以 0600 权限保存到 ECS；systemd 使用 `--access-token-file`、
   `--host 0.0.0.0 --port 8766 --no-open` 启动 iac-code Web。
 - `IAC_CODE_CONFIG_DIR` 固定为 `/var/lib/iac-code`。Bootstrap 将百炼 API Key 写入
@@ -27,6 +27,5 @@ API Key 参数。
 
 ## Stack Outputs
 
-保持 Golden YAML 的五个输出：`PublicUrl`、`WebAccessToken`、`InstanceId`、`EipAddress` 和
-`IacCodeVersion`。`PublicUrl` 使用 EIP 的 HTTP 8766 地址，`WebAccessToken` 来自同步
-Bootstrap 的执行结果。
+保持 Golden YAML 的四个输出：`PublicUrl`、`WebAccessToken`、`InstanceId` 和 `EipAddress`。
+`PublicUrl` 使用 EIP 的 HTTP 8766 地址，`WebAccessToken` 来自同步 Bootstrap 的执行结果。

--- a/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
@@ -16,6 +16,8 @@ Metadata:
           - InternetBandwidth
         Label:
           default: iac-code Web
+    TemplateTags:
+      - acs:solution:iac-code:iac-code-web
 Parameters:
   ZoneId:
     Type: String

--- a/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
@@ -179,6 +179,13 @@ Resources:
             root = pathlib.Path('/var/lib/iac-code')
             updates = {
                 root / '.credentials.yml': {'dashscope': os.environ['BAILIAN_API_KEY']},
+                root / '.cloud-credentials.yml': {
+                    'aliyun': {
+                        'mode': 'OAuth',
+                        'region_id': '${StackRegion}',
+                        'oauth_site_type': 'CN',
+                    }
+                },
                 root / 'settings.yml': {
                     'activeProvider': 'dashscope',
                     'memory': {'autoMemory': True},
@@ -186,7 +193,7 @@ Resources:
                     'providers': {
                         'dashscope': {
                             'apiBase': 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-                            'model': 'qwen3.7-max',
+                            'model': 'deepseek-v4-flash-0731',
                             'name': 'DashScope',
                         }
                     },
@@ -263,6 +270,8 @@ Resources:
                   - Key
             MasterAccountId:
               Ref: ALIYUN::TenantId
+            StackRegion:
+              Ref: ALIYUN::Region
 Outputs:
   PublicUrl:
     Label:

--- a/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
@@ -14,7 +14,6 @@ Metadata:
           - InstanceType
           - SystemDiskCategory
           - InternetBandwidth
-          - IacCodeVersion
         Label:
           default: iac-code Web
 Parameters:
@@ -60,14 +59,6 @@ Parameters:
     Label:
       en: Web access CIDR
       zh-cn: Web 访问网段
-    AssociationProperty: String
-  IacCodeVersion:
-    Type: String
-    Default: 0.11.0
-    AllowedPattern: ^[0-9]+\.[0-9]+\.[0-9]+(?:[a-zA-Z0-9.-]*)?$
-    Label:
-      en: iac-code version
-      zh-cn: iac-code 版本
     AssociationProperty: String
 Resources:
   Vpc:
@@ -159,7 +150,7 @@ Resources:
             id iac-code >/dev/null 2>&1 || useradd --system --create-home --home-dir /var/lib/iac-code iac-code
             install -d -m 0700 -o iac-code -g iac-code /var/lib/iac-code
             python3.11 -m venv /opt/iac-code/venv
-            /opt/iac-code/venv/bin/pip install --index-url https://mirrors.aliyun.com/pypi/simple/ "iac-code[http]==${IacCodeVersion}"
+            /opt/iac-code/venv/bin/pip install --upgrade --index-url https://mirrors.aliyun.com/pypi/simple/ "iac-code[http]"
 
             TOKEN_FILE=/var/lib/iac-code/web-access.token
             if [ -f "$TOKEN_FILE" ]; then
@@ -310,9 +301,3 @@ Outputs:
       Fn::GetAtt:
         - Eip
         - EipAddress
-  IacCodeVersion:
-    Label:
-      en: iac-code version
-      zh-cn: iac-code 版本
-    Value:
-      Ref: IacCodeVersion

--- a/src/iac_code/web/outputs.py
+++ b/src/iac_code/web/outputs.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from iac_code.agent.message import Message, ToolUseBlock
+from iac_code.tools.cloud.base_stack import stack_result_from_metadata
 from iac_code.web.session_manager import _tool_results_by_id
 
 TEMPLATE_SUFFIXES = {".json", ".yaml", ".yml", ".tf"}
@@ -111,10 +112,13 @@ def _leading_json_object(text: str) -> dict[str, Any] | None:
     return obj if isinstance(obj, dict) else None
 
 
-def _stack_result_dict(result: Any) -> dict[str, Any] | None:
+def _stack_result_dict(result: Any, metadata: Any = None) -> dict[str, Any] | None:
     """把单个 ros_stack 结果(str 或 dict)解析为含 stack_id 的字典,否则 None。"""
-    if isinstance(result, dict):
-        data: dict[str, Any] | None = result
+    structured = stack_result_from_metadata(metadata)
+    if structured is not None:
+        data = structured
+    elif isinstance(result, dict):
+        data = result
     elif isinstance(result, str):
         data = _leading_json_object(result)
     else:
@@ -126,7 +130,7 @@ def _stack_result_dict(result: Any) -> dict[str, Any] | None:
 
 def _stack_result_json(results: list[Any]) -> dict[str, Any] | None:
     for block in results:
-        data = _stack_result_dict(getattr(block, "content", None))
+        data = _stack_result_dict(getattr(block, "content", None), getattr(block, "metadata", None))
         if data:
             return data
     return None
@@ -344,7 +348,7 @@ def outputs_payload(manager: Any, session: Any, optimizing_indices: frozenset[in
         tool_name = data.get("toolName")
         tool_input = data.get("input") or {}
         if _is_stack_write_call(tool_name, tool_input.get("action")):
-            parsed = _stack_result_dict(data.get("result"))
+            parsed = _stack_result_dict(data.get("stackResult") or data.get("result"))
             if parsed:
                 add_stack(parsed, tool_input.get("region_id"))
         elif tool_name in {"write_file", "edit_file"}:

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -11,6 +11,7 @@ from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.pipeline.engine.step_spec import A2AArtifactSpec
 from iac_code.services.permissions.audit import fingerprint_text
 from iac_code.tools.cloud.aliyun.result_contract import ALIYUN_HTTP_METADATA_KEY
+from iac_code.tools.cloud.base_stack import STACK_RESULT_METADATA_KEY
 from iac_code.tools.result_storage import ResultStorage
 from iac_code.types.stream_events import (
     CandidateDetailEvent,
@@ -1785,6 +1786,46 @@ def test_stack_current_changed_emits_after_successful_ros_deploy_recreate() -> N
         "isSuccess": True,
         "current": True,
     }
+
+
+def test_stack_current_changed_uses_metadata_when_display_content_has_diagnostics() -> None:
+    ctx = _ctx()
+    ctx.emit_stack_events = True
+    translator = PipelineEventTranslator(ctx)
+    translator.translate(
+        ToolUseEndEvent(
+            tool_use_id="toolu-deploy",
+            name="ros_deploy",
+            input={
+                "action": "create",
+                "stack_name": "demo",
+                "template_url": "templates/demo.yml",
+                "region_id": "cn-hangzhou",
+            },
+        )
+    )
+    stack_result = {
+        "stack_id": "stack-failed",
+        "stack_name": "demo",
+        "status": "CREATE_FAILED",
+        "status_reason": "Bootstrap failed",
+        "is_success": False,
+    }
+
+    envelopes = translator.translate(
+        ToolResultEvent(
+            tool_use_id="toolu-deploy",
+            tool_name="ros_deploy",
+            result=json.dumps(stack_result) + "\n---\nROS local preflight diagnostics:\n3 limitations",
+            is_error=True,
+            metadata={STACK_RESULT_METADATA_KEY: stack_result},
+        )
+    )
+
+    assert [envelope["eventType"] for envelope in envelopes] == ["stack_current_changed", "tool_result"]
+    assert envelopes[0]["data"]["stackId"] == "stack-failed"
+    assert envelopes[0]["data"]["stackStatus"] == "CREATE_FAILED"
+    assert envelopes[1]["data"]["stackResult"] == stack_result
 
 
 def test_stack_current_changed_emits_when_create_stack_resource_is_observed() -> None:

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -21,6 +21,7 @@ from iac_code.types.stream_events import (
     AskUserQuestionEvent,
     MessageEndEvent,
     MessageStartEvent,
+    ResourceObservedEvent,
     TextDeltaEvent,
     ToolResultEvent,
     ToolUseEndEvent,
@@ -432,6 +433,86 @@ class TestStepExecutor:
         collected = []
         with patch("iac_code.agent.agent_loop.AgentLoop", FakeAgentLoop):
             async for event in executor.execute(step, PipelineContext({"template": []}), "session"):
+                collected.append(event)
+
+        results = [event for event in collected if isinstance(event, StepResult)]
+        assert len(results) == 1
+        assert results[0].status == StepStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_resource_observed_event_records_create_but_not_wait_stack_ownership(self, tmp_path):
+        from iac_code.pipeline.selling.tools.ros_deploy_tool import RosDeployTool
+
+        (tmp_path / "prompts").mkdir()
+        (tmp_path / "prompts" / "intent_parsing.md").write_text("Parse intent.", encoding="utf-8")
+        pipeline = _make_pipeline()
+        pipeline.pipeline_tools["ros_deploy"] = RosDeployTool
+        step = _make_step()
+        step.inject_tools = ["ros_deploy"]
+
+        class FakeAgentLoop:
+            def __init__(self, **kwargs):
+                self.tool_registry = kwargs["tool_registry"]
+
+            async def run_streaming(self, user_input):
+                deploy_tool = self.tool_registry.get("ros_deploy")
+                assert isinstance(deploy_tool, RosDeployTool)
+
+                yield ToolUseStartEvent(tool_use_id="create_1", name="ros_deploy")
+                yield ToolUseEndEvent(
+                    tool_use_id="create_1",
+                    name="ros_deploy",
+                    input={"action": "create", "stack_name": "demo"},
+                )
+                yield ResourceObservedEvent(
+                    provider="ros",
+                    resource_type="stack",
+                    resource_id="stack-created",
+                    action="CreateStack",
+                    tool_name="ros_stack",
+                    tool_use_id="create_1",
+                )
+                assert deploy_tool._is_owned_stack("stack-created")
+
+                yield ToolUseStartEvent(tool_use_id="wait_1", name="ros_deploy")
+                yield ToolUseEndEvent(
+                    tool_use_id="wait_1",
+                    name="ros_deploy",
+                    input={"action": "wait", "stack_id": "stack-external"},
+                )
+                yield ResourceObservedEvent(
+                    provider="ros",
+                    resource_type="stack",
+                    resource_id="stack-external",
+                    action="CreateStack",
+                    tool_name="ros_stack",
+                    tool_use_id="wait_1",
+                )
+                assert not deploy_tool._is_owned_stack("stack-external")
+
+                conclusion = {"type": "iac-code-web"}
+                yield ToolUseStartEvent(tool_use_id="done_1", name="complete_step")
+                yield ToolUseEndEvent(
+                    tool_use_id="done_1",
+                    name="complete_step",
+                    input={"conclusion": conclusion},
+                )
+                yield ToolResultEvent(
+                    tool_use_id="done_1",
+                    tool_name="complete_step",
+                    result="ok",
+                )
+
+        executor = StepExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=pipeline,
+            pipeline_dir=tmp_path,
+        )
+
+        collected = []
+        with patch("iac_code.agent.agent_loop.AgentLoop", FakeAgentLoop):
+            async for event in executor.execute(step, PipelineContext(SIMPLE_DEPS), "session"):
                 collected.append(event)
 
         results = [event for event in collected if isinstance(event, StepResult)]

--- a/tests/pipeline/selling/skills/test_iac_aliyun_architecture_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_architecture_skill.py
@@ -34,3 +34,12 @@ def test_architecture_prompt_guides_optional_memory_lookup_for_planning_context(
     assert "架构偏好" in body
     assert "已有 VPC" in body
     assert "当前用户意图为准" in body
+
+
+def test_architecture_keeps_iac_code_web_candidate_on_fixed_entry_topology():
+    body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "单 ECS + EIP" in body
+    assert "安全组仅开放 8766" in body
+    assert "不得增加其他入口资源" in body
+    assert "`candidate.name` 固定为 `iac-code-web-single-ecs`" in body

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -28,7 +28,10 @@ def test_solution_reference_is_shared_and_pipeline_prompts_are_minimal() -> None
     architecture = (SELLING / "skills/iac-aliyun-architecture/SKILL.md").read_text(encoding="utf-8")
     generating = (SELLING / "skills/iac-aliyun-template-generating/SKILL.md").read_text(encoding="utf-8")
     deploying = (SELLING / "skills/iac-aliyun-deploying/SKILL.md").read_text(encoding="utf-8")
-    assert "candidate.name = iac-code-web-single-ecs" in architecture
+    assert "`candidate.name` 固定为 `iac-code-web-single-ecs`" in architecture
+    assert "单 ECS + EIP" in architecture
+    assert "安全组仅开放 8766" in architecture
+    assert "不得增加其他入口资源" in architecture
     assert "references/solutions/iac-code-web.md" in generating
     assert "references/solutions/iac-code-web.ros.yml" in generating
     assert "iac-code-web-single-ecs" not in deploying

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -67,6 +67,9 @@ def test_golden_template_has_only_the_fixed_single_ecs_topology() -> None:
     template = _template()
     resources = template["Resources"]
 
+    assert template["Metadata"]["ALIYUN::ROS::Interface"]["TemplateTags"] == [
+        "acs:solution:iac-code:iac-code-web"
+    ]
     assert {name: resource["Type"] for name, resource in resources.items()} == {
         "Vpc": "ALIYUN::ECS::VPC",
         "VSwitch": "ALIYUN::ECS::VSwitch",

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -111,14 +111,14 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
         "BailianApiKeyB64": {"Fn::Base64Encode": {"Fn::GetAtt": ["BailianApiKey", "Key"]}},
         "MasterAccountId": {"Ref": "ALIYUN::TenantId"},
     }
-    assert "iac-code[http]==${IacCodeVersion}" in script
+    assert 'pip install --upgrade --index-url https://mirrors.aliyun.com/pypi/simple/ "iac-code[http]"' in script
+    assert "iac-code[http]==" not in script
     assert "--host 0.0.0.0 --port 8766 --access-token-file" in script
     assert "Restart=on-failure" in script
     assert "secrets.token_urlsafe(32)" in script
     assert 'exec >>"$LOG" 2>&1' in script
     assert "printf '%s' \"$TOKEN\" >&3" in script
     assert set(re.findall(r"\$\{([^}]+)\}", script)) == {
-        "IacCodeVersion",
         "BailianApiKeyB64",
         "MasterAccountId",
     }
@@ -138,7 +138,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
         assert expected in script
 
     outputs = template["Outputs"]
-    assert set(outputs) == {"PublicUrl", "WebAccessToken", "InstanceId", "EipAddress", "IacCodeVersion"}
+    assert set(outputs) == {"PublicUrl", "WebAccessToken", "InstanceId", "EipAddress"}
     assert all(set(output["Label"]) == {"en", "zh-cn"} for output in outputs.values())
     assert outputs["WebAccessToken"]["Value"] == {
         "Fn::Base64Decode": {"Fn::Jq": ["First", ".[0].Output", {"Fn::GetAtt": ["Bootstrap", "InvokeResults"]}]}

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -113,6 +113,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
     assert variables == {
         "BailianApiKeyB64": {"Fn::Base64Encode": {"Fn::GetAtt": ["BailianApiKey", "Key"]}},
         "MasterAccountId": {"Ref": "ALIYUN::TenantId"},
+        "StackRegion": {"Ref": "ALIYUN::Region"},
     }
     assert 'pip install --upgrade --index-url https://mirrors.aliyun.com/pypi/simple/ "iac-code[http]"' in script
     assert "iac-code[http]==" not in script
@@ -124,13 +125,18 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
     assert set(re.findall(r"\$\{([^}]+)\}", script)) == {
         "BailianApiKeyB64",
         "MasterAccountId",
+        "StackRegion",
     }
     for expected in (
         "'activeProvider': 'dashscope'",
+        "root / '.cloud-credentials.yml'",
+        "'mode': 'OAuth'",
+        "'region_id': '${StackRegion}'",
+        "'oauth_site_type': 'CN'",
         "'memory': {'autoMemory': True}",
         "'pipeline': {'sellingReviewStep': False}",
         "'apiBase': 'https://dashscope.aliyuncs.com/compatible-mode/v1'",
-        "'model': 'qwen3.7-max'",
+        "'model': 'deepseek-v4-flash-0731'",
         "'name': 'DashScope'",
         "'mode': 'normal'",
         "'permissionMode': 'bypass_permissions'",
@@ -139,6 +145,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
         "'userID': '${MasterAccountId}'",
     ):
         assert expected in script
+    assert "'model': 'qwen3.7-max'" not in script
 
     outputs = template["Outputs"]
     assert set(outputs) == {"PublicUrl", "WebAccessToken", "InstanceId", "EipAddress"}

--- a/tests/web/test_outputs.py
+++ b/tests/web/test_outputs.py
@@ -1,9 +1,11 @@
+import json
 from pathlib import Path
 
 import pytest
 from starlette.testclient import TestClient
 
 from iac_code.agent.message import Message, ToolResultBlock, ToolUseBlock
+from iac_code.tools.cloud.base_stack import STACK_RESULT_METADATA_KEY
 from iac_code.web import outputs
 from iac_code.web.app import create_app
 from iac_code.web.session_manager import WebSessionManager
@@ -90,11 +92,14 @@ class _FakeManager:
         return self._envelopes if context_id else []
 
 
-def _env_tool_result(tool_name, *, tool_input=None, result=None):
+def _env_tool_result(tool_name, *, tool_input=None, result=None, stack_result=None):
     """构造一个 pipeline A2A `tool_result` envelope(与真实日志同形)。"""
+    data = {"toolName": tool_name, "input": tool_input or {}, "result": result}
+    if stack_result is not None:
+        data["stackResult"] = stack_result
     return {
         "eventType": "tool_result",
-        "data": {"toolName": tool_name, "input": tool_input or {}, "result": result},
+        "data": data,
     }
 
 
@@ -122,11 +127,14 @@ def _tool_use(name, tool_id, **input_kwargs):
     return Message(role="assistant", content=[ToolUseBlock(id=tool_id, name=name, input=input_kwargs)])
 
 
-def _tool_result(tool_id, payload):
+def _tool_result(tool_id, payload, *, metadata=None):
     import json as _json
 
     body = payload if isinstance(payload, str) else _json.dumps(payload)
-    return Message(role="user", content=[ToolResultBlock(tool_use_id=tool_id, content=body)])
+    return Message(
+        role="user",
+        content=[ToolResultBlock(tool_use_id=tool_id, content=body, metadata=metadata or {})],
+    )
 
 
 ROS_JSON = '{"ROSTemplateFormatVersion": "2015-09-01", "Resources": {"v": {"Type": "ALIYUN::ECS::VPC"}}}'
@@ -422,6 +430,32 @@ def test_payload_pipeline_delete_and_create_shows_new_stack(tmp_path):
     assert stack["isSuccess"] is True
 
 
+def test_payload_pipeline_ros_deploy_prefers_structured_stack_result(tmp_path):
+    stack_result = {
+        "stack_id": "stack-failed",
+        "stack_name": "demo",
+        "status": "CREATE_FAILED",
+        "status_reason": "Bootstrap failed",
+        "is_success": False,
+    }
+    envelopes = [
+        _env_tool_result(
+            "ros_deploy",
+            tool_input={"action": "create", "region_id": "cn-hangzhou"},
+            result=json.dumps(stack_result) + "\n---\nROS local preflight diagnostics:\n3 limitations",
+            stack_result=stack_result,
+        )
+    ]
+
+    payload = outputs.outputs_payload(
+        _FakeManager([], envelopes),
+        _FakeSession(tmp_path, context_id="ctx-1"),
+    )
+
+    assert payload["stacks"][0]["stackId"] == "stack-failed"
+    assert payload["stacks"][0]["statusReason"] == "Bootstrap failed"
+
+
 def test_payload_pipeline_stack_appears_in_progress(tmp_path):
     # 部署开始:仅有进行中态 stack_current_changed(尚无终态 tool_result)时,资源栈就应出现,
     # 状态为 CREATE_IN_PROGRESS、isSuccess=False、带 console URL——让面板在创建开始即显示,而非完成后。
@@ -486,6 +520,29 @@ def test_payload_stack_ros_deploy_main_session():
     assert len(payload["stacks"]) == 1
     assert payload["stacks"][0]["stackId"] == "stk-d"
     assert payload["stacks"][0]["status"] == "CREATE_COMPLETE"
+
+
+def test_payload_stack_ros_deploy_main_session_uses_metadata():
+    stack_result = {
+        "stack_id": "stack-failed",
+        "stack_name": "app",
+        "status": "CREATE_FAILED",
+        "status_reason": "Bootstrap failed",
+        "is_success": False,
+    }
+    messages = [
+        _tool_use("ros_deploy", "t1", action="create", region_id="cn-hangzhou"),
+        _tool_result(
+            "t1",
+            json.dumps(stack_result) + "\n---\nROS local preflight diagnostics:\n3 limitations",
+            metadata={STACK_RESULT_METADATA_KEY: stack_result},
+        ),
+    ]
+
+    payload = outputs.outputs_payload(_FakeManager(messages), _FakeSession("/tmp/x"))
+
+    assert payload["stacks"][0]["stackId"] == "stack-failed"
+    assert payload["stacks"][0]["status"] == "CREATE_FAILED"
 
 
 def test_payload_pipeline_dedup_abs_and_relative_path(tmp_path):


### PR DESCRIPTION
## What changed

- Install the latest `iac-code` release in the ECS bootstrap instead of pinning a template parameter.
- Seed Alibaba Cloud OAuth credentials with the ROS stack region and use `deepseek-v4-flash-0731` as the default model.
- Keep the iac-code Web deployment candidate on the intended single-ECS + EIP topology with port 8766.
- Preserve structured ROS stack results through A2A events and Web output derivation while retaining compatibility with diagnostic text appended to tool output.
- Cover stack ownership when a stack is observed before the terminal deployment result.

## Why

ROS deployment diagnostics can make the display content no longer valid JSON, which prevented stack outputs from reaching the Web output panel. The deployment template also pinned an older package version and did not align its cloud region and model defaults with the deployed stack.

## Impact

Pipeline deployments use the latest published iac-code package, start with the correct Alibaba Cloud region and model defaults, and reliably surface ROS stack results in the Web UI.

## Validation

- `make lint`
- `371 passed` targeted tests
- `make test`: `13545 passed, 2 skipped`
- Independent Codex and Claude Code compatibility reviews: PASS
