### PR TITLE
test(a2a): relax tight timeouts in unix transport test

### DIFF
--- a/tests/a2a/test_unix_transport.py
+++ b/tests/a2a/test_unix_transport.py
@@ -22,7 +22,7 @@ def test_validate_socket_path_requires_existing_parent(tmp_path) -> None:
         validate_socket_path(str(tmp_path / "missing" / "iac-code.sock"))
 
 
-async def wait_for_socket(socket_path, timeout: float = 1.0) -> None:
+async def wait_for_socket(socket_path, timeout: float = 5.0) -> None:
     deadline = asyncio.get_running_loop().time() + timeout
     while not socket_path.exists():
         if asyncio.get_running_loop().time() >= deadline:
@@ -63,7 +63,7 @@ async def test_unix_server_and_client_handle_unary_request(monkeypatch, tmp_path
                         },
                     }
                 ),
-                timeout=1,
+                timeout=10,
             )
         finally:
             await client.aclose()


### PR DESCRIPTION
## Why

`tests/a2a/test_unix_transport.py::test_unix_server_and_client_handle_unary_request` flaked in CI (Python 3.12 job) with a `TimeoutError` while the same test passed on every other Python version and platform in the same run.

The unary round-trip uses a 1s `asyncio.wait_for` and the socket-readiness helper waits up to 1s. Those timeouts only guard against hangs; on a loaded CI runner (14k tests under `pytest -n auto`) a 1s budget is too tight and turns the test into an intermittent failure.

## What

- Widen the unary round-trip timeout from 1s to 10s
- Widen the `wait_for_socket` readiness timeout from 1s to 5s

No production code changes; test-only stabilization.

## Verification

- `pytest tests/a2a/test_unix_transport.py tests/a2a/test_stdio_transport.py` green locally
