### PR TITLE
chore: prepare 0.11.4 release

### DIFF
--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.3"
+__version__ = "0.11.4"
 __release_date__ = ""

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.3\n"
+"Project-Id-Version: iac-code 0.11.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
@@ -12752,3 +12752,4 @@ msgstr "Bash zulassen?"
 #~ msgstr ""
 #~ "Tool-Aufruf genehmigen: {tool}\n"
 #~ "Eingabezusammenfassung: {summary}"
+

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/webui.po
@@ -3752,7 +3752,12 @@ msgid ""
 "model responses, and tool inputs and outputs) to the telemetry it sends "
 "to iac-code's default backend or an explicitly configured OTLP endpoint, "
 "to help diagnose issues and improve the product."
-msgstr "Wenn aktiviert, hängt iac-code den vollständigen Gesprächsinhalt (deine Eingaben, Modellantworten sowie Werkzeug-Ein- und -Ausgaben) an die Telemetrie an, die es an das Standard-Backend von iac-code oder an einen explizit konfigurierten OTLP-Endpunkt sendet, um bei der Diagnose von Problemen und der Verbesserung des Produkts zu helfen."
+msgstr ""
+"Wenn aktiviert, hängt iac-code den vollständigen Gesprächsinhalt (deine "
+"Eingaben, Modellantworten sowie Werkzeug-Ein- und -Ausgaben) an die "
+"Telemetrie an, die es an das Standard-Backend von iac-code oder an einen "
+"explizit konfigurierten OTLP-Endpunkt sendet, um bei der Diagnose von "
+"Problemen und der Verbesserung des Produkts zu helfen."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "New session defaults"
@@ -3858,7 +3863,9 @@ msgstr "Debug-Optionen"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Control local debug highlighting and backend log verbosity."
-msgstr "Steuert die lokale Debug-Hervorhebung und die Ausführlichkeit der Backend-Protokolle."
+msgstr ""
+"Steuert die lokale Debug-Hervorhebung und die Ausführlichkeit der "
+"Backend-Protokolle."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Highlight failed tool calls in red"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.3\n"
+"Project-Id-Version: iac-code 0.11.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
@@ -12667,3 +12667,4 @@ msgstr "¿Permitir Bash?"
 #~ msgstr ""
 #~ "Aprobar llamada de herramienta: {tool}\n"
 #~ "Resumen de entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/webui.po
@@ -3740,7 +3740,13 @@ msgid ""
 "model responses, and tool inputs and outputs) to the telemetry it sends "
 "to iac-code's default backend or an explicitly configured OTLP endpoint, "
 "to help diagnose issues and improve the product."
-msgstr "Cuando se activa, iac-code adjunta el contenido completo de la conversación (tus indicaciones, las respuestas del modelo y las entradas y salidas de las herramientas) a la telemetría que envía al backend predeterminado de iac-code o a un endpoint OTLP configurado explícitamente, para ayudar a diagnosticar problemas y mejorar el producto."
+msgstr ""
+"Cuando se activa, iac-code adjunta el contenido completo de la "
+"conversación (tus indicaciones, las respuestas del modelo y las entradas "
+"y salidas de las herramientas) a la telemetría que envía al backend "
+"predeterminado de iac-code o a un endpoint OTLP configurado "
+"explícitamente, para ayudar a diagnosticar problemas y mejorar el "
+"producto."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "New session defaults"
@@ -3843,7 +3849,9 @@ msgstr "Opciones de depuración"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Control local debug highlighting and backend log verbosity."
-msgstr "Controla el resaltado de depuración local y el nivel de detalle de los registros del backend."
+msgstr ""
+"Controla el resaltado de depuración local y el nivel de detalle de los "
+"registros del backend."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Highlight failed tool calls in red"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.3\n"
+"Project-Id-Version: iac-code 0.11.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
@@ -12732,3 +12732,4 @@ msgstr "Autoriser Bash ?"
 #~ msgstr ""
 #~ "Approuver l'appel d'outil : {tool}\n"
 #~ "Résumé de l'entrée : {summary}"
