### PR TITLE
fix(aliyun): validate DestinationResource locally instead of relying on HTTP 400

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -6141,6 +6141,15 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
+"value. Allowed values: {allowed}."
+msgstr ""
+"Der Parameter {parameter} der Alibaba-Cloud-API {operation} ist kein "
+"zulässiger Wert. Zulässige Werte: {allowed}."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
 "value."
 msgstr ""
 "Der Parameter {parameter} der Alibaba-Cloud-API {operation} ist kein "

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6104,6 +6104,15 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
+"value. Allowed values: {allowed}."
+msgstr ""
+"El parámetro {parameter} de la API de Alibaba Cloud {operation} no es un "
+"valor permitido. Valores permitidos: {allowed}."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
 "value."
 msgstr ""
 "El parámetro {parameter} de la API de Alibaba Cloud {operation} no es un "

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6123,6 +6123,15 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
+"value. Allowed values: {allowed}."
+msgstr ""
+"Le paramètre {parameter} de l'API Alibaba Cloud {operation} n'est pas une"
+" valeur autorisée. Valeurs autorisées : {allowed}."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
 "value."
 msgstr ""
 "Le paramètre {parameter} de l'API Alibaba Cloud {operation} n'est pas une"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -5809,6 +5809,13 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
+"value. Allowed values: {allowed}."
+msgstr "Alibaba Cloud API {operation} のパラメーター {parameter} は許可された値ではありません。許可された値: {allowed}。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
 "value."
 msgstr "Alibaba Cloud API {operation} のパラメーター {parameter} は許可された値ではありません。"
 

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6065,6 +6065,15 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
+"value. Allowed values: {allowed}."
+msgstr ""
+"O parâmetro {parameter} da API do Alibaba Cloud {operation} não é um "
+"valor permitido. Valores permitidos: {allowed}."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
 "value."
 msgstr ""
 "O parâmetro {parameter} da API do Alibaba Cloud {operation} não é um "

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -5728,6 +5728,13 @@ msgstr "阿里云 API {operation} 的参数 {parameter} 需要 {expected}，但�
 #, python-brace-format
 msgid ""
 "Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
+"value. Allowed values: {allowed}."
+msgstr "阿里云 API {operation} 的参数 {parameter} 不是允许的值。允许的值：{allowed}。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} parameter {parameter} is not an allowed "
 "value."
 msgstr "阿里云 API {operation} 的参数 {parameter} 不是允许的值。"
 

--- a/src/iac_code/tools/cloud/aliyun/api_contract.py
+++ b/src/iac_code/tools/cloud/aliyun/api_contract.py
@@ -870,11 +870,13 @@ class ApiContractResolver:
         path_parameters = _override_mapping(version_record, "path_parameters")
         parameter_styles = _override_mapping(version_record, "parameter_styles")
         parameter_locations = _override_mapping(version_record, "parameter_locations")
+        parameter_enums = _override_mapping(version_record, "parameter_enums")
         additional_parameters = _override_mapping(version_record, "additional_parameters")
         for source, target in (
             (action_record.get("path_parameters", {}) or {}, path_parameters),
             (action_record.get("parameter_styles", {}) or {}, parameter_styles),
             (action_record.get("parameter_locations", {}) or {}, parameter_locations),
+            (action_record.get("parameter_enums", {}) or {}, parameter_enums),
             (action_record.get("additional_parameters", {}) or {}, additional_parameters),
         ):
             if not isinstance(source, Mapping):
@@ -884,6 +886,7 @@ class ApiContractResolver:
             not isinstance(path_parameters, Mapping)
             or not isinstance(parameter_styles, Mapping)
             or not isinstance(parameter_locations, Mapping)
+            or not isinstance(parameter_enums, Mapping)
         ):
             raise ApiContractError("invalid_api_overrides")
         result: list[ParameterMetadata] = []
@@ -902,6 +905,11 @@ class ApiContractResolver:
                 if location not in _SAFE_PARAMETER_LOCATIONS:
                     raise ApiContractError("invalid_api_overrides")
                 replacement = replace(replacement, location=location)
+            if parameter.name in parameter_enums:
+                replacement = replace(
+                    replacement,
+                    schema=_schema_with_reviewed_enum(replacement.schema, parameter_enums[parameter.name]),
+                )
             result.append(replacement)
         existing_names = {parameter.name.casefold() for parameter in parameters}
         for name, raw in additional_parameters.items():
