### PR TITLE
fix(a2a): 修复 pipeline 事件计数不对称，完成事件多于启动事件

### DIFF
--- a/src/iac_code/a2a/pipeline_events.py
+++ b/src/iac_code/a2a/pipeline_events.py
@@ -97,6 +97,12 @@ _NESTED_DATA_KEY_ALIASES = {
 }
 _STACK_TOOL_ACTIONS = {"CreateStack", "UpdateStack", "ContinueCreateStack", "DeleteStack"}
 _STACK_CLEAR_ACTIONS = {"DeleteStack"}
+_PIPELINE_TERMINAL_EVENT_TYPES = {"pipeline_completed", "pipeline_failed", "pipeline_canceled"}
+_PIPELINE_LIFECYCLE_EVENT_TYPES = {
+    "pipeline_started",
+    "pipeline_resumed",
+    *_PIPELINE_TERMINAL_EVENT_TYPES,
+}
 
 
 @dataclass
@@ -143,6 +149,13 @@ class PipelineEventTranslator:
         self._current_parent_step_id: str | None = None
         self._tool_inputs: dict[str, dict[str, Any]] = {}
         self._emitted_candidate_detail_tool_ids: set[str] = set()
+        # 完成事件幂等账本。引擎会从多个终态分支重复 yield PIPELINE_COMPLETED
+        # (pipeline_runner._continue_from_current 的 emit_pipeline_completed 只对
+        # telemetry 去重),并在 input_required 恢复路径上跳过 step_started 却再次
+        # yield STEP_COMPLETED,导致 a2a 事件流里完成事件多于启动事件、无法 1:1
+        # 配对。归类层按 (step_id, attempt) 与 run 维度只放行首个完成事件。
+        self._completed_step_keys: set[tuple[str, int]] = set()
+        self._pipeline_terminal_emitted = False
 
     @property
     def last_sequence(self) -> int:
@@ -154,6 +167,8 @@ class PipelineEventTranslator:
 
     def hydrate_from_events(self, events: list[dict[str, Any]]) -> None:
         latest_parent_step_sequence = -1
+        latest_lifecycle_sequence = -1
+        latest_lifecycle_event_type: str | None = None
         for event in events:
             if not isinstance(event, dict):
                 continue
@@ -164,6 +179,11 @@ class PipelineEventTranslator:
             self._sequence = max(self._sequence, sequence)
             self._hydrate_candidate_state(event)
 
+            event_type = _string_or_none(event.get("eventType"))
+            if event_type in _PIPELINE_LIFECYCLE_EVENT_TYPES and sequence >= latest_lifecycle_sequence:
+                latest_lifecycle_sequence = sequence
+                latest_lifecycle_event_type = event_type
+
             step = event.get("step")
             if not isinstance(step, dict):
                 continue
@@ -172,8 +192,9 @@ class PipelineEventTranslator:
             if step_id is None or attempt is None or attempt <= 0:
                 continue
             self._parent_step_attempts[step_id] = max(self._parent_step_attempts.get(step_id, 1), attempt)
+            self._hydrate_parent_step_pairing(event_type, step_id, attempt)
 
-            if sequence >= latest_parent_step_sequence and event.get("eventType") not in {
+            if sequence >= latest_parent_step_sequence and event_type not in {
                 "step_completed",
                 "step_failed",
                 "pipeline_completed",
@@ -182,6 +203,16 @@ class PipelineEventTranslator:
             }:
                 latest_parent_step_sequence = sequence
                 self._current_parent_step_id = step_id
+
+        if latest_lifecycle_event_type is not None:
+            # 只有当 journal 的最后一个生命周期事件仍是终态时,才认为本 run 已经
+            # 派发过终态事件。若之后又出现 pipeline_started/resumed,说明进入了新
+            # 的一轮,终态额度需要重新开放。
+            self._pipeline_terminal_emitted = latest_lifecycle_event_type in _PIPELINE_TERMINAL_EVENT_TYPES
+
+    def _hydrate_parent_step_pairing(self, event_type: str | None, step_id: str, attempt: int) -> None:
+        if event_type == "step_completed":
+            self._completed_step_keys.add((step_id, attempt))
 
     def _hydrate_candidate_state(self, event: dict[str, Any]) -> None:
         candidate = event.get("candidate")
@@ -365,8 +396,10 @@ class PipelineEventTranslator:
         created_at = _created_at_from_timestamp(event.timestamp)
 
         if event.type == PipelineEventType.PIPELINE_STARTED:
+            self._pipeline_terminal_emitted = False
             return [self._envelope("pipeline_started", "pipeline", "working", _event_data(data), created_at=created_at)]
         if event.type == PipelineEventType.PIPELINE_RESUMED:
+            self._pipeline_terminal_emitted = False
             return [self._envelope("pipeline_resumed", "pipeline", "working", _event_data(data), created_at=created_at)]
         if event.type == PipelineEventType.PIPELINE_WARNING:
             return [
@@ -399,12 +432,20 @@ class PipelineEventTranslator:
                 )
             ]
         if event.type == PipelineEventType.PIPELINE_COMPLETED:
