### PR TITLE
fix: persist rotated OAuth tokens safely

### DIFF
--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -1,15 +1,17 @@
 import contextvars
 import json
 import os
+import threading
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
-from dataclasses import dataclass, field
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
 from iac_code.config import _load_yaml, _save_yaml, get_cloud_credentials_path
 from iac_code.i18n import _
+from iac_code.utils.state_io import cross_process_append_lock
 
 DEFAULT_REGION = "cn-hangzhou"
 DEFAULT_ALIYUN_CLI_CONFIG_PATH = os.path.expanduser("~/.aliyun/config.json")
@@ -102,11 +104,43 @@ class AliyunCredential:
     oauth_refresh_token: str = ""
     oauth_access_token_expire: int = 0
     oauth_refresh_token_expire: int = 0
+    # Runtime-only origin metadata. It lets OAuth refresh reload the same
+    # iac-code credential file after acquiring its cross-process lock without
+    # changing the persisted credential schema.
+    credential_source: str = field(default="", repr=False, compare=False)
+    credential_source_path: str = field(default="", repr=False, compare=False)
 
 
 _aliyun_credential_override: contextvars.ContextVar[AliyunCredential | None] = contextvars.ContextVar(
     "iac_code_aliyun_credential_override", default=None
 )
+_cloud_credential_lock_paths: contextvars.ContextVar[frozenset[str]] = contextvars.ContextVar(
+    "iac_code_cloud_credential_lock_paths", default=frozenset()
+)
+_cloud_credential_thread_lock = threading.RLock()
+
+
+@contextmanager
+def _cloud_credential_file_lock(path: Path) -> Iterator[None]:
+    """Serialize read-modify-write credential operations across threads and processes."""
+    lock_key = str(path.resolve(strict=False))
+    held_paths = _cloud_credential_lock_paths.get()
+    if lock_key in held_paths:
+        yield
+        return
+
+    with _cloud_credential_thread_lock:
+        with cross_process_append_lock(path):
+            token = _cloud_credential_lock_paths.set(held_paths | {lock_key})
+            try:
+                yield
+            finally:
+                _cloud_credential_lock_paths.reset(token)
+
+
+def _copy_credential(target: AliyunCredential, source: AliyunCredential) -> None:
+    for credential_field in fields(AliyunCredential):
+        setattr(target, credential_field.name, getattr(source, credential_field.name))
 
 
 @contextmanager
@@ -211,56 +245,92 @@ class AliyunCredentials:
         has_sts = bool(credential.access_key_id and credential.access_key_secret and credential.sts_token)
         if has_sts and not is_epoch_expired(credential.sts_expiration, current, STS_SKEW_SECONDS):
             return credential
-
         if not credential.oauth_site_type:
             raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth site is missing."))
 
-        owns_client = oauth_client is None
-        client = AliyunOAuthClient(get_oauth_site(credential.oauth_site_type)) if oauth_client is None else oauth_client
-
-        try:
-            refreshed_access_token = False
-            if is_epoch_expired(credential.oauth_access_token_expire, current, ACCESS_TOKEN_SKEW_SECONDS):
-                if not credential.oauth_refresh_token:
+        source_path = (
+            Path(credential.credential_source_path)
+            if credential.credential_source == "iac_code" and credential.credential_source_path
+            else None
+        )
+        lock = _cloud_credential_file_lock(source_path) if source_path is not None else nullcontext()
+        with lock:
+            if source_path is not None:
+                stored = AliyunCredentials._load_from_iac_code_path(source_path)
+                if stored is None:
                     raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth refresh token is missing."))
-                token = client.refresh_access_token(credential.oauth_refresh_token, now=current)
-                credential.oauth_access_token = token.access_token
-                credential.oauth_refresh_token = token.refresh_token
-                credential.oauth_access_token_expire = token.access_token_expire
-                credential.oauth_refresh_token_expire = token.refresh_token_expire
-                refreshed_access_token = True
+                _copy_credential(credential, stored)
+                if credential.mode != "OAuth":
+                    return credential
 
-            if not credential.oauth_access_token:
-                raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth access token is missing."))
+                # Another process may have completed the refresh while this
+                # caller waited for the credential-file lock.
+                has_sts = bool(credential.access_key_id and credential.access_key_secret and credential.sts_token)
+                if has_sts and not is_epoch_expired(credential.sts_expiration, current, STS_SKEW_SECONDS):
+                    return credential
+
+            if not credential.oauth_site_type:
+                raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth site is missing."))
+
+            owns_client = oauth_client is None
+            client = (
+                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type))
+                if oauth_client is None
+                else oauth_client
+            )
 
             try:
-                sts = client.exchange_access_token_for_sts(credential.oauth_access_token)
-            except AliyunOAuthError as error:
-                if refreshed_access_token or not _is_short_lived_access_token_sts_exchange_error(error):
-                    raise
-                if not credential.oauth_refresh_token:
-                    raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth refresh token is missing.")) from error
-                token = client.refresh_access_token(credential.oauth_refresh_token, now=current)
-                credential.oauth_access_token = token.access_token
-                credential.oauth_refresh_token = token.refresh_token
-                credential.oauth_access_token_expire = token.access_token_expire
-                credential.oauth_refresh_token_expire = token.refresh_token_expire
-                sts = client.exchange_access_token_for_sts(credential.oauth_access_token)
-            credential.access_key_id = sts.access_key_id
-            credential.access_key_secret = sts.access_key_secret
-            credential.sts_token = sts.sts_token
-            credential.sts_expiration = sts.sts_expiration
+                refreshed_access_token = False
+                if is_epoch_expired(credential.oauth_access_token_expire, current, ACCESS_TOKEN_SKEW_SECONDS):
+                    if not credential.oauth_refresh_token:
+                        raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth refresh token is missing."))
+                    token = client.refresh_access_token(credential.oauth_refresh_token, now=current)
+                    credential.oauth_access_token = token.access_token
+                    credential.oauth_refresh_token = token.refresh_token
+                    credential.oauth_access_token_expire = token.access_token_expire
+                    credential.oauth_refresh_token_expire = token.refresh_token_expire
+                    refreshed_access_token = True
+                    # Refresh tokens rotate. Persist the replacement before any
+                    # later network request so a transient STS exchange failure
+                    # cannot strand the old, already-invalid token on disk.
+                    AliyunCredentials.save(credential)
 
-            AliyunCredentials.save(credential)
-            return credential
-        finally:
-            if owns_client:
-                client.close()
+                if not credential.oauth_access_token:
+                    raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth access token is missing."))
+
+                try:
+                    sts = client.exchange_access_token_for_sts(credential.oauth_access_token)
+                except AliyunOAuthError as error:
+                    if refreshed_access_token or not _is_short_lived_access_token_sts_exchange_error(error):
+                        raise
+                    if not credential.oauth_refresh_token:
+                        raise AliyunOAuthReloginRequired(_("Alibaba Cloud OAuth refresh token is missing.")) from error
+                    token = client.refresh_access_token(credential.oauth_refresh_token, now=current)
+                    credential.oauth_access_token = token.access_token
+                    credential.oauth_refresh_token = token.refresh_token
+                    credential.oauth_access_token_expire = token.access_token_expire
+                    credential.oauth_refresh_token_expire = token.refresh_token_expire
+                    AliyunCredentials.save(credential)
+                    sts = client.exchange_access_token_for_sts(credential.oauth_access_token)
+                credential.access_key_id = sts.access_key_id
+                credential.access_key_secret = sts.access_key_secret
+                credential.sts_token = sts.sts_token
+                credential.sts_expiration = sts.sts_expiration
+
+                AliyunCredentials.save(credential)
+                return credential
+            finally:
+                if owns_client:
+                    client.close()
 
     @staticmethod
     def _load_from_iac_code_config() -> AliyunCredential | None:
         """Load credentials from ~/.iac-code/.cloud-credentials.yml."""
-        cloud_creds = _load_yaml(get_cloud_credentials_path())
+        return AliyunCredentials._load_from_iac_code_path(get_cloud_credentials_path())
+
+    @staticmethod
+    def _load_from_iac_code_path(path: Path) -> AliyunCredential | None:
+        cloud_creds = _load_yaml(path)
         aliyun_data = cloud_creds.get("aliyun")
         if not aliyun_data or not isinstance(aliyun_data, dict):
             return None
@@ -270,10 +340,13 @@ class AliyunCredentials:
             return None
 
         if mode == "EcsRamRole":
