### PR TITLE
docs: localize IaC Code Skill guide

### DIFF
--- a/website/docs/a2a/skill-integration.md
+++ b/website/docs/a2a/skill-integration.md
@@ -1,100 +1,211 @@
 ---
 sidebar_position: 7
-title: Skill Integration
-description: External agents drive iac-code through the packaged iac-code Skill and Skill Runtime.
+title: Install and Use the IaC Code Skill
+description: Download and install the IaC Code Skill so an external agent can manage Alibaba Cloud infrastructure.
 ---
 
-# Skill Integration
+# Install and Use the IaC Code Skill
 
-iac-code ships a packaged Skill for external agents. An external agent (a planner agent or an agent platform) does not install the iac-code Python package and does not invoke headless commands; it drives a local authenticated A2A runtime through a standard-library-only bridge script to run Alibaba Cloud infrastructure work such as ROS/Terraform template generation, cost estimation, resource selection, and deployment.
+The IaC Code Skill is designed for external agents that support Skills. Once installed, a host agent can delegate
+cloud architecture planning, ROS or Terraform template generation and review, cost estimation, resource selection,
+stack operations, and deployment to IaC Code. The Skill uses a Python standard-library bridge to start a locally
+authenticated A2A Runtime. You do not need to install IaC Code with pip, and the host must not fall back to headless
+commands.
 
-## Components
+## Download the Skill
 
-| Component | Location | Description |
+### Latest stable release
+
+Download the latest stable release directly:
+
+[Download iac-code-skill.zip](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/iac-code-skill.zip)
+
+This fixed URL always points to the Skill package promoted to the stable channel. It is suitable for browser downloads
+and manual installation, and it does not change when a new version is released.
+
+Installers that need the version, file size, SHA-256 digest, and immutable version URL can read the stable channel
+metadata:
+
+[View latest.json](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/latest.json)
+
+The document contains:
+
+- `skillVersion`: the current stable Skill version.
+- `skill.url`: the immutable ZIP URL for that version.
+- `skill.sha256` and `skill.size`: values used to verify the download.
+- `manifest.url`: the immutable release manifest for that version.
+
+For strict verification or reproducible automated installation, read `latest.json`, download `skill.url`, and verify
+`skill.sha256`. Do not construct a version URL yourself.
+
+## Install the Skill
+
+### Prerequisites
+
+- The host agent supports local Skills defined by `SKILL.md`.
+- CPython 3.8–3.14 is installed. Use `python3` on macOS/Linux and prefer `py -3` on Windows.
+- The environment can access the OSS URLs above to download the Skill ZIP and the Runtime required on first use.
+- Model service configuration is available. A least-privilege Alibaba Cloud identity is also required for tasks that
+  query or manage cloud resources.
+
+Official Skill Runtime releases support these platforms:
+
+| Operating system | Architecture |
+|---|---|
+| macOS | Apple Silicon (arm64) |
+| Linux | x86_64 |
+| Windows | x86_64 |
+
+The minimum operating-system and Linux glibc versions are defined by the Runtime manifest pinned by the Skill. The
+bridge checks compatibility before downloading. On an unsupported platform, it returns an error instead of
+downloading an artifact for another platform or ABI.
+
+### Extract into the host agent's Skill directory
+
+Extract the ZIP directly into the host agent's Skill root. The exact Skill root varies by product; follow the host
+product's documentation. The final layout must be:
+
+```text
+<Agent Skill root>/
+└── iac-code/
+    ├── SKILL.md
+    ├── agents/
+    │   └── openai.yaml
+    └── scripts/
+        └── iac_code.py
+```
+
+The ZIP already contains the top-level `iac-code/` directory. Do not add another directory with the same name. After
+installing or updating, restart the host agent or open a new session so that it discovers the Skill again.
+
+### Verify the installation
+
+In the extracted `iac-code` directory, run this command on macOS or Linux:
+
+```bash
+python3 scripts/iac_code.py ensure-runtime
+```
+
+In Windows PowerShell, run:
+
+```powershell
+py -3 scripts\iac_code.py ensure-runtime
+```
+
+On first use, the command downloads the Runtime for the current platform, verifies its size and SHA-256 digest, and
+prints JSON containing `skillVersion`, `runtimeTag`, and the installation path. A verified cached Runtime is reused
+without another download.
+
+## Configure the Model and Alibaba Cloud Identity
+
+The Skill Runtime uses the same configuration directory as other IaC Code modes: `~/.iac-code/` by default. If you
+already configured IaC Code through the REPL, Web app, or Desktop app, the Skill can reuse those settings. Set
+`IAC_CODE_CONFIG_DIR` to use a different configuration directory.
+
+In automated environments, provide these variables through a secret-management solution:
+
+| Category | Environment variable | Description |
 |---|---|---|
-| Skill package | `skills/iac-code/` | `SKILL.md` instructions, `agents/` agent metadata, and `scripts/iac_code.py`, the bridge script |
-| Skill Runtime | Published per platform | CPython 3.12 native executable embedding the iac-code A2A server |
-| Distribution contracts | `skill-runtime/skill-package-contract.json`, `skill-runtime/publisher-contract.json` | Format and verification constraints for skill packages and publishers |
+| Model | `IAC_CODE_PROVIDER` | Model provider |
+| Model | `IAC_CODE_MODEL` | Model name |
+| Model | `IAC_CODE_API_KEY` | Model service API key |
+| Model | `IAC_CODE_BASE_URL` | Optional compatible endpoint override |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_ID` | AccessKey ID |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | AccessKey secret |
+| Alibaba Cloud | `ALIBABA_CLOUD_SECURITY_TOKEN` | Security token for STS credentials |
+| Alibaba Cloud | `ALIBABA_CLOUD_REGION_ID` | Default region |
 
-The bridge script is written entirely with the Python standard library and stays compatible with Python 3.8+; CI compiles and smoke-runs it on the full 3.8–3.14 matrix. Do not add third-party dependencies or newer-only syntax to the bridge.
+Never put real credentials in `SKILL.md`, host-agent prompts, project files, or shell history. Prefer temporary
+credentials, RAM roles, or OAuth, and grant only the cloud API permissions required by the task. See
+[LLM Providers](../configuration/llm-providers.md) and
+[Alibaba Cloud Credentials](../configuration/alibaba-cloud-credentials.md) for complete instructions.
 
-## Runtime Acquisition and Cache
+## First Use
 
-On first use the bridge reads the manifest, downloads the artifact for the current platform, verifies its size and SHA-256, installs it, and caches it under `<IAC_CODE_CONFIG_DIR or ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/`.
+After installation and configuration, open a new session in the host agent and describe an Alibaba Cloud
+infrastructure task directly. For example:
 
-- `python3 scripts/iac_code.py ensure-runtime` — prepare the runtime ahead of time; a cached runtime is reused.
-- `python3 scripts/iac_code.py cache list` — show installed runtimes and candidate packages.
-- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — clean runtime caches or candidate packages; requires explicit `--confirm`.
+```text
+Use iac-code to review the ROS template in this project. List security risks and recommended changes without modifying the file.
+```
 
-## Configuration Preflight
+Hosts that support explicit Skill syntax can use `$iac-code` to select the Skill. The host reads `SKILL.md`, writes the
+complete request to a UTF-8 file inside the workspace, and uses the bridge to create and follow one task. The user does
+not need to start an A2A Server manually.
 
-Before creating a job, `start` runs a configuration readiness check through the runtime. The preflight does not read secret values; it only reports readiness:
+Expected flow:
+
+1. The bridge checks whether model and Alibaba Cloud configuration is ready.
+2. On first use, it downloads and verifies the IaC Code Runtime pinned by the Skill.
+3. The Runtime listens only on a random `127.0.0.1` port and generates a process-specific Bearer token.
+4. The host agent presents progress, questions, candidate plans, and permission requests returned by IaC Code.
+5. When the task completes, the host agent returns the final result and files generated in the workspace.
+
+## Update and Uninstall
+
+For a manual update, download `skill/stable/iac-code-skill.zip` again and replace the complete `iac-code/` directory in
+the host's Skill root. An automatic updater can compare `skillVersion` from `latest.json`, then download and verify the
+new package using its immutable URL and SHA-256 digest. Each official Skill is pinned to a verified Runtime. Do not
+replace only `scripts/iac_code.py` or edit its Runtime URL or digest manually.
+
+To uninstall, remove `iac-code/` from the host agent's Skill root. The Runtime cache is not removed with the Skill
+directory. Run `cache list` and `cache clean` only when the user explicitly asks to remove it.
+
+## Runtime Cache
+
+The Runtime downloaded on first use is cached under
+`<IAC_CODE_CONFIG_DIR or ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` and reused automatically. Normal use does
+not require managing this directory. To inspect disk usage or remove historical versions, use:
+
+- `python3 scripts/iac_code.py cache list` — list installed Runtimes and candidate packages.
+- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — remove Runtime caches or
+  candidate packages; `--confirm` is required.
+
+The current Runtime and any Runtime used by a live process are protected from cleanup. The package format and Runtime
+constraints are defined by `skill-runtime/skill-package-contract.json` in the source repository; users do not need to
+modify this file.
+
+## Troubleshooting
+
+### Configuration is incomplete
+
+The Skill checks configuration before creating a task but never reads or returns secret values:
 
 | Situation | Result |
 |---|---|
-| LLM provider or API key incomplete | Returns `llm_not_configured` and refuses to create the job |
-| Selling pipeline with incomplete Alibaba Cloud credentials | Returns `cloud_credentials_not_configured` and refuses to create the job |
-| Normal mode with incomplete Alibaba Cloud credentials | May continue for work that does not call cloud APIs, with a preflight warning |
+| LLM provider or API key is incomplete | Returns `llm_not_configured` and does not create the task |
+| Alibaba Cloud credentials are incomplete for the selling Pipeline | Returns `cloud_credentials_not_configured` and does not create the task |
+| Alibaba Cloud credentials are incomplete in normal mode | Tasks that do not call cloud APIs may continue with a preflight warning |
 
-## Command Reference
+### Why execution pauses
 
-| Command | Purpose |
-|---|---|
-| `start` | Create a job: `--mode normal|pipeline`, `--pipeline-name`, `--cwd` absolute workspace, `--prompt-file` UTF-8 prompt file, `--language auto|en|zh|es|fr|de|ja|pt`, optional `--follow` |
-| `follow` | Consume the event stream until the next interaction boundary: `--job-id`, `--cursor`, `--wait-seconds` (default 60s, maximum 120s) |
-| `continue` | Continue a normal-mode conversation in the same job: `--job-id`, `--prompt-file`, optional `--follow` |
-| `respond` | Answer a pending input, see [User input](#input-required) |
-| `poll` | One-shot polling for diagnosis and recovery only; do not use it as a `follow` replacement |
-| `cancel` | Cancel the job |
-| `ensure-runtime` / `cache list` / `cache clean` | Runtime and cache management |
+IaC Code pauses when it needs permission, additional information, or a plan selection. The host agent presents the
+request directly:
 
-`start --follow` and `follow` write step boundaries and low-frequency heartbeats to stderr; stdout carries exactly one bounded JSON result.
+- A tool or deployment permission request (`permission`).
+- A multiple-choice question or request for more information (`ask_user_question`).
+- A Pipeline candidate plan selection (`candidate_selection`).
 
-## Interaction Boundaries {#boundaries}
+Before confirming, review the target resource, region, expected impact, and price. The host agent cannot override a
+denial from IaC Code. A one-time approval is represented as `allow_once` in the protocol.
 
-`--follow` consumes the event stream until the next step boundary, permission request, user question, candidate selection, `turn_completed`, or terminal state. A boundary result carries:
+> **Host agent integration note**
+>
+> When a bridge result contains `inputRequired`, the host agent must present the current request and wait for a
+> response. `boundaryReached` marks a presentation or interaction boundary, not task completion; the host must show
+> the update and continue following the same task.
 
-- `boundaryReached: true` — a boundary was reached; this does **not** mean the job is complete;
-- `presentationRequired: true` and `userUpdates` — localized strings ready to display to the user;
-- the `cursor` needed to continue.
+## Security
 
-The external agent must first present every received `userUpdates` string in a user-visible reply, then immediately call `follow` again with the returned `cursor`. Do not answer the infrastructure task in parallel or raise unrelated questions while a follow is running.
+- The Runtime listens only on a random `127.0.0.1` port. Every start generates a new Bearer token, and every bridge
+  request carries that token.
+- The bridge keeps artifacts and results in the job workspace. Results are written to `.iac-code-skill-results/`.
+- Preflight and permission display fields are sanitized; secrets and credentials do not appear in display fields.
 
-## User Input {#input-required}
+## Related Documentation
 
-A result contains `inputRequired` when user input is needed. There are three kinds:
-
-- `permission` — a tool or deployment permission request. The envelope contains `inputId`, `toolUseId`, a title, purpose, effect, target, read-only flag, `safeSummary`, and, for deployment requests, `deploymentSummary`. The external agent should decide according to its own permission policy: if the same operation would proceed without asking when the agent runs it directly, answer `allow_once`; if its policy would deny, answer `deny`; otherwise ask the user. iac-code's own denials must not be overridden.
-- `ask_user_question` — a multiple-choice or free-text question. Present the prompt and options as-is; accept free text only when `allowFreeText` is `true`.
-- `candidate_selection` — pipeline plan selection. Present each candidate's summary, architecture diagram (Mermaid), total monthly cost, and cost items first, then return the selected candidate. Never replace the provided prices with rough estimates.
-
-`respond` has two forms:
-
-```bash
-# Inline decision for permissions
-python3 scripts/iac_code.py respond --job-id <job-id> \
-  --input-id <inputId> --tool-use-id <toolUseId> --decision allow_once --follow
-
-# Questions and candidate selections use an answer file
-python3 scripts/iac_code.py respond --job-id <job-id> --input-file <answer.json> --follow
-```
-
-An answer must preserve every correlation field of the pending input and stays bound to the current `kind`, `inputId`, `requestTaskId`, and `contextId`; never reuse an answer from another request, and never reinterpret a resource selection as a deployment confirmation.
-
-## Language Control
-
-`start --language` sets the job's preferred language (use `auto` when unknown). Every result of that job repeats `preferredLanguage`; treat it as durable control state: progress, questions, permission prompts, candidate plans, and final results are presented in that language, while protocol field names, enums, IDs, and commands stay unchanged. When authoritative text already uses that language, present it directly or summarize it in the same language; never translate Chinese user-visible content into English.
-
-## Relationship with the A2A Protocol
-
-The bridge talks to the local runtime over HTTP A2A JSON-RPC; task states, artifacts, and permission interactions reuse the iac-code A2A protocol:
-
-- Permission sideband responses use the `schemaVersion 1` message format; see [Protocol reference](./protocol-reference.md) for fields and constraints.
-- In pipeline mode, passing `candidatePresentation: rich-v1` returns structured candidate presentation payloads.
-- Job result states map to A2A task states: `turn_completed` finishes a normal turn; pipeline terminal states are `completed`, `failed`, `canceled`, and `rejected`, with `pipelineResult` and `artifacts` as the authoritative result.
-
-## Security Boundary
-
-- The runtime listens only on a random port on `127.0.0.1`; every startup generates a fresh random Bearer token, and every bridge request carries it.
-- The bridge keeps artifacts and results inside the job workspace; results are written to `.iac-code-skill-results/` in the workspace.
-- Preflight reports and permission display fields are sanitized; secrets and credentials never appear in display fields.
+- [A2A Protocol Overview](./overview.md)
+- [A2A Protocol Reference](./protocol-reference.md)
+- [LLM Providers](../configuration/llm-providers.md)
+- [Alibaba Cloud Credentials](../configuration/alibaba-cloud-credentials.md)
+- [Runtime Configuration](../configuration/runtime-configuration.md)

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
@@ -1,100 +1,225 @@
 ---
 sidebar_position: 7
-title: Skill-Integration
-description: Externe Agenten steuern iac-code ueber das paketierte iac-code-Skill und die Skill-Runtime an.
+title: IaC Code Skill installieren und verwenden
+description: Laden Sie den IaC Code Skill herunter und installieren Sie ihn, damit ein externer Agent Alibaba-Cloud-Ressourcen verwalten kann.
 ---
 
-# Skill-Integration
+# IaC Code Skill installieren und verwenden
 
-iac-code liefert ein paketiertes Skill fuer externe Agenten. Ein externer Agent (ein Planner-Agent oder eine Agentenplattform) installiert weder das Python-Paket von iac-code noch ruft er Headless-Befehle auf; er steuert eine lokale authentifizierte A2A-Runtime ueber ein Bridge-Skript mit reiner Standardbibliothek an, um Alibaba-Cloud-Infrastrukturaufgaben wie ROS-/Terraform-Vorlagenerzeugung, Kostenschaetzung, Ressourcenauswahl und Deployment auszufuehren.
+Der IaC Code Skill richtet sich an externe Agenten, die Skills unterstützen. Nach der Installation kann ein
+Host-Agent die Planung von Cloud-Architekturen, das Erstellen und Prüfen von ROS- oder Terraform-Vorlagen,
+Kostenschätzungen, die Ressourcenauswahl, Stack-Operationen und Bereitstellungen an IaC Code delegieren. Der Skill
+verwendet eine ausschließlich mit der Python-Standardbibliothek erstellte Bridge, um eine lokale, authentifizierte
+A2A-Runtime zu starten. IaC Code muss nicht mit pip installiert werden, und der Host darf nicht auf Headless-Befehle
+ausweichen.
 
-## Bestandteile
+## Skill herunterladen
 
-| Bestandteil | Ort | Beschreibung |
+### Neueste stabile Version
+
+Laden Sie die neueste stabile Version direkt herunter:
+
+[iac-code-skill.zip herunterladen](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/iac-code-skill.zip)
+
+Diese feste URL verweist immer auf das Skill-Paket, das für den stabilen Kanal freigegeben wurde. Sie eignet sich für
+Downloads im Browser und für die manuelle Installation und ändert sich bei einer neuen Version nicht.
+
+Installationsprogramme, die Version, Dateigröße, SHA-256-Prüfsumme und die unveränderliche versionsspezifische URL
+benötigen, können die Metadaten des stabilen Kanals abrufen:
+
+[latest.json anzeigen](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/latest.json)
+
+Das Dokument enthält:
+
+- `skillVersion`: die aktuelle stabile Version des Skills;
+- `skill.url`: die unveränderliche ZIP-URL für diese Version;
+- `skill.sha256` und `skill.size`: Werte zur Überprüfung des Downloads;
+- `manifest.url`: das unveränderliche Release-Manifest für diese Version.
+
+Für eine strenge Überprüfung oder eine reproduzierbare automatisierte Installation lesen Sie `latest.json`, laden
+`skill.url` herunter und überprüfen `skill.sha256`. Erstellen Sie eine versionsspezifische URL nicht selbst.
+
+## Skill installieren
+
+### Voraussetzungen
+
+- Der Host-Agent unterstützt lokale Skills, die durch `SKILL.md` definiert werden.
+- CPython 3.8 bis 3.14 ist installiert. Verwenden Sie unter macOS/Linux `python3` und unter Windows vorzugsweise
+  `py -3`.
+- Die Umgebung kann auf die oben genannten OSS-URLs zugreifen, um das Skill-ZIP und die beim ersten Start benötigte
+  Runtime herunterzuladen.
+- Eine Modellservice-Konfiguration ist vorhanden. Für Aufgaben, die Cloud-Ressourcen abfragen oder verwalten, ist
+  außerdem eine Alibaba-Cloud-Identität mit minimal erforderlichen Berechtigungen nötig.
+
+Offizielle Skill-Runtime-Versionen unterstützen folgende Plattformen:
+
+| Betriebssystem | Architektur |
+|---|---|
+| macOS | Apple Silicon (arm64) |
+| Linux | x86_64 |
+| Windows | x86_64 |
+
+Die Mindestversionen des Betriebssystems und der Linux-glibc werden durch das vom Skill festgelegte Runtime-Manifest
+bestimmt. Die Bridge prüft die Kompatibilität vor dem Download. Auf einer nicht unterstützten Plattform gibt sie
+einen Fehler zurück, statt ein Artefakt für eine andere Plattform oder ABI herunterzuladen.
+
+### In das Skill-Verzeichnis des Host-Agenten entpacken
+
+Entpacken Sie das ZIP direkt in das Skill-Stammverzeichnis des Host-Agenten. Der genaue Pfad ist vom jeweiligen
+Produkt abhängig; beachten Sie die Dokumentation des Host-Agenten. Die endgültige Verzeichnisstruktur muss so
+aussehen:
+
+```text
+<Skill-Stammverzeichnis des Agenten>/
+└── iac-code/
+    ├── SKILL.md
+    ├── agents/
+    │   └── openai.yaml
+    └── scripts/
+        └── iac_code.py
+```
+
+Das ZIP enthält bereits das oberste Verzeichnis `iac-code/`. Legen Sie kein weiteres Verzeichnis mit demselben Namen
+an. Starten Sie den Host-Agenten nach der Installation oder Aktualisierung neu oder öffnen Sie eine neue Sitzung,
+damit er den Skill erneut erkennt.
+
+### Installation überprüfen
+
+Führen Sie im entpackten Verzeichnis `iac-code` unter macOS oder Linux folgenden Befehl aus:
+
+```bash
+python3 scripts/iac_code.py ensure-runtime
+```
+
+Führen Sie in Windows PowerShell folgenden Befehl aus:
+
+```powershell
+py -3 scripts\iac_code.py ensure-runtime
+```
+
+Beim ersten Aufruf lädt der Befehl die Runtime für die aktuelle Plattform herunter, überprüft Größe und
+SHA-256-Prüfsumme und gibt JSON mit `skillVersion`, `runtimeTag` und dem Installationspfad aus. Eine überprüfte Runtime
+im Cache wird ohne erneuten Download wiederverwendet.
+
+## Modell und Alibaba-Cloud-Identität konfigurieren
+
+Die Skill Runtime verwendet dasselbe Konfigurationsverzeichnis wie die anderen IaC-Code-Modi: standardmäßig
+`~/.iac-code/`. Wenn Sie IaC Code bereits über REPL, Web-App oder Desktop-App konfiguriert haben, kann der Skill diese
+Einstellungen wiederverwenden. Mit `IAC_CODE_CONFIG_DIR` legen Sie ein anderes Konfigurationsverzeichnis fest.
+
+Stellen Sie in automatisierten Umgebungen die folgenden Variablen über eine Lösung zur Geheimnisverwaltung bereit:
+
+| Kategorie | Umgebungsvariable | Beschreibung |
 |---|---|---|
-| Skill-Paket | `skills/iac-code/` | `SKILL.md`-Anleitung, Agenten-Metadaten in `agents/` und `scripts/iac_code.py`, das Bridge-Skript |
-| Skill-Runtime | Pro Plattform veroeffentlicht | Native CPython-3.12-Executable mit eingebettetem iac-code-A2A-Server |
-| Verteilungsvertraege | `skill-runtime/skill-package-contract.json`, `skill-runtime/publisher-contract.json` | Format- und Verifizierungsbeschraenkungen fuer Skill-Pakete und Herausgeber |
+| Modell | `IAC_CODE_PROVIDER` | Modellanbieter |
+| Modell | `IAC_CODE_MODEL` | Modellname |
+| Modell | `IAC_CODE_API_KEY` | API-Schlüssel des Modellservice |
+| Modell | `IAC_CODE_BASE_URL` | Optionale Überschreibung des kompatiblen Endpunkts |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_ID` | AccessKey-ID |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | AccessKey-Secret |
+| Alibaba Cloud | `ALIBABA_CLOUD_SECURITY_TOKEN` | Sicherheitstoken für STS-Anmeldeinformationen |
+| Alibaba Cloud | `ALIBABA_CLOUD_REGION_ID` | Standardregion |
 