+

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/webui.po
@@ -3754,7 +3754,12 @@ msgid ""
 "model responses, and tool inputs and outputs) to the telemetry it sends "
 "to iac-code's default backend or an explicitly configured OTLP endpoint, "
 "to help diagnose issues and improve the product."
-msgstr "Lorsqu'elle est activée, iac-code joint l'intégralité du contenu de la conversation (vos invites, les réponses du modèle ainsi que les entrées et sorties des outils) à la télémétrie qu'il envoie au backend par défaut d'iac-code ou à un point de terminaison OTLP explicitement configuré, afin d'aider à diagnostiquer les problèmes et à améliorer le produit."
+msgstr ""
+"Lorsqu'elle est activée, iac-code joint l'intégralité du contenu de la "
+"conversation (vos invites, les réponses du modèle ainsi que les entrées "
+"et sorties des outils) à la télémétrie qu'il envoie au backend par défaut"
+" d'iac-code ou à un point de terminaison OTLP explicitement configuré, "
+"afin d'aider à diagnostiquer les problèmes et à améliorer le produit."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "New session defaults"
@@ -3860,7 +3865,9 @@ msgstr "Options de débogage"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Control local debug highlighting and backend log verbosity."
-msgstr "Contrôle la mise en évidence de débogage locale et le niveau de détail des journaux du backend."
+msgstr ""
+"Contrôle la mise en évidence de débogage locale et le niveau de détail "
+"des journaux du backend."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Highlight failed tool calls in red"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.3\n"
+"Project-Id-Version: iac-code 0.11.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
@@ -11760,3 +11760,4 @@ msgstr "Bash を許可しますか？"
 #~ msgstr ""
 #~ "ツール呼び出しを承認: {tool}\n"
 #~ "入力サマリー: {summary}"
+

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/webui.po
@@ -3650,7 +3650,9 @@ msgid ""
 "model responses, and tool inputs and outputs) to the telemetry it sends "
 "to iac-code's default backend or an explicitly configured OTLP endpoint, "
 "to help diagnose issues and improve the product."
-msgstr "有効にすると、iac-code は送信するテレメトリに完全な会話内容(あなたのプロンプト、モデルの応答、ツールの入力と出力)を添付し、iac-code の既定のバックエンドまたは明示的に構成された OTLP エンドポイントに送信して、問題の診断と製品の改善に役立てます。"
+msgstr ""
+"有効にすると、iac-code は送信するテレメトリに完全な会話内容(あなたのプロンプト、モデルの応答、ツールの入力と出力)を添付し、iac-"
+"code の既定のバックエンドまたは明示的に構成された OTLP エンドポイントに送信して、問題の診断と製品の改善に役立てます。"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "New session defaults"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.3\n"
+"Project-Id-Version: iac-code 0.11.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"
@@ -12562,3 +12562,4 @@ msgstr "Permitir Bash?"
 #~ msgstr ""
 #~ "Aprovar chamada de ferramenta: {tool}\n"
 #~ "Resumo da entrada: {summary}"
+

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/webui.po
@@ -3733,7 +3733,12 @@ msgid ""
 "model responses, and tool inputs and outputs) to the telemetry it sends "
 "to iac-code's default backend or an explicitly configured OTLP endpoint, "
 "to help diagnose issues and improve the product."
-msgstr "Quando ativado, o iac-code anexa o conteúdo completo da conversa (seus prompts, respostas do modelo e entradas e saídas das ferramentas) à telemetria que envia ao backend padrão do iac-code ou a um endpoint OTLP configurado explicitamente, para ajudar a diagnosticar problemas e melhorar o produto."
+msgstr ""
+"Quando ativado, o iac-code anexa o conteúdo completo da conversa (seus "
+"prompts, respostas do modelo e entradas e saídas das ferramentas) à "
+"telemetria que envia ao backend padrão do iac-code ou a um endpoint OTLP "
+"configurado explicitamente, para ajudar a diagnosticar problemas e "
+"melhorar o produto."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "New session defaults"
@@ -3835,7 +3840,9 @@ msgstr "Opções de depuração"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Control local debug highlighting and backend log verbosity."
-msgstr "Controla o destaque de depuração local e o nível de detalhe dos logs do backend."
+msgstr ""
+"Controla o destaque de depuração local e o nível de detalhe dos logs do "
+"backend."
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "Highlight failed tool calls in red"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.11.3\n"
+"Project-Id-Version: iac-code 0.11.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"
@@ -11543,3 +11543,4 @@ msgstr "允许 Bash?"
 #~ msgstr ""
 #~ "批准工具调用：{tool}\n"
 #~ "输入摘要：{summary}"
