### PR TITLE
fix(aliyun): coerce losslessly convertible aliyun_api parameter types

### DIFF
--- a/src/iac_code/tools/cloud/aliyun/api_contract.py
+++ b/src/iac_code/tools/cloud/aliyun/api_contract.py
@@ -985,7 +985,9 @@ class RequestBuilder:
         for name, value in params.items():
             parameter = metadata.get(name)
             if parameter is not None:
-                _validate_parameter(parameter, value)
+                coerced = _coerce_parameter(parameter, value)
+                _validate_parameter(parameter, coerced)
+                params[name] = coerced
 
         pathname = contract.pathname
         query: dict[str, str] = {}
@@ -1060,9 +1062,11 @@ class RequestBuilder:
         elif body_present:
             _validate_content_type(content_type, "json", contract.consumes)
             declared_body = [parameter for parameter in contract.parameters if parameter.location == "body"]
+            body_value = tool_input["body"]
             if len(declared_body) == 1:
-                _validate_parameter(declared_body[0], tool_input["body"])
-            body = _json_bytes(tool_input["body"])
+                body_value = _coerce_parameter(declared_body[0], body_value)
+                _validate_parameter(declared_body[0], body_value)
+            body = _json_bytes(body_value)
             content_type = content_type or _preferred_media(contract.consumes, "json") or "application/json"
         elif body_parameters:
             _validate_content_type(content_type, "json", contract.consumes)
@@ -1179,6 +1183,82 @@ def _validate_pathname(pathname: str) -> None:
         or "://" in pathname
     ):
         raise ApiContractError("invalid_pathname")
+
+
+def _coerce_parameter(parameter: ParameterMetadata, value: Any) -> Any:
+    """Repair a losslessly convertible value so it matches the declared contract type.
+
+    Models routinely send `"2"` for an integer parameter or a bare string for an array
+    parameter. Those inputs carry the intended value unambiguously, so rejecting them
+    only produced a tool error and a retry. Coercion runs before validation and is
+    strictly lossless: anything that cannot round-trip is returned unchanged and still
+    fails closed in `_validate_parameter`.
+    """
+
+    schema = parameter.schema or {}
+    return _coerce_parameter_schema(value, schema, depth=_MAX_PARAMETER_SCHEMA_DEPTH)
+
+
+def _coerce_parameter_schema(value: Any, schema: Mapping[str, Any], *, depth: int) -> Any:
+    if depth <= 0 or not isinstance(schema, Mapping):
+        return value
+    coerced = _coerce_scalar_value(value, schema.get("type"))
+    if isinstance(coerced, list) and isinstance(items := schema.get("items"), Mapping):
+        coerced = [_coerce_parameter_schema(item, items, depth=depth - 1) for item in coerced]
+    branches = schema.get("allOf")
+    if isinstance(branches, list | tuple):
+        for branch in branches:
+            coerced = _coerce_parameter_schema(coerced, branch, depth=depth - 1)
+    return coerced
+
+
+def _coerce_scalar_value(value: Any, expected: Any) -> Any:
+    if expected == "array" and not isinstance(value, list | tuple):
+        # A JSON array literal must be parsed rather than wrapped, otherwise
+        # '["a","b"]' would silently become a single-element array on the wire.
+        if isinstance(value, str) and isinstance(parsed := _parsed_json_array(value), list):
+            return parsed
+        return [value] if value is not None else value
+    if not isinstance(value, str):
+        return value
+    if expected == "integer":
+        return _coerced_integer(value)
+    if expected == "number":
+        return _coerced_number(value)
+    if expected == "boolean" and value in {"true", "false"}:
+        return value == "true"
+    return value
+
+
+def _parsed_json_array(value: str) -> Any:
+    if not value.strip().startswith("["):
+        return None
+    try:
+        return json.loads(value)
+    except ValueError:
+        return None
+
+
+def _coerced_integer(value: str) -> Any:
+    candidate = value.strip()
+    try:
+        parsed = int(candidate)
+    except ValueError:
+        return value
+    # Only an exact round-trip is lossless: "007" and "+2" keep their original form
+    # so the caller still sees a stable contract error instead of a rewritten request.
+    return parsed if str(parsed) == candidate else value
+
+
+def _coerced_number(value: str) -> Any:
+    candidate = value.strip()
+    if (parsed := _coerced_integer(candidate)) is not value and isinstance(parsed, int):
+        return parsed
+    try:
+        number = float(candidate)
+    except ValueError:
+        return value
+    return number if str(number) == candidate else value
 
 
 def _validate_parameter(parameter: ParameterMetadata, value: Any) -> None:

