### PR TITLE
Update website homepage and add GA product guidance

### DIFF
--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -275,7 +275,7 @@ ros_estimate_template_cost(
 
 | 文件 | 内容 | 何时查阅 |
 |------|------|----------|
-| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md） | 需要了解产品属性、规格选型、库存相关字段时 |
+| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md、ga.md） | 需要了解产品属性、规格选型、库存相关字段时 |
 | [references/template-parameters.md](references/template-parameters.md) | 模板参数规范：AssociationProperty、Label、分组 | 修复 Parameters 定义（缺少 AssociationProperty、Label 等）时 |
 | [references/ros-template.md](references/ros-template.md) | ROS 模板最佳实践：RunCommand、嵌套栈、条件部署 | 修复资源定义、内置函数用法等模板结构问题时 |
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -173,5 +173,5 @@ conclusion_schema:
 | 文件 | 内容 |
 |------|------|
 | [references/template-parameters.md](references/template-parameters.md) | 模板参数规范：AssociationProperty、Label、分组 |
-| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md） |
+| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md、ga.md） |
 | [references/ros-template.md](references/ros-template.md) | ROS 原生模板最佳实践：RunCommand、嵌套栈、条件部署 |

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -110,5 +110,5 @@ conclusion_schema:
 | 文件 | 内容 |
 |------|------|
 | [references/template-parameters.md](references/template-parameters.md) | 模板参数规范：AssociationProperty、Label、分组 |
-| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md） |
+| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md、ga.md） |
 | [references/ros-template.md](references/ros-template.md) | ROS 模板最佳实践：RunCommand、嵌套栈、条件部署 |

--- a/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
@@ -66,6 +66,7 @@ auto_trigger:
 | RDS | ZoneId, DBInstanceClass, DBInstanceStorageType |
 | Redis | ZoneId, InstanceClass |
 | SLB/ALB | ZoneId |
+| GA | `IpSets.AccelerateRegion[].AccelerateRegionId`（标准型 EIP）/ `BasicIpSet.AccelerateRegionId`（基础型）, EndpointGroupRegion |
 
 以下属性**不需要**参数化，直接使用合理默认值：
 - 网络：VPC CIDR、VSwitch CIDR
@@ -171,7 +172,7 @@ auto_trigger:
 |------|------|
 | [references/template-parameters.md](references/template-parameters.md) | 模板参数规范：AssociationProperty、Label、分组（ROS/Terraform 共用） |
 | [references/template-parameter-recommendation.md](references/template-parameter-recommendation.md) | 已有 ROS 可部署模板的部署前参数推荐流程 |
-| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md） |
+| [references/cloud-products/](references/cloud-products/) | 云产品选型文件（ecs.md、rds.md、redis.md、slb.md、vpc.md、oss.md、ga.md） |
 | [references/ros-template.md](references/ros-template.md) | ROS 原生模板最佳实践：RunCommand、嵌套栈、条件部署 |
 | [references/terraform-template.md](references/terraform-template.md) | Terraform 最佳实践：文件组织、变量、Data Source、ROS 集成 |
 

--- a/src/iac_code/skills/bundled/iac_aliyun/auto_trigger.py
+++ b/src/iac_code/skills/bundled/iac_aliyun/auto_trigger.py
@@ -31,6 +31,13 @@ _ALIYUN_SCOPE_PATTERNS = [
     r"云资源",
 ]
 
+_GA_FULL_NAME_PATTERNS = [r"全球加速", r"\bglobal\s+accelerator\b"]
+_GA_ABBREVIATION_PATTERN = (
+    r"(?:\bga\b\s*(?:\bros\b|\bterraform\b|模[板版]|资源栈)|"
+    r"(?:\bros\b|\bterraform\b|模[板版]|资源栈)\s*\bga\b)"
+)
+_NON_ALIYUN_GA_PATTERNS = [r"\baws\b", r"\bamazon\s+web\s+services\b", r"\bcloudformation\b"]
+
 _ES_TEMPLATE_ACTIONS = r"genera|generar|crea|crear|despliega|desplegar|explica|explicar|valida|validar|mejora|mejorar"
 _FR_TEMPLATE_ACTIONS = (
     r"cr[eé]e|cr[eé]er|g[eé]n[eé]re|g[eé]n[eé]rer|d[eé]ploie|d[eé]ployer|"
@@ -91,7 +98,17 @@ def should_trigger(prompt: str) -> bool:
 
 
 def has_aliyun_scope(text: str) -> bool:
-    return any(re.search(pattern, text, re.IGNORECASE) for pattern in _ALIYUN_SCOPE_PATTERNS)
+    if any(re.search(pattern, text, re.IGNORECASE) for pattern in _ALIYUN_SCOPE_PATTERNS):
+        return True
+    return has_ga_product_scope(text)
+
+
+def has_ga_product_scope(text: str) -> bool:
+    if any(re.search(pattern, text, re.IGNORECASE) for pattern in _NON_ALIYUN_GA_PATTERNS):
+        return False
+    if any(re.search(pattern, text, re.IGNORECASE) for pattern in _GA_FULL_NAME_PATTERNS):
+        return True
+    return re.search(_GA_ABBREVIATION_PATTERN, text, re.IGNORECASE) is not None
 
 
 def has_iac_workflow(text: str) -> bool:

--- a/src/iac_code/skills/bundled/iac_aliyun/references/cloud-products/ga.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/cloud-products/ga.md
@@ -1,0 +1,130 @@
+# 阿里云全球加速 GA 选型指南
+
+## 全局规则
+
+- 本文只固化产品选型和安全边界。资源属性、枚举、支持的终端节点类型、地域覆盖和账号资格可能变化，**每次生成前必须查询当前 Schema 和可用性 API**。
+- ROS Schema：`aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<类型>"})`。
+- Terraform Schema：`aliyun_api(product="IaCService", action="GetResourceType", style="ROA", method="GET", pathname="/resourceType/<类型>")`。
+- 下文资源名是查询 Schema 的定位锚点，不代表当前版本一定支持全部能力。只有 Schema 返回完整资源链和准确属性后才能生成；缺失时说明限制并询问是否切换 IaC 实现，不得编造属性或用其他资源冒充。
+- Anycast、自定义路由、WAF、跨境线路、高防、大规格和特定 ISP 等受限能力，生成前确认当前地域、账号资格与产品约束；未确认不得默认启用。
+- 证书、已有资源 ID、外部源站 IP/域名均由用户提供或从真实 API 结果中选择，禁止编造。
+
+## 默认选型顺序
+
+用户未指定时，按以下顺序推荐：
+
+1. **标准型按量付费**：默认选择，适合大多数 TCP、UDP、HTTP、HTTPS 跨地域加速场景。
+2. **标准型包年包月**：仅在流量长期稳定、希望按固定带宽付费时选择。
+3. **基础型**：仅在明确需要三层点到点加速、自定义协议或源站主动访问公网，且一个加速区域对应一个终端节点组时选择。
+
+不得仅因成本原因把标准型静默降级为基础型；二者的协议层级、拓扑和能力不同。
+
+| 需求 | 推荐形态 |
+|------|----------|
+| 网站、API、企业应用、AI 服务、通用 TCP/UDP | 标准型 + 智能路由 |
+| 按监听端口确定性映射到指定后端 IP/端口 | 标准型 + 自定义路由 |
+| 三层点到点、私有协议、源站主动访问公网 | 基础型 |
+| 海外用户分散且需要统一入口 IP | 标准型 + Anycast；先确认当前覆盖和资格 |
+
+## 付费模式映射
+
+ROS 与 Terraform 的字段名和枚举不同，不能通过大小写或 snake_case 机械转换：
+
+| 形态 | ROS | Terraform | 说明 |
+|------|-----|-----------|------|
+| 标准型按量付费（默认） | `InstanceChargeType: POSTPAY`、`BandwidthBillingType: CDT` | `payment_type = "PayAsYouGo"`、`bandwidth_billing_type = "CDT"` | 无需基础带宽包 |
+| 标准型包年包月 | `InstanceChargeType: PREPAY`、`BandwidthBillingType: BandwidthPackage` | `payment_type = "Subscription"`、`bandwidth_billing_type = "BandwidthPackage"` | 创建并绑定基础带宽包 |
+| 基础型 | ROS 使用 `ChargeType`；Terraform 使用 `payment_type` | 取值按上述按量/包年包月映射 | 不得生成 Terraform `charge_type` |
+
+付费模式创建后不得在模板更新中静默切换。`Spec`、价格、可售带宽类型和账期约束不在本文固化，以当前 Schema、询价和售卖能力为准。
+
+## 接入与路由决策
+
+### EIP 与 Anycast
+
+| 接入方式 | 稳定选型规则 |
+|----------|--------------|
+| EIP 自定义就近接入 | 需要指定加速地域、按地域控制入口或分配带宽时使用；标准型地域位于 `IpSets.AccelerateRegion` 列表内 |
+| Anycast 自动就近接入 | 需要海外多地域统一入口 IP 时考虑；不配置独立加速地域，生成前查询当前 IaC Schema、覆盖和资格 |
+
+若所选 IaC Schema 未返回 Anycast 接入属性，说明限制并改用当前支持的 ROS、Terraform 或 OpenAPI 方案；不得凭经验编造 `ip_set_config`、`access_mode` 等字段。
+
+### 智能路由（默认）
+
+- 根据时延、健康状态和权重转发，适用于绝大多数标准协议场景。
+- ROS 从 `ALIYUN::GA::Listener` 查询当前监听属性；Terraform 从 `alicloud_ga_listener` 查询。不得根据经验猜测 `Type`、`ListenerType` 或 `listener_type`。
+- 监听协议必须匹配业务；HTTPS 引用真实证书并选择当前 Schema 支持的 TLS 策略。
+- ROS 智能路由终端节点组以 `ALIYUN::GA::EndpointGroup` / `EndpointGroups` 为查询锚点；Terraform 以 `alicloud_ga_endpoint_group` 为查询锚点。根据 Schema 返回的终端节点类型和必填字段选择资源，不固化当前类型清单。
+
+### 自定义路由
+
+- 仅用于分房游戏、音视频等“监听端口 → 指定后端地址和端口”的确定性映射场景。
+- 同一 GA 实例不能混用智能路由和自定义路由；监听路由类型创建后不能变更，切换时重建监听及关联资源。
+- 终端节点使用 VSwitch ID（`vsw-...`）；后端 IP、协议、端口和放行策略由 Schema 中的目的端口与流量策略资源表达，不能把 CIDR 填入 VSwitch ID 属性。
+- 自定义路由不使用智能路由的健康检查。生成前分别查询监听、终端节点组、终端节点、目的端口和流量策略的完整资源链；链路不完整时报告限制，不能用普通智能路由终端节点组代替。
+
+## 高频场景
+
+| 场景 | 选型要点 |
+|------|----------|
+| 加速指定 IP、域名、网站或 API | 标准型按量付费 + 智能路由；加速地域靠近客户端，终端节点组地域与源站一致 |
+| DSW、模型或镜像下载、Model Studio API | 标准型智能路由；使用真实公网域名，固定调用方时仅放行其 NAT/出口 IP |
+| Web 业务接入 WAF | 标准型 HTTP/HTTPS；先确认当前支持地域、付费模式和账号资格 |
+| 海外多地域统一 IP | 标准型 + Anycast；先查询当前覆盖与 IaC Schema |
+| SSL-VPN | 监听协议和端口与 VPN 一致；GA 只加速传输，不替代 VPN 加密 |
+| 分房游戏、确定性端口映射 | 标准型自定义路由；仅在所选 IaC Schema 返回完整资源链时生成 |
+
+## 客户端源 IP、安全与高可用
+
+- HTTP/HTTPS 通过 `X-Forwarded-For` 获取真实客户端 IP，后端正确解析代理链。
+- TCP 仅在后端支持时启用 Proxy Protocol 或 Schema 返回的源 IP 保留能力，否则会导致协议解析失败。IPv6 客户端访问 IPv4 源站时，UDP 不保证保留 IPv6 源 IP。
+- 监听只开放业务所需端口；固定客户端使用 ACL 白名单；HTTPS 证书作为外部输入。
+- 涉及中国内地 Web 服务时检查 ICP 备案；涉及跨境网络时依据用户资质和当前可用线路生成，不猜测资质。
+- 健康检查、终端节点权重和终端节点组流量比例仅用于**标准型智能路由**。生产环境默认开启健康检查；HTTP(S) 使用专用健康路径，TCP 使用 TCP 探测，具体参数以源站约束和当前 Schema 为准。
+- 基础型和自定义路由不套用上述健康检查或权重属性，使用业务探测或独立监控设计容灾。
+
+## IaC 资源定位
+
+| 能力 | ROS 查询锚点 | Terraform 查询锚点 |
+|------|--------------|--------------------|
+| 标准型实例 | `ALIYUN::GA::Accelerator` | `alicloud_ga_accelerator` |
+| 监听 | `ALIYUN::GA::Listener` | `alicloud_ga_listener` |
+| EIP 加速地域 | `ALIYUN::GA::IpSets` | `alicloud_ga_ip_set` |
+| 智能路由终端节点组 | `ALIYUN::GA::EndpointGroup` / `EndpointGroups` | `alicloud_ga_endpoint_group` |
+| 转发规则与 ACL | `ALIYUN::GA::ForwardingRules`、`Acl`、`AclsListenerAssociation` | 查询 `alicloud_ga_*` 当前对应资源 |
+| 基础带宽包及绑定 | `ALIYUN::GA::BandwidthPackage`、`BandwidthPackageAcceleratorAddition` | `alicloud_ga_bandwidth_package`、`alicloud_ga_bandwidth_package_attachment` |
+| 基础型 | `ALIYUN::GA::Basic*` | `alicloud_ga_basic_*` |
+| 自定义路由 | 查询当前 `ALIYUN::GA::*CustomRouting*` 及关联 Schema | 查询当前 `alicloud_ga_custom_routing_*` 完整资源链 |
+
+资源名仅用于定位。选定 IaC 后，只生成该 Schema 当前返回的资源、属性、枚举和必填字段；不存在直接映射时报告差异，不做名称推导。
+
+## 模板参数
+
+| 参数 | 规则 |
+|------|------|
+| 标准型 EIP 加速地域 | ROS 位于 `IpSets.AccelerateRegion[].AccelerateRegionId`，不是 `IpSets.Properties` 顶层属性 |
+| 基础型加速地域 | 从 `BasicIpSet` 当前 Schema 查询 `AccelerateRegionId` |
+| `EndpointGroupRegion` | 与源站实际地域一致 |
+| 源站 ID / IP / 域名 | 使用已有资源或外部输入，禁止编造 |
+| HTTPS 证书 ID | 由用户提供或选择已有证书 |
+
+监听协议、端口、IP 版本和带宽建议参数化；业务已明确时可设置有依据的默认值和 `AllowedValues`。
+
+## 运行时查询与筛选
+
+GA OpenAPI 使用文档指定的控制面地域（当前为 `cn-hangzhou`，调用前以最新 API 文档为准）。
+
+| 用途 | API | 关键输入 |
+|------|-----|----------|
+| 标准型加速地域 | `ListAvailableAccelerateAreas` | 可选 `AcceleratorId`；查询 Anycast 时按当前 API 传 `AccessMode` |
+| 终端节点可用地域 | `ListAvailableBusiRegions` | 已有实例时传 `AcceleratorId` |
+| 公网线路类型 | `ListIspTypes` | `BusinessRegionId`、实例类型和可选实例 ID |
+| 源站验证 | ECS、VPC、SLB、OSS 等对应产品 API | 资源 ID、地域、VPC/VSwitch、地址 |
+
+筛选顺序：
+
+1. 用户指定的实例类型、付费模式、地域、协议、端口、IP 版本和源站类型均为硬约束。
+2. 查询所选 IaC 的当前资源 Schema，确认完整资源链、必填属性和枚举。
+3. 查询加速地域、终端节点地域和线路的当前可用性，并验证源站资源与地域一致。
+4. 能力需要额外资格或 Schema 缺失时，报告限制并给出可选实现；不得静默换 IaC、地域、协议或产品类型。
+5. 没有满足全部硬约束的组合时，说明冲突并请用户调整约束。

--- a/tests/desktop/test_sidecar_build.py
+++ b/tests/desktop/test_sidecar_build.py
@@ -34,6 +34,7 @@ def test_sidecar_staging_materializes_resources_and_desktop_helper_instructions(
             "slb.md",
             "vpc.md",
             "oss.md",
+            "ga.md",
         }
     assert list((package / "i18n/locales").glob("*/LC_MESSAGES/messages.mo"))
     assert list((package / "i18n/locales").glob("*/LC_MESSAGES/webui.mo"))

--- a/tests/pipeline/engine/test_loader.py
+++ b/tests/pipeline/engine/test_loader.py
@@ -99,6 +99,7 @@ class TestLoadPipelineDir:
         assert skill_root != skill_dir.resolve()
         assert (skill_root / "references" / "ros-template.md").is_file()
         assert (skill_root / "references" / "cloud-products" / "ecs.md").is_file()
+        assert (skill_root / "references" / "cloud-products" / "ga.md").is_file()
 
     def test_rejects_context_dependency_cycle(self, tmp_path):
         yaml_content = dedent("""\

--- a/tests/skills/bundled/test_iac_skill.py
+++ b/tests/skills/bundled/test_iac_skill.py
@@ -3,6 +3,11 @@ from pathlib import Path
 from iac_code.skills.bundled import _bundled_skills, get_bundled_skills, init_bundled_skills
 
 IAC_SKILL_ROOT = Path("src/iac_code/skills/bundled/iac_aliyun")
+SELLING_IAC_SKILLS = [
+    Path("src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md"),
+    Path("src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md"),
+    Path("src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md"),
+]
 
 
 def _iac_aliyun_asset_text() -> str:
@@ -103,3 +108,23 @@ class TestIacSkill:
         assert "纯 Terraform" in content
         assert "IaCService" in content
         assert "脱敏后的摘要" in content
+
+    def test_cloud_product_catalogs_list_all_bundled_product_references(self):
+        product_names = {path.name for path in (IAC_SKILL_ROOT / "references" / "cloud-products").glob("*.md")}
+
+        for skill_path in [IAC_SKILL_ROOT / "SKILL.md", *SELLING_IAC_SKILLS]:
+            content = skill_path.read_text(encoding="utf-8")
+            missing = sorted(name for name in product_names if name not in content)
+            assert not missing, f"{skill_path} is missing cloud product references: {missing}"
+
+    def test_ga_reference_keeps_ros_and_terraform_boundaries_explicit(self):
+        content = (IAC_SKILL_ROOT / "references" / "cloud-products" / "ga.md").read_text(encoding="utf-8")
+
+        assert "每次生成前必须查询当前 Schema 和可用性 API" in content
+        assert "不得根据经验猜测 `Type`、`ListenerType` 或 `listener_type`" in content
+        assert '`payment_type = "PayAsYouGo"`' in content
+        assert "`IpSets.AccelerateRegion[].AccelerateRegionId`" in content
+        assert "未返回 Anycast 接入属性" in content
+        assert "完整资源链" in content
+        assert "只生成该 Schema 当前返回的资源、属性、枚举和必填字段" in content
+        assert "VSwitch ID（`vsw-...`）" in content

--- a/tests/skills/test_auto_trigger.py
+++ b/tests/skills/test_auto_trigger.py
@@ -172,6 +172,22 @@ def test_iac_aliyun_trigger_matches_alicloud_provider_prompt():
     assert should_trigger('用 provider "alicloud" 写一个 ECS 安全组模板')
 
 
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "生成一个全球加速 ROS 模板",
+        "生成一个 GA ROS 模板",
+        "生成一个 GA Terraform 模板",
+        "GA\nROS 模板生成",
+        "Write a Global Accelerator Terraform template",
+    ],
+)
+def test_iac_aliyun_trigger_matches_ga_template_prompts(prompt):
+    from iac_code.skills.bundled.iac_aliyun.auto_trigger import should_trigger
+
+    assert should_trigger(prompt)
+
+
 def test_iac_aliyun_trigger_rejects_infraguard_policy_generation():
     from iac_code.skills.bundled.iac_aliyun.auto_trigger import should_trigger
 
@@ -291,6 +307,10 @@ def test_iac_aliyun_trigger_matches_supported_languages(prompt):
         "阿里云 ECS 价格怎么样？",
         "阿里云 ECS 部署失败了，帮我排查 SSH 登录",
         "ROS 机器人导航怎么做？",
+        "Create a Terraform template after this feature reaches GA",
+        "这个 ROS 资源栈功能 GA 了吗？",
+        "Create an AWS Global Accelerator Terraform template",
+        "Write a Global Accelerator CloudFormation template",
     ],
 )
 def test_iac_aliyun_trigger_rejects_non_iac_prompts(prompt):

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -33,6 +33,7 @@ def _assert_expanded_selling_references(package_root: Path, skill_names: tuple[s
         assert (references / "ros-template.md").is_file()
         assert (references / "template-parameters.md").is_file()
         assert (references / "cloud-products" / "ecs.md").is_file()
+        assert (references / "cloud-products" / "ga.md").is_file()
         assert (references / "solutions" / "iac-code-web.md").is_file()
         assert (references / "solutions" / "iac-code-web.ros.yml").is_file()
         recommendation = (references / "template-parameter-recommendation.md").read_text(encoding="utf-8")
@@ -71,6 +72,7 @@ def test_selling_skill_references_expand_windows_symlink_placeholder_files(monke
     (bundled_refs / "ros-template.md").write_text("real ros template reference", encoding="utf-8")
     (bundled_refs / "template-parameters.md").write_text("real parameter reference", encoding="utf-8")
     (cloud_products / "ecs.md").write_text("real ecs reference", encoding="utf-8")
+    (cloud_products / "ga.md").write_text("real ga reference", encoding="utf-8")
     (solutions / "iac-code-web.md").write_text("real solution reference", encoding="utf-8")
     (solutions / "iac-code-web.ros.yml").write_text("ROSTemplateFormatVersion: '2015-09-01'", encoding="utf-8")
     (selling_refs / "template-parameter-recommendation.md").write_text(

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -6,20 +6,24 @@
   --home-cyan: #9edff7;
   overflow: hidden;
   background:
-    radial-gradient(circle at 4% 36%, rgba(127, 211, 249, 0.13), transparent 23%),
-    radial-gradient(circle at 96% 62%, rgba(177, 117, 246, 0.1), transparent 24%),
-    #ffffff;
+    radial-gradient(ellipse 46% 8% at 14% 2%, rgba(114, 211, 249, 0.38), transparent 76%),
+    radial-gradient(ellipse 44% 8% at 78% 2%, rgba(104, 125, 250, 0.29), transparent 76%),
+    radial-gradient(ellipse 34% 7% at 96% 7%, rgba(225, 119, 217, 0.24), transparent 78%),
+    radial-gradient(ellipse 46% 11% at 3% 21%, rgba(105, 207, 247, 0.34), transparent 73%),
+    radial-gradient(ellipse 48% 12% at 97% 31%, rgba(198, 106, 235, 0.3), transparent 74%),
+    radial-gradient(ellipse 47% 12% at 4% 43%, rgba(91, 158, 247, 0.3), transparent 73%),
+    radial-gradient(ellipse 47% 12% at 96% 55%, rgba(226, 116, 207, 0.28), transparent 74%),
+    radial-gradient(ellipse 47% 12% at 4% 68%, rgba(104, 208, 243, 0.31), transparent 73%),
+    radial-gradient(ellipse 48% 12% at 96% 80%, rgba(125, 109, 239, 0.27), transparent 74%),
+    radial-gradient(ellipse 49% 10% at 18% 96%, rgba(221, 119, 211, 0.25), transparent 76%),
+    linear-gradient(180deg, #f8fbff 0%, #f5f4ff 34%, #f4faff 68%, #faf5ff 100%);
   color: #1f2026;
 }
 
 .hero {
   position: relative;
   isolation: isolate;
-  background:
-    radial-gradient(ellipse 46% 34% at 16% 8%, rgba(143, 219, 249, 0.35), transparent 74%),
-    radial-gradient(ellipse 42% 34% at 78% 5%, rgba(102, 126, 255, 0.24), transparent 76%),
-    radial-gradient(ellipse 31% 30% at 92% 31%, rgba(222, 123, 222, 0.19), transparent 78%),
-    linear-gradient(180deg, #f8fbff 0%, #fcfaff 43%, #ffffff 100%);
+  background: transparent;
 }
 
 .hero::before {
@@ -542,6 +546,14 @@
   padding: 96px 24px;
 }
 
+.featureRowsSection {
+  position: relative;
+}
+
+.featureRowsSection + .featureRowsSection {
+  padding-top: 56px;
+}
+
 .rowsHeader {
   max-width: 760px;
   margin: 0 auto 72px;
@@ -570,24 +582,20 @@
   align-items: center;
   overflow: hidden;
   min-height: 530px;
-  border: 1px solid rgba(111, 126, 213, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.58);
   border-radius: 30px;
-  background:
-    radial-gradient(circle at 82% 9%, rgba(83, 140, 255, 0.3), transparent 36%),
-    radial-gradient(circle at 96% 82%, rgba(210, 106, 230, 0.24), transparent 43%),
-    radial-gradient(circle at 52% 100%, rgba(137, 103, 245, 0.2), transparent 42%),
-    linear-gradient(128deg, rgba(244, 251, 255, 0.98), rgba(243, 242, 255, 0.96) 58%, rgba(252, 241, 252, 0.96));
-  box-shadow: 0 24px 70px rgba(70, 82, 155, 0.09);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(111, 104, 205, 0.05));
+  box-shadow:
+    0 32px 90px rgba(66, 72, 145, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.18);
+  -webkit-backdrop-filter: blur(26px) saturate(158%);
+  backdrop-filter: blur(26px) saturate(158%);
   padding: 48px;
 }
 
 .featureRowReverse {
   grid-template-columns: minmax(420px, 1.1fr) minmax(280px, 0.9fr);
-  background:
-    radial-gradient(circle at 8% 12%, rgba(114, 210, 248, 0.31), transparent 36%),
-    radial-gradient(circle at 21% 88%, rgba(100, 119, 246, 0.26), transparent 43%),
-    radial-gradient(circle at 89% 14%, rgba(219, 123, 226, 0.2), transparent 38%),
-    linear-gradient(232deg, rgba(250, 242, 253, 0.97), rgba(242, 244, 255, 0.96) 56%, rgba(239, 251, 255, 0.98));
 }
 
 .featureRowReverse .featureRowCopy {
@@ -639,14 +647,14 @@
   flex-direction: column;
   align-items: center;
   overflow: hidden;
-  border: 1px solid rgba(105, 116, 216, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.58);
   border-radius: 30px;
-  background:
-    radial-gradient(circle at 12% 8%, rgba(110, 211, 247, 0.34), transparent 34%),
-    radial-gradient(circle at 84% 16%, rgba(99, 117, 246, 0.27), transparent 36%),
-    radial-gradient(circle at 72% 112%, rgba(226, 116, 210, 0.25), transparent 42%),
-    linear-gradient(120deg, #f6fcff, #f3f2ff 54%, #fff5fc);
-  box-shadow: 0 24px 70px rgba(75, 86, 161, 0.1);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(111, 104, 205, 0.06));
+  box-shadow:
+    0 32px 90px rgba(66, 72, 145, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  -webkit-backdrop-filter: blur(26px) saturate(158%);
+  backdrop-filter: blur(26px) saturate(158%);
   padding: 64px 24px;
   text-align: center;
 }


### PR DESCRIPTION
## Summary

- extend the website homepage gradient through the content area and refine the feature panel with a glassmorphism treatment
- add a concise Alibaba Cloud Global Accelerator product guide for the bundled `iac_aliyun` skill
- auto-trigger the skill for GA ROS and Terraform requests while excluding AWS and general-availability usages
- expose the GA reference through the selling pipeline, packaging, and sidecar resource paths
- add regression coverage for trigger classification, reference discovery, packaging, and runtime IaC boundaries

## Why

The homepage previously transitioned into a large plain area below the hero section. The updated styling keeps one visual tone across the page. The IaC skill also lacked GA-specific selection guidance, which could lead to incorrect product choices or guessed ROS and Terraform properties.

The GA guide keeps stable product decisions in context and requires current ROS, Terraform, and availability schemas to be queried for details that may change.

## Impact

- website visitors get a continuous background and clearer glass panel treatment
- GA template requests load the correct Alibaba Cloud guidance
- generated templates are instructed not to invent unsupported resources, properties, enum values, or external IDs
- temporary research notes under `docs/ga` remain ignored and are not part of this PR

## Validation

- `uv run pytest -q tests/skills tests/test_setup_packaging.py tests/desktop/test_sidecar_build.py::test_sidecar_staging_materializes_resources_and_desktop_helper_instructions tests/pipeline/engine/test_loader.py::TestLoadPipelineDir::test_selling_iac_aliyun_skill_reference_file_uses_bundled_root_fallback` (231 passed)
- `uv run ruff check` for the changed Python sources and tests
- `git diff --check`