+

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/webui.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/webui.po
@@ -3644,7 +3644,9 @@ msgid ""
 "model responses, and tool inputs and outputs) to the telemetry it sends "
 "to iac-code's default backend or an explicitly configured OTLP endpoint, "
 "to help diagnose issues and improve the product."
-msgstr "开启后,iac-code 会在发送的遥测数据中附带完整的对话内容(包括你的提示词、模型回复以及工具的输入与输出),发送到 iac-code 的默认遥测后端或你显式配置的 OTLP 端点,用于诊断问题和改进产品。"
+msgstr ""
+"开启后,iac-code 会在发送的遥测数据中附带完整的对话内容(包括你的提示词、模型回复以及工具的输入与输出),发送到 iac-code "
+"的默认遥测后端或你显式配置的 OTLP 端点,用于诊断问题和改进产品。"
 
 #: src/iac_code/web/static/js/components/workspace.js
 msgid "New session defaults"

--- a/src/iac_code/services/session_backup.py
+++ b/src/iac_code/services/session_backup.py
@@ -1373,8 +1373,7 @@ class SessionBackupService:
                 self._forget_prepared_dirs(path)
             else:
                 is_reparse_point = bool(
-                    getattr(path_stat, "st_file_attributes", 0)
-                    & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+                    getattr(path_stat, "st_file_attributes", 0) & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
                 )
                 if stat.S_ISDIR(path_stat.st_mode) and not is_reparse_point:
                     self._prepared_dirs.pop(path)

--- a/src/iac_code/tools/cloud/base_stack.py
+++ b/src/iac_code/tools/cloud/base_stack.py
@@ -45,6 +45,7 @@ def persisted_stack_metadata(metadata: Any) -> dict[str, Any]:
         persisted[STACK_RESULT_METADATA_KEY] = result
     return persisted
 
+
 POLL_INTERVAL = 5
 
 

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -1986,12 +1986,7 @@ def test_stack_operation_started_event_produces_no_a2a_envelope() -> None:
     )
     assert translator.translate(started) == []
     # Also inert when wrapped in a sub-pipeline envelope (only ResourceObservedEvent is special-cased).
-    assert (
-        translator.translate(
-            SubPipelineStreamEvent(sub_pipeline_id="sp", candidate_index=0, inner=started)
-        )
-        == []
-    )
+    assert translator.translate(SubPipelineStreamEvent(sub_pipeline_id="sp", candidate_index=0, inner=started)) == []
 
 
 def test_stack_current_changed_keeps_current_stack_after_statusless_successful_delete() -> None:

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -954,12 +954,15 @@ async def test_removed_step_backup_does_not_record_success_metric(tmp_path):
 
     [event async for event in runner._continue_from_current()]
 