-Das Bridge-Skript ist vollstaendig mit der Python-Standardbibliothek geschrieben und bleibt mit Python 3.8+ kompatibel; die CI kompiliert und startet es ueber die gesamte 3.8–3.14-Matrix als Smoke-Run. Fuegen Sie der Bridge keine Drittanbieter-Abhaengigkeiten und keine Syntax neuerer Versionen hinzu.
+Speichern Sie echte Anmeldeinformationen niemals in `SKILL.md`, in Prompts des Host-Agenten, in Projektdateien oder
+im Shell-Verlauf. Bevorzugen Sie temporäre Anmeldeinformationen, RAM-Rollen oder OAuth und vergeben Sie nur die für
+die Aufgabe erforderlichen Cloud-API-Berechtigungen. Vollständige Anleitungen finden Sie unter
+[LLM-Anbieter](../configuration/llm-providers.md) und
+[Alibaba-Cloud-Anmeldeinformationen](../configuration/alibaba-cloud-credentials.md).
 
-## Runtime-Beschaffung und Cache
+## Erste Verwendung
 
-Beim ersten Gebrauch liest die Bridge das Manifest, laedt das Artefakt fuer die aktuelle Plattform herunter, verifiziert Groesse und SHA-256, installiert es und legt es unter `<IAC_CODE_CONFIG_DIR oder ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` in den Cache.
+Öffnen Sie nach Installation und Konfiguration eine neue Sitzung im Host-Agenten und beschreiben Sie direkt eine
+Alibaba-Cloud-Infrastrukturaufgabe. Beispiel:
 
