### PR TITLE
fix(iac-aliyun): enforce element-level template completeness

### DIFF
--- a/src/iac_code/pipeline/selling/prompts/template_generating.md
+++ b/src/iac_code/pipeline/selling/prompts/template_generating.md
@@ -8,6 +8,8 @@
 - 参数化配置（Parameters）— 库存相关属性必须参数化
 - 输出值（Outputs）
 
+「完整」以技能引用的「元素级完备性」清单为准，不是「校验通过即完整」。
+
 ## 候选架构方案
 ```json
 {candidate}
@@ -21,7 +23,7 @@
 生成后的模板文件路径就是 `{candidate.output_path}`。调用 `ros_validate_template` 校验时，必须传 `template_url = "{candidate.output_path}"`。不要调用 `aliyun_api` 的 ROS `ValidateTemplate` 接口，不要传 `TemplateBody`、`TemplateId` 或 `TemplateScratchId`。
 
 ## 输出
-文件写入完成后调用 `complete_step` 提交结论。
+文件写入完成后，先按「元素级完备性」清单逐项自检并补齐缺失元素，再调用 `complete_step` 提交结论。
 
 > 注意：`template` 字段为 YAML 字符串（与磁盘文件内容一致），不是 JSON 对象。
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -46,9 +46,10 @@ conclusion_schema:
 3. **必须**阅读 [references/ros-template.md](references/ros-template.md)，了解 ROS 模板最佳实践，未阅读不得生成模板
 4. 生成 ROS YAML 模板（库存相关属性按 [references/cloud-products/](references/cloud-products/) 与 [references/template-parameters.md](references/template-parameters.md) 定义为 Parameters，所有 Parameters 必须添加 AssociationProperty）并写入文件
    - 生成的模板默认放在当前工作目录；仅当用户指定其他路径时才写入该路径，不要默认使用 `/tmp` 等工作目录外路径
-5. 调用 `ros_validate_template` 校验；`template_url` 使用刚写入的模板文件路径，已有具体地域时传 `region_id`，否则使用工具默认地域
-6. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
-7. 校验通过 → 完成
+5. 按 [references/ros-template.md](references/ros-template.md) 的「元素级完备性」清单逐项自检，补齐缺失元素后再校验
+6. 调用 `ros_validate_template` 校验；`template_url` 使用刚写入的模板文件路径，已有具体地域时传 `region_id`，否则使用工具默认地域
+7. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
+8. 校验通过 → 完成
 
 > **模板路径支持本地文件**：`ros_validate_template` 的 `template_url` 可传当前工作目录内的本地文件路径（如 `./template.yml`）。避免将大模板内容直接作为参数传递。
 
@@ -93,6 +94,7 @@ conclusion_schema:
 - 模板格式为 YAML
 - 使用 `!Ref`、`!GetAtt` 等内置函数引用参数和资源属性，避免硬编码
 - Outputs 中所有输出变量必须定义 Label
+- **必须**满足 [references/ros-template.md](references/ros-template.md) 的「元素级完备性」清单：资源 Tags、安全组 Ingress 规则、有状态资源 DeletionPolicy、Outputs Label。校验通过不代表完备，清单未逐项自检不得提交结论
 
 ## 资源和文档搜索
 

--- a/src/iac_code/skills/bundled/iac_aliyun/references/ros-template.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/ros-template.md
@@ -7,6 +7,49 @@
 - ALIYUN::ECS::SecurityGroup: 创建安全组（同时支持安全组规则）
 - ALIYUN::ECS::InstanceGroup: 创建N个ECS实例（通过 `MaxAmount` 指定数量）
 
+## 元素级完备性
+
+结构合法（`ros_validate_template` 通过）不代表模板完整。以下元素即使 ROS 校验不要求，也必须显式写出——缺失会让模板与业务期望的参考模板产生元素级差异：
+
+| 元素 | 适用范围 | 要求 |
+|------|---------|------|
+| `Tags` | 所有支持标签的资源 | 至少带一个标识业务用途的标签，便于分账和检索 |
+| 安全组 Ingress 规则 | 每个 `ALIYUN::ECS::SecurityGroup` | 按实际暴露端口逐条写出，不依赖默认规则 |
+| `DeletionPolicy` | 有状态资源（RDS、Redis、OSS 等） | 显式声明，避免误删数据 |
+| Outputs `Label` | 所有输出变量 | 必须定义；应用访问链接用 `Console.` 前缀 |
+
+标签和安全组规则属于「不需要参数化」的元素：直接使用合理默认值写在模板里，不要定义成 Parameters。完备性要求这些元素**存在**，参数化规则约束元素**取值来源**，两者不冲突。
+
+```yaml
+Resources:
+  WebSecurityGroup:
+    Type: ALIYUN::ECS::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: app
+          Value: web
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          PortRange: 80/80
+          SourceCidrIp: 0.0.0.0/0
+          Priority: 1
+        - IpProtocol: tcp
+          PortRange: 443/443
+          SourceCidrIp: 0.0.0.0/0
+          Priority: 1
+
+  AppDatabase:
+    Type: ALIYUN::RDS::DBInstance
+    DeletionPolicy: Retain
+    Properties:
+      Tags:
+        - Key: app
+          Value: web
+```
+
+用户明确要求资源可随栈删除时，把 `DeletionPolicy` 显式写成 `Delete`，而不是省略该字段。
+
 ## 在实例中执行命令
 
 **不要使用 UserData + WaitCondition**。根据场景选择：

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -17,6 +17,7 @@ SKILL_DIR = (
 SKILL_MD = SKILL_DIR / "SKILL.md"
 EVALS_JSON = SKILL_DIR / "evals.json"
 TEMPLATE_PROMPT_MD = SKILL_DIR.parents[1] / "prompts" / "template_generating.md"
+ROS_TEMPLATE_REFERENCE_MD = SKILL_DIR / "references" / "ros-template.md"
 
 
 def _parse_frontmatter(text: str) -> dict:
@@ -143,6 +144,46 @@ class TestSkillContentRosOnly:
         assert "bash" not in body.lower()
         assert "mkdir" not in body.lower()
 
+    def test_requires_element_completeness_checklist(self, body):
+        assert "元素级完备性" in body
+        assert "references/ros-template.md" in body
+        assert "校验通过不代表完备" in body
+        assert "清单未逐项自检不得提交结论" in body
+
+    def test_element_completeness_selfcheck_precedes_validation(self, body):
+        checklist_index = body.index("「元素级完备性」清单逐项自检")
+        validate_index = body.index("调用 `ros_validate_template` 校验")
+        assert checklist_index < validate_index
+
+
+class TestElementCompletenessReference:
+    @pytest.fixture()
+    def reference(self) -> str:
+        return ROS_TEMPLATE_REFERENCE_MD.read_text(encoding="utf-8")
+
+    def test_reference_is_reachable_from_skill_dir(self):
+        assert ROS_TEMPLATE_REFERENCE_MD.exists()
+
+    def test_declares_element_completeness_section(self, reference):
+        assert "## 元素级完备性" in reference
+
+    def test_lists_elements_missing_from_generated_templates(self, reference):
+        assert "Tags" in reference
+        assert "SecurityGroupIngress" in reference
+        assert "DeletionPolicy" in reference
+
+    def test_states_validation_success_is_not_completeness(self, reference):
+        assert "结构合法" in reference
+        assert "不代表模板完整" in reference
+
+    def test_reconciles_completeness_with_parameterization_rule(self, reference):
+        assert "不要定义成 Parameters" in reference
+        assert "两者不冲突" in reference
+
+    def test_deletion_policy_stays_explicit_when_resources_are_disposable(self, reference):
+        assert "`Delete`" in reference
+        assert "而不是省略该字段" in reference
+
 
 class TestSkillDiscovery:
     def test_discovered_by_pipeline_loader(self):
@@ -184,6 +225,17 @@ class TestSkillPromptRendering:
         assert "不要把候选推荐值当成用户硬约束" not in body
         assert "查询可用区、实例规格" not in body
         assert "对用户未指定的参数直接使用合理默认值" not in body
+
+    def test_prompt_defines_completeness_instead_of_validation_success(self):
+        body = TEMPLATE_PROMPT_MD.read_text(encoding="utf-8")
+        assert "元素级完备性" in body
+        assert "不是「校验通过即完整」" in body
+
+    def test_prompt_requires_selfcheck_before_completing_step(self):
+        body = TEMPLATE_PROMPT_MD.read_text(encoding="utf-8")
+        selfcheck_index = body.index("逐项自检并补齐缺失元素")
+        complete_index = body.index("再调用 `complete_step` 提交结论")
+        assert selfcheck_index < complete_index
 
     def test_full_prompt_includes_skill_base_directory(self, tmp_path):
         from iac_code.pipeline.engine.context import PipelineContext


### PR DESCRIPTION
## 问题

ROS 模板生成阶段只要求「结构完整 + 校验通过」，而 `ros_validate_template` 仅校验 schema 合法性。缺少 Tags、安全组 Ingress 规则、有状态资源 DeletionPolicy 这类业务期望元素时校验依然通过，导致产出模板与参考模板存在元素级差异：CorrectnessScore 高（均值 91.667）但 SimilarityScore 持续低分（均值 61、全部 ≤78），template_quality 评估记录 6/6 命中 `missing_element`。

## 根因

指令侧三个载体此前都没有必选元素清单，因此模型会系统性省略这些元素，与具体模型变体无关：

- `references/ros-template.md` — 最佳实践参考，全文无 DeletionPolicy / Tags / 安全组规则相关内容
- `SKILL.md` — 生成要求仅 3 条（YAML、内置函数、Outputs Label）
- `prompts/template_generating.md` — 只要求「所有必要的云资源定义」，"必要" 无定义

## 变更

- `references/ros-template.md` 新增「元素级完备性」章节，给出清单与可套用片段，并说明它与「不需要参数化」规则正交——完备性要求元素存在，参数化规则约束取值来源。
- `SKILL.md` 把清单自检插入校验之前，并在生成要求中声明校验通过不代表完备。
- `prompts/template_generating.md` 明确「完整」以清单为准，自检发生在 `complete_step` 之前。
- 补 10 条断言锁定上述内容不被回退。

`iac-code-rs` 下的同名副本是 Rust 移植的一次性快照，Python 侧 references 此后已独立演进且无同步机制，Rust 侧也不含 selling pipeline，故不跟改。

## 测试

- `tests/pipeline/selling/skills/test_template_generating_skill.py` — 43 passed（基线 33）
- `tests/pipeline/selling` + `tests/skills` + `tests/agent` — 925 passed
- `ruff check` + `ty check` — 全部通过

仅改 Markdown 指令与参考文档，不动执行代码。

## 验收

需平台重跑评测 `et-9e89ad8e-0077-4c61-a01d-702171ae28fc` 后核对：SimilarityScore 均值 ≥75、`missing_element` 命中 ≤2、`one_ge_90_other_lt_60` 降至 0。