-    assert call(
-        step_id=None,
-        reason=BackupReason.TERMINAL.value,
-        critical=True,
-        retry_count=1,
-    ) in runner._observability.backup_succeeded.call_args_list
+    assert (
+        call(
+            step_id=None,
+            reason=BackupReason.TERMINAL.value,
+            critical=True,
+            retry_count=1,
+        )
+        in runner._observability.backup_succeeded.call_args_list
+    )
     assert all(
         item.kwargs["reason"] != BackupReason.PIPELINE_STEP_COMPLETED.value
         for item in runner._observability.backup_succeeded.call_args_list
@@ -1167,9 +1170,7 @@ async def test_interrupt_pause_backup_is_deferred_only_for_a2a(tmp_path, surface
     runner = _build_two_step_runner(tmp_path, backup_service=backup, surface=surface)
     runner.session = RecordingPipelineSession()
 
-    event = await runner.save_interrupt_pause(
-        InterruptVerdict(action="continue", reason="judge failed", paused=True)
-    )
+    event = await runner.save_interrupt_pause(InterruptVerdict(action="continue", reason="judge failed", paused=True))
 
     assert event.type == PipelineEventType.USER_INPUT_REQUIRED
     assert [backup_call["reason"] for backup_call in backup.calls] == expected_reasons

--- a/tests/pipeline/engine/test_prerequisites.py
+++ b/tests/pipeline/engine/test_prerequisites.py
@@ -427,7 +427,7 @@ def test_default_run_command_timeout_terminates_descendant_process(tmp_path):
     try:
         result = prereq_module._default_run_command(
             [sys.executable, "-c", parent_code, str(ticks_path), str(pid_path), child_code],
-            timeout_seconds=0.5,
+            timeout_seconds=5,
         )
         assert result.returncode == 124
 

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -67,9 +67,7 @@ def test_golden_template_has_only_the_fixed_single_ecs_topology() -> None:
     template = _template()
     resources = template["Resources"]
 
-    assert template["Metadata"]["ALIYUN::ROS::Interface"]["TemplateTags"] == [
-        "acs:solution:iac-code:iac-code-web"
-    ]
+    assert template["Metadata"]["ALIYUN::ROS::Interface"]["TemplateTags"] == ["acs:solution:iac-code:iac-code-web"]
     assert {name: resource["Type"] for name, resource in resources.items()} == {
         "Vpc": "ALIYUN::ECS::VPC",
         "VSwitch": "ALIYUN::ECS::VSwitch",

--- a/tests/pipeline/selling/test_intent_ask_user_question_config.py
+++ b/tests/pipeline/selling/test_intent_ask_user_question_config.py
@@ -51,9 +51,7 @@ def test_other_cloud_guard_does_not_match_provider_tokens_inside_aliyun_resource
     loaded = load_pipeline_dir(_selling_dir())
     intent_step = next(step for step in loaded.steps if step.step_id == "intent_parsing")
     guard = next(
-        guard
-        for guard in intent_step.completion_guards
-        if guard.get("message_key") == "intent_alibaba_cloud_only"
+        guard for guard in intent_step.completion_guards if guard.get("message_key") == "intent_alibaba_cloud_only"
     )
     pattern = guard["when_user_message_matches_any"][0]
 

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -128,7 +128,7 @@ def test_legacy_setup_declares_package_metadata(monkeypatch):
     kwargs = setup_module._TEST_SETUP_KWARGS
 
     assert kwargs["name"] == "iac_code"
-    assert kwargs["version"] == "0.11.3"
+    assert kwargs["version"] == "0.11.4"
     assert kwargs["package_dir"] == {"": "src"}
     assert "iac_code.pipeline.selling.tools" in kwargs["packages"]
     assert "iac_code.pipeline.selling.hooks" in kwargs["packages"]

--- a/tests/tools/cloud/test_base_stack.py
+++ b/tests/tools/cloud/test_base_stack.py
@@ -312,9 +312,7 @@ class TestBaseCloudStackExecute:
         assert progress_index > 0
 
     @pytest.mark.asyncio
-    async def test_execute_does_not_emit_stack_operation_started_for_create(
-        self, stack: MockCloudStack
-    ) -> None:
+    async def test_execute_does_not_emit_stack_operation_started_for_create(self, stack: MockCloudStack) -> None:
         queue: asyncio.Queue = asyncio.Queue()
         context = ToolContext(event_queue=queue, tool_use_id="toolu-create")
 

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -3263,6 +3263,7 @@ def test_session_prompt_route_returns_truthful_local_snapshot(tmp_path) -> None:
 
 
 def test_session_prompt_route_populates_available_local_sources(tmp_path, monkeypatch) -> None:
+    from iac_code.web import cleanup as cleanup_module
     from iac_code.web.app import create_app
     from iac_code.web.memory import save_project_instruction
     from iac_code.web.session_manager import WebSessionManager
@@ -3294,6 +3295,7 @@ def test_session_prompt_route_populates_available_local_sources(tmp_path, monkey
         }
 
     monkeypatch.setattr("iac_code.web.pipeline.pipeline_state_from_query", fake_pipeline_state)
+    monkeypatch.setattr(cleanup_module, "pipeline_state_from_query", fake_pipeline_state)
     save_active_provider(
         {
             "provider": "openai",
@@ -3332,6 +3334,7 @@ def test_session_prompt_route_populates_available_local_sources(tmp_path, monkey
 
 
 def test_status_and_debug_merge_recovered_pipeline_snapshot(tmp_path, monkeypatch) -> None:
+    from iac_code.web import cleanup as cleanup_module
     from iac_code.web.app import create_app
     from iac_code.web.session_manager import WebSessionManager
     from iac_code.web.settings import save_active_provider
@@ -3357,6 +3360,7 @@ def test_status_and_debug_merge_recovered_pipeline_snapshot(tmp_path, monkeypatc
         }
 
     monkeypatch.setattr("iac_code.web.pipeline.pipeline_state_from_query", fake_pipeline_state)
+    monkeypatch.setattr(cleanup_module, "pipeline_state_from_query", fake_pipeline_state)
     save_active_provider(
         {
             "provider": "openai",

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -10605,7 +10605,7 @@ def test_app_wires_live_stacks_into_output_panel() -> None:
     assert "liveStacksFromState" in app_source
     # 两个 live 来源:resource.observed(t0 最早占位)与工具卡 stackProgress(轮询真实状态)。
     assert "stackProgress" in app_source
-    assert 'resourceType' in app_source
+    assert "resourceType" in app_source
     # resource.observed 到达即刷新输出面板,让「创建中」栈立即出现,而非等首个 stack.progress(约 5s 后)。
     assert 'event.type === "resource.observed"' in app_source
     # 非 create 写操作(delete/update/continue)也须在 t0 映射出对应 *_IN_PROGRESS,

--- a/tests/web/test_outputs.py
+++ b/tests/web/test_outputs.py
@@ -368,8 +368,7 @@ def test_payload_pipeline_ros_deploy_stack(tmp_path):
 # ros_stack/ros_deploy 的结果 JSON 后可能被 attach_ros_validation 追加本地预检诊断块
 # (见 tools/cloud/aliyun/ros_validation/outcome.py),使整体结果内容不再是合法 JSON。
 _PREFLIGHT_SUFFIX = (
-    "\n\n---\nROS local preflight diagnostics:\n"
-    "ROS local validation completed: 0 errors, 0 warnings, 5 restrictions.\n"
+    "\n\n---\nROS local preflight diagnostics:\nROS local validation completed: 0 errors, 0 warnings, 5 restrictions.\n"
 )
 
 
@@ -382,8 +381,7 @@ def test_payload_pipeline_stack_result_with_preflight_diagnostics_suffix(tmp_pat
             tool_input={"action": "create", "region_id": "cn-hangzhou"},
             result=(
                 '{"stack_id": "stk-diag", "stack_name": "webapp", '
-                '"status": "CREATE_COMPLETE", "status_reason": "ok", "is_success": true}'
-                + _PREFLIGHT_SUFFIX
+                '"status": "CREATE_COMPLETE", "status_reason": "ok", "is_success": true}' + _PREFLIGHT_SUFFIX
             ),
         ),
     ]


### PR DESCRIPTION
## Summary

- bump the runtime and package version from 0.11.3 to 0.11.4
- refresh the i18n catalogs and apply repository formatting
- stabilize process-timeout and web cleanup test isolation under parallel pytest

## Why

Prepare the next patch release while keeping generated catalogs and repository checks green.

## Impact

The package now reports version 0.11.4. There are no intended production behavior changes beyond version metadata.

## Validation

- `make format`
- `make lint`
- `make translate`
- `make test` — 13,545 passed, 2 skipped