-- `python3 scripts/iac_code.py ensure-runtime` - bereitet die Runtime vor; eine gecachte Runtime wird wiederverwendet.
-- `python3 scripts/iac_code.py cache list` - zeigt installierte Runtimes und Kandidatenpakete an.
-- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` - bereinigt Runtime-Caches oder Kandidatenpakete; erfordert explizites `--confirm`.
+```text
+Verwende iac-code, um die ROS-Vorlage in diesem Projekt zu prüfen. Liste Sicherheitsrisiken und empfohlene Änderungen auf, ohne die Datei zu verändern.
+```
 
-## Konfigurations-Preflight
+Host-Agenten mit einer expliziten Skill-Syntax können den Skill mit `$iac-code` auswählen. Der Host-Agent liest
+`SKILL.md`, schreibt die vollständige Anfrage in eine UTF-8-Datei im Arbeitsbereich und verwendet die Bridge, um eine
+Aufgabe zu erstellen und zu verfolgen. Der Benutzer muss keinen A2A-Server manuell starten.
 
-Vor dem Anlegen eines Jobs fuehrt `start` ueber die Runtime einen Konfigurationsbereitschafts-Check aus. Der Preflight liest keine Geheimwerte; er meldet nur die Bereitschaft:
+Erwarteter Ablauf:
+
+1. Die Bridge prüft, ob die Modell- und Alibaba-Cloud-Konfiguration vollständig ist.
+2. Bei der ersten Verwendung lädt sie die vom Skill festgelegte IaC Code Runtime herunter und überprüft sie.
+3. Die Runtime lauscht ausschließlich an einem zufälligen Port auf `127.0.0.1` und erzeugt ein prozessspezifisches
+   Bearer-Token.
+4. Der Host-Agent zeigt Fortschritt, Fragen, Planvorschläge und Berechtigungsanfragen von IaC Code an.
+5. Nach Abschluss der Aufgabe gibt der Host-Agent das Endergebnis und die im Arbeitsbereich erzeugten Dateien zurück.
+
+## Aktualisieren und deinstallieren
+
+Laden Sie für eine manuelle Aktualisierung `skill/stable/iac-code-skill.zip` erneut herunter und ersetzen Sie das
+gesamte Verzeichnis `iac-code/` im Skill-Stammverzeichnis des Hosts. Ein automatisches Aktualisierungsprogramm kann
+`skillVersion` aus `latest.json` vergleichen und anschließend das neue Paket über dessen unveränderliche URL und
+SHA-256-Prüfsumme herunterladen und überprüfen. Jeder offizielle Skill ist auf eine überprüfte Runtime festgelegt.
+Ersetzen Sie nicht nur `scripts/iac_code.py` und ändern Sie Runtime-URL oder Prüfsumme nicht manuell.
+
+Zum Deinstallieren entfernen Sie `iac-code/` aus dem Skill-Stammverzeichnis des Host-Agenten. Der Runtime-Cache wird
+nicht zusammen mit dem Skill-Verzeichnis gelöscht. Führen Sie `cache list` und `cache clean` nur aus, wenn der Benutzer
+ausdrücklich das Löschen des Caches verlangt.
+
+## Runtime-Cache
+
+Die bei der ersten Verwendung heruntergeladene Runtime wird unter
+`<IAC_CODE_CONFIG_DIR oder ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` zwischengespeichert und automatisch
+wiederverwendet. Im normalen Betrieb müssen Sie dieses Verzeichnis nicht verwalten. Mit folgenden Befehlen können Sie
+den Speicherbedarf prüfen oder ältere Versionen entfernen:
+
+- `python3 scripts/iac_code.py cache list` — installierte Runtimes und Kandidatenpakete auflisten;
+- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — Runtime-Caches oder
+  Kandidatenpakete entfernen; `--confirm` ist erforderlich.
+
+Die aktuelle Runtime und jede Runtime, die von einem laufenden Prozess verwendet wird, sind vor dem Bereinigen
+geschützt. Paketformat und Runtime-Einschränkungen werden im Quelldepot durch
+`skill-runtime/skill-package-contract.json` definiert; Benutzer müssen diese Datei nicht ändern.
+
+## Fehlerbehebung
+
+### Konfiguration ist unvollständig
+
+Der Skill prüft die Konfiguration vor dem Erstellen einer Aufgabe, liest oder übermittelt jedoch niemals geheime
+Werte:
 
 | Situation | Ergebnis |
 |---|---|
-| LLM-Provider oder API-Key unvollstaendig | Liefert `llm_not_configured` und verweigert das Anlegen des Jobs |
-| Selling-Pipeline mit unvollstaendigen Alibaba-Cloud-Zugangsdaten | Liefert `cloud_credentials_not_configured` und verweigert das Anlegen des Jobs |
-| Normalmodus mit unvollstaendigen Alibaba-Cloud-Zugangsdaten | Kann fuer Arbeiten ohne Cloud-API-Aufrufe fortgesetzt werden, mit Preflight-Warnung |
+| LLM-Anbieter oder API-Schlüssel ist unvollständig | Gibt `llm_not_configured` zurück und erstellt die Aufgabe nicht |
+| Alibaba-Cloud-Anmeldeinformationen für die Selling Pipeline sind unvollständig | Gibt `cloud_credentials_not_configured` zurück und erstellt die Aufgabe nicht |
+| Alibaba-Cloud-Anmeldeinformationen sind im normalen Modus unvollständig | Aufgaben ohne Cloud-API-Aufrufe können mit einer Vorabwarnung fortgesetzt werden |
 
-## Befehlsreferenz
+### Warum die Ausführung pausiert
 
-| Befehl | Zweck |
-|---|---|
-| `start` | Job anlegen: `--mode normal|pipeline`, `--pipeline-name`, `--cwd` absoluter Workspace, `--prompt-file` UTF-8-Promptdatei, `--language auto|en|zh|es|fr|de|ja|pt`, optional `--follow` |
-| `follow` | Konsumiert den Ereignisstrom bis zur naechsten Interaktionsgrenze: `--job-id`, `--cursor`, `--wait-seconds` (Standard 60 s, maximal 120 s) |
-| `continue` | Setzt eine Normalmodus-Konversation im selben Job fort: `--job-id`, `--prompt-file`, optional `--follow` |
-| `respond` | Beantwortet eine ausstehende Eingabe, siehe [Benutzereingabe](#input-required) |
-| `poll` | Einmaliges Pollen nur fuer Diagnose und Wiederherstellung; nicht als `follow`-Ersatz verwenden |
-| `cancel` | Bricht den Job ab |
-| `ensure-runtime` / `cache list` / `cache clean` | Runtime- und Cache-Verwaltung |
+IaC Code pausiert, wenn eine Berechtigung, zusätzliche Informationen oder die Auswahl eines Plans erforderlich ist.
+Der Host-Agent zeigt die Anfrage unmittelbar an:
 
-`start --follow` und `follow` schreiben Step-Grenzen und niederfrequente Heartbeats nach stderr; stdout liefert genau ein begrenztes JSON-Ergebnis.
+- eine Berechtigungsanfrage für ein Tool oder eine Bereitstellung (`permission`);
+- eine Multiple-Choice-Frage oder eine Bitte um weitere Informationen (`ask_user_question`);
+- die Auswahl eines Planvorschlags aus der Pipeline (`candidate_selection`).
 
-## Interaktionsgrenzen {#boundaries}
+Prüfen Sie vor der Bestätigung Zielressource, Region, erwartete Auswirkungen und Preis. Der Host-Agent kann eine
+Ablehnung von IaC Code nicht außer Kraft setzen. Eine einmalige Genehmigung wird im Protokoll als `allow_once`
+dargestellt.
 
-`--follow` konsumiert den Ereignisstrom bis zur naechsten Step-Grenze, Berechtigungsanfrage, Benutzerfrage, Kandidatenauswahl, `turn_completed` oder zum Endzustand. Ein Grenzergebnis traegt:
+> **Hinweis zur Integration des Host-Agenten**
+>
+> Enthält ein Bridge-Ergebnis `inputRequired`, muss der Host-Agent die aktuelle Anfrage anzeigen und auf eine Antwort
+> warten. `boundaryReached` kennzeichnet eine Anzeige- oder Interaktionsgrenze, nicht den Abschluss der Aufgabe; der
+> Host muss die Aktualisierung anzeigen und dieselbe Aufgabe weiter verfolgen.
 
-- `boundaryReached: true` - eine Grenze wurde erreicht; das bedeutet **nicht**, dass der Job abgeschlossen ist;
-- `presentationRequired: true` und `userUpdates` - lokalisierte, unmittelbar anzeigbare Zeichenketten;
-- den `cursor` zum Fortsetzen.
+## Sicherheit
 
-Der externe Agent muss zunaechst jede empfangene `userUpdates`-Zeichenkette in einer fuer den Benutzer sichtbaren Antwort praesentieren und danach sofort erneut `follow` mit dem zurueckgegebenen `cursor` aufrufen. Beantworten Sie die Infrastrukturaufgabe nicht parallel und stellen Sie keine unzusammenhaengenden Fragen, waehrend ein Follow laeuft.
+- Die Runtime lauscht ausschließlich an einem zufälligen Port auf `127.0.0.1`. Bei jedem Start wird ein neues
+  Bearer-Token erzeugt, das jede Anfrage der Bridge mitführt.
+- Die Bridge speichert Artefakte und Ergebnisse im Arbeitsbereich der Aufgabe. Ergebnisse werden in
+  `.iac-code-skill-results/` geschrieben.
+- Anzeigefelder der Vorabprüfung und der Berechtigungsanfragen werden bereinigt; Geheimnisse und Anmeldeinformationen
+  erscheinen dort nicht.
 
-## Benutzereingabe {#input-required}
+## Verwandte Dokumentation
 
-Ein Ergebnis enthaelt `inputRequired`, wenn Benutzereingabe noetig ist. Es gibt drei Arten:
-
-- `permission` - eine Tool- oder Deployment-Berechtigungsanfrage. Der Umschlag enthaelt `inputId`, `toolUseId`, Titel, Zweck, Wirkung, Ziel, Nur-Lese-Markierung, `safeSummary` und bei Deploy-Anfragen `deploymentSummary`. Der externe Agent sollte gemaess seiner eigenen Berechtigungsrichtlinie entscheiden: Wuerde dieselbe Operation bei direkter Ausfuehrung ohne Rueckfrage fortgesetzt, antworten Sie `allow_once`; wuerde die Richtlinie sie ablehnen, antworten Sie `deny`; andernfalls fragen Sie den Benutzer. Ablehnungen von iac-code selbst duerfen nicht uebersteuert werden.
-- `ask_user_question` - eine Auswahl- oder Freitextfrage. Praesentieren Sie Prompt und Optionen unveraendert; Freitext wird nur akzeptiert, wenn `allowFreeText` `true` ist.
-- `candidate_selection` - Planauswahl der Pipeline. Praesentieren Sie zuerst Zusammenfassung, Architekturdiagramm (Mermaid), monatliche Gesamtkosten und Kostenpositionen jedes Kandidaten und liefern Sie dann den gewaehlten Kandidaten zurueck. Ersetzen Sie die gelieferten Preise nie durch grobe Schaetzungen.
-
-`respond` hat zwei Formen:
-
-```bash
-# Inline-Entscheidung fuer Berechtigungen
-python3 scripts/iac_code.py respond --job-id <job-id> \
-  --input-id <inputId> --tool-use-id <toolUseId> --decision allow_once --follow
-
-# Fragen und Kandidatenauswahlen verwenden eine Antwortdatei
-python3 scripts/iac_code.py respond --job-id <job-id> --input-file <answer.json> --follow
-```
-
-Eine Antwort muss alle Korrelationsfelder der ausstehenden Eingabe unveraendert lassen und bleibt an die aktuellen `kind`, `inputId`, `requestTaskId` und `contextId` gebunden; verwenden Sie nie eine Antwort aus einer anderen Anfrage erneut und interpretieren Sie eine Ressourcenauswahl nie als Deployment-Bestaetigung um.
-
-## Sprachsteuerung
-
-`start --language` setzt die bevorzugte Sprache des Jobs (bei Unbekanntheit `auto`). Jedes Ergebnis dieses Jobs wiederholt `preferredLanguage`; behandeln Sie es als dauerhaften Steuerungszustand: Fortschritt, Fragen, Berechtigungs-Prompts, Kandidatenplaene und Endergebnisse werden in dieser Sprache praesentiert, waehrend Protokollfeldnamen, Aufzaehlungen, IDs und Befehle unveraendert bleiben. Wenn massgeblicher Text bereits diese Sprache verwendet, praesentieren Sie ihn direkt oder fassen Sie ihn in derselben Sprache zusammen; uebersetzen Sie chinesische, fuer Benutzer sichtbare Inhalte nie ins Englische.
-
-## Verhaeltnis zum A2A-Protokoll
-
-Die Bridge spricht mit der lokalen Runtime ueber HTTP A2A JSON-RPC; Task-Zustaende, Artefakte und Berechtigungsinteraktionen nutzen das A2A-Protokoll von iac-code wieder:
-
-- Sideband-Antworten fuer Berechtigungen verwenden das `schemaVersion 1`-Nachrichtenformat; Felder und Einschraenkungen stehen in der [Protokollreferenz](./protocol-reference.md).
-- Im Pipeline-Modus liefert `candidatePresentation: rich-v1` strukturierte Kandidatenpraesentations-Payloads.
-- Job-Ergebniszustaende entsprechen A2A-Task-Zustaenden: `turn_completed` beendet einen normalen Turn; Pipeline-Endzustaende sind `completed`, `failed`, `canceled` und `rejected`, wobei `pipelineResult` und `artifacts` das massgebliche Ergebnis sind.
-
-## Sicherheitsgrenze
-
-- Die Runtime lauscht nur auf einem zufaelligen Port auf `127.0.0.1`; jeder Start erzeugt einen frischen zufaelligen Bearer-Token, und jede Bridge-Anfrage traegt ihn.
-- Die Bridge haelt Artefakte und Ergebnisse innerhalb des Job-Workspaces; Ergebnisse werden nach `.iac-code-skill-results/` im Workspace geschrieben.
-- Preflight-Berichte und Berechtigungs-Anzeigefelder sind bereinigt; Geheimwerte und Zugangsdaten erscheinen nie in Anzeigefeldern.
+- [Übersicht zum A2A-Protokoll](./overview.md)
+- [Referenz zum A2A-Protokoll](./protocol-reference.md)
+- [LLM-Anbieter](../configuration/llm-providers.md)
+- [Alibaba-Cloud-Anmeldeinformationen](../configuration/alibaba-cloud-credentials.md)
+- [Runtime-Konfiguration](../configuration/runtime-configuration.md)

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
@@ -1,100 +1,218 @@
 ---
 sidebar_position: 7
-title: Integración de Skill
-description: Agentes externos impulsan iac-code mediante el Skill empaquetado de iac-code y el Skill Runtime.
+title: Instalar y usar el Skill de IaC Code
+description: Descarga e instala el Skill de IaC Code para que un agente externo pueda gestionar recursos de Alibaba Cloud.
 ---
 
-# Integración de Skill
+# Instalar y usar el Skill de IaC Code
 
-iac-code incluye un Skill empaquetado para agentes externos. Un agente externo (un agente planificador o una plataforma de agentes) no instala el paquete Python de iac-code ni invoca comandos headless; impulsa un runtime A2A local autenticado mediante un script puente de solo biblioteca estándar para ejecutar trabajo de infraestructura de Alibaba Cloud como generación de plantillas ROS/Terraform, estimación de costes, selección de recursos y despliegue.
+El Skill de IaC Code está diseñado para agentes externos compatibles con Skills. Una vez instalado, un agente host
+puede delegar en IaC Code la planificación de arquitecturas cloud, la generación y revisión de plantillas ROS o
+Terraform, la estimación de costes, la selección de recursos, las operaciones con stacks y el despliegue. El Skill
+utiliza un puente escrito únicamente con la biblioteca estándar de Python para iniciar un Runtime A2A local y
+autenticado. No es necesario instalar IaC Code con pip y el host no debe recurrir a comandos headless.
 
-## Componentes
+## Descargar el Skill
 
-| Componente | Ubicación | Descripción |
+### Última versión estable
+
+Descarga directamente la última versión estable:
+
+[Descargar iac-code-skill.zip](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/iac-code-skill.zip)
+
+Esta URL fija siempre apunta al paquete del Skill publicado en el canal estable. Es adecuada para descargarlo desde el
+navegador o instalarlo manualmente, y no cambia cuando se publica una nueva versión.
+
+Los instaladores que necesiten conocer la versión, el tamaño del archivo, el resumen SHA-256 y la URL inmutable de la
+versión pueden consultar los metadatos del canal estable:
+
+[Ver latest.json](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/latest.json)
+
+El documento contiene:
+
+- `skillVersion`: versión estable actual del Skill;
+- `skill.url`: URL inmutable del archivo ZIP de esa versión;
+- `skill.sha256` y `skill.size`: valores para verificar la descarga;
+- `manifest.url`: manifiesto de publicación inmutable de esa versión.
+
+Para realizar una verificación estricta o una instalación automatizada reproducible, lee `latest.json`, descarga
+`skill.url` y verifica `skill.sha256`. No construyas por tu cuenta una URL a partir del número de versión.
+
+## Instalar el Skill
+
+### Requisitos previos
+
+- El agente host admite Skills locales definidos mediante `SKILL.md`.
+- CPython 3.8–3.14 está instalado. Usa `python3` en macOS/Linux y, preferiblemente, `py -3` en Windows.
+- El entorno puede acceder a las URL de OSS anteriores para descargar el ZIP del Skill y el Runtime necesario en el
+  primer uso.
+- La configuración del servicio de modelos está disponible. Para las tareas que consultan o gestionan recursos cloud,
+  también se necesita una identidad de Alibaba Cloud con privilegios mínimos.
+
+Las versiones oficiales del Skill Runtime son compatibles con estas plataformas:
+
+| Sistema operativo | Arquitectura |
+|---|---|
+| macOS | Apple Silicon (arm64) |
+| Linux | x86_64 |
+| Windows | x86_64 |
+
+Las versiones mínimas del sistema operativo y de glibc en Linux se definen en el manifiesto del Runtime fijado por el
+Skill. El puente comprueba la compatibilidad antes de descargar. En una plataforma no compatible, devuelve un error en
+lugar de descargar un artefacto destinado a otra plataforma o ABI.
+
+### Extraer en el directorio de Skills del agente host
+
+Extrae el ZIP directamente en la raíz de Skills del agente host. La ubicación exacta depende de cada producto;
+consulta la documentación del agente host. La estructura final debe ser:
+
+```text
+<Raíz de Skills del agente>/
+└── iac-code/
+    ├── SKILL.md
+    ├── agents/
+    │   └── openai.yaml
+    └── scripts/
+        └── iac_code.py
+```
+
+El ZIP ya contiene el directorio superior `iac-code/`. No añadas otro directorio con el mismo nombre. Después de
+instalar o actualizar, reinicia el agente host o abre una sesión nueva para que vuelva a detectar el Skill.
+
+### Verificar la instalación
+
+En el directorio `iac-code` extraído, ejecuta este comando en macOS o Linux:
+
+```bash
+python3 scripts/iac_code.py ensure-runtime
+```
+
+En Windows PowerShell, ejecuta:
+
+```powershell
+py -3 scripts\iac_code.py ensure-runtime
+```
+
+En la primera ejecución, el comando descarga el Runtime para la plataforma actual, verifica su tamaño y su resumen
+SHA-256, y muestra un objeto JSON con `skillVersion`, `runtimeTag` y la ruta de instalación. Un Runtime verificado que
+ya esté en caché se reutiliza sin volver a descargarlo.
+
+## Configurar el modelo y la identidad de Alibaba Cloud
+
+El Skill Runtime utiliza el mismo directorio de configuración que los demás modos de IaC Code: `~/.iac-code/` de forma
+predeterminada. Si ya has configurado IaC Code mediante el REPL, la aplicación web o la aplicación Desktop, el Skill
+puede reutilizar esos ajustes. Define `IAC_CODE_CONFIG_DIR` para usar otro directorio de configuración.
+
+En entornos automatizados, proporciona estas variables mediante una solución de gestión de secretos:
+
+| Categoría | Variable de entorno | Descripción |
 |---|---|---|
-| Paquete del Skill | `skills/iac-code/` | Instrucciones en `SKILL.md`, metadatos de agente en `agents/` y `scripts/iac_code.py`, el script puente |
-| Skill Runtime | Publicado por plataforma | Ejecutable nativo CPython 3.12 que incorpora el servidor A2A de iac-code |
-| Contratos de distribución | `skill-runtime/skill-package-contract.json`, `skill-runtime/publisher-contract.json` | Restricciones de formato y verificación para paquetes de skill y publicadores |
+| Modelo | `IAC_CODE_PROVIDER` | Proveedor del modelo |
+| Modelo | `IAC_CODE_MODEL` | Nombre del modelo |
+| Modelo | `IAC_CODE_API_KEY` | Clave de API del servicio de modelos |
+| Modelo | `IAC_CODE_BASE_URL` | Sustitución opcional del endpoint compatible |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_ID` | ID de AccessKey |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | Secreto de AccessKey |
+| Alibaba Cloud | `ALIBABA_CLOUD_SECURITY_TOKEN` | Token de seguridad para credenciales STS |
+| Alibaba Cloud | `ALIBABA_CLOUD_REGION_ID` | Región predeterminada |
 
-El script puente está escrito por completo con la biblioteca estándar de Python y mantiene compatibilidad con Python 3.8+; el CI lo compila y lo ejecuta en pruebas de humo en la matriz completa 3.8–3.14. No añadas dependencias de terceros ni sintaxis exclusiva de versiones nuevas al puente.
+No incluyas nunca credenciales reales en `SKILL.md`, los prompts del agente host, los archivos del proyecto ni el
+historial del shell. Da preferencia a credenciales temporales, roles RAM u OAuth, y concede solo los permisos de API
+cloud necesarios para la tarea. Consulta [Proveedores de LLM](../configuration/llm-providers.md) y
+[Credenciales de Alibaba Cloud](../configuration/alibaba-cloud-credentials.md) para ver las instrucciones completas.
 
-## Obtención y caché del Runtime
+## Primer uso
 
-En el primer uso, el puente lee el manifiesto, descarga el artefacto de la plataforma actual, verifica su tamaño y SHA-256, lo instala y lo almacena en caché bajo `<IAC_CODE_CONFIG_DIR o ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/`.
+Después de instalar y configurar el Skill, abre una sesión nueva en el agente host y describe directamente una tarea
+de infraestructura de Alibaba Cloud. Por ejemplo:
 
-- `python3 scripts/iac_code.py ensure-runtime` — prepara el runtime con antelación; si está en caché se reutiliza.
-- `python3 scripts/iac_code.py cache list` — muestra los runtimes instalados y los paquetes candidatos.
-- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — limpia cachés del runtime o paquetes candidatos; requiere `--confirm` explícito.
+```text
+Usa iac-code para revisar la plantilla ROS de este proyecto. Enumera los riesgos de seguridad y los cambios recomendados sin modificar el archivo.
+```
 
-## Preflight de configuración
+Los hosts compatibles con una sintaxis explícita de Skills pueden seleccionar el Skill mediante `$iac-code`. El
+agente host lee `SKILL.md`, escribe la solicitud completa en un archivo UTF-8 del espacio de trabajo y utiliza el
+puente para crear y seguir una única tarea. El usuario no tiene que iniciar manualmente un servidor A2A.
 
-Antes de crear un trabajo, `start` ejecuta una comprobación de preparación de la configuración a través del runtime. El preflight no lee valores secretos; solo informa del estado de preparación:
+Flujo previsto:
+
+1. El puente comprueba si la configuración del modelo y de Alibaba Cloud está lista.
+2. En el primer uso, descarga y verifica el Runtime de IaC Code fijado por el Skill.
+3. El Runtime escucha únicamente en un puerto aleatorio de `127.0.0.1` y genera un token Bearer específico del proceso.
+4. El agente host muestra el progreso, las preguntas, los planes candidatos y las solicitudes de permisos devueltos
+   por IaC Code.
+5. Cuando termina la tarea, el agente host devuelve el resultado final y los archivos generados en el espacio de
+   trabajo.
+
+## Actualizar y desinstalar
+
+Para realizar una actualización manual, vuelve a descargar `skill/stable/iac-code-skill.zip` y sustituye todo el
+directorio `iac-code/` de la raíz de Skills del host. Un actualizador automático puede comparar el valor
+`skillVersion` de `latest.json` y, después, descargar y verificar el paquete nuevo mediante su URL inmutable y su
+resumen SHA-256. Cada Skill oficial está fijado a un Runtime verificado. No sustituyas únicamente
+`scripts/iac_code.py` ni modifiques manualmente la URL o el resumen del Runtime.
+
+Para desinstalarlo, elimina `iac-code/` de la raíz de Skills del agente host. La caché del Runtime no se elimina junto
+con el directorio del Skill. Ejecuta `cache list` y `cache clean` solo si el usuario solicita expresamente eliminarla.
+
+## Caché del Runtime
+
+El Runtime descargado durante el primer uso se almacena en
+`<IAC_CODE_CONFIG_DIR o ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` y se reutiliza automáticamente. Durante el
+uso normal no es necesario gestionar este directorio. Para consultar el espacio en disco utilizado o eliminar
+versiones antiguas, usa:
+
+- `python3 scripts/iac_code.py cache list` — enumera los Runtimes instalados y los paquetes candidatos;
+- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — elimina cachés del Runtime
+  o paquetes candidatos; `--confirm` es obligatorio.
+
+El Runtime actual y cualquier Runtime utilizado por un proceso activo están protegidos frente a la limpieza. El
+formato del paquete y las restricciones del Runtime se definen en `skill-runtime/skill-package-contract.json` dentro
+del repositorio de código fuente; los usuarios no necesitan modificar este archivo.
+
+## Solución de problemas
+
+### La configuración está incompleta
+
+El Skill comprueba la configuración antes de crear una tarea, pero nunca lee ni devuelve valores secretos:
 
 | Situación | Resultado |
 |---|---|