@@ -1213,7 +1221,11 @@ def _validate_parameter_schema(
         )
     enum = schema.get("enum")
     if isinstance(enum, list | tuple) and enum and not _enum_contains_value(enum, value, expected):
-        raise ApiContractError(f"invalid_parameter_enum:{parameter.name}")
+        raise ApiContractError(
+            f"invalid_parameter_enum:{parameter.name}",
+            parameter=parameter.name,
+            suggestions=tuple(_wire_scalar(item) for item in enum),
+        )
     if "allOf" not in schema:
         return
     branches = schema["allOf"]
@@ -1475,6 +1487,44 @@ def _override_mapping(record: Mapping[str, Any], key: str) -> dict[Any, Any]:
     if not isinstance(value, Mapping):
         raise ApiContractError("invalid_api_overrides")
     return dict(value)
+
+
+def _schema_with_reviewed_enum(schema: Mapping[str, Any] | None, values: Any) -> Mapping[str, Any]:
+    """Attach a reviewed closed value set to a parameter whose OpenMeta schema omits ``enum``.
+
+    OpenMeta documents some closed value sets only in prose, so an out-of-range value can only
+    be rejected by the target service as an HTTP 400. A reviewed override lets the request
+    builder reject it locally instead. An upstream ``enum`` always wins, so a stale override can
+    never narrow the value set OpenMeta currently declares.
+    """
+
+    if (
+        not isinstance(values, list)
+        or not values
+        or any(not isinstance(item, str | int | float | bool) for item in values)
+        or len({(type(item).__name__, item) for item in values}) != len(values)
+    ):
+        raise ApiContractError("invalid_api_overrides")
+    merged = copy.deepcopy(dict(schema)) if isinstance(schema, Mapping) else {}
+    expected = merged.get("type")
+    if expected is not None and any(not _schema_type_matches(expected, item) for item in values):
+        raise ApiContractError("invalid_api_overrides")
+    if isinstance(merged.get("enum"), list | tuple):
+        return MappingProxyType(merged)
+    merged["enum"] = list(values)
+    return MappingProxyType(merged)
+
+
+def _schema_type_matches(expected: Any, value: Any) -> bool:
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, int | float) and not isinstance(value, bool)
+    if expected == "string":
+        return isinstance(value, str)
+    return False
 
 
 def _request_body_type(

--- a/src/iac_code/tools/cloud/aliyun/data/openmeta/api_overrides.yml
+++ b/src/iac_code/tools/cloud/aliyun/data/openmeta/api_overrides.yml
@@ -74,6 +74,22 @@ products:
       "2018-08-08":
         parameter_styles:
           DestinationResource: null
+  Ecs:
+    versions:
+      "2014-05-26":
+        actions:
+          DescribeAvailableResource:
+            parameter_enums:
+              # OpenMeta documents these values only in the parameter description, so an
+              # out-of-range value reaches the target service and returns HTTP 400 Invalid.Param.
+              DestinationResource:
+                - Zone
+                - IoOptimized
+                - InstanceType
+                - Network
+                - ddh
+                - SystemDisk
+                - DataDisk
   Oss:
     default_signature_scheme: oss_v4
     versions:

--- a/src/iac_code/tools/cloud/aliyun/public_errors.py
+++ b/src/iac_code/tools/cloud/aliyun/public_errors.py
@@ -13,10 +13,13 @@ from iac_code.tools.cloud.aliyun.api_identifiers import is_safe_api_version
 
 _SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 _SAFE_PARAMETER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,126}(?:\*)?$")
+_SAFE_ALLOWED_VALUE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 _ASCII_WHITESPACE = " \t\n\r\f\v"
 _TARGET_HTTP_ERROR = re.compile(r"^aliyun_target_http_error:(\d{3})(?::([A-Za-z0-9][A-Za-z0-9_.:-]{0,127}))?$")
 _MAX_PUBLIC_PARAMETER_NAMES = 16
 _MAX_PUBLIC_PARAMETER_LIST_CHARS = 512
