### PR TITLE
feat: use ECS RAM role for iac-code web

### DIFF
--- a/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.md
@@ -8,10 +8,13 @@ API Key 参数。
 ## 资源与网络
 
 - 保留模板中的单个 VPC、VSwitch、安全组、ECS、EIP/EIPAssociation、
-  `ALIYUN::Bailian::ApiKey` 和同步 `ALIYUN::ECS::RunCommand`。
+  `ALIYUN::RAM::Role`、`ALIYUN::ECS::RamRoleAttachment`、`ALIYUN::Bailian::ApiKey`
+  和同步 `ALIYUN::ECS::RunCommand`。
 - ECS 使用 Alibaba Cloud Linux 3 x86_64，固定 `AllocatePublicIP: false`，公网入口只使用绑定的
   EIP。
 - 安全组只开放 TCP 8766，来源使用 `AccessCidr`；不要开放 SSH 端口。
+- RAM Role 只信任 `ecs.aliyuncs.com`，附加 `AdministratorAccess` 以支持通用云资源查询和部署，
+  并通过 `ALIYUN::ECS::RamRoleAttachment` 绑定到 ECS。
 - 百炼 API Key 由 ROS 创建，只允许该 EIP 调用，不要把 API Key 放入 Stack Outputs。
 
 ## Bootstrap
@@ -20,9 +23,9 @@ API Key 参数。
 - 生成 Web 访问 Token 并以 0600 权限保存到 ECS；systemd 使用 `--access-token-file`、
   `--host 0.0.0.0 --port 8766 --no-open` 以 root 用户启动 iac-code Web。
 - `IAC_CODE_CONFIG_DIR` 固定为 `/root/.iac-code`。Bootstrap 将百炼 API Key 写入
-  `.credentials.yml`，并在 `settings.yml` 中配置 DashScope（默认模型 `qwen3.8-max`）、
-  自动 Memory、中文 UI、`selling` Pipeline、普通会话模式和 `bypass_permissions`；
-  `userID` 使用 `ALIYUN::TenantId`。
+  `.credentials.yml`，将阿里云云凭证默认配置为当前 ECS 绑定角色对应的 `EcsRamRole`，并在
+  `settings.yml` 中配置 DashScope（默认模型 `qwen3.8-max`）、自动 Memory、中文 UI、
+  `selling` Pipeline、普通会话模式和 `bypass_permissions`；`userID` 使用 `ALIYUN::TenantId`。
 - Bootstrap 在 `/root/AGENTS.md` 注入当前 ECS 的实例 ID、规格、地域、可用区、VPC、
   VSwitch、安全组、EIP 和 ECS 控制台详情链接。iac-code 将未明确指定目标的 ECS 查询、
   系统运维和负载检查理解为针对本机；可能中断当前 Web 的本机停机、重启、释放、网络和

--- a/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/solutions/iac-code-web.ros.yml
@@ -1,7 +1,7 @@
 ROSTemplateFormatVersion: '2015-09-01'
 Description:
-  en: Deploy one iac-code Web instance with an EIP, encrypted token transport, and a ROS-managed Bailian API key.
-  zh-cn: 部署一套带 EIP、Token 加密通道和 ROS 托管百炼 API Key 的 iac-code Web。
+  en: Deploy one iac-code Web instance with an EIP, ECS RAM Role credentials, encrypted token transport, and a ROS-managed Bailian API key.
+  zh-cn: 部署一套带 EIP、ECS RAM Role 凭证、Token 加密通道和 ROS 托管百炼 API Key 的 iac-code Web。
 Metadata:
   ALIYUN::ROS::Interface:
     ParameterGroups:
@@ -119,6 +119,33 @@ Resources:
           - AllocationId
       InstanceId:
         Ref: Instance
