### PR TITLE
feat(selling): 跨步骤成本一致性校验，避免用户按低估口径确认部署

### DIFF
--- a/src/iac_code/pipeline/selling/hooks/confirm_and_select.py
+++ b/src/iac_code/pipeline/selling/hooks/confirm_and_select.py
@@ -1,0 +1,168 @@
+"""Hook for the confirm_and_select step.
+
+Adds a deterministic cross-step cost-consistency check before the user
+confirms a plan. The architecture planning step emits a rough monthly cost
+range (``candidate.monthly_estimate``) while the ``cost_estimating`` sub-step
+produces the authoritative price from ``ros_estimate_template_cost``
+(``cost.monthly_estimate``). When the two diverge beyond a threshold the user
+was previously confirming on the under-estimated planning figure. This hook
+annotates each evaluated candidate with a structured ``cost_consistency``
+result so the confirmation surfaces can restate the real monthly cost and gate
+deployment behind an explicit second confirmation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+from iac_code.pipeline.engine.context import PipelineContext
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DEVIATION_THRESHOLD = 1.5
+_THRESHOLD_ENV_VAR = "IAC_CODE_SELLING_COST_DEVIATION_THRESHOLD"
+
+# Matches monetary amounts such as ``80``, ``120.5``, ``1,234.00``.
+_AMOUNT_PATTERN = re.compile(r"\d[\d,]*(?:\.\d+)?")
+
+
+def _resolve_threshold() -> float:
+    raw = os.environ.get(_THRESHOLD_ENV_VAR, "").strip()
+    if not raw:
+        return _DEFAULT_DEVIATION_THRESHOLD
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to default", _THRESHOLD_ENV_VAR, raw)
+        return _DEFAULT_DEVIATION_THRESHOLD
+    if value <= 1:
+        logger.warning("%s=%r must be > 1; falling back to default", _THRESHOLD_ENV_VAR, raw)
+        return _DEFAULT_DEVIATION_THRESHOLD
+    return value
+
+
+def _parse_amounts(value: Any) -> list[float]:
+    """Extract all monetary amounts from a cost string in order of appearance."""
+    if not isinstance(value, str):
+        return []
+    amounts: list[float] = []
+    for match in _AMOUNT_PATTERN.finditer(value):
+        try:
+            amounts.append(float(match.group(0).replace(",", "")))
+        except ValueError:
+            continue
+    return amounts
+
+
+def parse_planning_estimate(value: Any) -> float | None:
+    """Parse the planning rough estimate; use the upper bound of any range.
+
+    The architecture planning step emits values like ``¥80-120/月`` or
+    ``¥100/月``. The upper bound is the most optimistic-friendly comparison
+    basis (a real price above the highest planned figure is unambiguously an
+    under-estimate).
+    """
+    amounts = _parse_amounts(value)
+    if not amounts:
+        return None
+    return max(amounts)
+
+
+def parse_actual_estimate(value: Any) -> float | None:
+    """Parse the authoritative price; use the list price (first amount).
+
+    ``cost_estimating`` returns strings such as ``¥289.81/月`` or
+    ``¥96.80/月（列表价，合同优惠后约¥13.76/月）``. The first amount is the list
+    price, which is the same basis the confirmation surfaces display.
+    """
+    amounts = _parse_amounts(value)
+    if not amounts:
+        return None
+    return amounts[0]
+
+
+def evaluate_cost_consistency(
+    planning_estimate: Any,
+    actual_estimate: Any,
+    *,
+    threshold: float | None = None,
+) -> dict[str, Any] | None:
+    """Compare the planning estimate with the actual price.
+
+    Returns a structured result, or ``None`` when either figure cannot be
+    parsed into a positive number (e.g. pricing failed).
+    """
+    planning = parse_planning_estimate(planning_estimate)
+    actual = parse_actual_estimate(actual_estimate)
+    if planning is None or actual is None:
+        return None
+    if planning <= 0 or actual <= 0:
+        return None
+
+    resolved_threshold = threshold if threshold is not None else _resolve_threshold()
+    deviation_ratio = round(actual / planning, 2)
+    exceeds_threshold = deviation_ratio >= resolved_threshold or (1 / deviation_ratio) >= resolved_threshold
+
+    result: dict[str, Any] = {
+        "planning_estimate": planning_estimate,
+        "actual_estimate": actual_estimate,
+        "planning_amount": planning,
+        "actual_amount": actual,
+        "deviation_ratio": deviation_ratio,
+        "threshold": resolved_threshold,
+        "exceeds_threshold": exceeds_threshold,
+    }
+    if exceeds_threshold:
+        result["message"] = (
+            "候选实际询价月费约 {actual} 与架构规划预估约 {planning} 偏差约 {ratio} 倍，"
+            "已超过一致性阈值 {threshold} 倍；确认部署前必须以实际询价为准并二次确认。"
+        ).format(
+            actual=actual_estimate,
+            planning=planning_estimate,
+            ratio=deviation_ratio,
+            threshold=resolved_threshold,
+        )
+    return result
+
+
+def annotate_cost_consistency(
+    evaluated_candidates: Any,
+    *,
+    threshold: float | None = None,
+) -> bool:
+    """Annotate each non-failed candidate in place with ``cost_consistency``.
+
+    Returns whether any candidate exceeded the deviation threshold.
+    """
+    if not isinstance(evaluated_candidates, list):
+        return False
+
+    any_exceeds = False
+    for result in evaluated_candidates:
+        if not isinstance(result, dict) or result.get("failed"):
+            continue
+        candidate = result.get("candidate")
+        cost = result.get("cost")
+        if not isinstance(candidate, dict) or not isinstance(cost, dict):
+            continue
+        consistency = evaluate_cost_consistency(
+            candidate.get("monthly_estimate"),
+            cost.get("monthly_estimate"),
+            threshold=threshold,
+        )
+        if consistency is None:
+            result.pop("cost_consistency", None)
+            continue
+        result["cost_consistency"] = consistency
+        if consistency.get("exceeds_threshold"):
+            any_exceeds = True
+    return any_exceeds
+
+
+def on_enter(ctx: PipelineContext) -> None:
+    """Annotate evaluated candidates with cross-step cost consistency."""
+    evaluated_candidates = ctx.get_conclusion("evaluated_candidates")
+    annotate_cost_consistency(evaluated_candidates)

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -473,6 +473,7 @@ steps:
     context_fields: [evaluated_candidates]
     auto_advance: false
     ui_mode: candidate_selection
+    hooks_file: hooks/confirm_and_select.py
     inject_tools: [show_architecture_diagram, show_candidate_detail]
     surface_overrides:
       a2a:

--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.md
@@ -64,3 +64,4 @@
 - 不要在本步骤重新询价。
 - 不要修改模板 Default。
 - 不要把 `parameter_overrides` 写入模板；后续部署步骤会基于最终选择结果处理部署参数。
+- 成本一致性：流程已把跨步骤成本偏差写入 `evaluated_candidates[i].cost_consistency`。当某候选 `cost_consistency.exceeds_threshold` 为 `true` 时，其 `summary` 必须以成本预估真实询价为准并说明与规划预估的偏差倍数（取 `cost_consistency.deviation_ratio`），`user_prompt` 需提醒用户实际月费与规划预估显著偏差，确认真实月费后再选择部署。

--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.rich.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.rich.md
@@ -28,6 +28,12 @@
 
 不要使用 `evaluated_candidates[i].candidate.monthly_estimate`，它只是架构规划阶段的粗略估算。不要重新询价或自行补算价格。若费用明细没有规格字段，省略 `spec`，不要猜测。
 
+### 成本一致性回显（跨步骤偏差告警）
+
+流程已在进入本步骤前对每个候选比对「架构规划粗估」与「成本预估真实询价」，结果写入 `evaluated_candidates[i].cost_consistency`。当某候选的 `cost_consistency.exceeds_threshold` 为 `true` 时：
+- 该候选的 `summary` 必须以真实询价 `total_monthly_cost` 为准，并明确说明它与规划预估的偏差倍数（取 `cost_consistency.deviation_ratio`）。
+- `user_prompt` 必须提醒用户成本与规划预估存在显著偏差，请在确认真实月费后再选择部署，不得沿用规划粗估口径。
+
 `user_prompt`、`summary` 和 Mermaid 节点标签应使用用户当前语言；字段名、枚举值和其他协议字段保持上面的固定形式。
 
 `complete_step.conclusion.user_prompt` 必须是展示给用户的选择提示，例如“请选择要部署的方案：”。

--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
@@ -50,6 +50,13 @@
 
 不要使用 `evaluated_candidates[i].candidate.monthly_estimate`，该字段是架构规划阶段的粗略估算。不要重新询价，也不要重新估算价格。
 
+### 成本一致性回显（跨步骤偏差告警）
+
+流程已在进入本步骤前对每个候选比对「架构规划粗估」与「成本预估真实询价」，结果写入 `evaluated_candidates[i].cost_consistency`。展示方案时：
+- 始终以 `cost.monthly_estimate`（真实询价）作为用户看到的月费口径。
+- 当某候选的 `cost_consistency.exceeds_threshold` 为 `true` 时，必须在该方案摘要或选择提示中明确重述真实月费，并说明它与规划预估的偏差倍数（取 `cost_consistency.deviation_ratio`、`cost_consistency.message`），提示用户实际账单以询价为准。
+- 存在任一超阈值候选时，`user_prompt` 必须提醒用户成本与规划预估存在显著偏差，请在确认真实月费后再选择部署；不得沿用规划粗估口径诱导确认。
+
 如果多个方案都需要展示，必须对每个方案都调用一次“架构图 + 方案详情”的并行展示；不要为了架构图优化额外阻塞方案详情展示。
 
 - 不要用文字输出对比表格或方案信息 — 所有展示数据通过上述工具传递

--- a/tests/pipeline/selling/test_confirm_and_select_hook.py
+++ b/tests/pipeline/selling/test_confirm_and_select_hook.py
@@ -1,0 +1,164 @@
+from iac_code.pipeline.engine.context import PipelineContext
+from iac_code.pipeline.selling.hooks.confirm_and_select import (
+    annotate_cost_consistency,
+    evaluate_cost_consistency,
+    on_enter,
+    parse_actual_estimate,
+    parse_planning_estimate,
+)
+
+
+def test_parse_planning_estimate_uses_upper_bound_of_range():
+    assert parse_planning_estimate("¥80-120/月") == 120.0
+
+
+def test_parse_planning_estimate_single_value():
+    assert parse_planning_estimate("约 ¥100/月") == 100.0
+
+
+def test_parse_planning_estimate_handles_thousands_separator():
+    assert parse_planning_estimate("¥1,234-2,000/月") == 2000.0
+
+
+def test_parse_planning_estimate_returns_none_when_unparseable():
+    assert parse_planning_estimate("询价失败") is None
+    assert parse_planning_estimate(None) is None
+
+
+def test_parse_actual_estimate_uses_list_price_first_amount():
+    assert parse_actual_estimate("¥289.81/月") == 289.81
+
+
+def test_parse_actual_estimate_uses_list_price_when_discount_present():
+    assert parse_actual_estimate("¥96.80/月（列表价，合同优惠后约¥13.76/月）") == 96.80
+
+
+def test_parse_actual_estimate_returns_none_on_pricing_failure():
+    assert parse_actual_estimate("询价失败") is None
+
+
+def test_evaluate_cost_consistency_flags_large_deviation():
+    result = evaluate_cost_consistency("¥80-120/月", "¥289.81/月")
+    assert result is not None
+    assert result["deviation_ratio"] == round(289.81 / 120.0, 2)
+    assert result["exceeds_threshold"] is True
+    assert "偏差" in result["message"]
+
+
+def test_evaluate_cost_consistency_within_threshold():
+    result = evaluate_cost_consistency("¥80-120/月", "¥130/月", threshold=1.5)
+    assert result is not None
+    assert result["exceeds_threshold"] is False
+    assert "message" not in result
+
+
+def test_evaluate_cost_consistency_flags_reverse_deviation():
+    # Actual far below planning also breaks consistency.
+    result = evaluate_cost_consistency("¥1000/月", "¥100/月", threshold=1.5)
+    assert result is not None
+    assert result["exceeds_threshold"] is True
+
+
+def test_evaluate_cost_consistency_returns_none_when_pricing_failed():
+    assert evaluate_cost_consistency("¥80-120/月", "询价失败") is None
+    assert evaluate_cost_consistency(None, "¥100/月") is None
+
+
+def test_evaluate_cost_consistency_respects_custom_threshold():
+    result = evaluate_cost_consistency("¥100/月", "¥180/月", threshold=2.0)
+    assert result is not None
+    assert result["exceeds_threshold"] is False
+
+
+def test_evaluate_cost_consistency_respects_env_threshold(monkeypatch):
+    monkeypatch.setenv("IAC_CODE_SELLING_COST_DEVIATION_THRESHOLD", "3.0")
+    result = evaluate_cost_consistency("¥100/月", "¥250/月")
+    assert result is not None
+    assert result["threshold"] == 3.0
+    assert result["exceeds_threshold"] is False
+
+
+def test_annotate_cost_consistency_marks_over_threshold_candidate():
+    evaluated = [
+        {
+            "candidate": {"name": "Cheap", "monthly_estimate": "¥80-120/月"},
+            "cost": {"monthly_estimate": "¥289.81/月"},
+            "failed": False,
+        }
+    ]
+    any_exceeds = annotate_cost_consistency(evaluated)
+    assert any_exceeds is True
+    assert evaluated[0]["cost_consistency"]["exceeds_threshold"] is True
+
+
+def test_annotate_cost_consistency_skips_failed_candidate():
+    evaluated = [
+        {
+            "candidate": {"name": "Broken", "monthly_estimate": "¥80-120/月"},
+            "cost": {"monthly_estimate": "¥289.81/月"},
+            "failed": True,
+        }
+    ]
+    any_exceeds = annotate_cost_consistency(evaluated)
+    assert any_exceeds is False
+    assert "cost_consistency" not in evaluated[0]
+
+
+def test_annotate_cost_consistency_omits_when_pricing_missing():
+    evaluated = [
+        {
+            "candidate": {"name": "NoPrice", "monthly_estimate": "¥80-120/月"},
+            "cost": {"monthly_estimate": "询价失败"},
+            "failed": False,
+        }
+    ]
+    any_exceeds = annotate_cost_consistency(evaluated)
+    assert any_exceeds is False
+    assert "cost_consistency" not in evaluated[0]
+
+
+def test_annotate_cost_consistency_is_idempotent_and_clears_stale():
+    evaluated = [
+        {
+            "candidate": {"name": "Cheap", "monthly_estimate": "¥80-120/月"},
+            "cost": {"monthly_estimate": "¥130/月"},
+            "failed": False,
+            "cost_consistency": {"stale": True},
+        }
+    ]
+    annotate_cost_consistency(evaluated)
+    assert evaluated[0]["cost_consistency"]["exceeds_threshold"] is False
+    # Re-running keeps the same non-stale structure.
+    annotate_cost_consistency(evaluated)
+    assert "stale" not in evaluated[0]["cost_consistency"]
+
+
+def test_annotate_cost_consistency_handles_non_list():
+    assert annotate_cost_consistency(None) is False
+    assert annotate_cost_consistency({}) is False
+
+
+def test_on_enter_annotates_evaluated_candidates_in_context():
+    context = PipelineContext({"evaluated_candidates": [], "selected_plan": ["evaluated_candidates"]})
+    context.set_conclusion(
+        "evaluated_candidates",
+        [
+            {
+                "candidate": {"name": "Cheap", "monthly_estimate": "¥80-120/月"},
+                "cost": {"monthly_estimate": "¥289.81/月"},
+                "failed": False,
+            }
+        ],
+    )
+
+    on_enter(context)
+
+    evaluated = context.get_conclusion("evaluated_candidates")
+    assert evaluated[0]["cost_consistency"]["exceeds_threshold"] is True
+
+
+def test_on_enter_no_op_when_field_missing():
+    context = PipelineContext({"evaluated_candidates": []})
+    # Should not raise when the field was never set.
+    on_enter(context)
+    assert context.get_conclusion("evaluated_candidates") is None


### PR DESCRIPTION
## 背景
针对 Session `d4c6272042684114b45d190aaefc753e`：架构规划步骤预估月费（如 ¥80-120）与候选 `cost_estimating` 步骤真实询价（如 ¥289.81/月）严重不一致、偏差约 2.4 倍，且 `confirm_and_select` 前缺少跨步骤成本一致性校验与差异回显，用户在低估口径上确认部署后被误导。

## 变更
- 新增 `pipeline/selling/hooks/confirm_and_select.py`：`on_enter` 钩子对每个未失败候选比对 `candidate.monthly_estimate`（规划粗估，取区间上界）与 `cost.monthly_estimate`（真实询价，取列表价），偏差超阈值时就地富化结构化 `cost_consistency`（`deviation_ratio` / `exceeds_threshold` / `message`）。阈值默认 1.5，可用 `IAC_CODE_SELLING_COST_DEVIATION_THRESHOLD` 覆盖。
- `pipeline.yaml`：`confirm_and_select` 挂 `hooks_file`。
- 更新 `confirm_and_select.md` / `.a2a.md` / `.a2a.rich.md`：偏差超阈值时必须以真实询价重述月费、说明偏差倍数，并提示用户确认真实月费后再选择部署。
- 新增 `tests/pipeline/selling/test_confirm_and_select_hook.py`（20 条）。

## 验证
- `uv run pytest tests/pipeline/` 通过 1628（唯一失败为 test_prerequisites 网络依赖用例，pristine baseline 同样失败，与本改动无关）。
- 变更文件 `make lint`（ruff + ty）通过。

不合并，仅提交评审。