-            return _ecs_ram_role_credential(
+            credential = _ecs_ram_role_credential(
                 aliyun_data.get("region_id", DEFAULT_REGION),
                 aliyun_data.get("ram_role_name", ""),
             )
+            credential.credential_source = "iac_code"
+            credential.credential_source_path = str(path)
+            return credential
 
         return AliyunCredential(
             mode=mode,
@@ -289,6 +362,8 @@ class AliyunCredentials:
             oauth_refresh_token=aliyun_data.get("oauth_refresh_token", ""),
             oauth_access_token_expire=int(aliyun_data.get("oauth_access_token_expire") or 0),
             oauth_refresh_token_expire=int(aliyun_data.get("oauth_refresh_token_expire") or 0),
+            credential_source="iac_code",
+            credential_source_path=str(path),
         )
 
     @staticmethod
@@ -373,10 +448,21 @@ class AliyunCredentials:
         """Save credentials to ~/.iac-code/.cloud-credentials.yml."""
         if config_path is not None:
             # For testing: save to specified path in aliyun CLI format
-            AliyunCredentials._save_to_aliyun_cli_format(credential, config_path)
+            path = Path(config_path)
+            with _cloud_credential_file_lock(path):
+                AliyunCredentials._save_to_aliyun_cli_format(credential, config_path)
             return
 
-        path = get_cloud_credentials_path()
+        path = (
+            Path(credential.credential_source_path)
+            if credential.credential_source == "iac_code" and credential.credential_source_path
+            else get_cloud_credentials_path()
+        )
+        with _cloud_credential_file_lock(path):
+            AliyunCredentials._save_to_iac_code_config(credential, path)
+
+    @staticmethod
+    def _save_to_iac_code_config(credential: AliyunCredential, path: Path) -> None:
         cloud_creds = _load_yaml(path)
 
         aliyun_data: dict[str, Any] = {
@@ -404,6 +490,8 @@ class AliyunCredentials:
 
         cloud_creds["aliyun"] = aliyun_data
         _save_yaml(path, cloud_creds)
+        credential.credential_source = "iac_code"
+        credential.credential_source_path = str(path)
 
         # The dynamic-credential runtime caches one provider per (mode, role name, IMDSv1
         # policy); a saved configuration change must not keep serving the old provider.

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -6,8 +6,9 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field, fields
+from functools import wraps
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from iac_code.config import _load_yaml, _save_yaml, get_cloud_credentials_path
 from iac_code.i18n import _
@@ -141,6 +142,29 @@ def _cloud_credential_file_lock(path: Path) -> Iterator[None]:
 def _copy_credential(target: AliyunCredential, source: AliyunCredential) -> None:
     for credential_field in fields(AliyunCredential):
         setattr(target, credential_field.name, getattr(source, credential_field.name))
+
+
+def _credential_save_path(credential: AliyunCredential, config_path: str | None) -> Path:
+    if config_path is not None:
+        return Path(config_path)
+    if credential.credential_source == "iac_code" and credential.credential_source_path:
+        return Path(credential.credential_source_path)
+    return get_cloud_credentials_path()
+
+
+class _CredentialSaveOperation(Protocol):
+    def __call__(self, credential: AliyunCredential, config_path: str | None = None) -> None: ...
+
+
+def _lock_cloud_credential_save(
+    save_operation: _CredentialSaveOperation,
+) -> _CredentialSaveOperation:
+    @wraps(save_operation)
+    def locked_save(credential: AliyunCredential, config_path: str | None = None) -> None:
+        with _cloud_credential_file_lock(_credential_save_path(credential, config_path)):
+            save_operation(credential, config_path)
+
+    return locked_save
 
 
 @contextmanager
@@ -441,6 +465,7 @@ class AliyunCredentials:
         return AliyunCredentials._load_from_aliyun_cli(config_path)
 
     @staticmethod
+    @_lock_cloud_credential_save
     def save(
         credential: AliyunCredential,
         config_path: str | None = None,
@@ -448,52 +473,45 @@ class AliyunCredentials:
         """Save credentials to ~/.iac-code/.cloud-credentials.yml."""
         if config_path is not None:
             # For testing: save to specified path in aliyun CLI format
-            path = Path(config_path)
-            with _cloud_credential_file_lock(path):
-                AliyunCredentials._save_to_aliyun_cli_format(credential, config_path)
+            AliyunCredentials._save_to_aliyun_cli_format(credential, config_path)
             return
 
-        path = (
-            Path(credential.credential_source_path)
-            if credential.credential_source == "iac_code" and credential.credential_source_path
-            else get_cloud_credentials_path()
-        )
-        with _cloud_credential_file_lock(path):
-            cloud_creds = _load_yaml(path)
+        path = _credential_save_path(credential, config_path)
+        cloud_creds = _load_yaml(path)
 
-            aliyun_data: dict[str, Any] = {
-                "mode": credential.mode,
-                "region_id": credential.region_id,
-            }
+        aliyun_data: dict[str, Any] = {
+            "mode": credential.mode,
+            "region_id": credential.region_id,
+        }
 
-            # Save fields relevant to the credential mode
-            mode_fields = MODE_FIELDS.get(credential.mode, [])
-            for field_name, _label, _sensitive in mode_fields:
-                value = getattr(credential, field_name, "")
-                if value in ("", None):
-                    continue
-                if (
-                    field_name
-                    in {
-                        "sts_expiration",
-                        "oauth_access_token_expire",
-                        "oauth_refresh_token_expire",
-                    }
-                    and value == 0
-                ):
-                    continue
-                aliyun_data[field_name] = value
+        # Save fields relevant to the credential mode
+        mode_fields = MODE_FIELDS.get(credential.mode, [])
+        for field_name, _label, _sensitive in mode_fields:
+            value = getattr(credential, field_name, "")
+            if value in ("", None):
+                continue
+            if (
+                field_name
+                in {
+                    "sts_expiration",
+                    "oauth_access_token_expire",
+                    "oauth_refresh_token_expire",
+                }
+                and value == 0
+            ):
+                continue
+            aliyun_data[field_name] = value
 
-            cloud_creds["aliyun"] = aliyun_data
-            _save_yaml(path, cloud_creds)
-            credential.credential_source = "iac_code"
-            credential.credential_source_path = str(path)
+        cloud_creds["aliyun"] = aliyun_data
+        _save_yaml(path, cloud_creds)
+        credential.credential_source = "iac_code"
+        credential.credential_source_path = str(path)
 
-            # The dynamic-credential runtime caches one provider per (mode, role name, IMDSv1
-            # policy); a saved configuration change must not keep serving the old provider.
-            from iac_code.services.providers.aliyun_credentials_runtime import invalidate_aliyun_credential_runtime
+        # The dynamic-credential runtime caches one provider per (mode, role name, IMDSv1
+        # policy); a saved configuration change must not keep serving the old provider.
+        from iac_code.services.providers.aliyun_credentials_runtime import invalidate_aliyun_credential_runtime
 
-            invalidate_aliyun_credential_runtime()
+        invalidate_aliyun_credential_runtime()
 
     @staticmethod
     def _save_to_aliyun_cli_format(credential: AliyunCredential, config_path: str) -> None:

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -462,10 +462,10 @@ class AliyunCredentials:
             AliyunCredentials._save_to_iac_code_config(credential, path)
 
     @staticmethod
-    # OAuth credentials intentionally persist between runs; _save_yaml writes
-    # atomically and restricts the file to the current user on every platform.
-    # codeql[py/clear-text-storage-sensitive-data]
-    def _save_to_iac_code_config(credential: AliyunCredential, path: Path) -> None:
+    def _save_to_iac_code_config(  # codeql[py/clear-text-storage-sensitive-data]
+        credential: AliyunCredential, path: Path
+    ) -> None:
+        """Persist OAuth credentials atomically to an owner-only file."""
         cloud_creds = _load_yaml(path)
 
         aliyun_data: dict[str, Any] = {

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -459,48 +459,41 @@ class AliyunCredentials:
             else get_cloud_credentials_path()
         )
         with _cloud_credential_file_lock(path):
-            AliyunCredentials._save_to_iac_code_config(credential, path)
+            cloud_creds = _load_yaml(path)
 
-    @staticmethod
-    def _save_to_iac_code_config(  # codeql[py/clear-text-storage-sensitive-data]
-        credential: AliyunCredential, path: Path
-    ) -> None:
-        """Persist OAuth credentials atomically to an owner-only file."""
-        cloud_creds = _load_yaml(path)
+            aliyun_data: dict[str, Any] = {
+                "mode": credential.mode,
+                "region_id": credential.region_id,
+            }
 
-        aliyun_data: dict[str, Any] = {
-            "mode": credential.mode,
-            "region_id": credential.region_id,
-        }
+            # Save fields relevant to the credential mode
+            mode_fields = MODE_FIELDS.get(credential.mode, [])
+            for field_name, _label, _sensitive in mode_fields:
+                value = getattr(credential, field_name, "")
+                if value in ("", None):
+                    continue
+                if (
+                    field_name
+                    in {
+                        "sts_expiration",
+                        "oauth_access_token_expire",
+                        "oauth_refresh_token_expire",
+                    }
+                    and value == 0
+                ):
+                    continue
+                aliyun_data[field_name] = value
 
-        # Save fields relevant to the credential mode
-        mode_fields = MODE_FIELDS.get(credential.mode, [])
-        for field_name, _label, _sensitive in mode_fields:
-            value = getattr(credential, field_name, "")
-            if value in ("", None):
-                continue
-            if (
-                field_name
-                in {
-                    "sts_expiration",
-                    "oauth_access_token_expire",
-                    "oauth_refresh_token_expire",
-                }
-                and value == 0
-            ):
-                continue
-            aliyun_data[field_name] = value
+            cloud_creds["aliyun"] = aliyun_data
+            _save_yaml(path, cloud_creds)
+            credential.credential_source = "iac_code"
+            credential.credential_source_path = str(path)
 
-        cloud_creds["aliyun"] = aliyun_data
-        _save_yaml(path, cloud_creds)
-        credential.credential_source = "iac_code"
-        credential.credential_source_path = str(path)
+            # The dynamic-credential runtime caches one provider per (mode, role name, IMDSv1
+            # policy); a saved configuration change must not keep serving the old provider.
+            from iac_code.services.providers.aliyun_credentials_runtime import invalidate_aliyun_credential_runtime
 
-        # The dynamic-credential runtime caches one provider per (mode, role name, IMDSv1
-        # policy); a saved configuration change must not keep serving the old provider.
-        from iac_code.services.providers.aliyun_credentials_runtime import invalidate_aliyun_credential_runtime
-
-        invalidate_aliyun_credential_runtime()
+            invalidate_aliyun_credential_runtime()
 
     @staticmethod
     def _save_to_aliyun_cli_format(credential: AliyunCredential, config_path: str) -> None:

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -462,6 +462,9 @@ class AliyunCredentials:
             AliyunCredentials._save_to_iac_code_config(credential, path)
 
     @staticmethod
+    # OAuth credentials intentionally persist between runs; _save_yaml writes
+    # atomically and restricts the file to the current user on every platform.
+    # codeql[py/clear-text-storage-sensitive-data]
     def _save_to_iac_code_config(credential: AliyunCredential, path: Path) -> None:
         cloud_creds = _load_yaml(path)
 

--- a/tests/services/providers/test_aliyun.py
+++ b/tests/services/providers/test_aliyun.py
@@ -1,5 +1,7 @@
 import json
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 import pytest
@@ -966,7 +968,7 @@ class TestAliyunCredentialsOAuthRefresh:
 
         assert refreshed is cred
         assert calls == ["exchange:old-access", "refresh:old-refresh", "exchange:new-access"]
-        assert saved == [cred]
+        assert saved == [cred, cred]
         assert cred.oauth_access_token == "new-access"
         assert cred.oauth_refresh_token == "new-refresh"
         assert cred.oauth_access_token_expire == 4600
@@ -1004,7 +1006,7 @@ class TestAliyunCredentialsOAuthRefresh:
         refreshed = AliyunCredentials.refresh_oauth_if_needed(cred, oauth_client=FakeClient(), now=1000)
 
         assert refreshed is cred
-        assert saved == [cred]
+        assert saved == [cred, cred]
         assert cred.oauth_access_token == "new-access"
         assert cred.oauth_refresh_token == "new-refresh"
         assert cred.oauth_access_token_expire == 4600
@@ -1013,6 +1015,116 @@ class TestAliyunCredentialsOAuthRefresh:
         assert cred.access_key_secret == "new-sk"
         assert cred.sts_token == "new-sts"
         assert cred.sts_expiration == 2500
+
+    def test_refresh_oauth_persists_rotated_token_before_sts_exchange(self, tmp_path):
+        cloud_creds_file = tmp_path / ".cloud-credentials.yml"
+        cred = AliyunCredential(
+            mode="OAuth",
+            oauth_site_type="CN",
+            oauth_access_token="old-access",
+            oauth_refresh_token="old-refresh",
+            oauth_access_token_expire=900,
+            oauth_refresh_token_expire=3000,
+            access_key_id="old-ak",
+            access_key_secret="old-sk",
+            sts_token="old-sts",
+            sts_expiration=900,
+        )
+
+        class FakeClient:
+            def refresh_access_token(self, refresh_token, *, now=None):
+                assert refresh_token == "old-refresh"
+                assert now == 1000
+                return OAuthToken("new-access", "new-refresh", 4600, 5000)
+
+            def exchange_access_token_for_sts(self, access_token):
+                assert access_token == "new-access"
+                raise AliyunOAuthError("temporary STS exchange failure")
+
+        class RecoveringClient:
+            def refresh_access_token(self, refresh_token, *, now=None):
+                raise AssertionError("the persisted replacement refresh token should not be used")
+
+            def exchange_access_token_for_sts(self, access_token):
+                assert access_token == "new-access"
+                return OAuthStsCredentials("new-ak", "new-sk", "new-sts", 2500)
+
+        with patch("iac_code.services.providers.aliyun.get_cloud_credentials_path", return_value=cloud_creds_file):
+            AliyunCredentials.save(cred)
+            with pytest.raises(AliyunOAuthError, match="temporary STS exchange failure"):
+                AliyunCredentials.refresh_oauth_if_needed(cred, oauth_client=FakeClient(), now=1000)
+            persisted = AliyunCredentials.load_from_iac_code_config()
+            assert persisted is not None
+            assert persisted.oauth_access_token == "new-access"
+            assert persisted.oauth_refresh_token == "new-refresh"
+            assert persisted.oauth_access_token_expire == 4600
+            assert persisted.oauth_refresh_token_expire == 5000
+            assert persisted.sts_token == "old-sts"
+            assert persisted.sts_expiration == 900
+
+            recovered = AliyunCredentials.refresh_oauth_if_needed(
+                persisted,
+                oauth_client=RecoveringClient(),
+                now=1000,
+            )
+
+        assert recovered.oauth_refresh_token == "new-refresh"
+        assert recovered.access_key_id == "new-ak"
+        assert recovered.sts_token == "new-sts"
+        assert recovered.sts_expiration == 2500
+
+    def test_refresh_oauth_serializes_stale_in_process_credentials(self, tmp_path):
+        cloud_creds_file = tmp_path / ".cloud-credentials.yml"
+        original = AliyunCredential(
+            mode="OAuth",
+            oauth_site_type="CN",
+            oauth_access_token="old-access",
+            oauth_refresh_token="old-refresh",
+            oauth_access_token_expire=900,
+            oauth_refresh_token_expire=3000,
+            access_key_id="old-ak",
+            access_key_secret="old-sk",
+            sts_token="old-sts",
+            sts_expiration=900,
+        )
+        start = threading.Barrier(2)
+
+        class RotatingClient:
+            def __init__(self):
+                self.refresh_token = "old-refresh"
+                self.refresh_calls = 0
+                self._lock = threading.Lock()
+
+            def refresh_access_token(self, refresh_token, *, now=None):
+                with self._lock:
+                    assert refresh_token == self.refresh_token
+                    assert now == 1000
+                    self.refresh_calls += 1
+                    self.refresh_token = "new-refresh"
+                return OAuthToken("new-access", "new-refresh", 4600, 5000)
+
+            def exchange_access_token_for_sts(self, access_token):
+                assert access_token == "new-access"
+                return OAuthStsCredentials("new-ak", "new-sk", "new-sts", 2500)
+
+        client = RotatingClient()
+        with patch("iac_code.services.providers.aliyun.get_cloud_credentials_path", return_value=cloud_creds_file):
+            AliyunCredentials.save(original)
+            first = AliyunCredentials.load_from_iac_code_config()
+            second = AliyunCredentials.load_from_iac_code_config()
+            assert first is not None
+            assert second is not None
+
+            def refresh(stale: AliyunCredential) -> AliyunCredential:
+                start.wait()
+                return AliyunCredentials.refresh_oauth_if_needed(stale, oauth_client=client, now=1000)
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(refresh, (first, second)))
+
+        assert client.refresh_calls == 1
+        assert [result.oauth_refresh_token for result in results] == ["new-refresh", "new-refresh"]
+        assert [result.sts_token for result in results] == ["new-sts", "new-sts"]
 
     def test_refresh_oauth_requires_relogin_when_refresh_token_missing(self):
         cred = AliyunCredential(


### PR DESCRIPTION
## Summary

- persist rotated OAuth access and refresh tokens before exchanging them for STS credentials
- serialize credential refreshes across threads and processes, reloading the latest persisted credential after acquiring the lock
- add regression coverage for transient STS failures and concurrent stale credential copies

## Validation

- `make test` (14282 passed, 2 skipped)
- `make lint`
- end-to-end test with expired OAuth and STS credentials