+  InstanceRamRole:
+    Type: ALIYUN::RAM::Role
+    Properties:
+      RoleName:
+        Fn::Sub: iac-code-web-${ALIYUN::StackId}
+      Description: Managed by the iac-code Web ROS stack
+      DeletionForce: true
+      AssumeRolePolicyDocument:
+        Version: '1'
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs.aliyuncs.com
+      PolicyAttachments:
+        System:
+          - AdministratorAccess
+  InstanceRamRoleAttachment:
+    Type: ALIYUN::ECS::RamRoleAttachment
+    Properties:
+      RamRoleName:
+        Fn::GetAtt:
+          - InstanceRamRole
+          - RoleName
+      InstanceIds:
+        - Ref: Instance
   BailianApiKey:
     Type: ALIYUN::Bailian::ApiKey
     Properties:
@@ -132,7 +159,9 @@ Resources:
               - EipAddress
   Bootstrap:
     Type: ALIYUN::ECS::RunCommand
-    DependsOn: EipAssociation
+    DependsOn:
+      - EipAssociation
+      - InstanceRamRoleAttachment
     Properties:
       InstanceIds:
         - Ref: Instance
@@ -180,9 +209,9 @@ Resources:
                 root / '.credentials.yml': {'dashscope': os.environ['BAILIAN_API_KEY']},
                 root / '.cloud-credentials.yml': {
                     'aliyun': {
-                        'mode': 'OAuth',
+                        'mode': 'EcsRamRole',
                         'region_id': '${StackRegion}',
-                        'oauth_site_type': 'CN',
+                        'ram_role_name': '${InstanceRamRoleName}',
                     }
                 },
                 root / 'settings.yml': {
@@ -310,6 +339,10 @@ Resources:
               Ref: ALIYUN::TenantId
             StackRegion:
               Ref: ALIYUN::Region
+            InstanceRamRoleName:
+              Fn::GetAtt:
+                - InstanceRamRole
+                - RoleName
             LocalInstanceId:
               Ref: Instance
             LocalInstanceType:

--- a/tests/pipeline/selling/test_iac_code_web_solution.py
+++ b/tests/pipeline/selling/test_iac_code_web_solution.py
@@ -42,7 +42,10 @@ def test_solution_reference_is_shared_and_pipeline_prompts_are_minimal() -> None
     assert "海外地域" not in reference
     for deployment_detail in (
         "AllocatePublicIP: false",
+        "ALIYUN::RAM::Role",
+        "ALIYUN::ECS::RamRoleAttachment",
         "ALIYUN::Bailian::ApiKey",
+        "EcsRamRole",
         "--access-token-file",
         "IAC_CODE_CONFIG_DIR",
         "PublicUrl",
@@ -75,6 +78,8 @@ def test_golden_template_has_only_the_fixed_single_ecs_topology() -> None:
         "Instance": "ALIYUN::ECS::Instance",
         "Eip": "ALIYUN::VPC::EIP",
         "EipAssociation": "ALIYUN::VPC::EIPAssociation",
+        "InstanceRamRole": "ALIYUN::RAM::Role",
+        "InstanceRamRoleAttachment": "ALIYUN::ECS::RamRoleAttachment",
         "BailianApiKey": "ALIYUN::Bailian::ApiKey",
         "Bootstrap": "ALIYUN::ECS::RunCommand",
     }
@@ -88,6 +93,26 @@ def test_golden_template_has_only_the_fixed_single_ecs_topology() -> None:
             "AuthSetMode": "Custom",
             "AccessIps": [{"Fn::GetAtt": ["Eip", "EipAddress"]}],
         },
+    }
+    assert resources["InstanceRamRole"]["Properties"] == {
+        "RoleName": {"Fn::Sub": "iac-code-web-${ALIYUN::StackId}"},
+        "Description": "Managed by the iac-code Web ROS stack",
+        "DeletionForce": True,
+        "AssumeRolePolicyDocument": {
+            "Version": "1",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"Service": ["ecs.aliyuncs.com"]},
+                }
+            ],
+        },
+        "PolicyAttachments": {"System": ["AdministratorAccess"]},
+    }
+    assert resources["InstanceRamRoleAttachment"]["Properties"] == {
+        "RamRoleName": {"Fn::GetAtt": ["InstanceRamRole", "RoleName"]},
+        "InstanceIds": [{"Ref": "Instance"}],
     }
     assert "ExistingBailianApiKey" not in template["Parameters"]
 
