### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/desktop/helpers/Cargo.lock
+++ b/desktop/helpers/Cargo.lock
@@ -183,7 +183,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iac-code-desktop-helpers"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/desktop/helpers/Cargo.toml
+++ b/desktop/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iac-code-desktop-helpers"
-version = "0.13.0"
+version = "0.13.1"
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.77.2"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iac-code-desktop",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iac-code-desktop",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iac-code-desktop",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev --features updater",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "iac-code-desktop"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "fs2",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "iac-code-desktop-helpers"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iac-code-desktop"
-version = "0.13.0"
+version = "0.13.1"
 description = "iac-code"
 authors = ["iac-code contributors"]
 license = "Apache-2.0"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "iac-code",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "identifier": "com.alibaba.cloud.iaccode.desktop",
   "build": {
     "frontendDist": "../bootstrap"

--- a/src/iac_code/__init__.py
+++ b/src/iac_code/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __release_date__ = ""

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.13.0\n"
+"Project-Id-Version: iac-code 0.13.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.13.0\n"
+"Project-Id-Version: iac-code 0.13.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.13.0\n"
+"Project-Id-Version: iac-code 0.13.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.13.0\n"
+"Project-Id-Version: iac-code 0.13.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.13.0\n"
+"Project-Id-Version: iac-code 0.13.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-05-13 00:00+0000\n"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: iac-code 0.13.0\n"
+"Project-Id-Version: iac-code 0.13.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-04 15:58+0800\n"
 "PO-Revision-Date: 2026-04-02 00:00+0000\n"


### PR DESCRIPTION
## Summary

- bump the package version from 0.13.0 to 0.13.1
- synchronize Desktop npm, Tauri, and Cargo versions
- refresh translation catalog project-version headers

## Testing

- `uv run python desktop/scripts/sync_version.py --check`
- `uv run pytest -q tests/desktop/test_sync_version.py`
- pre-commit lint hook