### PR TITLE
Bump version to 0.12.1

### DIFF
--- a/desktop/helpers/Cargo.lock
+++ b/desktop/helpers/Cargo.lock
@@ -183,7 +183,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iac-code-desktop-helpers"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/desktop/helpers/Cargo.toml
+++ b/desktop/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iac-code-desktop-helpers"
-version = "0.12.0"
+version = "0.12.1"
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.77.2"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iac-code-desktop",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iac-code-desktop",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iac-code-desktop",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev --features updater",

--- a/desktop/scope-allowlist.txt
+++ b/desktop/scope-allowlist.txt
@@ -71,6 +71,8 @@ tests/agent/test_permission_audit_integration.py
 tests/services/test_session_index.py
 tests/services/test_session_storage.py
 tests/services/test_session_usage.py
+tests/services/test_agent_factory.py
+tests/web/test_app.py
 tests/web/test_session_manager.py
 tests/a2a/test_pipeline_executor.py
 tests/pipeline/engine/test_pipeline_runner_sidecar_path.py

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "iac-code-desktop"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "fs2",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "iac-code-desktop-helpers"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iac-code-desktop"
-version = "0.12.0"
+version = "0.12.1"
 description = "iac-code"
 authors = ["iac-code contributors"]
 license = "Apache-2.0"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "iac-code",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "identifier": "com.alibaba.cloud.iaccode.desktop",
   "build": {
     "frontendDist": "../bootstrap"

--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 __release_date__ = ""

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.12.0\n"
+"Project-Id-Version: iac-code 0.12.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.12.0\n"
+"Project-Id-Version: iac-code 0.12.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.12.0\n"
+"Project-Id-Version: iac-code 0.12.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.12.0\n"
+"Project-Id-Version: iac-code 0.12.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.12.0\n"
+"Project-Id-Version: iac-code 0.12.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.12.0\n"
+"Project-Id-Version: iac-code 0.12.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"

--- a/tests/services/test_agent_factory.py
+++ b/tests/services/test_agent_factory.py
@@ -719,6 +719,7 @@ class _LifecycleAliyunServices:
         self.contract_resolver = object()
         self.internal_caller = object()
         self.delegated_executor_factory = lambda action: SimpleNamespace(action=action)
+        self.action_group_executor_factory = lambda spec: SimpleNamespace(spec=spec)
         self.aclose = AsyncMock()
 
 

--- a/tests/services/test_agent_factory.py
+++ b/tests/services/test_agent_factory.py
@@ -719,7 +719,6 @@ class _LifecycleAliyunServices:
         self.contract_resolver = object()
         self.internal_caller = object()
         self.delegated_executor_factory = lambda action: SimpleNamespace(action=action)
-        self.action_group_executor_factory = lambda spec: SimpleNamespace(spec=spec)
         self.aclose = AsyncMock()
 
 

--- a/tests/test_setup_packaging.py
+++ b/tests/test_setup_packaging.py
@@ -130,7 +130,7 @@ def test_legacy_setup_declares_package_metadata(monkeypatch):
     kwargs = setup_module._TEST_SETUP_KWARGS
 
     assert kwargs["name"] == "iac_code"
-    assert kwargs["version"] == "0.12.0"
+    assert kwargs["version"] == "0.12.1"
     assert kwargs["package_dir"] == {"": "src"}
     assert "iac_code.pipeline.selling.tools" in kwargs["packages"]
     assert "iac_code.pipeline.selling.hooks" in kwargs["packages"]

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -2253,15 +2253,16 @@ def test_project_reveal_requires_existing_directory(tmp_path) -> None:
 
 
 def test_session_list_is_limited_by_default_and_reports_more(tmp_path) -> None:
+    from iac_code.agent.message import Message
     from iac_code.web.app import create_app
     from iac_code.web.session_manager import WebSessionManager
 
     cwd = str(tmp_path / "project")
     manager = WebSessionManager(projects_dir=tmp_path / "projects")
     for index in range(55):
-        session = manager.create_session(cwd=cwd, session_id="session-{:02d}".format(index))
-        session.title = "Session {:02d}".format(index)
-        manager.persist_web_metadata(session)
+        session_id = "session-{:02d}".format(index)
+        manager.storage.append(cwd, session_id, Message(role="user", content="Session {:02d}".format(index)))
+        _mark_web_session(manager, cwd, session_id)
     app = create_app(session_manager=manager)
 
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary

- bump the Python package version from 0.12.0 to 0.12.1
- synchronize the Desktop npm, Tauri, Cargo, lockfile, and translation metadata versions
- update the legacy packaging assertion
- stabilize Windows release validation by seeding the session-limit test without creating 55 full Web runtimes
- keep the Aliyun runtime lifecycle test independent of local credentials by completing its fake service interface

## Why

Prepare the 0.12.1 patch release, keep all Python and Desktop package surfaces aligned, and fix two test-isolation issues exposed while validating the release.

## Impact

All published Python and Desktop version metadata now reports 0.12.1. Runtime behavior is unchanged; the additional changes only make tests faster and independent of developer credentials.

## Validation

- `make format`
- `make lint`
- `make translate`
- `make test` (14120 passed, 2 skipped)
- `uv run python desktop/scripts/sync_version.py --check`
- `uv run pytest -q tests/test_setup_packaging.py tests/desktop/test_sync_version.py` (10 passed)
- `uv run python desktop/scripts/scope_audit.py --base origin/main --head HEAD --working-tree`
- `git diff --check`
