### PR TITLE
Fix Bailian API key deployment region

### DIFF
--- a/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
@@ -122,6 +122,7 @@ Resources:
   BailianApiKey:
     Type: ALIYUN::Bailian::ApiKey
     Properties:
+      RegionId: cn-beijing
       Description: Managed by the iac-code Web ROS stack
       AuthSetModel:
         AuthSetMode: Custom

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -82,6 +82,7 @@ def test_golden_template_has_only_the_fixed_single_ecs_topology() -> None:
     assert ingress == [{"IpProtocol": "tcp", "PortRange": "8766/8766", "SourceCidrIp": {"Ref": "AccessCidr"}}]
     assert resources["Instance"]["Properties"]["AllocatePublicIP"] is False
     assert resources["BailianApiKey"]["Properties"] == {
+        "RegionId": "cn-beijing",
         "Description": "Managed by the iac-code Web ROS stack",
         "AuthSetModel": {
             "AuthSetMode": "Custom",


### PR DESCRIPTION
## Summary

- Pin the ROS-managed Bailian API key resource to `cn-beijing`.
- Update the golden solution contract test for the resource-level region.

## Root cause

The iac-code Web solution can be deployed in any user-selected stack region, but Bailian does not provide a workspace in every ROS region. Without a resource-level region override, API key creation inherited an unsupported stack-region context and failed before bootstrap.

## Impact

The ECS, VPC, EIP, and bootstrap resources continue to use the user-selected stack region. Only `ALIYUN::Bailian::ApiKey` is created in Beijing, matching the configured DashScope endpoint.

## Validation

- `uv run pytest tests/pipeline/selling/test_iac_code_web_solution.py` (4 passed)
- ROS `ValidateTemplate` with stack region `cn-shenzhen`
- `git diff --check`
