### PR TITLE
style(website): switch docs accent color from cyan to brand blue

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,6 +1,15 @@
-import {themes as prismThemes} from 'prism-react-renderer';
+import {themes as prismThemes, type PrismTheme} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+
+// The stock GitHub light theme tints symbol/constant tokens teal (#36acaa), which
+// reads as a leftover of the old cyan brand accent; re-hue those tokens to brand blue.
+const githubBrandBlue: PrismTheme = {
+  ...prismThemes.github,
+  styles: prismThemes.github.styles.map((style) =>
+    style.style.color === '#36acaa' ? {...style, style: {...style.style, color: '#1b56ba'}} : style,
+  ),
+};
 
 const config: Config = {
   title: 'iac-code',
@@ -184,7 +193,7 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} IaC Code contributors.`,
     },
     prism: {
-      theme: prismThemes.github,
+      theme: githubBrandBlue,
       darkTheme: prismThemes.dracula,
       additionalLanguages: ['bash', 'json', 'yaml', 'python', 'hcl'],
     },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,11 +1,11 @@
 :root {
-  --ifm-color-primary: #27d9de;
-  --ifm-color-primary-dark: #16c7cd;
-  --ifm-color-primary-darker: #0fb9bf;
-  --ifm-color-primary-darkest: #0b9398;
-  --ifm-color-primary-light: #67eef2;
-  --ifm-color-primary-lighter: #95f5f7;
-  --ifm-color-primary-lightest: #d9fdfe;
+  --ifm-color-primary: #2f6fe0;
+  --ifm-color-primary-dark: #2160cc;
+  --ifm-color-primary-darker: #1b56ba;
+  --ifm-color-primary-darkest: #16478f;
+  --ifm-color-primary-light: #5f8fe7;
+  --ifm-color-primary-lighter: #8fb1ee;
+  --ifm-color-primary-lightest: #e3ebfa;
   --ifm-font-family-base:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --ifm-heading-font-weight: 750;
@@ -14,13 +14,13 @@
 }
 
 [data-theme='dark'] {
-  --ifm-color-primary: #67eef2;
-  --ifm-color-primary-dark: #27d9de;
-  --ifm-color-primary-darker: #16c7cd;
-  --ifm-color-primary-darkest: #0b9398;
-  --ifm-color-primary-light: #95f5f7;
-  --ifm-color-primary-lighter: #c2fbfc;
-  --ifm-color-primary-lightest: #e8feff;
+  --ifm-color-primary: #7fa7f5;
+  --ifm-color-primary-dark: #2f6fe0;
+  --ifm-color-primary-darker: #2160cc;
+  --ifm-color-primary-darkest: #16478f;
+  --ifm-color-primary-light: #a5c1f8;
+  --ifm-color-primary-lighter: #c9dbfb;
+  --ifm-color-primary-lightest: #eef4fe;
   --ifm-background-color: #07111f;
   --ifm-background-surface-color: #0f172a;
 }
@@ -103,7 +103,7 @@
 }
 
 .footer__link-item:hover {
-  color: #0fb9bf;
+  color: #2160cc;
 }
 
 .footer__copyright {


### PR DESCRIPTION
## What

Replace the cyan accent palette of the docs site with a blue palette derived from the homepage brand blue (`#2f6fe0`), so the docs visual style matches the rest of the site.

- `website/src/css/custom.css`: light-theme `--ifm-color-primary` palette `#27d9de` → `#2f6fe0` family; dark-theme palette `#67eef2` → `#7fa7f5` family; footer link hover `#0fb9bf` → `#2160cc`.

## Covered elements

All Infima primary-driven accents: navbar active link, sidebar active item (+ light-blue background), breadcrumb pills, pagination card borders/links, inline content links, and link hover states in both light and dark modes.

## Not changed

The homepage terminal mock cyan (`src/pages/index.module.css`) is part of the terminal aesthetic and intentionally kept.

## Verification

Built the site (`npm run build`) and verified via headless-browser screenshots: navbar/sidebar/breadcrumbs, pagination, inline links (light) and dark mode all render the new blue.