-| Proveedor LLM o API key incompletos | Devuelve `llm_not_configured` y rechaza crear el trabajo |
-| Pipeline selling con credenciales de Alibaba Cloud incompletas | Devuelve `cloud_credentials_not_configured` y rechaza crear el trabajo |
-| Modo normal con credenciales de Alibaba Cloud incompletas | Puede continuar para trabajo que no llama a API de la nube, con una advertencia de preflight |
+| El proveedor de LLM o la clave de API están incompletos | Devuelve `llm_not_configured` y no crea la tarea |
+| Las credenciales de Alibaba Cloud están incompletas para el Pipeline de venta | Devuelve `cloud_credentials_not_configured` y no crea la tarea |
+| Las credenciales de Alibaba Cloud están incompletas en el modo normal | Las tareas que no llaman a API cloud pueden continuar con una advertencia previa |
 
-## Referencia de comandos
+### Por qué se pausa la ejecución
 
-| Comando | Propósito |
-|---|---|
-| `start` | Crear un trabajo: `--mode normal|pipeline`, `--pipeline-name`, `--cwd` espacio de trabajo absoluto, `--prompt-file` archivo de prompt UTF-8, `--language auto|en|zh|es|fr|de|ja|pt`, opcional `--follow` |
-| `follow` | Consume el flujo de eventos hasta el siguiente límite de interacción: `--job-id`, `--cursor`, `--wait-seconds` (60 s por defecto, máximo 120 s) |
-| `continue` | Continúa una conversación en modo normal dentro del mismo trabajo: `--job-id`, `--prompt-file`, opcional `--follow` |
-| `respond` | Responde a una entrada pendiente, consulta [Entrada del usuario](#input-required) |
-| `poll` | Sondeo de un solo uso solo para diagnóstico y recuperación; no lo uses como sustituto de `follow` |
-| `cancel` | Cancela el trabajo |
-| `ensure-runtime` / `cache list` / `cache clean` | Gestión del runtime y la caché |
+IaC Code se pausa cuando necesita un permiso, información adicional o la selección de un plan. El agente host muestra
+directamente la solicitud:
 
-`start --follow` y `follow` escriben los límites de paso y latidos de baja frecuencia en stderr; stdout emite exactamente un resultado JSON acotado.
+- una solicitud de permiso para una herramienta o un despliegue (`permission`);
+- una pregunta de opción múltiple o una solicitud de información (`ask_user_question`);
+- la selección de un plan candidato del Pipeline (`candidate_selection`).
 
-## Límites de interacción {#boundaries}
+Antes de confirmar, revisa el recurso de destino, la región, el impacto previsto y el precio. El agente host no puede
+anular una denegación de IaC Code. En el protocolo, una autorización para una sola vez se representa como `allow_once`.
 
-`--follow` consume el flujo de eventos hasta el siguiente límite de paso, solicitud de permiso, pregunta del usuario, selección de candidato, `turn_completed` o estado terminal. Un resultado de límite incluye:
+> **Nota sobre la integración del agente host**
+>
+> Cuando un resultado del puente contiene `inputRequired`, el agente host debe mostrar la solicitud actual y esperar
+> una respuesta. `boundaryReached` indica un límite de presentación o interacción, no que la tarea haya finalizado; el
+> host debe mostrar la actualización y continuar siguiendo la misma tarea.
 
-- `boundaryReached: true` — se alcanzó un límite; esto **no** significa que el trabajo haya terminado;
-- `presentationRequired: true` y `userUpdates` — cadenas localizadas listas para mostrar al usuario;
-- el `cursor` necesario para continuar.
+## Seguridad
 
-El agente externo debe presentar primero cada cadena `userUpdates` recibida en una respuesta visible para el usuario y luego llamar de inmediato a `follow` otra vez con el `cursor` devuelto. No respondas la tarea de infraestructura en paralelo ni plantees preguntas no relacionadas mientras hay un follow en ejecución.
+- El Runtime escucha únicamente en un puerto aleatorio de `127.0.0.1`. Cada inicio genera un token Bearer nuevo y cada
+  solicitud del puente incluye ese token.
+- El puente conserva los artefactos y resultados en el espacio de trabajo de la tarea. Los resultados se escriben en
+  `.iac-code-skill-results/`.
+- Los campos que se muestran durante las comprobaciones previas y las solicitudes de permisos se depuran; no contienen
+  secretos ni credenciales.
 
-## Entrada del usuario {#input-required}
+## Documentación relacionada
 
-Un resultado contiene `inputRequired` cuando se necesita entrada del usuario. Hay tres tipos:
-
-- `permission` — una solicitud de permiso de herramienta o despliegue. El sobre contiene `inputId`, `toolUseId`, título, propósito, efecto, objetivo, indicador de solo lectura, `safeSummary` y, en solicitudes de despliegue, `deploymentSummary`. El agente externo debe decidir según su propia política de permisos: si la misma operación continuaría sin preguntar cuando el agente la ejecuta directamente, responde `allow_once`; si su política la denegaría, responde `deny`; en caso contrario, pregunta al usuario. Las denegaciones propias de iac-code no deben anularse.
-- `ask_user_question` — una pregunta de opción múltiple o texto libre. Presenta el aviso y las opciones tal cual; acepta texto libre solo cuando `allowFreeText` es `true`.
-- `candidate_selection` — selección de plan del pipeline. Presenta primero el resumen, el diagrama de arquitectura (Mermaid), el coste mensual total y las partidas de coste de cada candidato, y luego devuelve el candidato seleccionado. Nunca sustituyas los precios proporcionados por estimaciones aproximadas.
-
-`respond` tiene dos formas:
-
-```bash
-# Decisión en línea para permisos
-python3 scripts/iac_code.py respond --job-id <job-id> \
-  --input-id <inputId> --tool-use-id <toolUseId> --decision allow_once --follow
-
-# Las preguntas y selecciones de candidato usan un archivo de respuesta
-python3 scripts/iac_code.py respond --job-id <job-id> --input-file <answer.json> --follow
-```
-
-Una respuesta debe conservar todos los campos de correlación de la entrada pendiente y queda vinculada al `kind`, `inputId`, `requestTaskId` y `contextId` actuales; nunca reutilices una respuesta de otra solicitud ni reinterpretes una selección de recurso como una confirmación de despliegue.
-
-## Control de idioma
-
-`start --language` establece el idioma preferido del trabajo (usa `auto` cuando sea desconocido). Cada resultado de ese trabajo repite `preferredLanguage`; trátalo como estado de control duradero: el progreso, las preguntas, los avisos de permisos, los planes candidatos y los resultados finales se presentan en ese idioma, mientras que los nombres de campos del protocolo, los enumerados, los ID y los comandos permanecen sin cambios. Cuando el texto autorizado ya usa ese idioma, preséntalo directamente o resúmelo en el mismo idioma; nunca traduzcas contenido chino visible para el usuario al inglés.
-
-## Relación con el protocolo A2A
-
-El puente se comunica con el runtime local mediante HTTP A2A JSON-RPC; los estados de tarea, los artefactos y las interacciones de permisos reutilizan el protocolo A2A de iac-code:
-
-- Las respuestas de banda lateral de permisos usan el formato de mensaje `schemaVersion 1`; consulta la [Referencia del protocolo](./protocol-reference.md) para los campos y restricciones.
-- En modo pipeline, pasar `candidatePresentation: rich-v1` devuelve cargas estructuradas de presentación de candidatos.
-- Los estados de resultado del trabajo se corresponden con estados de tarea A2A: `turn_completed` termina un turno normal; los estados terminales del pipeline son `completed`, `failed`, `canceled` y `rejected`, con `pipelineResult` y `artifacts` como resultado autorizado.
-
-## Límite de seguridad
-
-- El runtime escucha únicamente en un puerto aleatorio de `127.0.0.1`; cada arranque genera un token Bearer aleatorio nuevo y cada solicitud del puente lo incluye.
-- El puente mantiene los artefactos y resultados dentro del espacio de trabajo del trabajo; los resultados se escriben en `.iac-code-skill-results/` del espacio de trabajo.
-- Los informes de preflight y los campos de visualización de permisos están saneados; los secretos y credenciales nunca aparecen en los campos de visualización.
+- [Descripción general del protocolo A2A](./overview.md)
+- [Referencia del protocolo A2A](./protocol-reference.md)
+- [Proveedores de LLM](../configuration/llm-providers.md)
+- [Credenciales de Alibaba Cloud](../configuration/alibaba-cloud-credentials.md)
+- [Configuración del Runtime](../configuration/runtime-configuration.md)

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
@@ -1,100 +1,222 @@
 ---
 sidebar_position: 7
-title: Intégration Skill
-description: Des agents externes pilotent iac-code via le Skill empaqueté d'iac-code et le Skill Runtime.
+title: Installer et utiliser le Skill IaC Code
+description: Téléchargez et installez le Skill IaC Code afin qu'un agent externe puisse gérer des ressources cloud Alibaba Cloud.
 ---
 
-# Intégration Skill
+# Installer et utiliser le Skill IaC Code
 
-iac-code fournit un Skill empaqueté destiné aux agents externes. Un agent externe (un agent planificateur ou une plateforme d'agents) n'installe pas le paquet Python d'iac-code et n'invoque pas de commandes headless ; il pilote un runtime A2A local authentifié via un script pont utilisant uniquement la bibliothèque standard, afin d'exécuter des travaux d'infrastructure Alibaba Cloud tels que la génération de templates ROS/Terraform, l'estimation des coûts, la sélection de ressources et le déploiement.
+Le Skill IaC Code s'adresse aux agents externes qui prennent en charge les Skills. Une fois installé, il permet à un
+agent hôte de déléguer à IaC Code la conception d'architectures cloud, la génération et la vérification de modèles ROS
+ou Terraform, l'estimation des coûts, le choix des ressources, les opérations sur les stacks et le déploiement. Le
+Skill utilise un pont écrit uniquement avec la bibliothèque standard de Python pour démarrer un Runtime A2A local et
+authentifié. Il n'est pas nécessaire d'installer IaC Code avec pip, et l'agent hôte ne doit pas se rabattre sur des
+commandes headless.
 
-## Composants
+## Télécharger le Skill
 
-| Composant | Emplacement | Description |
+### Dernière version stable
+
+Téléchargez directement la dernière version stable :
+
+[Télécharger iac-code-skill.zip](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/iac-code-skill.zip)
+
+Cette URL fixe pointe toujours vers le paquet du Skill promu sur le canal stable. Elle convient au téléchargement
+depuis un navigateur et à l'installation manuelle, et ne change pas à chaque nouvelle version.
+
+Les programmes d'installation qui ont besoin de la version, de la taille du fichier, de l'empreinte SHA-256 et de
+l'URL immuable propre à la version peuvent consulter les métadonnées du canal stable :
+
+[Consulter latest.json](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/latest.json)
+
+Ce document contient :
+
+- `skillVersion` : version stable actuelle du Skill ;
+- `skill.url` : URL immuable du fichier ZIP correspondant à cette version ;
+- `skill.sha256` et `skill.size` : valeurs utilisées pour vérifier le téléchargement ;
+- `manifest.url` : manifeste de publication immuable correspondant à cette version.
+
+Pour une vérification stricte ou une installation automatisée reproductible, lisez `latest.json`, téléchargez
+`skill.url`, puis vérifiez `skill.sha256`. Ne construisez pas vous-même une URL à partir du numéro de version.
+
+## Installer le Skill
+
+### Prérequis
+
+- L'agent hôte prend en charge les Skills locaux définis par un fichier `SKILL.md`.
+- CPython 3.8 à 3.14 est installé. Utilisez `python3` sous macOS/Linux et, de préférence, `py -3` sous Windows.
+- L'environnement peut accéder aux URL OSS ci-dessus afin de télécharger le fichier ZIP du Skill et le Runtime requis
+  lors de la première utilisation.
+- La configuration du service de modèles est disponible. Une identité Alibaba Cloud avec le principe du moindre
+  privilège est également requise pour les tâches qui consultent ou gèrent des ressources cloud.
+
+Les versions officielles du Skill Runtime prennent en charge les plateformes suivantes :
+
+| Système d'exploitation | Architecture |
+|---|---|
+| macOS | Apple Silicon (arm64) |
+| Linux | x86_64 |
+| Windows | x86_64 |
+
+Les versions minimales du système d'exploitation et de la glibc sous Linux sont définies par le manifeste du Runtime
+épinglé par le Skill. Le pont vérifie la compatibilité avant le téléchargement. Sur une plateforme non prise en
+charge, il renvoie une erreur au lieu de télécharger un artefact destiné à une autre plateforme ou ABI.
+
+### Extraire le paquet dans le répertoire des Skills de l'agent hôte
+
+Extrayez directement le fichier ZIP à la racine des Skills de l'agent hôte. L'emplacement exact dépend du produit ;
+consultez la documentation de l'agent hôte. L'arborescence finale doit être la suivante :
+
+```text
+<Racine des Skills de l'agent>/
+└── iac-code/
+    ├── SKILL.md
+    ├── agents/
+    │   └── openai.yaml
+    └── scripts/
+        └── iac_code.py
+```
+
+Le fichier ZIP contient déjà le répertoire de premier niveau `iac-code/`. N'ajoutez pas un second répertoire du même
+nom. Après une installation ou une mise à jour, redémarrez l'agent hôte ou ouvrez une nouvelle session afin qu'il
+détecte à nouveau le Skill.
+
+### Vérifier l'installation
+
+Dans le répertoire `iac-code` extrait, exécutez la commande suivante sous macOS ou Linux :
+
+```bash
+python3 scripts/iac_code.py ensure-runtime
+```
+
+Dans Windows PowerShell, exécutez :
+
+```powershell
+py -3 scripts\iac_code.py ensure-runtime
+```
+
+Lors de la première exécution, cette commande télécharge le Runtime correspondant à la plateforme, vérifie sa taille
+et son empreinte SHA-256, puis affiche un objet JSON contenant `skillVersion`, `runtimeTag` et le chemin
+d'installation. Un Runtime déjà vérifié et mis en cache est réutilisé sans nouveau téléchargement.
+
+## Configurer le modèle et l'identité Alibaba Cloud
+
+Le Skill Runtime utilise le même répertoire de configuration que les autres modes de IaC Code : `~/.iac-code/` par
+défaut. Si IaC Code est déjà configuré via le REPL, l'application Web ou l'application Desktop, le Skill peut
+réutiliser ces paramètres. Définissez `IAC_CODE_CONFIG_DIR` pour employer un autre répertoire de configuration.
+
+Dans les environnements automatisés, fournissez les variables suivantes au moyen d'une solution de gestion des
+secrets :
+
+| Catégorie | Variable d'environnement | Description |
 |---|---|---|
-| Paquet du Skill | `skills/iac-code/` | Instructions `SKILL.md`, métadonnées d'agent dans `agents/` et `scripts/iac_code.py`, le script pont |
-| Skill Runtime | Publié par plateforme | Exécutable natif CPython 3.12 intégrant le serveur A2A d'iac-code |
-| Contrats de distribution | `skill-runtime/skill-package-contract.json`, `skill-runtime/publisher-contract.json` | Contraintes de format et de vérification pour les paquets de skill et les éditeurs |
+| Modèle | `IAC_CODE_PROVIDER` | Fournisseur du modèle |
+| Modèle | `IAC_CODE_MODEL` | Nom du modèle |
+| Modèle | `IAC_CODE_API_KEY` | Clé API du service de modèles |
+| Modèle | `IAC_CODE_BASE_URL` | Remplacement facultatif de l'endpoint compatible |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_ID` | ID de l'AccessKey |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | Secret de l'AccessKey |
+| Alibaba Cloud | `ALIBABA_CLOUD_SECURITY_TOKEN` | Jeton de sécurité pour les identifiants STS |
+| Alibaba Cloud | `ALIBABA_CLOUD_REGION_ID` | Région par défaut |
 
-Le script pont est écrit entièrement avec la bibliothèque standard de Python et reste compatible avec Python 3.8+ ; la CI le compile et l'exécute en test de fumée sur toute la matrice 3.8–3.14. N'ajoutez ni dépendance tierce ni syntaxe réservée aux versions récentes au pont.
+Ne placez jamais d'identifiants réels dans `SKILL.md`, les prompts de l'agent hôte, les fichiers du projet ou
+l'historique du shell. Privilégiez les identifiants temporaires, les rôles RAM ou OAuth, et n'accordez que les
+autorisations d'API cloud nécessaires à la tâche. Pour les instructions complètes, consultez
+[Fournisseurs de LLM](../configuration/llm-providers.md) et
+[Identifiants Alibaba Cloud](../configuration/alibaba-cloud-credentials.md).
 
-## Acquisition et cache du Runtime
+## Première utilisation
 
-À la première utilisation, le pont lit le manifeste, télécharge l'artefact correspondant à la plateforme courante, vérifie sa taille et son SHA-256, l'installe et le met en cache sous `<IAC_CODE_CONFIG_DIR ou ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/`.
+Après l'installation et la configuration, ouvrez une nouvelle session dans l'agent hôte et décrivez directement une
+tâche d'infrastructure Alibaba Cloud. Par exemple :
 
-- `python3 scripts/iac_code.py ensure-runtime` — prépare le runtime à l'avance ; un runtime en cache est réutilisé.
-- `python3 scripts/iac_code.py cache list` — affiche les runtimes installés et les paquets candidats.
-- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — nettoie les caches du runtime ou les paquets candidats ; nécessite `--confirm` explicite.
+```text
+Utilise iac-code pour vérifier le modèle ROS de ce projet. Répertorie les risques de sécurité et les modifications recommandées sans modifier le fichier.
+```
 
-## Prévol de configuration
+Les agents hôtes qui prennent en charge une syntaxe explicite peuvent sélectionner le Skill avec `$iac-code`.
+L'agent hôte lit `SKILL.md`, écrit la demande complète dans un fichier UTF-8 de l'espace de travail, puis utilise le
+pont pour créer et suivre une seule tâche. L'utilisateur n'a pas besoin de démarrer manuellement un serveur A2A.
 
-Avant de créer un job, `start` exécute une vérification de préparation de la configuration via le runtime. Le prévol ne lit pas les valeurs secrètes ; il signale uniquement l'état de préparation :
+Déroulement attendu :
+
+1. Le pont vérifie que la configuration du modèle et d'Alibaba Cloud est prête.
+2. Lors de la première utilisation, il télécharge et vérifie le Runtime IaC Code épinglé par le Skill.
+3. Le Runtime écoute uniquement sur un port aléatoire de `127.0.0.1` et génère un jeton Bearer propre au processus.
+4. L'agent hôte présente la progression, les questions, les plans candidats et les demandes d'autorisation renvoyés
+   par IaC Code.
+5. Une fois la tâche terminée, l'agent hôte renvoie le résultat final et les fichiers générés dans l'espace de travail.
+
+## Mettre à jour et désinstaller
+
+Pour effectuer une mise à jour manuelle, téléchargez à nouveau `skill/stable/iac-code-skill.zip` et remplacez
+l'intégralité du répertoire `iac-code/` dans la racine des Skills de l'agent hôte. Un programme de mise à jour
+automatique peut comparer la valeur `skillVersion` de `latest.json`, puis télécharger et vérifier le nouveau paquet à
+l'aide de son URL immuable et de son empreinte SHA-256. Chaque Skill officiel est épinglé à un Runtime vérifié. Ne
+remplacez pas uniquement `scripts/iac_code.py` et ne modifiez pas manuellement l'URL ou l'empreinte du Runtime.
+
+Pour désinstaller le Skill, supprimez `iac-code/` de la racine des Skills de l'agent hôte. Le cache du Runtime n'est
+pas supprimé avec le répertoire du Skill. N'exécutez `cache list` et `cache clean` que si l'utilisateur demande
+explicitement de supprimer ce cache.
+
+## Cache du Runtime
+
+Le Runtime téléchargé lors de la première utilisation est mis en cache dans
+`<IAC_CODE_CONFIG_DIR ou ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` et réutilisé automatiquement. En usage
+normal, il n'est pas nécessaire de gérer ce répertoire. Pour examiner l'espace disque utilisé ou supprimer
+d'anciennes versions, utilisez :
+
+- `python3 scripts/iac_code.py cache list` — répertorie les Runtimes installés et les paquets candidats ;
+- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — supprime les caches du
+  Runtime ou les paquets candidats ; l'option `--confirm` est obligatoire.
+
+Le Runtime actuel et tout Runtime utilisé par un processus actif sont protégés contre le nettoyage. Le format du
+paquet et les contraintes du Runtime sont définis par `skill-runtime/skill-package-contract.json` dans le dépôt
+source ; les utilisateurs n'ont pas à modifier ce fichier.
+
+## Résolution des problèmes
+
+### La configuration est incomplète
+
+Le Skill vérifie la configuration avant de créer une tâche, mais ne lit ni ne renvoie jamais les valeurs secrètes :
 
 | Situation | Résultat |
 |---|---|
-| Fournisseur LLM ou clé API incomplet | Renvoie `llm_not_configured` et refuse de créer le job |
-| Pipeline selling avec identifiants Alibaba Cloud incomplets | Renvoie `cloud_credentials_not_configured` et refuse de créer le job |
-| Mode normal avec identifiants Alibaba Cloud incomplets | Peut continuer pour les travaux n'appelant pas d'API cloud, avec un avertissement de prévol |
+| Le fournisseur de LLM ou la clé API est incomplet | Renvoie `llm_not_configured` et ne crée pas la tâche |
+| Les identifiants Alibaba Cloud sont incomplets pour le Pipeline de vente | Renvoie `cloud_credentials_not_configured` et ne crée pas la tâche |
+| Les identifiants Alibaba Cloud sont incomplets en mode normal | Les tâches qui n'appellent pas d'API cloud peuvent continuer avec un avertissement préalable |
 
-## Référence des commandes
+### Pourquoi l'exécution se met en pause
 
-| Commande | Objet |
-|---|---|
-| `start` | Créer un job : `--mode normal|pipeline`, `--pipeline-name`, `--cwd` espace de travail absolu, `--prompt-file` fichier de prompt UTF-8, `--language auto|en|zh|es|fr|de|ja|pt`, `--follow` facultatif |
-| `follow` | Consomme le flux d'événements jusqu'à la prochaine frontière d'interaction : `--job-id`, `--cursor`, `--wait-seconds` (60 s par défaut, 120 s maximum) |
-| `continue` | Poursuit une conversation en mode normal dans le même job : `--job-id`, `--prompt-file`, `--follow` facultatif |
-| `respond` | Répond à une entrée en attente, voir [Entrée utilisateur](#input-required) |
-| `poll` | Interrogation unique réservée au diagnostic et à la récupération ; ne pas l'utiliser en remplacement de `follow` |
-| `cancel` | Annule le job |
-| `ensure-runtime` / `cache list` / `cache clean` | Gestion du runtime et du cache |
+IaC Code se met en pause lorsqu'il attend une autorisation, une information complémentaire ou le choix d'un plan.
+L'agent hôte présente directement la demande :
 
-`start --follow` et `follow` écrivent les frontières d'étape et les battements basse fréquence sur stderr ; stdout produit exactement un résultat JSON borné.
+- une demande d'autorisation pour un outil ou un déploiement (`permission`) ;
+- une question à choix multiple ou une demande d'informations (`ask_user_question`) ;
+- le choix d'un plan candidat du Pipeline (`candidate_selection`).
 
-## Frontières d'interaction {#boundaries}
+Avant de confirmer, vérifiez la ressource cible, la région, l'impact prévu et le prix. L'agent hôte ne peut pas passer
+outre un refus de IaC Code. Dans le protocole, une autorisation ponctuelle est représentée par `allow_once`.
 
-`--follow` consomme le flux d'événements jusqu'à la prochaine frontière d'étape, demande de permission, question utilisateur, sélection de candidat, `turn_completed` ou état terminal. Un résultat de frontière porte :
+> **Note pour l'intégration de l'agent hôte**
+>
+> Lorsqu'un résultat du pont contient `inputRequired`, l'agent hôte doit présenter la demande en cours et attendre une
+> réponse. `boundaryReached` indique une limite d'affichage ou d'interaction, et non la fin de la tâche ; l'agent hôte
+> doit afficher la mise à jour et continuer à suivre la même tâche.
 
-- `boundaryReached: true` — une frontière est atteinte ; cela ne signifie **pas** que le job est terminé ;
-- `presentationRequired: true` et `userUpdates` — des chaînes localisées prêtes à être affichées à l'utilisateur ;
-- le `cursor` nécessaire pour continuer.
+## Sécurité
 
-L'agent externe doit d'abord présenter chaque chaîne `userUpdates` reçue dans une réponse visible par l'utilisateur, puis rappeler immédiatement `follow` avec le `cursor` renvoyé. Ne répondez pas à la tâche d'infrastructure en parallèle et ne posez pas de questions sans rapport pendant qu'un follow est en cours.
+- Le Runtime écoute uniquement sur un port aléatoire de `127.0.0.1`. Chaque démarrage génère un nouveau jeton Bearer,
+  transmis avec chaque requête du pont.
+- Le pont conserve les artefacts et les résultats dans l'espace de travail de la tâche. Les résultats sont enregistrés
+  dans `.iac-code-skill-results/`.
+- Les champs affichés lors des vérifications préalables et des demandes d'autorisation sont nettoyés ; aucun secret ni
+  identifiant n'y apparaît.
 
-## Entrée utilisateur {#input-required}
+## Documentation associée
 
-Un résultat contient `inputRequired` lorsqu'une entrée utilisateur est nécessaire. Il existe trois sortes :
-
-- `permission` — une demande de permission d'outil ou de déploiement. L'enveloppe contient `inputId`, `toolUseId`, un titre, un objectif, un effet, une cible, un indicateur lecture seule, `safeSummary` et, pour les demandes de déploiement, `deploymentSummary`. L'agent externe doit décider selon sa propre politique de permissions : si la même opération se poursuivrait sans demande lorsque l'agent l'exécute directement, répondez `allow_once` ; si sa politique la refuserait, répondez `deny` ; sinon demandez à l'utilisateur. Les refus d'iac-code lui-même ne doivent pas être contournés.
-- `ask_user_question` — une question à choix multiples ou en texte libre. Présentez l'invite et les options telles quelles ; n'acceptez le texte libre que si `allowFreeText` vaut `true`.
-- `candidate_selection` — sélection de plan du pipeline. Présentez d'abord le résumé, le diagramme d'architecture (Mermaid), le coût mensuel total et les postes de coût de chaque candidat, puis renvoyez le candidat retenu. Ne remplacez jamais les prix fournis par des estimations approximatives.
-
-`respond` existe sous deux formes :
-
-```bash
-# Décision en ligne pour les permissions
-python3 scripts/iac_code.py respond --job-id <job-id> \
-  --input-id <inputId> --tool-use-id <toolUseId> --decision allow_once --follow
-
-# Les questions et sélections de candidat utilisent un fichier de réponse
-python3 scripts/iac_code.py respond --job-id <job-id> --input-file <answer.json> --follow
-```
-
-Une réponse doit conserver tous les champs de corrélation de l'entrée en attente et reste liée aux `kind`, `inputId`, `requestTaskId` et `contextId` courants ; ne réutilisez jamais une réponse provenant d'une autre requête et ne réinterprétez jamais une sélection de ressource comme une confirmation de déploiement.
-
-## Contrôle de la langue
-
-`start --language` définit la langue préférée du job (utilisez `auto` en cas d'inconnue). Chaque résultat de ce job répète `preferredLanguage` ; traitez-le comme un état de contrôle durable : la progression, les questions, les invites de permission, les plans candidats et les résultats finaux sont présentés dans cette langue, tandis que les noms de champs du protocole, les énumérations, les identifiants et les commandes restent inchangés. Lorsque le texte faisant autorité utilise déjà cette langue, présentez-le directement ou résumez-le dans la même langue ; ne traduisez jamais un contenu chinois visible par l'utilisateur vers l'anglais.
-
-## Relation avec le protocole A2A
-
-Le pont communique avec le runtime local via HTTP A2A JSON-RPC ; les états de tâche, les artefacts et les interactions de permissions réutilisent le protocole A2A d'iac-code :
-
-- Les réponses hors bande de permissions utilisent le format de message `schemaVersion 1` ; voir la [Référence du protocole](./protocol-reference.md) pour les champs et contraintes.
-- En mode pipeline, transmettre `candidatePresentation: rich-v1` renvoie des charges structurées de présentation des candidats.
-- Les états de résultat du job correspondent aux états de tâche A2A : `turn_completed` termine un tour normal ; les états terminaux du pipeline sont `completed`, `failed`, `canceled` et `rejected`, avec `pipelineResult` et `artifacts` comme résultat faisant autorité.
-
-## Limite de sécurité
-
-- Le runtime n'écoute que sur un port aléatoire de `127.0.0.1` ; chaque démarrage génère un nouveau jeton Bearer aléatoire, et chaque requête du pont le transmet.
-- Le pont conserve les artefacts et les résultats dans l'espace de travail du job ; les résultats sont écrits dans `.iac-code-skill-results/` de l'espace de travail.
-- Les rapports de prévol et les champs d'affichage des permissions sont assainis ; les secrets et identifiants n'apparaissent jamais dans les champs d'affichage.
+- [Présentation du protocole A2A](./overview.md)
+- [Référence du protocole A2A](./protocol-reference.md)
+- [Fournisseurs de LLM](../configuration/llm-providers.md)
+- [Identifiants Alibaba Cloud](../configuration/alibaba-cloud-credentials.md)
+- [Configuration du Runtime](../configuration/runtime-configuration.md)

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
@@ -1,100 +1,175 @@
 ---
 sidebar_position: 7
-title: Skill 統合
-description: 外部エージェントがパッケージ化された iac-code Skill と Skill Runtime を通じて iac-code を駆動する。
+title: IaC Code Skill のインストールと使用
+description: IaC Code Skill をダウンロードしてインストールし、外部エージェントから Alibaba Cloud インフラストラクチャを管理します。
 ---
 
-# Skill 統合
+# IaC Code Skill のインストールと使用
 
-iac-code は、外部エージェント向けにパッケージ化された Skill を同梱しています。外部エージェント（プラナーエージェントやエージェントプラットフォーム）は iac-code の Python パッケージをインストールせず、headless コマンドも直接呼び出しません。標準ライブラリのみで書かれたブリッジスクリプト経由でローカルの認証済み A2A runtime を駆動し、ROS/Terraform テンプレート生成、コスト見積もり、リソース選択、デプロイなどの Alibaba Cloud インフラ作業を実行します。
+IaC Code Skill は、Skill に対応する外部エージェント向けです。インストールすると、ホストエージェントはクラウドアーキテクチャの設計、ROS または Terraform テンプレートの生成とレビュー、コスト見積もり、リソース選択、スタック操作、デプロイを IaC Code に委任できます。Skill は Python 標準ライブラリだけで構成されたブリッジを使い、ローカルで認証された A2A Runtime を起動します。IaC Code を pip でインストールする必要はなく、Headless コマンドにフォールバックすることもありません。
 
-## 構成要素
+## Skill のダウンロード
 
-| コンポーネント | 場所 | 説明 |
+### 最新の安定版
+
+最新の安定版を直接ダウンロードします。
+
+[iac-code-skill.zip をダウンロード](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/iac-code-skill.zip)
+
+この固定 URL は、stable チャンネルに昇格された Skill パッケージを常に指します。ブラウザーからのダウンロードや手動インストールに利用でき、新しいバージョンが公開されても URL は変わりません。
+
+バージョン、ファイルサイズ、SHA-256、変更されないバージョン別 URL が必要なインストーラーは、stable チャンネルのメタデータを参照できます。
+
+[latest.json を表示](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/latest.json)
+
+このファイルには次の情報が含まれます。
+
+- `skillVersion`：現在の安定版 Skill のバージョン。
+- `skill.url`：そのバージョンに固定された ZIP の URL。
+- `skill.sha256` と `skill.size`：ダウンロードの検証に使う値。
+- `manifest.url`：そのバージョンに固定されたリリースマニフェスト。
+
+厳密な検証や再現可能な自動インストールが必要な場合は、`latest.json` を読み取り、`skill.url` からダウンロードして `skill.sha256` を検証してください。バージョン URL を独自に組み立てないでください。
+
+## Skill のインストール
+
+### 前提条件
+
+- ホストエージェントが `SKILL.md` で定義されたローカル Skill に対応していること。
+- CPython 3.8～3.14 がインストールされていること。macOS/Linux では `python3`、Windows では `py -3` の使用を推奨します。
+- 上記 OSS URL にアクセスでき、Skill ZIP と初回実行時に必要な Runtime をダウンロードできること。
+- モデルサービスが設定済みであること。クラウドリソースを照会または管理する場合は、最小権限の Alibaba Cloud ID も必要です。
+
+公式 Skill Runtime は次のプラットフォームをサポートします。
+
+| OS | アーキテクチャ |
+|---|---|
+| macOS | Apple Silicon（arm64） |
+| Linux | x86_64 |
+| Windows | x86_64 |
+
+最低 OS バージョンと Linux の glibc バージョンは、Skill に固定された Runtime manifest で定義されます。ブリッジはダウンロード前に互換性を確認します。未対応の環境では、別のプラットフォームや ABI の成果物をダウンロードせず、エラーを返します。
+
+### ホストエージェントの Skill ディレクトリに展開する
+
+ZIP をホストエージェントの Skill ルートへ直接展開します。Skill ルートは製品ごとに異なるため、ホスト製品のドキュメントを参照してください。最終的な構成は次のようになります。
+
+```text
+<Agent Skill ルート>/
+└── iac-code/
+    ├── SKILL.md
+    ├── agents/
+    │   └── openai.yaml
+    └── scripts/
+        └── iac_code.py
+```
+
+ZIP には最上位の `iac-code/` ディレクトリがすでに含まれています。同名のディレクトリを重ねて作成しないでください。インストールまたは更新後、ホストエージェントを再起動するか新しいセッションを開き、Skill を再検出させます。
+
+### インストールを確認する
+
+展開した `iac-code` ディレクトリで、macOS または Linux では次を実行します。
+
+```bash
+python3 scripts/iac_code.py ensure-runtime
+```
+
+Windows PowerShell では次を実行します。
+
+```powershell
+py -3 scripts\iac_code.py ensure-runtime
+```
+
+初回実行時に現在のプラットフォーム用 Runtime をダウンロードし、サイズと SHA-256 を検証したうえで、`skillVersion`、`runtimeTag`、インストール先を含む JSON を出力します。検証済みの Runtime がキャッシュにあれば再利用し、再ダウンロードしません。
+
+## モデルと Alibaba Cloud ID の設定
+
+Skill Runtime は、他の IaC Code 実行モードと同じ設定ディレクトリを使用します。既定は `~/.iac-code/` です。REPL、Web、Desktop のいずれかで IaC Code を設定済みであれば、その設定を再利用できます。別の設定ディレクトリを使う場合は `IAC_CODE_CONFIG_DIR` を指定します。
+
+自動化環境では、Secret 管理機能を使って次の環境変数を提供します。
+
+| 分類 | 環境変数 | 説明 |
 |---|---|---|
-| Skill パッケージ | `skills/iac-code/` | `SKILL.md` の使用手順、`agents/` のエージェントメタデータ、ブリッジスクリプト `scripts/iac_code.py` |
-| Skill Runtime | プラットフォームごとに公開 | iac-code A2A サーバーを組み込んだ CPython 3.12 ネイティブ実行ファイル |
-| 配布契約 | `skill-runtime/skill-package-contract.json`、`skill-runtime/publisher-contract.json` | Skill パッケージと発行者の形式・検証ルール |
+| モデル | `IAC_CODE_PROVIDER` | モデルプロバイダー |
+| モデル | `IAC_CODE_MODEL` | モデル名 |
+| モデル | `IAC_CODE_API_KEY` | モデルサービスの API Key |
+| モデル | `IAC_CODE_BASE_URL` | 任意の互換エンドポイント上書き |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_ID` | AccessKey ID |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | AccessKey Secret |
+| Alibaba Cloud | `ALIBABA_CLOUD_SECURITY_TOKEN` | STS 認証情報の Security Token |
+| Alibaba Cloud | `ALIBABA_CLOUD_REGION_ID` | 既定のリージョン |
 
-ブリッジスクリプトは完全に Python 標準ライブラリで書かれており、Python 3.8 以上との互換性を保ちます。CI は 3.8–3.14 の全マトリックスでコンパイルとスモーク実行を行います。ブリッジにサードパーティ依存や新しいバージョン専用の構文を追加しないでください。
+実際の認証情報を `SKILL.md`、ホストエージェントのプロンプト、プロジェクトファイル、シェル履歴に記録しないでください。一時認証情報、RAM Role、OAuth を優先し、タスクに必要なクラウド API 権限だけを付与します。詳しくは [LLM プロバイダー](../configuration/llm-providers.md) と [Alibaba Cloud 認証情報](../configuration/alibaba-cloud-credentials.md)を参照してください。
 
-## Runtime の取得とキャッシュ
+## 最初の利用
 
-ブリッジは初回実行時にマニフェストを読み取り、現在のプラットフォームの成果物をダウンロードし、サイズと SHA-256 を検証してからインストールし、`<IAC_CODE_CONFIG_DIR または ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` 配下にキャッシュします。
+インストールと設定が完了したら、ホストエージェントで新しいセッションを開き、Alibaba Cloud インフラストラクチャのタスクをそのまま記述します。例：
 
-- `python3 scripts/iac_code.py ensure-runtime` — Runtime を事前に準備します。キャッシュ済みなら再利用します。
-- `python3 scripts/iac_code.py cache list` — インストール済み Runtime と候補パッケージを表示します。
-- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — Runtime キャッシュまたは候補パッケージを削除します。明示的な `--confirm` が必要です。
+```text
+iac-code を使用して、このプロジェクトの ROS テンプレートをレビューしてください。ファイルは変更せず、セキュリティリスクと修正案を一覧にしてください。
+```
 
-## 構成プリフライト
+明示的な Skill 構文に対応するホストでは、`$iac-code` でこの Skill を選択できます。ホストエージェントは `SKILL.md` を読み取り、完全なリクエストをワークスペース内の UTF-8 ファイルに書き込み、ブリッジを使って同じタスクを作成して追跡します。ユーザーが A2A Server を手動で起動する必要はありません。
 
-`start` はジョブ作成前に Runtime を通じて構成の準備状況チェックを実行します。プリフライトは秘密情報そのものを読み取らず、準備状況のみを報告します:
+想定される流れ：
+
+1. ブリッジがモデルと Alibaba Cloud の設定状態を確認します。
+2. 初回実行時に、Skill に固定された IaC Code Runtime をダウンロードして検証します。
+3. Runtime は `127.0.0.1` のランダムなポートだけで待ち受け、プロセス固有の Bearer Token を生成します。
+4. ホストエージェントが、IaC Code から返された進捗、質問、候補プラン、権限リクエストを表示します。
+5. タスクが完了すると、ホストエージェントが最終結果とワークスペースで生成されたファイルを返します。
+
+## 更新とアンインストール
+
+手動で更新する場合は `skill/stable/iac-code-skill.zip` を再度ダウンロードし、ホストの Skill ルートにある `iac-code/` ディレクトリ全体を置き換えます。自動更新では `latest.json` の `skillVersion` を比較し、変更されない URL と SHA-256 を使って新しいパッケージをダウンロード、検証できます。公式 Skill はそれぞれ検証済み Runtime に固定されています。`scripts/iac_code.py` だけを置き換えたり、Runtime URL やダイジェストを手動で変更したりしないでください。
+
+アンインストールするには、ホストエージェントの Skill ルートから `iac-code/` を削除します。Runtime キャッシュは Skill ディレクトリと一緒には削除されません。ユーザーが明示的に削除を求めた場合にだけ `cache list` と `cache clean` を実行してください。
+
+## Runtime キャッシュ
+
+初回利用時にダウンロードされた Runtime は `<IAC_CODE_CONFIG_DIR または ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` にキャッシュされ、その後は自動的に再利用されます。通常はこのディレクトリを管理する必要はありません。ディスク使用量の確認や過去バージョンの削除には次を使用します。
+
+- `python3 scripts/iac_code.py cache list` — インストール済み Runtime と Candidate パッケージを表示します。
+- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — Runtime キャッシュまたは Candidate パッケージを削除します。`--confirm` が必須です。
+
+現在使用中の Runtime と実行中プロセスが使用している Runtime は削除から保護されます。パッケージ形式と Runtime の制約は、ソースリポジトリの `skill-runtime/skill-package-contract.json` で定義されます。通常のユーザーがこのファイルを操作する必要はありません。
+
+## トラブルシューティング
+
+### 設定が不完全と表示される
+
+Skill はタスク作成前に設定を確認しますが、Secret の値を読み取ったり返したりしません。
 
 | 状況 | 結果 |
 |---|---|
-| LLM プロバイダーまたは API Key が不完全 | `llm_not_configured` を返し、ジョブ作成を拒否 |
-| selling Pipeline かつ Alibaba Cloud 資格情報が不完全 | `cloud_credentials_not_configured` を返し、ジョブ作成を拒否 |
-| normal モードかつ Alibaba Cloud 資格情報が不完全 | クラウド API を呼び出さない作業は続行可能だが、プリフライト警告を出す |
+| LLM プロバイダーまたは API Key が不完全 | `llm_not_configured` を返し、タスクを作成しません |
+| selling Pipeline で Alibaba Cloud 認証情報が不完全 | `cloud_credentials_not_configured` を返し、タスクを作成しません |
+| normal モードで Alibaba Cloud 認証情報が不完全 | クラウド API を呼び出さないタスクは、事前確認の警告付きで続行できる場合があります |
 
-## コマンドリファレンス
+### 実行中に一時停止する理由
 
-| コマンド | 用途 |
-|---|---|
-| `start` | ジョブ作成: `--mode normal|pipeline`、`--pipeline-name`、`--cwd` 絶対ワークスペース、`--prompt-file` UTF-8 プロンプトファイル、`--language auto|en|zh|es|fr|de|ja|pt`、任意で `--follow` |
-| `follow` | 次のインタラクション境界までイベントストリームを消費: `--job-id`、`--cursor`、`--wait-seconds`（既定 60 秒、最大 120 秒） |
-| `continue` | 同じジョブで normal モードの会話を継続: `--job-id`、`--prompt-file`、任意で `--follow` |
-| `respond` | 保留中の入力への応答。[ユーザー入力](#input-required)を参照 |
-| `poll` | 診断・復旧専用の一回限りポーリング。`follow` の代用にしないこと |
-| `cancel` | ジョブのキャンセル |
-| `ensure-runtime` / `cache list` / `cache clean` | Runtime とキャッシュの管理 |
+IaC Code は権限の確認、追加情報、プラン選択が必要になると一時停止し、ホストエージェントが要求をユーザーに表示します。
 
-`start --follow` と `follow` はステップ境界と低頻度ハートビートを stderr に書き出し、stdout には 1 件のみ制限された JSON 結果を出力します。
+- ツールまたはデプロイの権限リクエスト（`permission`）。
+- 選択式の質問または追加情報の要求（`ask_user_question`）。
+- Pipeline の候補プラン選択（`candidate_selection`）。
 
-## インタラクション境界 {#boundaries}
+確認前に、対象リソース、リージョン、想定される影響、価格を確認してください。ホストエージェントは IaC Code の拒否を上書きできません。1 回限りの許可はプロトコル上 `allow_once` として表されます。
 
-`--follow` は、次のステップ境界、権限リクエスト、ユーザー質問、候補選択、`turn_completed`、または終端状態に達するまでイベントストリームを消費します。境界の結果には次が含まれます:
+> **ホストエージェントの統合に関する注意**
+>
+> ブリッジ結果に `inputRequired` が含まれる場合、ホストエージェントは現在の要求を表示し、応答を待つ必要があります。`boundaryReached` は表示または対話の境界に到達したことを示すだけで、タスクの完了を意味しません。ホストは更新を表示して、同じタスクの追跡を続けます。
 
-- `boundaryReached: true` — 境界に達したことを示します。ジョブの完了を意味し**ません**。
-- `presentationRequired: true` と `userUpdates` — ユーザーにすぐ表示できるローカライズ済み文字列。
-- 継続に必要な `cursor`。
+## セキュリティ
 
-外部エージェントは、受け取った `userUpdates` の文字列をすべてユーザーに見える返信で提示してから、返された `cursor` で直ちに `follow` を再び呼び出す必要があります。follow の実行中は、インフラタスクに並行して回答したり、無関係な質問を投げかけたりしないでください。
+- Runtime は `127.0.0.1` のランダムなポートだけで待ち受けます。起動ごとに新しい Bearer Token を生成し、すべてのブリッジリクエストに付与します。
+- ブリッジは成果物と結果をジョブのワークスペース内に保持します。結果は `.iac-code-skill-results/` に書き込まれます。
+- 事前確認と権限表示のフィールドはサニタイズされ、Secret や認証情報は表示されません。
 
-## ユーザー入力 {#input-required}
+## 関連ドキュメント
 
-結果に `inputRequired` が含まれる場合、ユーザー入力が必要です。種類は 3 つあります:
-
-- `permission` — ツールまたはデプロイの権限リクエスト。エンベロープには `inputId`、`toolUseId`、タイトル、目的、影響、対象、読み取り専用フラグ、`safeSummary` が含まれ、デプロイリクエストには `deploymentSummary` も含まれます。外部エージェントは自身の権限ポリシーに従って決定してください。直接実行時に確認なしで進む同等の操作なら `allow_once`、ポリシーが拒否するなら `deny`、それ以外はユーザーに質問します。iac-code 自身の拒否決定は覆せません。
-- `ask_user_question` — 選択式または自由記述の質問。プロンプトと選択肢をそのまま提示します。自由記述は `allowFreeText` が `true` の場合のみ受け付けます。
-- `candidate_selection` — Pipeline のプラン選択。各候補のサマリー、アーキテクチャ図（Mermaid）、月額総コスト、コスト内訳をまず提示し、選択した候補を返します。提示された価格を概算で置き換えないでください。
-
-`respond` には 2 つの形式があります:
-
-```bash
-# 権限のインライン決定
-python3 scripts/iac_code.py respond --job-id <job-id> \
-  --input-id <inputId> --tool-use-id <toolUseId> --decision allow_once --follow
-
-# 質問と候補選択は応答ファイルを使用
-python3 scripts/iac_code.py respond --job-id <job-id> --input-file <answer.json> --follow
-```
-
-応答は保留中入力の相関フィールドをすべてそのまま保持する必要があり、現在の `kind`、`inputId`、`requestTaskId`、`contextId` にのみ束縛されます。他のリクエストの応答を再利用したり、リソース選択の応答をデプロイ確認として解釈し直したりしないでください。
-
-## 言語制御
-
-`start --language` はジョブの優先言語を設定します（不明な場合は `auto`）。そのジョブのすべての結果は `preferredLanguage` を繰り返します。これを永続的な制御状態として扱ってください。進捗、質問、権限プロンプト、候補プラン、最終結果はその言語で提示され、プロトコルフィールド名、列挙値、ID、コマンドは変わりません。権威あるテキストがすでにその言語を使っている場合は、そのまま提示するか同じ言語で要約し、中国語のユーザー向けコンテンツを英語に翻訳しないでください。
-
-## A2A プロトコルとの関係
-
-ブリッジは HTTP A2A JSON-RPC でローカル Runtime と通信します。タスク状態、artifact、権限インタラクションはすべて iac-code の A2A プロトコルを再利用します:
-
-- 権限のサイドバンド応答は `schemaVersion 1` のメッセージ形式を使います。フィールドと制約は[プロトコルリファレンス](./protocol-reference.md)を参照してください。
-- Pipeline モードで `candidatePresentation: rich-v1` を渡すと、構造化された候補表示ペイロードが返されます。
-- ジョブ結果の状態は A2A タスク状態に対応します。`turn_completed` は normal ターンの完了を示し、Pipeline の終端状態は `completed`、`failed`、`canceled`、`rejected` で、`pipelineResult` と `artifacts` が権威ある結果です。
-
-## セキュリティ境界
-
-- Runtime は `127.0.0.1` のランダムポートでのみリッスンします。起動ごとに新しいランダム Bearer token が生成され、ブリッジのすべてのリクエストがそれを携行します。
-- ブリッジは成果物と結果をジョブワークスペース内に保ち、結果はワークスペースの `.iac-code-skill-results/` に書き込まれます。
-- プリフライト報告と権限表示フィールドはいずれもサニタイズ済みです。秘密情報や資格情報が表示フィールドに出ることはありません。
+- [A2A プロトコル概要](./overview.md)
+- [A2A プロトコルリファレンス](./protocol-reference.md)
+- [LLM プロバイダー](../configuration/llm-providers.md)
+- [Alibaba Cloud 認証情報](../configuration/alibaba-cloud-credentials.md)
+- [Runtime 設定](../configuration/runtime-configuration.md)

--- a/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
+++ b/website/i18n/pt/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
@@ -1,100 +1,214 @@
 ---
 sidebar_position: 7
-title: Integração de Skill
-description: Agentes externos acionam o iac-code por meio do Skill empacotado do iac-code e do Skill Runtime.
+title: Instalar e usar o Skill do IaC Code
+description: Baixe e instale o Skill do IaC Code para que um agente externo possa gerenciar recursos do Alibaba Cloud.
 ---
 
-# Integração de Skill
+# Instalar e usar o Skill do IaC Code
 
-O iac-code fornece um Skill empacotado para agentes externos. Um agente externo (um agente planejador ou uma plataforma de agentes) não instala o pacote Python do iac-code nem invoca comandos headless; ele aciona um runtime A2A local autenticado por meio de um script ponte de apenas biblioteca padrão para executar trabalho de infraestrutura Alibaba Cloud como geração de templates ROS/Terraform, estimativa de custos, seleção de recursos e deploy.
+O Skill do IaC Code foi desenvolvido para agentes externos compatíveis com Skills. Depois da instalação, um agente
+host pode delegar ao IaC Code o planejamento de arquiteturas de nuvem, a geração e revisão de templates ROS ou
+Terraform, a estimativa de custos, a seleção de recursos, as operações com stacks e o deploy. O Skill usa uma ponte
+escrita apenas com a biblioteca padrão do Python para iniciar um Runtime A2A local e autenticado. Não é necessário
+instalar o IaC Code com pip, e o host não deve recorrer a comandos headless.
 
-## Componentes
+## Baixar o Skill
 
-| Componente | Local | Descrição |
+### Versão estável mais recente
+
+Baixe diretamente a versão estável mais recente:
+
+[Baixar iac-code-skill.zip](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/iac-code-skill.zip)
+
+Essa URL fixa sempre aponta para o pacote do Skill promovido ao canal estável. Ela é adequada para downloads pelo
+navegador e instalações manuais e não muda quando uma nova versão é publicada.
+
+Instaladores que precisam da versão, do tamanho do arquivo, do hash SHA-256 e da URL imutável específica da versão
+podem consultar os metadados do canal estável:
+
+[Ver latest.json](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/latest.json)
+
+O documento contém:
+
+- `skillVersion`: versão estável atual do Skill;
+- `skill.url`: URL imutável do ZIP dessa versão;
+- `skill.sha256` e `skill.size`: valores usados para verificar o download;
+- `manifest.url`: manifesto de release imutável dessa versão.
+
+Para uma verificação rigorosa ou uma instalação automatizada reproduzível, leia `latest.json`, baixe `skill.url` e
+verifique `skill.sha256`. Não monte manualmente uma URL com base no número da versão.
+
+## Instalar o Skill
+
+### Pré-requisitos
+
+- O agente host é compatível com Skills locais definidos por `SKILL.md`.
+- O CPython 3.8–3.14 está instalado. Use `python3` no macOS/Linux e, de preferência, `py -3` no Windows.
+- O ambiente consegue acessar as URLs OSS acima para baixar o ZIP do Skill e o Runtime necessário no primeiro uso.
+- A configuração do serviço de modelo está disponível. Para tarefas que consultam ou gerenciam recursos de nuvem,
+  também é necessária uma identidade do Alibaba Cloud com o mínimo de privilégios.
+
+Os releases oficiais do Skill Runtime são compatíveis com estas plataformas:
+
+| Sistema operacional | Arquitetura |
+|---|---|
+| macOS | Apple Silicon (arm64) |
+| Linux | x86_64 |
+| Windows | x86_64 |
+
+As versões mínimas do sistema operacional e da glibc no Linux são definidas pelo manifesto do Runtime fixado pelo
+Skill. A ponte verifica a compatibilidade antes de baixar. Em uma plataforma não compatível, ela retorna um erro em
+vez de baixar um artefato destinado a outra plataforma ou ABI.
+
+### Extrair no diretório de Skills do agente host
+
+Extraia o ZIP diretamente na raiz de Skills do agente host. O local exato varia de acordo com o produto; consulte a
+documentação do agente host. A estrutura final deve ser:
+
+```text
+<Raiz de Skills do agente>/
+└── iac-code/
+    ├── SKILL.md
+    ├── agents/
+    │   └── openai.yaml
+    └── scripts/
+        └── iac_code.py
+```
+
+O ZIP já contém o diretório de nível superior `iac-code/`. Não adicione outro diretório com o mesmo nome. Depois de
+instalar ou atualizar, reinicie o agente host ou abra uma nova sessão para que ele detecte o Skill novamente.
+
+### Verificar a instalação
+
+No diretório `iac-code` extraído, execute este comando no macOS ou Linux:
+
+```bash
+python3 scripts/iac_code.py ensure-runtime
+```
+
+No Windows PowerShell, execute:
+
+```powershell
+py -3 scripts\iac_code.py ensure-runtime
+```
+
+Na primeira execução, o comando baixa o Runtime da plataforma atual, verifica o tamanho e o hash SHA-256 e imprime um
+objeto JSON com `skillVersion`, `runtimeTag` e o caminho de instalação. Um Runtime verificado que já esteja no cache é
+reutilizado sem um novo download.
+
+## Configurar o modelo e a identidade do Alibaba Cloud
+
+O Skill Runtime usa o mesmo diretório de configuração que os outros modos do IaC Code: `~/.iac-code/` por padrão. Se
+você já configurou o IaC Code pelo REPL, pelo aplicativo Web ou pelo aplicativo Desktop, o Skill pode reutilizar essas
+configurações. Defina `IAC_CODE_CONFIG_DIR` para usar outro diretório de configuração.
+
+Em ambientes automatizados, forneça estas variáveis por meio de uma solução de gerenciamento de segredos:
+
+| Categoria | Variável de ambiente | Descrição |
 |---|---|---|
-| Pacote do Skill | `skills/iac-code/` | Instruções em `SKILL.md`, metadados de agente em `agents/` e `scripts/iac_code.py`, o script ponte |
-| Skill Runtime | Publicado por plataforma | Executável nativo CPython 3.12 incorporando o servidor A2A do iac-code |
-| Contratos de distribuição | `skill-runtime/skill-package-contract.json`, `skill-runtime/publisher-contract.json` | Restrições de formato e verificação para pacotes de skill e publicadores |
+| Modelo | `IAC_CODE_PROVIDER` | Provedor do modelo |
+| Modelo | `IAC_CODE_MODEL` | Nome do modelo |
+| Modelo | `IAC_CODE_API_KEY` | Chave de API do serviço de modelo |
+| Modelo | `IAC_CODE_BASE_URL` | Substituição opcional do endpoint compatível |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_ID` | ID da AccessKey |
+| Alibaba Cloud | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | Segredo da AccessKey |
+| Alibaba Cloud | `ALIBABA_CLOUD_SECURITY_TOKEN` | Token de segurança para credenciais STS |
+| Alibaba Cloud | `ALIBABA_CLOUD_REGION_ID` | Região padrão |
 
-O script ponte é escrito inteiramente com a biblioteca padrão do Python e mantém compatibilidade com Python 3.8+; a CI o compila e executa em smoke tests na matriz completa 3.8–3.14. Não adicione dependências de terceiros nem sintaxe exclusiva de versões novas à ponte.
+Nunca coloque credenciais reais em `SKILL.md`, nos prompts do agente host, nos arquivos do projeto ou no histórico do
+shell. Prefira credenciais temporárias, funções RAM ou OAuth e conceda apenas as permissões de API de nuvem necessárias
+para a tarefa. Consulte [Provedores de LLM](../configuration/llm-providers.md) e
+[Credenciais do Alibaba Cloud](../configuration/alibaba-cloud-credentials.md) para obter instruções completas.
 
-## Obtenção e cache do Runtime
+## Primeiro uso
 
-No primeiro uso, a ponte lê o manifesto, baixa o artefato da plataforma atual, verifica tamanho e SHA-256, instala e armazena em cache sob `<IAC_CODE_CONFIG_DIR ou ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/`.
+Depois da instalação e da configuração, abra uma nova sessão no agente host e descreva diretamente uma tarefa de
+infraestrutura do Alibaba Cloud. Por exemplo:
 
-- `python3 scripts/iac_code.py ensure-runtime` — prepara o runtime com antecedência; um runtime em cache é reutilizado.
-- `python3 scripts/iac_code.py cache list` — mostra runtimes instalados e pacotes candidatos.
-- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — limpa caches do runtime ou pacotes candidatos; exige `--confirm` explícito.
+```text
+Use o iac-code para revisar o template ROS deste projeto. Liste os riscos de segurança e as alterações recomendadas sem modificar o arquivo.
+```
 
-## Preflight de configuração
+Hosts compatíveis com uma sintaxe explícita de Skills podem selecionar o Skill usando `$iac-code`. O agente host lê
+`SKILL.md`, grava a solicitação completa em um arquivo UTF-8 dentro do workspace e usa a ponte para criar e acompanhar
+uma única tarefa. O usuário não precisa iniciar manualmente um servidor A2A.
 
-Antes de criar um job, `start` executa uma verificação de prontidão da configuração por meio do runtime. O preflight não lê valores secretos; apenas relata a prontidão:
+Fluxo esperado:
+
+1. A ponte verifica se a configuração do modelo e do Alibaba Cloud está pronta.
+2. No primeiro uso, ela baixa e verifica o Runtime do IaC Code fixado pelo Skill.
+3. O Runtime escuta apenas em uma porta aleatória de `127.0.0.1` e gera um token Bearer específico do processo.
+4. O agente host apresenta o progresso, as perguntas, os planos candidatos e as solicitações de permissão retornados
+   pelo IaC Code.
+5. Quando a tarefa termina, o agente host retorna o resultado final e os arquivos gerados no workspace.
+
+## Atualizar e desinstalar
+
+Para fazer uma atualização manual, baixe `skill/stable/iac-code-skill.zip` novamente e substitua todo o diretório
+`iac-code/` na raiz de Skills do host. Um atualizador automático pode comparar o valor `skillVersion` de `latest.json`
+e, em seguida, baixar e verificar o novo pacote usando a URL imutável e o hash SHA-256. Cada Skill oficial é fixado a
+um Runtime verificado. Não substitua apenas `scripts/iac_code.py` nem altere manualmente a URL ou o hash do Runtime.
+
+Para desinstalar, remova `iac-code/` da raiz de Skills do agente host. O cache do Runtime não é removido com o
+diretório do Skill. Execute `cache list` e `cache clean` somente quando o usuário solicitar explicitamente a remoção.
+
+## Cache do Runtime
+
+O Runtime baixado no primeiro uso é armazenado em
+`<IAC_CODE_CONFIG_DIR ou ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` e reutilizado automaticamente. No uso
+normal, não é necessário gerenciar esse diretório. Para verificar o uso do disco ou remover versões antigas, use:
+
+- `python3 scripts/iac_code.py cache list` — lista os Runtimes instalados e os pacotes candidatos;
+- `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — remove caches do Runtime
+  ou pacotes candidatos; `--confirm` é obrigatório.
+
+O Runtime atual e qualquer Runtime usado por um processo ativo são protegidos contra a limpeza. O formato do pacote e
+as restrições do Runtime são definidos por `skill-runtime/skill-package-contract.json` no repositório de código-fonte;
+os usuários não precisam modificar esse arquivo.
+
+## Solução de problemas
+
+### A configuração está incompleta
+
+O Skill verifica a configuração antes de criar uma tarefa, mas nunca lê nem retorna valores secretos:
 
 | Situação | Resultado |
 |---|---|
-| Provedor LLM ou API key incompletos | Retorna `llm_not_configured` e recusa criar o job |
-| Pipeline selling com credenciais Alibaba Cloud incompletas | Retorna `cloud_credentials_not_configured` e recusa criar o job |
-| Modo normal com credenciais Alibaba Cloud incompletas | Pode continuar para trabalho que não chama APIs de nuvem, com aviso de preflight |
+| O provedor de LLM ou a chave de API está incompleto | Retorna `llm_not_configured` e não cria a tarefa |
+| As credenciais do Alibaba Cloud estão incompletas para o Pipeline de vendas | Retorna `cloud_credentials_not_configured` e não cria a tarefa |
+| As credenciais do Alibaba Cloud estão incompletas no modo normal | Tarefas que não chamam APIs de nuvem podem continuar com um aviso prévio |
 
-## Referência de comandos
+### Por que a execução é pausada
 
-| Comando | Finalidade |
-|---|---|
-| `start` | Criar um job: `--mode normal|pipeline`, `--pipeline-name`, `--cwd` workspace absoluto, `--prompt-file` arquivo de prompt UTF-8, `--language auto|en|zh|es|fr|de|ja|pt`, opcional `--follow` |
-| `follow` | Consome o fluxo de eventos até o próximo limite de interação: `--job-id`, `--cursor`, `--wait-seconds` (padrão 60 s, máximo 120 s) |
-| `continue` | Continua uma conversa em modo normal no mesmo job: `--job-id`, `--prompt-file`, opcional `--follow` |
-| `respond` | Responde a uma entrada pendente, veja [Entrada do usuário](#input-required) |
-| `poll` | Polling de uso único apenas para diagnóstico e recuperação; não use como substituto do `follow` |
-| `cancel` | Cancela o job |
-| `ensure-runtime` / `cache list` / `cache clean` | Gerenciamento do runtime e do cache |
+O IaC Code pausa quando precisa de permissão, informações adicionais ou da seleção de um plano. O agente host apresenta
+a solicitação diretamente:
 
-`start --follow` e `follow` escrevem limites de etapa e heartbeats de baixa frequência no stderr; o stdout emite exatamente um resultado JSON limitado.
+- uma solicitação de permissão para uma ferramenta ou um deploy (`permission`);
+- uma pergunta de múltipla escolha ou uma solicitação de mais informações (`ask_user_question`);
+- a seleção de um plano candidato do Pipeline (`candidate_selection`).
 
-## Limites de interação {#boundaries}
+Antes de confirmar, revise o recurso de destino, a região, o impacto esperado e o preço. O agente host não pode anular
+uma recusa do IaC Code. Uma aprovação única é representada no protocolo como `allow_once`.
 
-`--follow` consome o fluxo de eventos até o próximo limite de etapa, solicitação de permissão, pergunta do usuário, seleção de candidato, `turn_completed` ou estado terminal. Um resultado de limite carrega:
+> **Observação sobre a integração do agente host**
+>
+> Quando um resultado da ponte contém `inputRequired`, o agente host deve apresentar a solicitação atual e aguardar
+> uma resposta. `boundaryReached` indica um limite de apresentação ou interação, e não a conclusão da tarefa; o host
+> deve mostrar a atualização e continuar acompanhando a mesma tarefa.
 
-- `boundaryReached: true` — um limite foi alcançado; isso **não** significa que o job terminou;
-- `presentationRequired: true` e `userUpdates` — strings localizadas prontas para exibir ao usuário;
-- o `cursor` necessário para continuar.
+## Segurança
 
-O agente externo deve primeiro apresentar cada string `userUpdates` recebida em uma resposta visível ao usuário e então chamar `follow` novamente com o `cursor` retornado. Não responda à tarefa de infraestrutura em paralelo nem faça perguntas sem relação enquanto um follow está em execução.
+- O Runtime escuta apenas em uma porta aleatória de `127.0.0.1`. Cada inicialização gera um novo token Bearer, e cada
+  solicitação da ponte inclui esse token.
+- A ponte mantém artefatos e resultados no workspace da tarefa. Os resultados são gravados em
+  `.iac-code-skill-results/`.
+- Os campos exibidos na verificação prévia e nas solicitações de permissão são higienizados; segredos e credenciais
+  não aparecem nesses campos.
 
-## Entrada do usuário {#input-required}
+## Documentação relacionada
 
-Um resultado contém `inputRequired` quando é necessária entrada do usuário. Há três tipos:
-
-- `permission` — uma solicitação de permissão de ferramenta ou deploy. O envelope contém `inputId`, `toolUseId`, título, propósito, efeito, alvo, marcador de somente leitura, `safeSummary` e, em solicitações de deploy, `deploymentSummary`. O agente externo deve decidir conforme sua própria política de permissões: se a mesma operação prosseguiria sem perguntar quando o agente a executa diretamente, responda `allow_once`; se a política a negaria, responda `deny`; caso contrário, pergunte ao usuário. Negações do próprio iac-code não devem ser sobrepostas.
-- `ask_user_question` — uma pergunta de múltipla escolha ou texto livre. Apresente o prompt e as opções como estão; aceite texto livre somente quando `allowFreeText` for `true`.
-- `candidate_selection` — seleção de plano do pipeline. Apresente primeiro o resumo, o diagrama de arquitetura (Mermaid), o custo mensal total e os itens de custo de cada candidato, e então retorne o candidato escolhido. Nunca substitua os preços fornecidos por estimativas aproximadas.
-
-`respond` tem duas formas:
-
-```bash
-# Decisão inline para permissões
-python3 scripts/iac_code.py respond --job-id <job-id> \
-  --input-id <inputId> --tool-use-id <toolUseId> --decision allow_once --follow
-
-# Perguntas e seleções de candidato usam arquivo de resposta
-python3 scripts/iac_code.py respond --job-id <job-id> --input-file <answer.json> --follow
-```
-
-Uma resposta deve preservar todos os campos de correlação da entrada pendente e fica vinculada aos atuais `kind`, `inputId`, `requestTaskId` e `contextId`; nunca reutilize uma resposta de outra requisição nem reinterprete uma seleção de recurso como confirmação de deploy.
-
-## Controle de idioma
-
-`start --language` define o idioma preferido do job (use `auto` quando desconhecido). Todo resultado desse job repete `preferredLanguage`; trate-o como estado de controle durável: progresso, perguntas, prompts de permissão, planos candidatos e resultados finais são apresentados nesse idioma, enquanto nomes de campos do protocolo, enums, IDs e comandos permanecem inalterados. Quando o texto autorizado já usa esse idioma, apresente-o diretamente ou resuma-o no mesmo idioma; nunca traduza conteúdo chinês visível ao usuário para o inglês.
-
-## Relação com o protocolo A2A
-
-A ponte se comunica com o runtime local por HTTP A2A JSON-RPC; estados de tarefa, artefatos e interações de permissão reutilizam o protocolo A2A do iac-code:
-
-- Respostas de banda lateral de permissão usam o formato de mensagem `schemaVersion 1`; veja a [Referência do protocolo](./protocol-reference.md) para campos e restrições.
-- No modo pipeline, passar `candidatePresentation: rich-v1` retorna payloads estruturados de apresentação de candidatos.
-- Os estados de resultado do job correspondem a estados de tarefa A2A: `turn_completed` encerra um turno normal; os estados terminais do pipeline são `completed`, `failed`, `canceled` e `rejected`, com `pipelineResult` e `artifacts` como resultado autorizado.
-
-## Limite de segurança
-
-- O runtime escuta apenas em uma porta aleatória de `127.0.0.1`; cada inicialização gera um novo Bearer token aleatório, e toda requisição da ponte o carrega.
-- A ponte mantém artefatos e resultados dentro do workspace do job; os resultados são escritos em `.iac-code-skill-results/` do workspace.
-- Relatórios de preflight e campos de exibição de permissão são sanitizados; segredos e credenciais nunca aparecem nos campos de exibição.
+- [Visão geral do protocolo A2A](./overview.md)
+- [Referência do protocolo A2A](./protocol-reference.md)
+- [Provedores de LLM](../configuration/llm-providers.md)
+- [Credenciais do Alibaba Cloud](../configuration/alibaba-cloud-credentials.md)
+- [Configuração do Runtime](../configuration/runtime-configuration.md)

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/a2a/skill-integration.md
@@ -1,34 +1,167 @@
 ---
 sidebar_position: 7
-title: Skill 集成
-description: 外部 agent 通过打包的 iac-code Skill 与 Skill Runtime 驱动 iac-code。
+title: 安装和使用 IaC Code Skill
+description: 下载并安装 IaC Code Skill，让外部 Agent 获得阿里云基础设施管理能力。
 ---
 
-# Skill 集成
+# 安装和使用 IaC Code Skill
 
-iac-code 随仓库提供一个面向外部 agent 的 Skill 包。外部 agent（上层规划 agent、agent 平台）不需要安装 iac-code 的 Python 包，也不直接调用 headless 命令，而是通过一个纯标准库的桥接脚本驱动本地认证的 A2A runtime，完成 ROS/Terraform 模板生成、成本估算、资源选择与部署等阿里云基础设施任务。
+IaC Code Skill 面向支持 Skill 的外部 Agent。安装后，宿主 Agent 可以把云架构规划、ROS 或
+Terraform 模板生成与审查、成本估算、资源选择、资源栈操作和部署等任务委派给 IaC Code。
+Skill 会通过纯 Python 标准库桥接脚本启动本地认证的 A2A Runtime；不需要通过 pip 安装
+IaC Code，也不应改用 Headless 命令。
 
-## 组成
+## 下载 Skill
 
-| 组件 | 位置 | 说明 |
+### 最新稳定版
+
+直接下载最新稳定版：
+
+[下载 iac-code-skill.zip](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/iac-code-skill.zip)
+
+该固定地址始终指向已经提升到 stable 频道的 Skill 包，适合浏览器下载和手工安装。发布新
+版本时地址保持不变，不需要修改下载链接。
+
+需要获取版本号、文件大小、SHA-256 和不可变版本地址的安装器，可以读取稳定频道元数据：
+
+[查看 latest.json](https://ros-public-tools.oss-cn-beijing.aliyuncs.com/github-releases/aliyun/iac-code/skill/stable/latest.json)
+
+其中：
+
+- `skillVersion` 是当前稳定版 Skill 版本。
+- `skill.url` 是对应版本不可变的 ZIP 下载地址。
+- `skill.sha256` 和 `skill.size` 用于校验下载文件。
+- `manifest.url` 指向该版本不可变的发布清单。
+
+自动化安装需要严格校验或可重复构建时，应先读取 `latest.json`，再下载 `skill.url` 并校验
+`skill.sha256`。不要自行拼接版本地址。
+
+## 安装 Skill
+
+### 前提条件
+
+- 宿主 Agent 支持由 `SKILL.md` 定义的本地 Skill。
+- 已安装 CPython 3.8～3.14。macOS/Linux 使用 `python3`，Windows 优先使用 `py -3`。
+- 可以访问上述 OSS 地址，以下载 Skill ZIP 和首次运行所需的 Runtime。
+- 已准备模型服务配置；需要查询或管理云资源时，还需准备最小权限的阿里云身份。
+
+正式发布的 Skill Runtime 支持以下平台：
+
+| 操作系统 | 架构 |
+|---|---|
+| macOS | Apple Silicon（arm64） |
+| Linux | x86_64 |
+| Windows | x86_64 |
+
+最低操作系统和 Linux glibc 版本以 Skill 固定的 Runtime manifest 为准。桥接脚本会在
+下载前检查平台，平台不受支持时会直接返回错误，不会下载其他平台或 ABI 的产物。
+
+### 解压到宿主 Agent 的 Skill 目录
+
+下载 ZIP 后，将其直接解压到宿主 Agent 的 Skill 根目录。不同 Agent 的 Skill 根目录可能
+不同，请以宿主产品文档为准。解压后的最终结构必须是：
+
+```text
+<Agent Skill 根目录>/
+└── iac-code/
+    ├── SKILL.md
+    ├── agents/
+    │   └── openai.yaml
+    └── scripts/
+        └── iac_code.py
+```
+
+ZIP 已经包含顶层 `iac-code/` 目录。不要再手工增加一层同名目录。安装或更新完成后，重新
+启动宿主 Agent 或新建会话，让它重新发现 Skill。
+
+### 校验安装
+
+进入解压后的 `iac-code` 目录，在 macOS 或 Linux 上运行：
+
+```bash
+python3 scripts/iac_code.py ensure-runtime
+```
+
+Windows PowerShell 运行：
+
+```powershell
+py -3 scripts\iac_code.py ensure-runtime
+```
+
+首次运行会下载当前平台的 Runtime、校验大小和 SHA-256，并输出包含 `skillVersion`、
+`runtimeTag` 和安装位置的 JSON。已经缓存且校验通过时会直接复用，不会重复下载。
+
+## 配置模型和阿里云身份
+
+Skill Runtime 与其他 IaC Code 运行方式使用相同的配置目录，默认为 `~/.iac-code/`。如果
+已经使用 REPL、Web 或 Desktop 完成配置，Skill 可以复用这些设置；也可以通过
+`IAC_CODE_CONFIG_DIR` 指向另一个配置目录。
+
+在自动化环境中，可通过 Secret 管理方案提供以下环境变量：
+
+| 类别 | 环境变量 | 说明 |
 |---|---|---|
-| Skill 包 | `skills/iac-code/` | `SKILL.md` 使用说明、`agents/` agent 元数据、`scripts/iac_code.py` 桥接脚本 |
-| Skill Runtime | 按平台发布 | 内置 iac-code A2A server 的 CPython 3.12 原生可执行文件 |
-| 分发契约 | `skill-runtime/skill-package-contract.json`、`skill-runtime/publisher-contract.json` | Skill 包与发布者的格式和校验约束 |
+| 模型 | `IAC_CODE_PROVIDER` | 模型提供商 |
+| 模型 | `IAC_CODE_MODEL` | 模型名称 |
+| 模型 | `IAC_CODE_API_KEY` | 模型服务 API Key |
+| 模型 | `IAC_CODE_BASE_URL` | 可选的兼容端点覆盖 |
+| 阿里云 | `ALIBABA_CLOUD_ACCESS_KEY_ID` | AccessKey ID |
+| 阿里云 | `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | AccessKey Secret |
+| 阿里云 | `ALIBABA_CLOUD_SECURITY_TOKEN` | 使用 STS 时的安全令牌 |
+| 阿里云 | `ALIBABA_CLOUD_REGION_ID` | 默认地域 |
 
-桥接脚本完全使用 Python 标准库编写并兼容 Python 3.8+，CI 在 3.8–3.14 全矩阵上编译并冒烟运行它。不要为桥接脚本引入第三方依赖或仅新版本支持的语法。
+不要把真实密钥写入 `SKILL.md`、宿主 Agent 提示词、项目文件或命令历史。优先使用临时凭证、
+RAM Role 或 OAuth，并只授予任务实际需要的云 API 权限。完整说明参见
+[LLM 提供商](../configuration/llm-providers.md)和
+[阿里云凭证](../configuration/alibaba-cloud-credentials.md)。
 
-## Runtime 获取与缓存
+## 首次使用
 
-桥接脚本在首次执行时读取 manifest、下载对应平台的 Runtime 产物，校验大小和 SHA-256 后安装，并缓存在 `<IAC_CODE_CONFIG_DIR 或 ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/` 下。
+安装并配置后，在宿主 Agent 中新建会话，直接描述阿里云基础设施任务。例如：
 
-- `python3 scripts/iac_code.py ensure-runtime` — 提前完成 Runtime 准备；已缓存时直接复用。
+```text
+使用 iac-code 检查当前项目中的 ROS 模板，列出安全风险和修改建议，不要修改文件。
+```
+
+支持显式 Skill 语法的宿主也可以使用 `$iac-code` 指定该 Skill。宿主 Agent 应读取
+`SKILL.md`，把完整请求写入工作区内的 UTF-8 文件，并通过桥接脚本创建和跟进同一个任务；
+用户不需要自己启动 A2A Server。
+
+预期流程如下：
+
+1. 桥接脚本检查模型和阿里云配置是否就绪。
+2. 首次运行时下载并校验 Skill 固定的 IaC Code Runtime。
+3. Runtime 仅在 `127.0.0.1` 随机端口启动，并生成本次进程专用的 Bearer Token。
+4. 宿主 Agent 展示 IaC Code 返回的进度、问题、候选方案和权限请求。
+5. 任务完成后，宿主 Agent 返回最终结果和工作区内生成的文件。
+
+## 更新和卸载
+
+手工更新时重新下载固定地址 `skill/stable/iac-code-skill.zip`，然后完整替换宿主 Skill 目录
+中的 `iac-code/`。自动更新程序可以读取 `latest.json` 比较 `skillVersion`，并通过其中的
+不可变地址和 SHA-256 下载、校验新包。每个正式 Skill 都固定到经过校验的 Runtime，不能
+只替换 `scripts/iac_code.py` 或手工修改其中的 Runtime URL 和摘要。
+
+卸载时删除宿主 Agent Skill 根目录中的 `iac-code/` 即可。Runtime 缓存不会随 Skill 目录
+一起删除；只有用户明确要求清理时，才执行后文的 `cache list` 和 `cache clean`。
+
+## Runtime 缓存
+
+首次使用下载的 Runtime 会缓存在
+`<IAC_CODE_CONFIG_DIR 或 ~/.iac-code>/skill-runtime/<runtime-tag>/<target>/`，后续调用自动复用。
+普通使用无需管理该目录。需要查看占用空间或清理历史版本时，使用：
+
 - `python3 scripts/iac_code.py cache list` — 查看已安装的 Runtime 与候选包。
 - `python3 scripts/iac_code.py cache clean [--runtime-tag <tag>] [--candidates] --confirm` — 清理 Runtime 缓存或候选包；必须显式传 `--confirm`。
 
-## 配置预检
+当前使用的 Runtime 和正在运行的进程会受到保护，不会被清理。Skill 包格式和运行约束由
+源码仓库中的 `skill-runtime/skill-package-contract.json` 定义，普通用户无需操作该文件。
 
-`start` 在创建任务前会通过 Runtime 做一次不读取密钥明文的配置就绪检查：
+## 常见问题
+
+### 提示配置不完整
+
+Skill 会在创建任务前检查配置，但不会读取或返回密钥明文：
 
 | 情况 | 结果 |
 |---|---|
@@ -36,65 +169,33 @@ iac-code 随仓库提供一个面向外部 agent 的 Skill 包。外部 agent（
 | selling Pipeline 且阿里云凭证不完整 | 返回 `cloud_credentials_not_configured`，拒绝创建任务 |
 | normal 模式且阿里云凭证不完整 | 可继续执行不调用云 API 的任务，但会给出预检警告 |
 
-## 命令参考
+### 为什么执行过程中会暂停
 
-| 命令 | 用途 |
-|---|---|
-| `start` | 创建任务：`--mode normal|pipeline`、`--pipeline-name`、`--cwd` 绝对工作区、`--prompt-file` UTF-8 提示文件、`--language auto|en|zh|es|fr|de|ja|pt`，可选 `--follow` |
-| `follow` | 消费事件流直到下一个交互边界：`--job-id`、`--cursor`、`--wait-seconds`（默认 60 秒，最大 120 秒） |
-| `continue` | 在同一 job 中继续 normal 模式对话：`--job-id`、`--prompt-file`，可选 `--follow` |
-| `respond` | 应答一次待决输入，见[用户输入](#input-required) |
-| `poll` | 仅用于诊断和恢复的单次轮询，不要用它替代 `follow` |
-| `cancel` | 取消 job |
-| `ensure-runtime` / `cache list` / `cache clean` | Runtime 与缓存管理 |
+IaC Code 在需要确认权限、补充信息或选择方案时会暂停，宿主 Agent 会直接向用户展示：
 
-`start --follow` 与 `follow` 会把步骤边界和低频心跳写到 stderr，stdout 只输出一条有界 JSON 结果。
+- 工具或部署权限请求（`permission`）。
+- 选择题或补充信息（`ask_user_question`）。
+- Pipeline 候选方案选择（`candidate_selection`）。
 
-## 交互边界
+确认前请核对目标资源、地域、预期影响和价格。拒绝操作不会被宿主 Agent 绕过；允许单次
+操作在协议中表示为 `allow_once`。
 
-`--follow` 会消费事件流，直到遇到下一个步骤边界、权限请求、用户提问、候选选择、`turn_completed` 或终态。到达边界时，结果会携带：
+> **宿主 Agent 集成说明**
+>
+> 桥接结果出现 `inputRequired` 时，宿主 Agent 应展示当前请求并等待应答。
+> `boundaryReached` 只表示到达一个展示或交互边界，不代表任务已经完成；宿主 Agent 应
+> 展示本次更新并继续跟进同一个任务。
 
-- `boundaryReached: true` — 表示到达边界，**不代表任务完成**；
-- `presentationRequired: true` 与 `userUpdates` — 已本地化、可直接展示给用户的文本；
-- 继续执行所需的 `cursor`。
-
-外部 agent 必须先把它收到的 `userUpdates` 逐条呈现在用户可见的回复正文中，再立即用返回的 `cursor` 继续 `follow`；在 follow 运行期间不要并行回答基础设施问题或提出无关提问。
-
-## 用户输入（inputRequired） {#input-required}
-
-结果中出现 `inputRequired` 时表示需要用户输入，共三类：
-
-- `permission` — 工具或部署权限请求。信封包含 `inputId`、`toolUseId`、标题、目的、影响、目标、是否只读、`safeSummary`，部署类请求还包含 `deploymentSummary`。外部 agent 应按自身权限策略决策；同等操作若在其直接执行时无需询问，可应答 `allow_once`，策略不允许则应答 `deny`，其余情况询问用户。iac-code 自身的拒绝决策不可被覆盖。
-- `ask_user_question` — 选择题或自由文本提问。原样呈现提示与选项；仅当 `allowFreeText` 为 `true` 时才接受自由文本。
-- `candidate_selection` — Pipeline 方案选择。先呈现每个候选的摘要、架构图（Mermaid）、月度总成本与分项成本，再返回所选候选，不要用粗略估价替换给出的价格。
-
-`respond` 有两种形式：
-
-```bash
-# 权限的内联决策
-python3 scripts/iac_code.py respond --job-id <job-id> \
-  --input-id <inputId> --tool-use-id <toolUseId> --decision allow_once --follow
-
-# 问题与候选选择使用应答文件
-python3 scripts/iac_code.py respond --job-id <job-id> --input-file <answer.json> --follow
-```
-
-应答必须完整保留待决输入的所有关联字段，且只绑定当前的 `kind`、`inputId`、`requestTaskId` 与 `contextId`；不得复用其他请求的应答，也不得把资源选择的应答重新解释为部署确认。
-
-## 语言控制
-
-`start --language` 指定 job 的首选语言（未知时用 `auto`）。此后该 job 的每次结果都会重复 `preferredLanguage`，应把它当作持久控制状态：进度、提问、权限提示、候选方案与最终结果都按该语言呈现；协议字段名、枚举值、ID 和命令保持不变。当权威文本已经使用该语言时，直接呈现或同语言摘要，不要把中文用户可见内容翻译成英文。
-
-## 与 A2A 协议的关系
-
-桥接脚本通过 HTTP A2A JSON-RPC 与本地 Runtime 通信，任务状态、artifact 与权限交互都复用 iac-code 的 A2A 协议：
-
-- 权限旁路应答使用 `schemaVersion 1` 的消息格式，字段与约束见[协议参考](./protocol-reference.md)。
-- Pipeline 模式下传入 `candidatePresentation: rich-v1` 可获得结构化候选展示载荷。
-- job 结果状态与 A2A 任务状态对应：`turn_completed` 表示 normal 轮次完成；Pipeline 终态包括 `completed`、`failed`、`canceled`、`rejected`，到达终态时以 `pipelineResult` 与 `artifacts` 为权威结果。
-
-## 安全边界
+## 安全说明
 
 - Runtime 只监听 `127.0.0.1` 上的随机端口，每次启动生成独立的随机 Bearer token，桥接脚本的每个请求都携带该 token。
 - 桥接脚本把产物和结果限制在 job 工作区内，结果写入工作区的 `.iac-code-skill-results/`。
 - 预检与权限展示字段均经脱敏处理；密钥、凭证等敏感值不会出现在展示字段中。
+
+## 相关文档
+
+- [A2A 协议概述](./overview.md)
+- [A2A 协议参考](./protocol-reference.md)
+- [LLM 提供商](../configuration/llm-providers.md)
+- [阿里云凭证](../configuration/alibaba-cloud-credentials.md)
+- [运行时配置](../configuration/runtime-configuration.md)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
         'cli/sessions',
         'web-app',
         'desktop-app',
+        'a2a/skill-integration',
         {
           type: 'category',
           label: 'MCP Integration',
@@ -79,7 +80,6 @@ const sidebars: SidebarsConfig = {
             'a2a/protocol-reference',
             'a2a/http-transport',
             'a2a/examples',
-            'a2a/skill-integration',
           ],
         },
       ],


### PR DESCRIPTION
## Summary

- rewrite the IaC Code Skill guide around installation, configuration, first use, updates, troubleshooting, and security
- add natural English, Simplified Chinese, Japanese, French, German, Spanish, and Portuguese versions
- move the guide from the A2A Protocol subsection to the top-level Using IaC Code documentation category

## Testing

- `.venv/bin/python -m pytest -q tests/test_website_skill_docs.py`
- `cd website && npm run build`