--- a/tests/tools/cloud/aliyun/test_api_contract.py
+++ b/tests/tools/cloud/aliyun/test_api_contract.py
@@ -2217,6 +2217,125 @@ async def test_request_builder_accepts_numeric_values_for_string_numeric_openmet
 
 
 @pytest.mark.asyncio
+async def test_request_builder_coerces_evaluate_candidate_instance_type_parameters() -> None:
+    """The candidate evaluation inputs that used to fail and force an aliyun_api retry."""
+
+    api = contract(
+        parameter("InstanceTypes", "query", style="repeatList", schema={"type": "array", "items": {"type": "string"}}),
+        parameter("MinimumCpuCoreCount", "query", schema={"type": "integer"}),
+        action="DescribeInstanceTypes",
+    )
+
+    built = await RequestBuilder().build(
+        api,
+        {"params": {"InstanceTypes": "ecs.u1-c1m2.large", "MinimumCpuCoreCount": "2"}},
+    )
+
+    assert dict(built.canonical_query) == {
+        "InstanceTypes.1": "ecs.u1-c1m2.large",
+        "MinimumCpuCoreCount": "2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_builder_parses_json_array_literal_instead_of_wrapping_it() -> None:
+    api = contract(
+        parameter("InstanceTypes", "query", style="repeatList", schema={"type": "array", "items": {"type": "string"}})
+    )
+
+    built = await RequestBuilder().build(api, {"params": {"InstanceTypes": '["ecs.g6.large","ecs.g7.large"]'}})
+
+    assert dict(built.canonical_query) == {
+        "InstanceTypes.1": "ecs.g6.large",
+        "InstanceTypes.2": "ecs.g7.large",
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_builder_coerces_array_items_against_the_declared_item_schema() -> None:
+    api = contract(
+        parameter("Ports", "query", style="repeatList", schema={"type": "array", "items": {"type": "integer"}})
+    )
+
+    built = await RequestBuilder().build(api, {"params": {"Ports": ["80", "443"]}})
+
+    assert dict(built.canonical_query) == {"Ports.1": "80", "Ports.2": "443"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("schema_type", "value", "expected"),
+    [
+        ("integer", "2", "2"),
+        ("integer", "-7", "-7"),
+        ("number", "1.5", "1.5"),
+        ("number", "3", "3"),
+        ("boolean", "true", "true"),
+        ("boolean", "false", "false"),
+    ],
+)
+async def test_request_builder_coerces_lossless_scalar_strings(schema_type: str, value: str, expected: str) -> None:
+    api = contract(parameter("Value", "query", schema={"type": schema_type}))
+
+    built = await RequestBuilder().build(api, {"params": {"Value": value}})
+
+    assert dict(built.canonical_query) == {"Value": expected}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("schema_type", "value", "expected_type", "actual_type"),
+    [
+        ("integer", "007", "integer", "string"),
+        ("integer", "+2", "integer", "string"),
+        ("integer", "2.5", "integer", "string"),
+        ("integer", "abc", "integer", "string"),
+        ("number", "2.50", "number", "string"),
+        ("number", "1e3", "number", "string"),
+        ("boolean", "True", "boolean", "string"),
+        ("string", 7, "string", "integer"),
+    ],
+)
+async def test_request_builder_still_rejects_values_that_cannot_convert_losslessly(
+    schema_type: str,
+    value: Any,
+    expected_type: str,
+    actual_type: str,
+) -> None:
+    api = contract(parameter("Value", "query", schema={"type": schema_type}))
+
+    with pytest.raises(ApiContractError, match="^invalid_parameter_type:Value$") as raised:
+        await RequestBuilder().build(api, {"params": {"Value": value}})
+
+    assert raised.value.expected_type == expected_type
+    assert raised.value.actual_type == actual_type
+
+
+@pytest.mark.asyncio
+async def test_request_builder_enforces_enum_against_the_coerced_value() -> None:
+    api = contract(parameter("PageSize", "query", schema={"type": "integer", "enum": [30, 50]}))
+
+    built = await RequestBuilder().build(api, {"params": {"PageSize": "30"}})
+    assert dict(built.canonical_query) == {"PageSize": "30"}
+
+    with pytest.raises(ApiContractError, match="^invalid_parameter_enum:PageSize$"):
+        await RequestBuilder().build(api, {"params": {"PageSize": "31"}})
+
+
+@pytest.mark.asyncio
+async def test_request_builder_coerces_single_declared_json_body_parameter() -> None:
+    api = contract(
+        parameter("Ports", "body", schema={"type": "array", "items": {"type": "integer"}}),
+        consumes=("application/json",),
+        request_body_type="json",
+    )
+
+    built = await RequestBuilder().build(api, {"body": "8080"})
+
+    assert built.body == b"[8080]"
+
+
+@pytest.mark.asyncio
 async def test_request_builder_enforces_local_ref_sibling_type() -> None:
     api, name = await local_ref_sibling_contract("query", {"type": "string"}, component_schema={})
 


### PR DESCRIPTION
## Problem

The `aliyun_api` request builder only *asserted* parameter types against the canonical OpenMeta contract. An input that carried the intended value in the wrong JSON type was rejected outright, even when the intent was unambiguous.

In the selling pipeline's `evaluate_candidate` step this turned two unambiguous inputs into tool errors plus recovery retries:

- `InstanceTypes` is declared as an `array` but received a bare string
- `MinimumCpuCoreCount` is declared as an `integer` but received `"2"`

The agent then retried with corrected parameters and succeeded, so the only outcome was wasted latency, extra tokens, and `tool_errors` noise in pipeline metrics.

Reproduced locally against the current contract (no network, no cloud credentials):

```
case1 FAILS: invalid_parameter_type:InstanceTypes expected=array actual=string
case2 FAILS: invalid_parameter_type:MinimumCpuCoreCount expected=integer actual=string
```

## Change

Coerce losslessly convertible values against the declared schema in `RequestBuilder` before validating them, so the request is repaired in place instead of failing and relying on an agent retry.

Coercion is strictly lossless and otherwise fails closed exactly as before:

- `array` ← non-array wraps the value, but a JSON array literal is **parsed** so `'["a","b"]'` cannot silently become a single-element array; declared `items` schemas are applied recursively
- `integer` / `number` ← string only when the parsed value round-trips exactly, so `"007"`, `"+2"` and `"2.50"` keep raising the existing contract error
- `boolean` ← only the canonical `"true"` / `"false"` wire literals
- no reverse or narrowing conversions; `allOf` conflicts, `enum` checks and every public error code are unchanged

Coercion runs inside `RequestBuilder.build` *after* the handoff digest check and only rewrites values — never parameter names, locations, or the body source — so permission snapshots and `hook_call_shape_changed` validation are unaffected.

## Tests

Added 17 cases to `tests/tools/cloud/aliyun/test_api_contract.py` covering the two real session parameters, JSON-array-literal parsing, recursive `items` coercion, the lossless scalar matrix, and the reverse cases that must still fail.

- `tests/tools/cloud/` — 2410 passed
- `tests/tools/cloud/aliyun/test_api_contract.py` — 195 passed
- `ruff check` and `ty check src/` — clean

## Result

The candidate evaluation step no longer emits `aliyun_api` type errors or retries for these parameter shapes, and the fix applies to every `aliyun_api` caller rather than patching only the pipeline step.
