### PR TITLE
fix(a2a): deterministic cancel cleanup for runs without resources

### DIFF
--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -4178,7 +4178,11 @@ def _public_cleanup_snapshot_has_pending_evidence(cleanup: Any) -> bool:
     if isinstance(resource_count, int) and resource_count > 0:
         return True
     status = cleanup.get("status")
-    if isinstance(status, str) and status in {"pending", "started", "in_progress", "failed", "unavailable"}:
+    # "unavailable" is not real cleanup evidence: it is what a prior missing/corrupt
+    # ledger already degraded to. Treating it as pending here re-derives "unavailable"
+    # on every recovery even when the run created no resources (resourceCount=0), so a
+    # deterministically empty cancel state gets stuck reporting "inspect manually".
+    if isinstance(status, str) and status in {"pending", "started", "in_progress", "failed"}:
         return True
     return False
 

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -6512,6 +6512,46 @@ def test_cleanup_handoff_missing_ledger_does_not_reconstruct_prompt_from_public_
     assert "stack-public-only" not in repr(cleanup)
 
 
+def test_cleanup_handoff_missing_ledger_treats_unavailable_snapshot_without_resources_as_empty(
+    tmp_path: Path,
+) -> None:
+    # Regression (session 9dc515b2…): a canceled run that never created resources
+    # has no cleanup.yaml and a public snapshot whose only "evidence" is a prior
+    # status="unavailable" with resourceCount=0. That must resolve to a
+    # deterministic empty cleanup state (None handoff cleanup), not re-derive
+    # "unavailable" and ask the user to inspect resources manually.
+    from iac_code.a2a.pipeline_executor import _pipeline_cleanup_handoff_data_from_session
+
+    cleanup = _pipeline_cleanup_handoff_data_from_session(
+        cwd=str(tmp_path),
+        session_id="session-unavailable-no-resources",
+        public_snapshot={"cleanup": {"status": "unavailable", "resourceCount": 0, "resources": []}},
+    )
+
+    assert cleanup is None
+
+
+def test_public_cleanup_snapshot_pending_evidence_ignores_unavailable_without_resources() -> None:
+    from iac_code.a2a.pipeline_executor import _public_cleanup_snapshot_has_pending_evidence
+
+    assert (
+        _public_cleanup_snapshot_has_pending_evidence(
+            {"status": "unavailable", "resourceCount": 0, "resources": []}
+        )
+        is False
+    )
+    # Real pending evidence must still be honored so ledger-loss with known
+    # resources keeps surfacing an unavailable cleanup state.
+    assert _public_cleanup_snapshot_has_pending_evidence({"status": "pending"}) is True
+    assert _public_cleanup_snapshot_has_pending_evidence({"resourceCount": 1}) is True
+    assert (
+        _public_cleanup_snapshot_has_pending_evidence(
+            {"status": "unavailable", "resourceCount": 2, "resources": []}
+        )
+        is True
+    )
+
+
 @pytest.mark.asyncio
 async def test_pipeline_executor_routes_second_prompt_as_interrupt(tmp_path: Path) -> None:
     from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator


### PR DESCRIPTION
## 背景
针对 Session `9dc515b2084a4da49a24ede6a624372b`：`pipeline_canceled` 后资源清理状态被置为 `unavailable`（`resourceCount=0`，提示人工检查会话文件与云资源），缺少确定性资源对账。

## 根因
取消交接 `_pipeline_cleanup_handoff_data_from_session` 在 `cleanup.yaml` 缺失时，只要 public snapshot 命中 `_public_cleanup_snapshot_has_pending_evidence` 即降级为 `unavailable`。而该判定把 `status=="unavailable"` 也当作 pending 证据，形成自反馈环：一次降级写入 `unavailable` → 快照记录 `unavailable` → 恢复时再次判定 pending → 再次 `unavailable`。因此**从未创建资源**（`resourceCount=0`、无 `cleanup.yaml`）的取消也会一直报 `unavailable` 并要求人工排查。

## 修复
从 `_public_cleanup_snapshot_has_pending_evidence` 的 status 集合中移除 `"unavailable"`。仅真实证据（`resources` 非空 / `resourceCount>0` / status ∈ {pending, started, in_progress, failed}）才继续判定为待清理。

- 无资源取消：解析为确定性空态（交接无 cleanup 段，不再 `unavailable`/人工提示）。
- 部署后取消：`cleanup.yaml` 存在，走既有台账路径，列出资源并尝试 drain/标记（行为不变）。
- 台账丢失但快照确知有资源：仍返回 `unavailable`（确需人工介入，语义正确）。

## 测试
- 新增 `test_cleanup_handoff_missing_ledger_treats_unavailable_snapshot_without_resources_as_empty`、`test_public_cleanup_snapshot_pending_evidence_ignores_unavailable_without_resources`。
- `tests/a2a/test_pipeline_executor.py`、`test_executor_cleanup.py`、`tests/pipeline/engine/test_cleanup.py` 共 231 项全通过；`ruff check` 与 `ty check src/` 通过。