+            if self._pipeline_terminal_emitted:
+                return []
             event_type = "pipeline_failed" if data.get("failed") is True else "pipeline_completed"
             status = "failed" if event_type == "pipeline_failed" else "completed"
+            self._pipeline_terminal_emitted = True
             return [self._envelope(event_type, "pipeline", status, _event_data(data), created_at=created_at)]
         if event.type == PipelineEventType.STEP_STARTED:
             return [self._translate_parent_step_event(event, "step_started", "working", created_at)]
         if event.type == PipelineEventType.STEP_COMPLETED:
+            if event.step_id is not None:
+                step_key = self._parent_step_key(event.step_id, event.data)
+                if step_key in self._completed_step_keys:
+                    return []
+                self._completed_step_keys.add(step_key)
             envelope = self._translate_parent_step_event(event, "step_completed", "working", created_at)
             return [envelope, *self._completion_artifact_events(envelope)]
         if event.type == PipelineEventType.STEP_FAILED:
@@ -446,6 +487,12 @@ class PipelineEventTranslator:
         if event.step_id is not None:
             envelope["step"] = self._parent_step_coordinate(event.step_id, event.data or {})
         return envelope
+
+    def _parent_step_key(self, step_id: str, data: dict[str, Any] | None) -> tuple[str, int]:
+        explicit_attempt = _int_or_none((data or {}).get("attempt"))
+        if explicit_attempt is not None and explicit_attempt > 0:
+            return (step_id, explicit_attempt)
+        return (step_id, self._parent_step_attempts.get(step_id, 1))
 
     def _translate_input_event(
         self,

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -2630,3 +2630,206 @@ def test_sanitize_tool_input_passthrough_keeps_template_and_conclusion() -> None
     assert result == tool_input
     assert "[REDACTED]" not in json.dumps(result)
     assert "***" not in json.dumps(result)
+
+
+def _event_types(envelopes: list[dict]) -> list[str]:
+    return [envelope["eventType"] for envelope in envelopes]
+
+
+def _translate_all(translator: PipelineEventTranslator, events: list[PipelineEvent]) -> list[dict]:
+    envelopes: list[dict] = []
+    for event in events:
+        envelopes.extend(translator.translate(event))
+    return envelopes
+
+
+def _step_started(step_id: str, attempt: int) -> PipelineEvent:
+    return PipelineEvent(
+        type=PipelineEventType.STEP_STARTED,
+        step_id=step_id,
+        timestamp=time.time(),
+        data={"attempt": attempt, "name": step_id},
+    )
+
+
+def _step_completed(step_id: str, attempt: int) -> PipelineEvent:
+    return PipelineEvent(
+        type=PipelineEventType.STEP_COMPLETED,
+        step_id=step_id,
+        timestamp=time.time(),
+        data={"attempt": attempt, "conclusion_field": "intent", "conclusion": {"ok": True}},
+    )
+
+
+def _pipeline_started() -> PipelineEvent:
+    return PipelineEvent(
+        type=PipelineEventType.PIPELINE_STARTED,
+        step_id=None,
+        timestamp=time.time(),
+        data={"pipeline_type": "selling", "total_steps": 4},
+    )
+
+
+def _pipeline_completed(**data: object) -> PipelineEvent:
+    return PipelineEvent(
+        type=PipelineEventType.PIPELINE_COMPLETED,
+        step_id=None,
+        timestamp=time.time(),
+        data={"total_steps": 4, **data},
+    )
+
+
+def test_repeated_step_completed_for_same_attempt_is_deduplicated() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = _translate_all(
+        translator,
+        [
+            _step_started("confirm_and_select", 1),
+            _step_completed("confirm_and_select", 1),
+            # resume() 之后引擎再次为同一 attempt yield STEP_COMPLETED
+            _step_completed("confirm_and_select", 1),
+        ],
+    )
+
+    event_types = _event_types(envelopes)
+    assert event_types.count("step_started") == 1
+    assert event_types.count("step_completed") == 1
+
+
+def test_step_completed_keeps_conclusion_artifacts_after_dedup_guard() -> None:
+    context = _ctx()
+    context.a2a_artifacts_by_step_id = {
+        "reviewing": [{"path": "conclusion.file_path", "content": "conclusion.content"}]
+    }
+    translator = PipelineEventTranslator(context)
+
+    completion = PipelineEvent(
+        type=PipelineEventType.STEP_COMPLETED,
+        step_id="reviewing",
+        timestamp=time.time(),
+        data={
+            "attempt": 1,
+            "conclusion_field": "review",
+            "conclusion": {"file_path": "/tmp/template.yaml", "content": "ROSTemplate"},
+        },
+    )
+
+    # 首个完成事件仍完整放行，包含由 conclusion 派生的 artifact。
+    assert _event_types(translator.translate(completion)) == ["step_completed", "artifact_created"]
+    # 重复的完成事件被丢弃，不会重复派发 artifact。
+    assert translator.translate(completion) == []
+
+
+def test_input_required_resume_keeps_step_started_and_completed_paired() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = _translate_all(
+        translator,
+        [
+            _pipeline_started(),
+            _step_started("intent_parsing", 1),
+            _step_completed("intent_parsing", 1),
+            _step_started("confirm_and_select", 1),
+            # 首轮完成后进入 input_required 等待用户输入
+            _step_completed("confirm_and_select", 1),
+            # resume() 续跑：引擎跳过 step_started，仅再次 yield step_completed
+            _step_completed("confirm_and_select", 1),
+        ],
+    )
+
+    event_types = _event_types(envelopes)
+    assert event_types.count("step_started") == event_types.count("step_completed")
+
+
+def test_step_completed_for_new_attempt_is_not_deduplicated() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = _translate_all(
+        translator,
+        [
+            _step_started("intent_parsing", 1),
+            _step_completed("intent_parsing", 1),
+            _step_started("intent_parsing", 2),
+            _step_completed("intent_parsing", 2),
+        ],
+    )
+
+    event_types = _event_types(envelopes)
+    assert event_types.count("step_started") == 2
+    assert event_types.count("step_completed") == 2
+
+
+def test_repeated_pipeline_completed_emits_single_terminal_event() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = _translate_all(
+        translator,
+        [_pipeline_started(), _pipeline_completed(), _pipeline_completed()],
+    )
+
+    event_types = _event_types(envelopes)
+    assert event_types.count("pipeline_started") == 1
+    assert event_types.count("pipeline_completed") == 1
+
+
+def test_pipeline_failed_terminal_event_is_also_deduplicated() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = _translate_all(
+        translator,
+        [_pipeline_started(), _pipeline_completed(failed=True), _pipeline_completed(failed=True)],
+    )
+
+    event_types = _event_types(envelopes)
+    assert event_types.count("pipeline_failed") == 1
+    assert "pipeline_completed" not in event_types
+
+
+def test_pipeline_resumed_reopens_terminal_budget_for_next_round() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    envelopes = _translate_all(
+        translator,
+        [
+            _pipeline_started(),
+            _pipeline_completed(),
+            PipelineEvent(
+                type=PipelineEventType.PIPELINE_RESUMED,
+                step_id=None,
+                timestamp=time.time(),
+                data={"total_steps": 4},
+            ),
+            _pipeline_completed(),
+        ],
+    )
+
+    event_types = _event_types(envelopes)
+    assert event_types.count("pipeline_resumed") == 1
+    assert event_types.count("pipeline_completed") == 2
+
+
+def test_hydrate_from_events_keeps_pairing_ledger_across_resume() -> None:
+    context = _ctx()
+    first = PipelineEventTranslator(context)
+    journal = _translate_all(
+        first,
+        [_pipeline_started(), _step_started("confirm_and_select", 1), _step_completed("confirm_and_select", 1)],
+    )
+
+    resumed = PipelineEventTranslator(context)
+    resumed.hydrate_from_events(journal)
+
+    # 续跑进程重复收到同一 attempt 的完成事件时不应重复计数。
+    assert resumed.translate(_step_completed("confirm_and_select", 1)) == []
+
+
+def test_hydrate_from_terminal_journal_suppresses_duplicate_terminal_event() -> None:
+    context = _ctx()
+    first = PipelineEventTranslator(context)
+    journal = _translate_all(first, [_pipeline_started(), _pipeline_completed()])
+
+    resumed = PipelineEventTranslator(context)
+    resumed.hydrate_from_events(journal)
+
+    assert resumed.translate(_pipeline_completed()) == []


### PR DESCRIPTION
## 问题

同一 pipeline run 的 a2a 事件流出现计数不对称，完成事件多于启动事件，`start` / `complete` 无法 1:1 配对：

- `step_completed(6) > step_started(5)`
- `pipeline_completed(2) > pipeline_started(1)`

这会破坏 pipeline 运行状态的可观测性与一致性校验，使基于事件计数的进度追踪、终态判定与监控指标失真，难以可靠判断一次 run 是否真实完成。

## 根因

根因在引擎侧**完成事件缺少幂等约束**，而启动事件在恢复路径上被有意跳过，两者叠加导致计数不可配对。

### `step_completed > step_started`

`PipelineRunner._continue_from_current()` 从 `input_required` 暂停恢复时（`resume_current_step` 为真）只保存运行态、**不再 yield `STEP_STARTED`**；但该步随后走正常收尾，仍会 yield 一个 `STEP_COMPLETED`。

于是 `confirm_and_select` 这类步骤：首轮 `step_started` → `step_completed`（等待输入）→ 用户输入后 `resume()` → **无 `step_started`** → 再次 `step_completed`。同一 `(step_id, attempt)` 产生 2 个完成事件、1 个启动事件。

### `pipeline_completed > pipeline_started`

`pipeline_started` 只在 `run()` 入口发出一次，`resume()` 不发。而 `PIPELINE_COMPLETED` 有多处独立终态 yield 点，其守卫 `emit_pipeline_completed()` **只对 telemetry 去重**（`terminal_pipeline_telemetry_emitted`），并不拦截随后的 `yield PipelineEvent(PIPELINE_COMPLETED)`；且该标志是 `_continue_from_current()` 的**函数局部变量**，每次 `resume()` 重新进入都会重置为 `False`，跨轮次完全失去去重能力。

### 归类层无兜底

`PipelineEventTranslator` 是无状态直译，逐一映射且不做配对/去重，因此引擎层的重复原样出现在 a2a 事件流与 snapshot 计数里。

## 方案

在**事件归类层**建立幂等约束，而非改动引擎控制流，避免影响 `rollback` / `early_exit` / 失败收尾等既有语义：

1. `step_completed` 按 `(step_id, attempt)` 只放行首个完成事件，重复丢弃；首个事件及其派生的 `artifact_created` 保持原样。
2. 终态事件（`pipeline_completed` / `pipeline_failed`）按 run 维度只放行一次；`pipeline_started` / `pipeline_resumed` 会重新开放下一轮的终态额度，保证多轮 run 各自仍有一个终态。
3. 上述账本接入 `hydrate_from_events()`，使跨进程 / 跨 `resume()` 的 journal 续跑不会重复计数。

`pipeline_snapshot.py` 消费的是同一批 envelope，去重后 snapshot 计数自动恢复对称，无需单独改动。

## 变更文件

- `src/iac_code/a2a/pipeline_events.py` — 完成事件幂等约束 + hydrate 续跑恢复
- `tests/a2a/test_pipeline_events.py` — 新增 10 项回归用例

## 验证

- `uv run pytest tests/a2a tests/pipeline -q` → **3106 passed**
- `uv run ruff check` / `uv run ruff format --check` / `uv run ty check src/` → 全部通过
- 已验证移除本次修复后，新增的 10 项回归用例全部失败，确认用例真实覆盖该缺陷
- 既有失败 `tests/pipeline/engine/test_prerequisites.py::test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` 在未改动的干净工作区同样失败（依赖外网下载），与本次改动无关

## 兼容性

不改引擎控制流，不改 `step_failed` / `candidate_*` 语义；首个完成事件与其 conclusion / artifact 原样保留，前端与 web transcript 的既有事件契约保持兼容。
