### PR TITLE
fix(aliyun_api): coerce unambiguous parameter type mismatches before validation

### DIFF
--- a/src/iac_code/tools/cloud/aliyun/api_contract.py
+++ b/src/iac_code/tools/cloud/aliyun/api_contract.py
@@ -67,6 +67,8 @@ _AUTH_TYPES = {"AK", "Anonymous"}
 _OPENMETA_CACHE_STATUSES = {"memory_fresh", "disk_fresh", "remote", "disk_stale", "negative_hit", "miss"}
 _OSS_OPENMETA_FALLBACK_REASON = "oss_openmeta_required_for_complete_request"
 _MAX_PARAMETER_SCHEMA_DEPTH = 32
+_COERCIBLE_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]{0,18})$")
+_COERCIBLE_DECIMAL = re.compile(r"^-?(?:0|[1-9][0-9]{0,18})\.[0-9]{1,18}$")
 _DATA_DIR = Path(__file__).parent / "data"
 _OVERRIDES_PATH = _DATA_DIR / "openmeta" / "api_overrides.yml"
 _ENDPOINT_OVERRIDES_PATH = _DATA_DIR / "endpoints" / "overrides.yml"
@@ -985,7 +987,9 @@ class RequestBuilder:
         for name, value in params.items():
             parameter = metadata.get(name)
             if parameter is not None:
-                _validate_parameter(parameter, value)
+                coerced = _coerce_parameter_value(parameter, value)
+                _validate_parameter(parameter, coerced)
+                params[name] = coerced
 
         pathname = contract.pathname
         query: dict[str, str] = {}
@@ -1060,9 +1064,11 @@ class RequestBuilder:
         elif body_present:
             _validate_content_type(content_type, "json", contract.consumes)
             declared_body = [parameter for parameter in contract.parameters if parameter.location == "body"]
+            body_value = tool_input["body"]
             if len(declared_body) == 1:
-                _validate_parameter(declared_body[0], tool_input["body"])
-            body = _json_bytes(tool_input["body"])
+                body_value = _coerce_parameter_value(declared_body[0], body_value)
+                _validate_parameter(declared_body[0], body_value)
+            body = _json_bytes(body_value)
             content_type = content_type or _preferred_media(contract.consumes, "json") or "application/json"
         elif body_parameters:
             _validate_content_type(content_type, "json", contract.consumes)
@@ -1184,6 +1190,52 @@ def _validate_pathname(pathname: str) -> None:
 def _validate_parameter(parameter: ParameterMetadata, value: Any) -> None:
     schema = parameter.schema or {}
     _validate_parameter_schema(parameter, value, schema, depth=_MAX_PARAMETER_SCHEMA_DEPTH)