@@ -105,7 +130,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
     assert all(set(parameter["Label"]) == {"en", "zh-cn"} for parameter in parameters.values())
 
     bootstrap = template["Resources"]["Bootstrap"]
-    assert bootstrap["DependsOn"] == "EipAssociation"
+    assert bootstrap["DependsOn"] == ["EipAssociation", "InstanceRamRoleAttachment"]
     properties = bootstrap["Properties"]
     assert properties["Type"] == "RunShellScript"
     assert properties["ContentEncoding"] == "PlainText"
@@ -116,6 +141,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
         "BailianApiKeyB64": {"Fn::Base64Encode": {"Fn::GetAtt": ["BailianApiKey", "Key"]}},
         "MasterAccountId": {"Ref": "ALIYUN::TenantId"},
         "StackRegion": {"Ref": "ALIYUN::Region"},
+        "InstanceRamRoleName": {"Fn::GetAtt": ["InstanceRamRole", "RoleName"]},
         "LocalInstanceId": {"Ref": "Instance"},
         "LocalInstanceType": {"Ref": "InstanceType"},
         "LocalZoneId": {"Ref": "ZoneId"},
@@ -155,6 +181,7 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
     assert 'chmod 0600 "$AGENTS_TMP"' in script
     assert set(re.findall(r"\$\{([^}]+)\}", script)) == {
         "BailianApiKeyB64",
+        "InstanceRamRoleName",
         "LocalEipAddress",
         "LocalInstanceId",
         "LocalInstanceType",
@@ -169,9 +196,9 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
         "'activeProvider': 'dashscope'",
         "root = pathlib.Path('/root/.iac-code')",
         "root / '.cloud-credentials.yml'",
-        "'mode': 'OAuth'",
+        "'mode': 'EcsRamRole'",
         "'region_id': '${StackRegion}'",
-        "'oauth_site_type': 'CN'",
+        "'ram_role_name': '${InstanceRamRoleName}'",
         "'memory': {'autoMemory': True}",
         "'pipeline': {'sellingReviewStep': False}",
         "'apiBase': 'https://dashscope.aliyuncs.com/compatible-mode/v1'",
@@ -184,6 +211,8 @@ def test_golden_template_parameters_outputs_and_bootstrap_follow_contract() -> N
         "'userID': '${MasterAccountId}'",
     ):
         assert expected in script
+    assert "'mode': 'OAuth'" not in script
+    assert "'oauth_site_type': 'CN'" not in script
     assert "'model': 'deepseek-v4-flash-0731'" not in script
 
     outputs = template["Outputs"]


### PR DESCRIPTION
## Summary

- create an ECS-trusted RAM role with `AdministratorAccess` in the iac-code Web ROS solution
- attach the role to the deployed ECS instance and wait for the attachment before bootstrap
- configure Alibaba Cloud credentials as `EcsRamRole` by default, using the deployed region and actual role name
- update the bundled solution guidance and golden-template contract tests

## Why

`main` now supports ECS RAM Role credentials, so the single-ECS Web deployment can use automatically refreshed instance metadata credentials instead of persisting OAuth-backed cloud credentials.

## Impact

New iac-code Web stacks receive a stack-scoped ECS RAM role and use it as their default Alibaba Cloud credential source. The role is deleted with the stack.

## Validation

- `uv run pytest -q tests/pipeline/selling tests/test_setup_packaging.py` — 384 passed
- `uv run ruff check tests/pipeline/selling/test_iac_code_web_solution.py`
- strict local ROS validation — no errors or warnings
- real ROS `CreateStack` in `cn-hangzhou-b` — `CREATE_COMPLETE`
- verified role attachment, IMDSv2 credentials, matching configured role name, and `ecs_ram_role` provider on current `main`
- deleted the validation stack and confirmed all 10 resources reached `DELETE_COMPLETE`
