### PR TITLE
fix(a2a): terminate candidate sub-steps so completed candidates stay consistent

### DIFF
--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -36,6 +36,9 @@ _CLEANUP_STATUS_BY_EVENT_TYPE = {
     PIPELINE_EVENT_CLEANUP_FAILED: "failed",
 }
 _KNOWN_CLEANUP_STATUSES = {"pending", "started", "in_progress", "completed", "failed", "skipped"}
+_TERMINAL_CANDIDATE_STATUSES = {"completed", "failed", "canceled"}
+_TERMINAL_CANDIDATE_STEP_STATUSES = {"completed", "failed", "canceled", "skipped", "superseded"}
+_CANDIDATE_TERMINAL_WITHOUT_RESULT_REASON = "candidate_terminal_without_result"
 _PENDING_BACKUP_VISIBILITY = "pending_backup"
 _COMMITTED_BACKUP_VISIBILITY = "committed"
 _BACKUP_COMMITTED_EVENT_TYPE = "backup_committed"
@@ -266,9 +269,21 @@ class _PipelineSnapshotReducer:
                     valid_candidate_steps.append(candidate_step)
                     self._candidate_steps_by_run_id[candidate_step_run_id] = candidate_step
                 candidate["steps"] = valid_candidate_steps
+                self._repair_candidate_step_consistency(candidate)
             step["candidates"] = valid_candidates
         self._snapshot["steps"] = valid_steps
         self._sanitize_active_candidate_run_ids()
+
+    @staticmethod
+    def _repair_candidate_step_consistency(candidate: dict[str, Any]) -> None:
+        """Heal snapshots persisted before candidate steps were explicitly terminated."""
+        for candidate_step in candidate["steps"]:
+            _supersede_replaced_candidate_steps(candidate, candidate_step, candidate_step.get("startedAt"))
+        if _string_or_none(candidate.get("status")) in _TERMINAL_CANDIDATE_STATUSES:
+            _finalize_candidate_steps(
+                candidate,
+                _string_or_none(candidate.get("completedAt")) or _string_or_none(candidate.get("failedAt")),
+            )
 
     def _hydrate_messages(self) -> None:
         valid_messages: list[dict[str, Any]] = []
@@ -677,11 +692,13 @@ class _PipelineSnapshotReducer:
             candidate["status"] = "completed"
             _set_time(candidate, "completedAt", created_at)
             _merge_completion_data(candidate, event)
+            _finalize_candidate_steps(candidate, created_at)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
         elif event_type == "candidate_failed":
             candidate["status"] = "failed"
             _set_time(candidate, "failedAt", created_at)
             _merge_completion_data(candidate, event)
+            _finalize_candidate_steps(candidate, created_at)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
         elif event_type == "candidate_restart_requested":
             candidate["status"] = "restarting"
@@ -732,6 +749,7 @@ class _PipelineSnapshotReducer:
             candidate["steps"].append(candidate_step)
 
         _merge_coordinate(candidate_step, coordinate)
+        _supersede_replaced_candidate_steps(candidate, candidate_step, _string_or_none(event.get("createdAt")))
         self._apply_candidate_step_lifecycle(candidate_step, event)
         return candidate_step
 
@@ -1756,6 +1774,56 @@ def _merge_completion_data(target: dict[str, Any], event: dict[str, Any]) -> Non
     ):
         if key in data:
             target[key] = copy.deepcopy(data[key])
+
+
+def _supersede_replaced_candidate_steps(
+    candidate: dict[str, Any],
+    current: dict[str, Any],
+    created_at: str | None,
+) -> None:
+    """Terminate earlier attempts of the same candidate step id as ``superseded``.
+
+    A candidate step that is re-run gets a fresh ``runId`` (``…-<step_id>-<attempt>``),
+    so the previous attempt stays in ``candidate["steps"]``.  Without this it keeps the
+    ``pending`` skeleton status forever and the candidate looks inconsistent once it
+    reaches a terminal status.  Existing conclusion fields are left untouched so the
+    superseded entry still points at whatever it produced.
+    """
+    step_id = _string_or_none(current.get("id"))
+    if step_id is None:
+        return
+    current_run_id = _string_or_none(current.get("runId"))
+    current_attempt = _int_or_none(current.get("attempt")) or 1
+    for candidate_step in candidate.get("steps", []):
+        if not isinstance(candidate_step, dict) or candidate_step is current:
+            continue
+        if _string_or_none(candidate_step.get("id")) != step_id:
+            continue
+        if (_int_or_none(candidate_step.get("attempt")) or 1) >= current_attempt:
+            continue
+        if _string_or_none(candidate_step.get("status")) in _TERMINAL_CANDIDATE_STEP_STATUSES:
+            continue
+        candidate_step["status"] = "superseded"
+        _set_time(candidate_step, "supersededAt", created_at)
+        if current_run_id is not None:
+            candidate_step["supersededByRunId"] = current_run_id
+
+
+def _finalize_candidate_steps(candidate: dict[str, Any], created_at: str | None) -> None:
+    """Ensure a terminal candidate has no unterminated child steps.
+
+    Steps that never ran (or were interrupted) still carry the ``pending``/``working``
+    skeleton status.  Once the candidate itself is terminal those steps can no longer
+    produce a conclusion, so they are explicitly canceled.
+    """
+    for candidate_step in candidate.get("steps", []):
+        if not isinstance(candidate_step, dict):
+            continue
+        if _string_or_none(candidate_step.get("status")) in _TERMINAL_CANDIDATE_STEP_STATUSES:
+            continue
+        candidate_step["status"] = "canceled"
+        _set_time(candidate_step, "canceledAt", created_at)
+        candidate_step["terminalReason"] = _CANDIDATE_TERMINAL_WITHOUT_RESULT_REASON
 
 
 def _append_unique(values: list[Any], value: Any) -> None:

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -1477,6 +1477,135 @@ def test_store_returns_none_for_invalid_utf8_snapshot(tmp_path) -> None:
     assert store.load() is None
 
 