+_MAX_PUBLIC_ALLOWED_VALUES = 32
+_MAX_PUBLIC_ALLOWED_VALUE_CHARS = 512
 _PROTOCOL_UNSUPPORTED_REASONS = frozenset(
     {
         "api_style_unsupported",
@@ -183,6 +186,12 @@ def public_aliyun_error(
         )
     if code.startswith("invalid_parameter_enum:"):
         parameter = _safe_parameter(code.partition(":")[2], _("the requested parameter"))
+        allowed = _safe_allowed_values(getattr(error, "suggestions", ()))
+        if allowed is not None:
+            return _(
+                "Alibaba Cloud API {operation} parameter {parameter} is not an allowed value. "
+                "Allowed values: {allowed}."
+            ).format(operation=operation, parameter=parameter, allowed=allowed)
         return _("Alibaba Cloud API {operation} parameter {parameter} is not an allowed value.").format(
             operation=operation,
             parameter=parameter,
@@ -553,6 +562,17 @@ def _safe_parameter_list(value: Any) -> str | None:
     ):
         return None
     return ",".join(names)
+
+
+def _safe_allowed_values(values: Any) -> str | None:
+    """Render a closed value set that came from the local contract, never from tool input."""
+
+    if not isinstance(values, tuple) or not values or len(values) > _MAX_PUBLIC_ALLOWED_VALUES:
+        return None
+    if any(not isinstance(value, str) or _SAFE_ALLOWED_VALUE.fullmatch(value) is None for value in values):
+        return None
+    rendered = ", ".join(values)
+    return rendered if len(rendered) <= _MAX_PUBLIC_ALLOWED_VALUE_CHARS else None
 
 
 def _safe_type(value: Any) -> str:

--- a/tests/tools/cloud/aliyun/test_api_contract.py
+++ b/tests/tools/cloud/aliyun/test_api_contract.py
@@ -335,6 +335,124 @@ products:
     }
 
 
+def describe_available_resource_api(**schema_changes: Any) -> dict[str, Any]:
+    destination_schema: dict[str, Any] = {"type": "string", "required": True}
+    destination_schema.update(schema_changes)
+    return raw_api(
+        product="Ecs",
+        version="2014-05-26",
+        action="DescribeAvailableResource",
+        security=[{"AK": []}],
+        parameters=[
+            {"name": "RegionId", "in": "query", "schema": {"type": "string", "required": True}},
+            {"name": "DestinationResource", "in": "query", "schema": destination_schema},
+        ],
+    )
+
+
+def describe_available_resource_shape() -> ApiCallShape:
+    return shape(
+        action="DescribeAvailableResource",
+        parameter_names_by_location=MappingProxyType({"query": ("RegionId", "DestinationResource")}),
+    )
+
+
+async def resolve_with_shipped_overrides(raw: dict[str, Any]) -> CanonicalWireContract:
+    resolved = await ApiContractResolver(FakeOpenMeta(raw)).resolve(
+        describe_available_resource_shape(),
+        allow_fallback=False,
+    )
+    assert resolved.executable is True
+    return resolved
+
+
+@pytest.mark.asyncio
+async def test_reviewed_parameter_enum_rejects_out_of_range_value_before_the_request_is_sent() -> None:
+    resolved = await resolve_with_shipped_overrides(describe_available_resource_api())
+    forbidden = "instancetype"
+
+    with pytest.raises(ApiContractError, match="^invalid_parameter_enum:DestinationResource$") as raised:
+        await RequestBuilder().build(
+            resolved,
+            {"params": {"RegionId": "cn-hangzhou", "DestinationResource": forbidden}},
+        )
+
+    message = public_aliyun_error(raised.value, product="Ecs", action="DescribeAvailableResource")
+    assert message == (
+        "Alibaba Cloud API Ecs/DescribeAvailableResource parameter DestinationResource is not an allowed value. "
+        "Allowed values: Zone, IoOptimized, InstanceType, Network, ddh, SystemDisk, DataDisk."
+    )
+    assert forbidden not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_reviewed_parameter_enum_keeps_documented_values_executable() -> None:
+    resolved = await resolve_with_shipped_overrides(describe_available_resource_api())
+
+    built = await RequestBuilder().build(
+        resolved,
+        {"params": {"RegionId": "cn-hangzhou", "DestinationResource": "InstanceType"}},
+    )
+
+    assert dict(built.canonical_query) == {
+        "DestinationResource": "InstanceType",
+        "RegionId": "cn-hangzhou",
+    }
+
+
+@pytest.mark.asyncio
+async def test_upstream_enum_wins_over_a_reviewed_parameter_enum_override() -> None:
+    resolved = await resolve_with_shipped_overrides(describe_available_resource_api(enum=["InstanceType", "Zone"]))
+    destination = next(item for item in resolved.parameters if item.name == "DestinationResource")
+
+    assert destination.schema is not None
+    assert list(destination.schema["enum"]) == ["InstanceType", "Zone"]
+    with pytest.raises(ApiContractError, match="^invalid_parameter_enum:DestinationResource$"):
+        await RequestBuilder().build(
+            resolved,
+            {"params": {"RegionId": "cn-hangzhou", "DestinationResource": "SystemDisk"}},
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "values",
+    ["InstanceType", [], ["Zone", "Zone"], ["Zone", 7], [["Zone"]]],
+    ids=["not-a-list", "empty", "duplicate", "type-mismatch", "nested-container"],
+)
+async def test_invalid_parameter_enum_override_fails_closed(tmp_path: Path, values: Any) -> None:
+    overrides = tmp_path / "api_overrides.yml"
+    overrides.write_text(
+        json.dumps(
+            {
+                "contract_policy_version": 1,
+                "default_signature_scheme": "acs3",
+                "products": {
+                    "Ecs": {
+                        "versions": {
+                            "2014-05-26": {
+                                "actions": {
+                                    "DescribeAvailableResource": {
+                                        "parameter_enums": {"DestinationResource": values},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    resolver = ApiContractResolver(
+        FakeOpenMeta(describe_available_resource_api()),
+        overrides_path=overrides,
+    )
+
+    with pytest.raises(ApiContractError, match="^invalid_api_overrides$"):
+        await resolver.resolve(describe_available_resource_shape(), allow_fallback=False)
+
+
 @pytest.mark.asyncio
 async def test_signature_scheme_can_be_overridden_for_one_exact_version(tmp_path: Path) -> None:
     overrides = tmp_path / "api_overrides.yml"

--- a/tests/tools/cloud/aliyun/test_public_errors.py
+++ b/tests/tools/cloud/aliyun/test_public_errors.py
@@ -120,6 +120,7 @@ def test_aliyun_public_error_templates_are_directly_extractable(tmp_path: Path) 
         "Alibaba Cloud API version contains unsupported characters.",
         "Alibaba Cloud API {operation} is missing required parameters.",
         "Alibaba Cloud API {operation} parameter {parameter} is not an allowed value.",
+        "Alibaba Cloud API {operation} parameter {parameter} is not an allowed value. Allowed values: {allowed}.",
         "Alibaba Cloud API {operation} parameter {parameter} expects {expected} but received {actual}.",
         "Alibaba Cloud API {operation} requires parameters {parameters}.",
         "Alibaba Cloud API {operation} requires body_file for its binary request body.",


### PR DESCRIPTION
## 问题

ECS `DescribeAvailableResource` 的 `DestinationResource` 合法取值只写在 OpenMeta 的参数 `description` 里，schema 没有 `enum`。本地契约因此没有可校验的闭集，非法取值被原样签名发出，由目标服务返回 HTTP 400 `Invalid.Param`。`cost_estimating` 步骤于是在一个不可能成功的请求上消耗了一次可恢复重试。

对应 Session：`021498baff2d4d869faf4a16b94f1c54`。

## 改动

- `api_contract.py`：`_apply_parameter_overrides()` 支持 `parameter_enums` 覆盖（version 级 + action 级），为 OpenMeta 缺失 `enum` 的参数补齐经评审的闭集。上游已声明 `enum` 时以上游为准，过期覆盖无法收窄当前合法集合；覆盖数据非法（非列表 / 空 / 重复 / 类型不符）继续走 `invalid_api_overrides` fail-closed。
- `api_overrides.yml`：声明 `Ecs/2014-05-26/DescribeAvailableResource` 的 `DestinationResource` 官方取值。
- `public_errors.py`：`invalid_parameter_enum` 公开文案附带合法取值（取自本地契约，不回显用户输入），让调用方一次改对而不是盲目重试。

## 效果

非法 `DestinationResource` 现在在 `RequestBuilder.build()` 阶段本地拒绝，请求不再发出，也不再产生 `Invalid.Param` 及对应无效重试。合法取值行为不变。

## 验证

- `uv run pytest tests/tools/cloud/aliyun tests/i18n tests/pipeline/selling` — 2727 passed
- `uv run ruff check src tests`、`uv run ty check src/` — 均通过
- `make translate` 已同步 6 个 locale 的 `messages.po`
