### PR TITLE
feat(a2a): pipeline_canceled 增加结构化取消归因

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -42,6 +42,11 @@ from iac_code.a2a.parts import (
     resolve_workspace_path,
     trust_request_cwd,
 )
+from iac_code.a2a.pipeline_cancellation import (
+    CANCEL_REASON_USER_INITIATED,
+    CANCEL_TRIGGER_USER,
+    pipeline_cancellation,
+)
 from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
 from iac_code.a2a.pipeline_executor import (
     RICH_CANDIDATE_PRESENTATION,
@@ -1696,6 +1701,11 @@ class IacCodeA2AExecutor(AgentExecutor):
         if task_id and await self._task_store.cancel_task_and_wait(
             task_id,
             timeout=_CANCEL_ACTIVE_TASK_DRAIN_TIMEOUT_SECONDS,
+            cancellation=pipeline_cancellation(
+                CANCEL_REASON_USER_INITIATED,
+                trigger_source=CANCEL_TRIGGER_USER,
+                detail="a2a cancelTask request",
+            ),
         ):
             await self._publish_status(
                 event_queue,

--- a/src/iac_code/a2a/pipeline_cancellation.py
+++ b/src/iac_code/a2a/pipeline_cancellation.py
@@ -1,0 +1,128 @@
+"""Structured attribution for ``pipeline_canceled`` terminal events.
+
+``pipeline_canceled`` used to carry only a localized display string
+(``reason="Task canceled."``), so an audit could not tell a user-initiated stop
+apart from an upstream timeout, an executor crash or a resource limit. This
+module defines the machine-readable attribution that cancel call sites attach and
+terminal publication merges into the event ``data``, while leaving the existing
+``source`` and localized ``reason`` fields untouched for current consumers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from iac_code.utils.public_errors import sanitize_strict_text
+
+CANCEL_REASON_USER_INITIATED = "user_initiated"
+CANCEL_REASON_UPSTREAM_TIMEOUT = "upstream_timeout"
+CANCEL_REASON_EXECUTOR_ERROR = "executor_error"
+CANCEL_REASON_RESOURCE_LIMIT = "resource_limit"
+CANCEL_REASON_UNKNOWN = "unknown"
+
+CANCEL_REASON_CODES = frozenset(
+    {
+        CANCEL_REASON_USER_INITIATED,
+        CANCEL_REASON_UPSTREAM_TIMEOUT,
+        CANCEL_REASON_EXECUTOR_ERROR,
+        CANCEL_REASON_RESOURCE_LIMIT,
+        CANCEL_REASON_UNKNOWN,
+    }
+)
+
+CANCEL_TRIGGER_USER = "user"
+CANCEL_TRIGGER_SCHEDULER = "scheduler"
+CANCEL_TRIGGER_SYSTEM = "system"
+
+CANCEL_TRIGGER_SOURCES = frozenset({CANCEL_TRIGGER_USER, CANCEL_TRIGGER_SCHEDULER, CANCEL_TRIGGER_SYSTEM})
+
+_DEFAULT_TRIGGER_BY_REASON = {
+    CANCEL_REASON_USER_INITIATED: CANCEL_TRIGGER_USER,
+    CANCEL_REASON_UPSTREAM_TIMEOUT: CANCEL_TRIGGER_SCHEDULER,
+    CANCEL_REASON_EXECUTOR_ERROR: CANCEL_TRIGGER_SYSTEM,
+    CANCEL_REASON_RESOURCE_LIMIT: CANCEL_TRIGGER_SYSTEM,
+    CANCEL_REASON_UNKNOWN: CANCEL_TRIGGER_SYSTEM,
+}
+
+_DETAIL_MAX_CHARS = 200
+
+
+@dataclass(frozen=True)
+class PipelineCancellation:
+    """Machine-readable attribution for one cancellation.
+
+    ``detail`` is a short non-localized diagnostic hint (never user input) so
+    audits stay stable across locales.
+    """
+
+    reason_code: str = CANCEL_REASON_UNKNOWN
+    trigger_source: str = CANCEL_TRIGGER_SYSTEM
+    detail: str | None = None
+
+    def event_data(self) -> dict[str, str]:
+        payload = {
+            "reasonCode": self.reason_code,
+            "triggerSource": self.trigger_source,
+        }
+        if self.detail:
+            payload["detail"] = self.detail
+        return payload
+
+
+def pipeline_cancellation(
+    reason_code: str | None = None,
+    *,
+    trigger_source: str | None = None,
+    detail: str | None = None,
+) -> PipelineCancellation:
+    """Build a normalized attribution, falling back to ``unknown``/``system``."""
+
+    normalized_reason = reason_code if reason_code in CANCEL_REASON_CODES else CANCEL_REASON_UNKNOWN
+    if trigger_source in CANCEL_TRIGGER_SOURCES:
+        normalized_trigger = trigger_source
+    else:
+        normalized_trigger = _DEFAULT_TRIGGER_BY_REASON[normalized_reason]
+    return PipelineCancellation(
+        reason_code=normalized_reason,
+        trigger_source=normalized_trigger,
+        detail=_normalized_detail(detail),
+    )
+
+
+def unknown_pipeline_cancellation() -> PipelineCancellation:
+    """Attribution used when a cancel path did not declare its origin."""
+
+    return PipelineCancellation()
+
+
+def resolve_pipeline_cancellation(value: object) -> PipelineCancellation:
+    """Coerce a recorded attribution back into a normalized value."""
+
+    if isinstance(value, PipelineCancellation):
+        return pipeline_cancellation(
+            value.reason_code,
+            trigger_source=value.trigger_source,
+            detail=value.detail,
+        )
+    return unknown_pipeline_cancellation()
+
+
+def cancellation_event_data(
+    cancellation: object,
+    *,
+    base: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Merge structured attribution into an existing cancel event payload."""
+
+    payload: dict[str, object] = dict(base or {})
+    payload.update(resolve_pipeline_cancellation(cancellation).event_data())
+    return payload
+
+
+def _normalized_detail(detail: str | None) -> str | None:
+    if not detail:
+        return None
+    sanitized = sanitize_strict_text(detail).strip()
+    if not sanitized:
+        return None
+    return sanitized[:_DETAIL_MAX_CHARS]

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -20,6 +20,10 @@ from a2a.utils.errors import InvalidParamsError
 from iac_code.a2a.artifacts import artifact_store_for_session
 from iac_code.a2a.backup import backup_session_async
 from iac_code.a2a.events import make_text_part, publish_mcp_warnings
+from iac_code.a2a.pipeline_cancellation import (
+    cancellation_event_data,
+    resolve_pipeline_cancellation,
+)
 from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
 from iac_code.a2a.pipeline_flow_monitor import (
     PipelineA2AFlowIdentity,
@@ -614,7 +618,10 @@ class IacCodeA2APipelineExecutor:
             except asyncio.CancelledError:
                 try:
                     task.state = TASK_STATE_CANCELED
-                    cancel_data = {"source": "executor", "reason": _("Task canceled.")}
+                    cancel_data = cancellation_event_data(
+                        resolve_pipeline_cancellation(getattr(task, "cancellation", None)),
+                        base={"source": "executor", "reason": _("Task canceled.")},
+                    )
                     cancel_handoff_data = {"canceled": True, "reason": _("Task canceled.")}
 
                     async def publish_cancel_terminal() -> bool:
@@ -3477,6 +3484,7 @@ def cancel_waiting_input_task_from_sidecar(
     context_id: str,
     task_id: str,
     reason: str | None = None,
+    cancellation: Any | None = None,
     backup_service: Any | None = None,
     task_store: Any | None = None,
     task_record: Any | None = None,
@@ -3493,6 +3501,7 @@ def cancel_waiting_input_task_from_sidecar(
             context_id=context_id,
             task_id=task_id,
             reason=reason,
+            cancellation=cancellation,
             backup_service=backup_service,
             task_store=task_store,
             task_record=task_record,
@@ -3508,6 +3517,7 @@ def _cancel_waiting_input_task_from_sidecar_locked(
     context_id: str,
     task_id: str,
     reason: str,
+    cancellation: Any | None = None,
     backup_service: Any | None = None,
     task_store: Any | None = None,
     task_record: Any | None = None,
@@ -3546,7 +3556,10 @@ def _cancel_waiting_input_task_from_sidecar_locked(
         "pipeline_canceled",
         "pipeline",
         status="canceled",
-        data={"source": "a2a_cancel", "reason": reason},
+        data=cancellation_event_data(
+            resolve_pipeline_cancellation(cancellation),
+            base={"source": "a2a_cancel", "reason": reason},
+        ),
     )
     high_water_sequence = max(
         [int(event.get("sequence") or 0) for event in events if isinstance(event, dict)]

--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -529,6 +529,8 @@ class _PipelineSnapshotReducer:
             self._snapshot["pendingTerminal"] = None
             self._snapshot["pendingInput"] = None
             self._snapshot["control"]["activeCandidateRunIds"] = []
+            if terminal_status == "canceled":
+                self._snapshot["cancellation"] = _cancellation_attribution(data)
         elif (
             event_type not in {"input_required", "input_received", *_CLEANUP_STATUS_BY_EVENT_TYPE}
             and not _is_pending_backup_publication(event)
@@ -1085,8 +1087,23 @@ def _terminal_publication(event: dict[str, Any]) -> dict[str, Any]:
         "visibility": _publication_visibility(event),
         "data": data,
     }
+    cancellation = _cancellation_attribution(data)
+    if cancellation is not None:
+        terminal["cancellation"] = cancellation
     _merge_event_coordinates(terminal, event)
     return terminal
+
+
+def _cancellation_attribution(data: dict[str, Any]) -> dict[str, Any] | None:
+    """Lift the machine-readable cancel attribution so audits can group by it."""
+    reason_code = _string_or_none(data.get("reasonCode"))
+    if reason_code is None:
+        return None
+    attribution = {"reasonCode": reason_code, "triggerSource": _string_or_none(data.get("triggerSource"))}
+    detail = _string_or_none(data.get("detail"))
+    if detail is not None:
+        attribution["detail"] = detail
+    return attribution
 
 
 def _is_pending_backup_publication(event: dict[str, Any]) -> bool:
@@ -1315,6 +1332,7 @@ def _empty_snapshot() -> dict[str, Any]:
         "pendingNormalHandoff": None,
         "pendingTerminal": None,
         "pendingInput": None,
+        "cancellation": None,
         "control": {
             "activeCandidateRunIds": [],
             "inputHistory": [],

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -823,19 +823,27 @@ class A2ATaskStore(TaskStore):
             if validate_protocol_id(task_id) in self._expired_task_tombstones:
                 raise ValueError(_("A2A task expired"))
 
-    async def cancel_task(self, task_id: str) -> bool:
+    async def cancel_task(self, task_id: str, *, cancellation: Any | None = None) -> bool:
         async with self._mutation_lock:
             record = self._tasks.get(validate_protocol_id(task_id))
             if record is None or record.active_task is None or record.active_task.done():
                 return False
+            record.cancellation = cancellation
             record.active_task.cancel()
             return True
 
-    async def cancel_task_and_wait(self, task_id: str, *, timeout: float | None = None) -> bool:
+    async def cancel_task_and_wait(
+        self,
+        task_id: str,
+        *,
+        timeout: float | None = None,
+        cancellation: Any | None = None,
+    ) -> bool:
         async with self._mutation_lock:
             record = self._tasks.get(validate_protocol_id(task_id))
             if record is None or record.active_task is None or record.active_task.done():
                 return False
+            record.cancellation = cancellation
             active_task = record.active_task
             active_task.cancel()
 

--- a/src/iac_code/a2a/transports/dispatcher.py
+++ b/src/iac_code/a2a/transports/dispatcher.py
@@ -56,6 +56,11 @@ from iac_code.a2a.jsonrpc_passthrough import (
 )
 from iac_code.a2a.metrics import NoOpA2AMetrics
 from iac_code.a2a.persistence import A2APersistenceStore
+from iac_code.a2a.pipeline_cancellation import (
+    CANCEL_REASON_USER_INITIATED,
+    CANCEL_TRIGGER_USER,
+    pipeline_cancellation,
+)
 from iac_code.a2a.pipeline_executor import (
     _CANCEL_WAITING_INPUT_BACKUP_BLOCKED,
     WaitingInputCancelResult,
@@ -735,6 +740,11 @@ class IacCodeRequestHandler(DefaultRequestHandler):
             context_id=task.context_id,
             task_id=task.id,
             reason=_("Task canceled while waiting for input."),
+            cancellation=pipeline_cancellation(
+                CANCEL_REASON_USER_INITIATED,
+                trigger_source=CANCEL_TRIGGER_USER,
+                detail="a2a cancelTask on waiting-input task",
+            ),
             backup_service=self._backup_service,
             task_store=self.task_store,
             task_record=task_record,

--- a/src/iac_code/a2a/types.py
+++ b/src/iac_code/a2a/types.py
@@ -33,6 +33,9 @@ class A2ATaskRecord:
     output_text: list[str] = field(default_factory=list)
     active_task: asyncio.Task[Any] | None = None
     expired: bool = False
+    # Structured cancel attribution declared by the caller that requested the
+    # cancel, read back when the canceled run publishes its terminal event.
+    cancellation: Any | None = None
     updated_at: float = field(default_factory=time.time)
     created_at: float = field(default_factory=time.monotonic)
     last_active: float = field(default_factory=time.monotonic)

--- a/tests/a2a/test_pipeline_cancellation.py
+++ b/tests/a2a/test_pipeline_cancellation.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from iac_code.a2a.executor import IacCodeA2AExecutor
+from iac_code.a2a.metrics import NoOpA2AMetrics
+from iac_code.a2a.pipeline_cancellation import (
+    CANCEL_REASON_EXECUTOR_ERROR,
+    CANCEL_REASON_RESOURCE_LIMIT,
+    CANCEL_REASON_UNKNOWN,
+    CANCEL_REASON_UPSTREAM_TIMEOUT,
+    CANCEL_REASON_USER_INITIATED,
+    CANCEL_TRIGGER_SCHEDULER,
+    CANCEL_TRIGGER_SYSTEM,
+    CANCEL_TRIGGER_USER,
+    PipelineCancellation,
+    cancellation_event_data,
+    pipeline_cancellation,
+    resolve_pipeline_cancellation,
+    unknown_pipeline_cancellation,
+)
+from iac_code.a2a.pipeline_journal import A2APipelineJournal
+from iac_code.a2a.pipeline_snapshot import A2APipelineSnapshotStore, reduce_pipeline_events
+from iac_code.a2a.task_store import A2ATaskStore
+from tests.a2a.fakes import FakeEventQueue, FakeRequestContext
+
+
+def test_user_initiated_cancellation_defaults_trigger_to_user() -> None:
+    cancellation = pipeline_cancellation(CANCEL_REASON_USER_INITIATED)
+
+    assert cancellation.reason_code == CANCEL_REASON_USER_INITIATED
+    assert cancellation.trigger_source == CANCEL_TRIGGER_USER
+
+
+def test_system_reason_codes_default_to_expected_trigger_sources() -> None:
+    assert pipeline_cancellation(CANCEL_REASON_UPSTREAM_TIMEOUT).trigger_source == CANCEL_TRIGGER_SCHEDULER
+    assert pipeline_cancellation(CANCEL_REASON_EXECUTOR_ERROR).trigger_source == CANCEL_TRIGGER_SYSTEM
+    assert pipeline_cancellation(CANCEL_REASON_RESOURCE_LIMIT).trigger_source == CANCEL_TRIGGER_SYSTEM
+
+
+def test_unknown_reason_code_falls_back_to_unknown_system() -> None:
+    cancellation = pipeline_cancellation("not-a-real-code", trigger_source="not-a-real-source")
+
+    assert cancellation.reason_code == CANCEL_REASON_UNKNOWN
+    assert cancellation.trigger_source == CANCEL_TRIGGER_SYSTEM
+    assert unknown_pipeline_cancellation() == PipelineCancellation()
+
+
+def test_explicit_trigger_source_overrides_the_default() -> None:
+    cancellation = pipeline_cancellation(CANCEL_REASON_USER_INITIATED, trigger_source=CANCEL_TRIGGER_SCHEDULER)
+
+    assert cancellation.trigger_source == CANCEL_TRIGGER_SCHEDULER
+
+
+def test_event_data_preserves_legacy_fields_and_adds_attribution() -> None:
+    data = cancellation_event_data(
+        pipeline_cancellation(CANCEL_REASON_USER_INITIATED, detail="a2a cancelTask request"),
+        base={"source": "executor", "reason": "Task canceled."},
+    )
+
+    assert data == {
+        "source": "executor",
+        "reason": "Task canceled.",
+        "reasonCode": CANCEL_REASON_USER_INITIATED,
+        "triggerSource": CANCEL_TRIGGER_USER,
+        "detail": "a2a cancelTask request",
+    }
+
+
+def test_event_data_omits_detail_when_absent() -> None:
+    data = cancellation_event_data(pipeline_cancellation(CANCEL_REASON_UPSTREAM_TIMEOUT))
+
+    assert data == {
+        "reasonCode": CANCEL_REASON_UPSTREAM_TIMEOUT,
+        "triggerSource": CANCEL_TRIGGER_SCHEDULER,
+    }
+
+
+def test_event_data_from_missing_attribution_is_unknown_system() -> None:
+    data = cancellation_event_data(None, base={"source": "executor"})
+
+    assert data == {
+        "source": "executor",
+        "reasonCode": CANCEL_REASON_UNKNOWN,
+        "triggerSource": CANCEL_TRIGGER_SYSTEM,
+    }
+
+
+def test_resolve_normalizes_a_tampered_attribution() -> None:
+    resolved = resolve_pipeline_cancellation(PipelineCancellation(reason_code="bogus", trigger_source="bogus"))
+
+    assert resolved.reason_code == CANCEL_REASON_UNKNOWN
+    assert resolved.trigger_source == CANCEL_TRIGGER_SYSTEM
+
+
+def test_detail_is_truncated_and_blank_detail_is_dropped() -> None:
+    assert pipeline_cancellation(CANCEL_REASON_EXECUTOR_ERROR, detail="   ").detail is None
+    long_detail = pipeline_cancellation(CANCEL_REASON_EXECUTOR_ERROR, detail="x" * 500).detail
+    assert long_detail is not None
+    assert len(long_detail) == 200
+
+
+def _canceled_envelope(sequence: int, data: dict[str, object]) -> dict[str, object]:
+    return {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "eventId": f"evt-{sequence}",
+        "sequence": sequence,
+        "createdAt": "2026-08-21T10:00:00Z",
+        "eventType": "pipeline_canceled",
+        "scope": "pipeline",
+        "pipelineRunId": "ctx-1",
+        "taskId": "task-1",
+        "contextId": "ctx-1",
+        "pipelineName": "selling",
+        "status": "canceled",
+        "data": data,
+    }
+
+
+def test_snapshot_exposes_cancel_attribution_for_grouping() -> None:
+    user_snapshot = reduce_pipeline_events(
+        [
+            _canceled_envelope(
+                1,
+                {
+                    "source": "a2a_cancel",
+                    "reason": "Task canceled while waiting for input.",
+                    "reasonCode": CANCEL_REASON_USER_INITIATED,
+                    "triggerSource": CANCEL_TRIGGER_USER,
+                },
+            )
+        ]
+    )
+    system_snapshot = reduce_pipeline_events(
+        [
+            _canceled_envelope(
+                1,
+                {
+                    "source": "executor",
+                    "reason": "Task canceled.",
+                    "reasonCode": CANCEL_REASON_UPSTREAM_TIMEOUT,
+                    "triggerSource": CANCEL_TRIGGER_SCHEDULER,
+                },
+            )
+        ]
+    )
+
+    assert user_snapshot["status"] == "canceled"
+    assert user_snapshot["cancellation"] == {
+        "reasonCode": CANCEL_REASON_USER_INITIATED,
+        "triggerSource": CANCEL_TRIGGER_USER,
+    }
+    assert system_snapshot["cancellation"] == {
+        "reasonCode": CANCEL_REASON_UPSTREAM_TIMEOUT,
+        "triggerSource": CANCEL_TRIGGER_SCHEDULER,
+    }
+    assert user_snapshot["cancellation"] != system_snapshot["cancellation"]
+
+
+def test_snapshot_cancellation_is_none_for_legacy_generic_cancel() -> None:
+    snapshot = reduce_pipeline_events([_canceled_envelope(1, {"source": "executor", "reason": "Task canceled."})])
+
+    assert snapshot["status"] == "canceled"
+    assert snapshot["cancellation"] is None
+
+
+def test_pending_terminal_lifts_cancel_attribution() -> None:
+    envelope = _canceled_envelope(
+        1,
+        {
+            "source": "executor",
+            "reason": "Task canceled.",
+            "reasonCode": CANCEL_REASON_EXECUTOR_ERROR,
+            "triggerSource": CANCEL_TRIGGER_SYSTEM,
+            "detail": "executor drain failed",
+        },
+    )
+    envelope["visibility"] = "pending_backup"
+
+    snapshot = reduce_pipeline_events([envelope])
+
+    assert snapshot["pendingTerminal"]["cancellation"] == {
+        "reasonCode": CANCEL_REASON_EXECUTOR_ERROR,
+        "triggerSource": CANCEL_TRIGGER_SYSTEM,
+        "detail": "executor drain failed",
+    }
+
+
+def test_waiting_input_cancel_writes_attribution_into_the_journal(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import (
+        WaitingInputCancelResult,
+        cancel_waiting_input_task_from_sidecar,
+    )
+    from iac_code.a2a.pipeline_paths import a2a_pipeline_dir_for_session
+
+    cwd = tmp_path / "workspace"
+    session_id = "session-ctx-1"
+    context_id = "ctx-1"
+    pipeline_dir = a2a_pipeline_dir_for_session(cwd=str(cwd), session_id=session_id)
+    pending = {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "eventId": "evt-selection",
+        "sequence": 1,
+        "createdAt": "2026-08-21T10:00:00Z",
+        "eventType": "input_required",
+        "scope": "step",
+        "pipelineRunId": context_id,
+        "taskId": "task-1",
+        "contextId": context_id,
+        "pipelineName": "selling",
+        "status": "input_required",
+        "step": {"runId": "step-confirm_and_select-1", "id": "confirm_and_select", "attempt": 1},
+        "input": {
+            "inputId": "input-confirm_and_select-1",
+            "kind": "candidate_selection",
+            "prompt": "choose",
+            "options": [{"name": "A", "candidate_index": 0}],
+        },
+    }
+    A2APipelineJournal(pipeline_dir).append(pending)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([pending]))
+
+    result = cancel_waiting_input_task_from_sidecar(
+        cwd=str(cwd),
+        session_id=session_id,
+        context_id=context_id,
+        task_id="task-1",
+        reason="user canceled",
+        cancellation=pipeline_cancellation(
+            CANCEL_REASON_USER_INITIATED,
+            trigger_source=CANCEL_TRIGGER_USER,
+            detail="a2a cancelTask on waiting-input task",
+        ),
+    )
+
+    assert result == WaitingInputCancelResult.CANCELED
+    canceled = next(
+        event for event in A2APipelineJournal(pipeline_dir).read_all() if event["eventType"] == "pipeline_canceled"
+    )
+    assert canceled["data"]["source"] == "a2a_cancel"
+    assert canceled["data"]["reason"] == "user canceled"
+    assert canceled["data"]["reasonCode"] == CANCEL_REASON_USER_INITIATED
+    assert canceled["data"]["triggerSource"] == CANCEL_TRIGGER_USER
+    assert canceled["data"]["detail"] == "a2a cancelTask on waiting-input task"
+
+
+def test_waiting_input_cancel_without_attribution_falls_back_to_unknown(tmp_path: Path) -> None:
+    from iac_code.a2a.pipeline_executor import (
+        WaitingInputCancelResult,
+        cancel_waiting_input_task_from_sidecar,
+    )
+    from iac_code.a2a.pipeline_paths import a2a_pipeline_dir_for_session
+
+    cwd = tmp_path / "workspace"
+    session_id = "session-ctx-2"
+    context_id = "ctx-2"
+    pipeline_dir = a2a_pipeline_dir_for_session(cwd=str(cwd), session_id=session_id)
+    pending = {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "eventId": "evt-selection",
+        "sequence": 1,
+        "createdAt": "2026-08-21T10:00:00Z",
+        "eventType": "input_required",
+        "scope": "step",
+        "pipelineRunId": context_id,
+        "taskId": "task-2",
+        "contextId": context_id,
+        "pipelineName": "selling",
+        "status": "input_required",
+        "step": {"runId": "step-confirm_and_select-1", "id": "confirm_and_select", "attempt": 1},
+        "input": {
+            "inputId": "input-confirm_and_select-1",
+            "kind": "candidate_selection",
+            "prompt": "choose",
+            "options": [{"name": "A", "candidate_index": 0}],
+        },
+    }
+    A2APipelineJournal(pipeline_dir).append(pending)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([pending]))
+
+    result = cancel_waiting_input_task_from_sidecar(
+        cwd=str(cwd),
+        session_id=session_id,
+        context_id=context_id,
+        task_id="task-2",
+        reason="canceled",
+    )
+
+    assert result == WaitingInputCancelResult.CANCELED
+    canceled = next(
+        event for event in A2APipelineJournal(pipeline_dir).read_all() if event["eventType"] == "pipeline_canceled"
+    )
+    assert canceled["data"]["reasonCode"] == CANCEL_REASON_UNKNOWN
+    assert canceled["data"]["triggerSource"] == CANCEL_TRIGGER_SYSTEM
+    assert "detail" not in canceled["data"]
+
+
+@pytest.mark.asyncio
+async def test_active_run_cancel_records_user_attribution_from_task_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A2A ``cancelTask`` on a running pipeline must be attributed to the user."""
+
+    journal_events = await _run_and_cancel_pipeline(
+        monkeypatch,
+        tmp_path,
+        cancellation=pipeline_cancellation(
+            CANCEL_REASON_USER_INITIATED,
+            trigger_source=CANCEL_TRIGGER_USER,
+            detail="a2a cancelTask request",
+        ),
+    )
+
+    canceled = next(event for event in journal_events if event["eventType"] == "pipeline_canceled")
+    assert canceled["data"]["source"] == "executor"
+    assert canceled["data"]["reasonCode"] == CANCEL_REASON_USER_INITIATED
+    assert canceled["data"]["triggerSource"] == CANCEL_TRIGGER_USER
+    assert canceled["data"]["detail"] == "a2a cancelTask request"
+
+
+@pytest.mark.asyncio
+async def test_active_run_cancel_records_upstream_timeout_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A scheduler-driven timeout cancel stays distinguishable from a user stop."""
+
+    journal_events = await _run_and_cancel_pipeline(
+        monkeypatch,
+        tmp_path,
+        cancellation=pipeline_cancellation(CANCEL_REASON_UPSTREAM_TIMEOUT),
+    )
+
+    canceled = next(event for event in journal_events if event["eventType"] == "pipeline_canceled")
+    assert canceled["data"]["reasonCode"] == CANCEL_REASON_UPSTREAM_TIMEOUT
+    assert canceled["data"]["triggerSource"] == CANCEL_TRIGGER_SCHEDULER
+
+
+@pytest.mark.asyncio
+async def test_active_run_cancel_without_attribution_stays_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An undeclared cancel path keeps the legacy payload plus ``unknown``/``system``."""
+
+    journal_events = await _run_and_cancel_pipeline(monkeypatch, tmp_path, cancellation=None)
+
+    canceled = next(event for event in journal_events if event["eventType"] == "pipeline_canceled")
+    assert canceled["data"]["source"] == "executor"
+    assert canceled["data"]["reasonCode"] == CANCEL_REASON_UNKNOWN
+    assert canceled["data"]["triggerSource"] == CANCEL_TRIGGER_SYSTEM
+    assert "detail" not in canceled["data"]
+
+
+class _CancelingPipeline:
+    """Minimal pipeline whose stream raises ``CancelledError`` like a real cancel."""
+
+    def __init__(self, *, session_dir: Path) -> None:
+        self.pipeline_name = "selling"
+        self.sidecar_status = None
+        self.sidecar_restore_result = None
+        self.session = SimpleNamespace(session_dir=session_dir)
+
+    async def run(self, prompt: str):
+        raise asyncio.CancelledError()
+        yield None  # pragma: no cover - keeps ``run`` an async generator
+
+    def clear_sidecar(self) -> None:
+        self.sidecar_status = None
+
+    def should_switch_to_normal(self, data: dict) -> bool:
+        return True
+
+    def build_normal_handoff_summary(self, data: dict) -> str:
+        return "[Pipeline Handoff Context]\nOutcome: canceled"
+
+
+async def _run_and_cancel_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    cancellation: PipelineCancellation | None,
+) -> list[dict]:
+    """Drive one pipeline run through a cancel and return the journal events."""
+
+    monkeypatch.setenv("IAC_CODE_MODE", "pipeline")
+    session_dir = tmp_path / "sidecar"
+    pipeline = _CancelingPipeline(session_dir=session_dir)
+    monkeypatch.setattr("iac_code.a2a.pipeline_executor.create_pipeline", lambda *a, **k: pipeline)
+    monkeypatch.setattr(
+        "iac_code.a2a.pipeline_executor.create_agent_runtime",
+        lambda options: SimpleNamespace(provider_manager=object(), tool_registry=_NoopToolRegistry()),
+    )
+
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    task.cancellation = cancellation
+    executor = IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus", metrics=NoOpA2AMetrics())
+
+    await executor.execute(
+        FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}),
+        FakeEventQueue(),
+    )
+
+    return A2APipelineJournal(session_dir).read_all()
+
+
+class _NoopToolRegistry:
+    def register(self, tool) -> None:
+        pass
+
+    def unregister(self, tool_name: str) -> None:
+        pass


### PR DESCRIPTION
## 问题

`pipeline_canceled` 事件的 `data.reason` 只携带本地化展示文案 `"Task canceled."`，而 `asyncio.CancelledError` 汇聚了用户主动取消、上游超时、执行器异常、资源限制等所有取消路径。取消是部分 Session 唯一的终止路径，归因缺失会让审计无法区分用户主动停止与系统故障，阻塞恢复策略选择与告警分级。

## 改动

新增 `src/iac_code/a2a/pipeline_cancellation.py`，定义机读归因：

- `reasonCode`：`user_initiated` / `upstream_timeout` / `executor_error` / `resource_limit` / `unknown`
- `triggerSource`：`user` / `scheduler` / `system`
- 可选 `detail`：非本地化短诊断串（sanitize + 截断，不含用户输入）

归因沿取消链传播：

- `A2ATaskStore.cancel_task` / `cancel_task_and_wait` 新增可选 `cancellation` 参数，在 `.cancel()` 前记录到 task record。
- `IacCodeA2AExecutor.cancel`（A2A `cancelTask`）与 dispatcher 的 waiting-input 取消路径标注 `user_initiated` / `user`。
- `pipeline_executor.py` 两个 `pipeline_canceled` 生产点读取归因构造事件 `data`；未声明归因的路径回落 `unknown` / `system`。
- `pipeline_snapshot.py` 把归因提升为 `cancellation` 字段（终态快照与 `pendingTerminal`），供审计视图按归因类型分组统计。

## 兼容性

既有 `source` 与本地化 `reason` 字段原样保留，新增字段为纯增量；debugger（读 `data.reason`）、transcript 与现有快照消费方零改动，未触碰任何 locale 的 `messages.po`。归因参数全部可选，终态语义与 task state 机器不变。

## 验证

- 新增 `tests/a2a/test_pipeline_cancellation.py`（17 项）：用户主动取消 vs 上游超时取消归因可区分、缺失归因回落 `unknown`/`system`、旧字段未变、快照归因可分组、`detail` 截断与空值处理。
- `tests/a2a` + `tests/web/test_pipeline_transcript.py`：1563 passed。
- `ruff check src/`、`ty check src/`、`ruff format` 均通过。