+def test_reduce_supersedes_replaced_candidate_step_attempt() -> None:
+    parent = _base("evt-1", 1, "step_started", scope="step")
+    parent["step"] = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    candidate = _base("evt-2", 2, "candidate_started", scope="candidate")
+    candidate["step"] = parent["step"]
+    candidate["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}
+    first_completed = _base("evt-3", 3, "candidate_step_completed", scope="candidate_step")
+    first_completed["step"] = parent["step"]
+    first_completed["candidate"] = candidate["candidate"]
+    first_completed["candidateStep"] = {
+        "runId": "candidate-eval-0-1-template_generating-1",
+        "id": "template_generating",
+        "index": 1,
+        "total": 2,
+        "attempt": 1,
+    }
+    first_completed["data"] = {"conclusionField": "template", "conclusion": {"body": "first"}}
+    retry_started = _base("evt-4", 4, "candidate_step_started", scope="candidate_step")
+    retry_started["step"] = parent["step"]
+    retry_started["candidate"] = candidate["candidate"]
+    retry_started["candidateStep"] = {
+        "runId": "candidate-eval-0-1-template_generating-2",
+        "id": "template_generating",
+        "index": 1,
+        "total": 2,
+        "attempt": 2,
+    }
+
+    snapshot = reduce_pipeline_events([parent, candidate, first_completed, retry_started])
+
+    steps = snapshot["steps"][0]["candidates"][0]["steps"]
+    assert [(step["attempt"], step["status"]) for step in steps] == [(1, "completed"), (2, "working")]
+
+    pending_first = _base("evt-5", 3, "candidate_step_started", scope="candidate_step")
+    pending_first["step"] = parent["step"]
+    pending_first["candidate"] = candidate["candidate"]
+    pending_first["candidateStep"] = dict(first_completed["candidateStep"])
+    snapshot = reduce_pipeline_events([parent, candidate, pending_first, retry_started])
+
+    steps = snapshot["steps"][0]["candidates"][0]["steps"]
+    assert [(step["attempt"], step["status"]) for step in steps] == [(1, "superseded"), (2, "working")]
+    assert steps[0]["supersededByRunId"] == "candidate-eval-0-1-template_generating-2"
+
+
+def test_reduce_candidate_completed_terminates_leftover_candidate_steps() -> None:
+    parent = _base("evt-1", 1, "step_started", scope="step")
+    parent["step"] = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    candidate = _base("evt-2", 2, "candidate_started", scope="candidate")
+    candidate["step"] = parent["step"]
+    candidate["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}
+    template_started = _base("evt-3", 3, "candidate_step_started", scope="candidate_step")
+    template_started["step"] = parent["step"]
+    template_started["candidate"] = candidate["candidate"]
+    template_started["candidateStep"] = {
+        "runId": "candidate-eval-0-1-template_generating-1",
+        "id": "template_generating",
+        "index": 1,
+        "total": 2,
+        "attempt": 1,
+    }
+    completed = _base("evt-4", 4, "candidate_completed", scope="candidate")
+    completed["step"] = parent["step"]
+    completed["candidate"] = candidate["candidate"]
+
+    snapshot = reduce_pipeline_events([parent, candidate, template_started, completed])
+
+    result_candidate = snapshot["steps"][0]["candidates"][0]
+    assert result_candidate["status"] == "completed"
+    leftover = result_candidate["steps"][0]
+    assert leftover["status"] == "canceled"
+    assert leftover["terminalReason"] == "candidate_terminal_without_result"
+
+
+def test_reduce_repairs_completed_candidate_with_pending_steps_in_existing_snapshot() -> None:
+    existing = {
+        "schemaVersion": SNAPSHOT_SCHEMA_VERSION,
+        "status": "working",
+        "lastSequence": 4,
+        "seenEventIds": ["evt-1", "evt-2", "evt-3", "evt-4"],
+        "steps": [
+            {
+                "runId": "step-evaluate_candidates-1",
+                "id": "evaluate_candidates",
+                "attempt": 1,
+                "status": "completed",
+                "candidates": [
+                    {
+                        "runId": "candidate-eval-0-1",
+                        "id": "evaluate_candidate_7c06c02f",
+                        "attempt": 1,
+                        "status": "completed",
+                        "completedAt": "2026-06-08T10:05:00Z",
+                        "steps": [
+                            {
+                                "runId": "candidate-eval-0-1-template_generating-1",
+                                "id": "template_generating",
+                                "attempt": 1,
+                                "index": 1,
+                                "status": "pending",
+                            },
+                            {
+                                "runId": "candidate-eval-0-1-reviewing-1",
+                                "id": "reviewing",
+                                "attempt": 1,
+                                "index": 2,
+                                "status": "completed",
+                            },
+                            {
+                                "runId": "candidate-eval-0-1-cost_estimating-1",
+                                "id": "cost_estimating",
+                                "attempt": 1,
+                                "index": 3,
+                                "status": "pending",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    snapshot = reduce_pipeline_events([], existing)
+
+    steps = snapshot["steps"][0]["candidates"][0]["steps"]
+    assert [step["status"] for step in steps] == ["canceled", "completed", "canceled"]
+    assert steps[0]["canceledAt"] == "2026-06-08T10:05:00Z"
+    assert steps[2]["terminalReason"] == "candidate_terminal_without_result"
+
+
 def test_snapshot_schema_version_is_exported() -> None:
     assert SNAPSHOT_SCHEMA_VERSION == "1.1"
     assert "SNAPSHOT_SCHEMA_VERSION" in pipeline_snapshot.__all__


### PR DESCRIPTION
## 问题

候选子步骤被同名词的后续步骤取代时，状态机没有把旧子步骤显式终结，导致 `a2a-snapshot.json` 里出现「候选整体 `completed`，但候选内仍有 `pending` + 结论为 null 的子步骤」这种不自洽状态。

证据来自 Session `d10910d359354a6891f4d3efad68e3e2`：候选 `evaluate_candidate_7c06c02f` 已 `completed`，但 `pipeline_snapshot.steps.2.candidates.0.steps.0`（`template_generating`）与 `steps.2`（`cost_estimating`）仍为 `pending`。

## 根因

1. `_candidate_step_skeletons()`（`a2a/pipeline_events.py`）在 `candidate_started` 时为每个子步骤铺 `status="pending"` 的骨架，`runId` 为 `{candidate.runId}-{step_id}-{attempt}`。
2. `_start_candidate_step()` 每次 `SUB_STEP_STARTED` 都自增该子步骤的 attempt，于是重跑会产生**新的 `runId`**。
3. `_upsert_candidate_step()`（`a2a/pipeline_snapshot.py`）以 `runId` 为键，新 attempt 命中新键并追加为新条目；旧 attempt 的骨架永远停在 `pending`、无结论。
4. `_apply_candidate_lifecycle()` 处理 `candidate_completed` 时只改候选自身状态，不校验子步骤是否已终结。

候选层已有等价处理（`_remove_active_candidate_attempts()` 会移除同 id/index 的旧 attempt），子步骤层缺了对应逻辑。

## 改动

全部集中在 `src/iac_code/a2a/pipeline_snapshot.py` 的归约器，不改事件协议、不改 attempt 语义：

- `_supersede_replaced_candidate_steps()`：新 attempt 入库时，把同候选内 `id` 相同、`attempt` 更小且仍非终结的旧条目置为 `superseded`，写 `supersededAt` / `supersededByRunId`，**保留原有结论字段**。
- `_finalize_candidate_steps()`：候选进入 `completed` / `failed` 前，把残留 `pending` / `working` 子步骤置为 `canceled` 并写 `canceledAt` + `terminalReason="candidate_terminal_without_result"`。`candidate_restart_requested` 不收敛（候选还会重跑）。
- `_repair_candidate_step_consistency()`：hydration 阶段对历史快照做同样处理，已落盘的不自洽快照下次归约即自愈。

前端 `web/static/js/components/pipeline.js` 的进行中判定是白名单（`working/running/waiting_input/restarting`），新状态自动落到非进行中分支，无需前端配套改动。

## 验证

- 新增 3 个回归用例：同名子步骤重跑后旧 attempt 为 `superseded`；`candidate_completed` 后候选内无 `pending`/`working` 子步骤；含残留 pending 的历史快照经 `reduce_pipeline_events` 自愈。
- `uv run pytest tests/a2a/test_pipeline_snapshot.py` → 55 passed。
- `uv run pytest -n auto tests/a2a tests/web/test_pipeline_transcript.py tests/scripts/test_local_observe_pipeline_model.py` → 1565 passed。
- `uv run ruff check` + `uv run ty check src/` → 全部通过。
- 全量 `uv run pytest -n auto tests` → 14324 passed / 5 skipped / 15 failed；15 个 failure 已用 base commit 的文件复跑确认为预先存在（14 个 `tests/test_i18n.py` 依赖 `make translate` 生成的未入库 `messages.pot`，另 2 个依赖沙箱外部环境），与本次改动无关。