+
+
+def _schema_declared_types(schema: Mapping[str, Any], *, depth: int) -> set[str]:
+    if depth <= 0 or not isinstance(schema, Mapping):
+        return set()
+    types: set[str] = set()
+    expected = schema.get("type")
+    if isinstance(expected, str):
+        types.add(expected)
+    branches = schema.get("allOf")
+    if isinstance(branches, list | tuple):
+        for branch in branches:
+            types |= _schema_declared_types(branch, depth=depth - 1)
+    return types
+
+
+def _coerce_parameter_value(parameter: ParameterMetadata, value: Any) -> Any:
+    """Normalize an unambiguous JSON-type mismatch to the declared schema type.
+
+    Callers routinely send `"2"` for an `integer` field or a bare string for an
+    `array` field. The wire encoding of those shapes is identical either way, so
+    coercing here turns a tool error plus a retry into a single successful call.
+    Only lossless conversions are applied; anything ambiguous (numeric strings
+    that are not numbers, object/array interchange, conflicting `allOf` types)
+    is left untouched so `_validate_parameter` still rejects it. Scalars are not
+    widened into `string`, so a declared `string` field keeps rejecting numbers.
+    """
+
+    types = _schema_declared_types(parameter.schema or {}, depth=_MAX_PARAMETER_SCHEMA_DEPTH)
+    if len(types) != 1:
+        return value
+    expected = next(iter(types))
+    if expected == "array":
+        # `bool` is an `int` subclass, and a bare boolean is not a meaningful element.
+        if isinstance(value, str | int | float) and not isinstance(value, bool):
+            return [value]
+        return value
+    if not isinstance(value, str):
+        return value
+    if expected in {"integer", "number"} and _COERCIBLE_INTEGER.fullmatch(value):
+        return int(value)
+    if expected == "number" and _COERCIBLE_DECIMAL.fullmatch(value):
+        return float(value)
+    if expected == "boolean" and value in {"true", "false"}:
+        return value == "true"
+    return value
 
 
 def _validate_parameter_schema(

--- a/tests/tools/cloud/aliyun/test_api_contract.py
+++ b/tests/tools/cloud/aliyun/test_api_contract.py
@@ -2217,6 +2217,100 @@ async def test_request_builder_accepts_numeric_values_for_string_numeric_openmet
 
 
 @pytest.mark.asyncio
+async def test_request_builder_wraps_scalar_into_declared_array_parameter() -> None:
+    api = contract(parameter("InstanceTypes", "query", style="repeatList", schema={"type": "array"}))
+
+    built = await RequestBuilder().build(api, {"params": {"InstanceTypes": "ecs.g7.large"}})
+
+    assert dict(built.canonical_query) == {"InstanceTypes.1": "ecs.g7.large"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("schema_type", "value", "expected"),
+    [
+        ("integer", "2", "2"),
+        ("number", "2", "2"),
+        ("number", "2.5", "2.5"),
+        ("boolean", "true", "true"),
+        ("boolean", "false", "false"),
+    ],
+)
+async def test_request_builder_coerces_stringified_scalars_to_declared_type(
+    schema_type: str,
+    value: str,
+    expected: str,
+) -> None:
+    api = contract(parameter("MinimumCpuCoreCount", "query", schema={"type": schema_type}))
+
+    built = await RequestBuilder().build(api, {"params": {"MinimumCpuCoreCount": value}})
+
+    assert dict(built.canonical_query) == {"MinimumCpuCoreCount": expected}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("schema_type", "value", "actual_type"),
+    [
+        ("integer", "two", "string"),
+        ("integer", "2.5", "string"),
+        ("integer", "", "string"),
+        ("boolean", "yes", "string"),
+        ("object", "Name=demo", "string"),
+        ("array", {"Name": "demo"}, "object"),
+        ("integer", ["2"], "array"),
+    ],
+)
+async def test_request_builder_still_rejects_ambiguous_type_mismatches(
+    schema_type: str,
+    value: Any,
+    actual_type: str,
+) -> None:
+    api = contract(parameter("Mode", "query", schema={"type": schema_type}))
+
+    with pytest.raises(ApiContractError, match="^invalid_parameter_type:Mode$") as raised:
+        await RequestBuilder().build(api, {"params": {"Mode": value}})
+
+    assert raised.value.expected_type == schema_type
+    assert raised.value.actual_type == actual_type
+
+
+@pytest.mark.asyncio
+async def test_coercion_does_not_bypass_enum_validation() -> None:
+    api = contract(parameter("PageSize", "query", schema={"type": "integer", "enum": [30, 50]}))
+
+    with pytest.raises(ApiContractError, match="^invalid_parameter_enum:PageSize$"):
+        await RequestBuilder().build(api, {"params": {"PageSize": "40"}})
+
+    built = await RequestBuilder().build(api, {"params": {"PageSize": "30"}})
+    assert dict(built.canonical_query) == {"PageSize": "30"}
+
+
+@pytest.mark.asyncio
+async def test_conflicting_all_of_types_are_not_coerced() -> None:
+    api = contract(parameter("Mode", "query", schema={"type": "string", "allOf": [{"type": "integer"}]}))
+
+    with pytest.raises(ApiContractError, match="^invalid_parameter_type:Mode$") as raised:
+        await RequestBuilder().build(api, {"params": {"Mode": "2"}})
+
+    assert raised.value.expected_type == "integer"
+    assert raised.value.actual_type == "string"
+
+
+@pytest.mark.asyncio
+async def test_single_declared_body_parameter_is_coerced_before_validation() -> None:
+    api = contract(
+        parameter("Count", "body", required=True, schema={"type": "integer"}),
+        consumes=("application/json",),
+        request_body_type="json",
+    )
+
+    built = await RequestBuilder().build(api, {"body": "3"})
+
+    assert built.body == b"3"
+
+
+@pytest.mark.asyncio
 async def test_request_builder_enforces_local_ref_sibling_type() -> None:
     api, name = await local_ref_sibling_contract("query", {"type": "string"}, component_schema={})
 


### PR DESCRIPTION
## Problem

`aliyun_api` validated `params` against the declared OpenAPI schema but only ever **rejected** a type mismatch. Callers that sent:

- `InstanceTypes` as a `string` (declared `array`)
- `MinimumCpuCoreCount` as `"2"` (declared `integer`)

got a tool-level error and had to retry with corrected types. Both shapes encode **identically** on the wire (`repeatList` expands an array to `Name.1`; scalars go through `_wire_scalar`), so the rejection produced no safety benefit — only extra `tool_errors` and a slower pipeline.

Observed in session `0909ab34e25c480890dfded5ea82db26`: two `aliyun_api` calls failed on exactly these two fields (`a2a_events.137` / `a2a_events.175`), succeeding only after the model guessed the right types.

## Change

Add a conservative, schema-driven coercion step in `RequestBuilder` before schema validation:

| Declared type | Accepted input | Coerced to |
| --- | --- | --- |
| `array` | scalar (`str`/`int`/`float`) | single-element list |
| `integer` / `number` | numeric string (`"2"`) | `int` |
| `number` | decimal string (`"2.5"`) | `float` |
| `boolean` | `"true"` / `"false"` | `bool` |

Deliberately **not** coerced, so validation still fails closed:

- non-numeric strings for numeric fields (`"two"`, `"2.5"` for `integer`, `""`)
- `object` ↔ `array` interchange
- arrays for scalar fields
- conflicting `allOf` types (more than one declared type ⇒ no coercion)
- scalars are **not** widened into `string`, so a declared `string` field keeps rejecting numbers

`enum` validation runs **after** coercion, so allowed-value checks are unaffected.

## Safety

- Coercion mutates only `RequestBuilder`'s local deep copy, never the caller's `params` (covered by the existing no-mutation test).
- `ApiCallShape.security_view()` is unchanged, so `security_digest` and the approved invocation binding still match — no permission or handoff impact.
- Only parameters declared by the resolved contract are coerced; undeclared parameters behave exactly as before.
- No change to signing, endpoint resolution, transport selection, or permissions.

## Tests

11 new cases in `tests/tools/cloud/aliyun/test_api_contract.py` covering each coercion, each non-coercible case, enum interaction, `allOf` conflicts, and the single declared body parameter.

`tests/tools/cloud/aliyun`: **2316 passed**. `ruff check`, `ruff format --check`, and `ty check src/` all clean.

No user-facing translatable strings were changed, so no catalog updates are required.
