### PR TITLE
fix(a2a): 区分 pipeline 终态与备份子状态，消除 snapshot.status 语义歧义

### DIFF
--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -21,7 +21,7 @@ from iac_code.pipeline.constants import (
 from iac_code.utils.public_errors import sanitize_strict_text
 from iac_code.utils.state_io import atomic_write_json, atomic_write_text
 
-SNAPSHOT_SCHEMA_VERSION = "1.1"
+SNAPSHOT_SCHEMA_VERSION = "1.2"
 logger = logging.getLogger(__name__)
 
 _TERMINAL_STATUS_BY_EVENT_TYPE = {
@@ -39,6 +39,10 @@ _KNOWN_CLEANUP_STATUSES = {"pending", "started", "in_progress", "completed", "fa
 _PENDING_BACKUP_VISIBILITY = "pending_backup"
 _COMMITTED_BACKUP_VISIBILITY = "committed"
 _BACKUP_COMMITTED_EVENT_TYPE = "backup_committed"
+_BACKUP_STATE_NONE = "none"
+_BACKUP_STATE_PENDING = "pending_backup"
+_BACKUP_STATE_COMMITTED = "committed"
+_TERMINAL_SNAPSHOT_STATUSES = frozenset(_TERMINAL_STATUS_BY_EVENT_TYPE.values())
 
 
 class A2APipelineSnapshotStore:
@@ -179,6 +183,7 @@ class _PipelineSnapshotReducer:
         self._cleanup_history_keys: set[str] = set()
         self._skip_sequences_through = 0
         self._hydrate_existing_snapshot(existing_snapshot)
+        self._refresh_backup_derived_state()
 
     def reduce(self, events: list[dict[str, Any]]) -> None:
         for event in sorted(events, key=_sequence_value):
@@ -508,6 +513,7 @@ class _PipelineSnapshotReducer:
                 self._snapshot["normalHandoff"] = None
                 self._snapshot["pendingNormalHandoff"] = None
                 self._snapshot["pendingTerminal"] = None
+                self._snapshot["pipelineStatus"] = None
             self._snapshot["pendingInput"] = self._pending_input(event)
             self._snapshot["status"] = "waiting_input"
         elif event_type == "input_received":
@@ -518,14 +524,22 @@ class _PipelineSnapshotReducer:
             self._snapshot["normalHandoff"] = None
             self._snapshot["pendingNormalHandoff"] = None
             self._snapshot["pendingTerminal"] = None
+            self._snapshot["pipelineStatus"] = None
             self._snapshot["pendingInput"] = self._backup_blocked_pending_input(event)
             self._snapshot["status"] = "waiting_input"
 
         terminal_status = _TERMINAL_STATUS_BY_EVENT_TYPE.get(event_type)
         if terminal_status is not None and _is_pending_backup_publication(event):
             self._snapshot["pendingTerminal"] = _terminal_publication(event)
+            # The pipeline itself already reached its terminal step; only the
+            # handoff backup is still in flight.  ``status`` intentionally stays
+            # ``working`` so the ``backup_committed`` gate keeps holding the A2A
+            # task state, while ``pipelineStatus`` exposes the real pipeline
+            # outcome for downstream observers.
+            self._snapshot["pipelineStatus"] = terminal_status
         elif terminal_status is not None:
             self._snapshot["status"] = terminal_status
+            self._snapshot["pipelineStatus"] = terminal_status
             self._snapshot["pendingTerminal"] = None
             self._snapshot["pendingInput"] = None
             self._snapshot["control"]["activeCandidateRunIds"] = []
@@ -534,10 +548,28 @@ class _PipelineSnapshotReducer:
             and not _is_pending_backup_publication(event)
             and not (
                 event_type == "pipeline_handoff_ready"
-                and self._snapshot["status"] in {"completed", "failed", "canceled"}
+                and self._snapshot["status"] in _TERMINAL_SNAPSHOT_STATUSES
             )
         ):
             self._apply_event_status(event)
+
+        self._refresh_backup_derived_state()
+
+    def _refresh_backup_derived_state(self) -> None:
+        """Keep ``pipelineStatus`` / ``backupState`` consistent with the pending
+        publication fields.
+
+        ``status`` answers "can the A2A task be handed off yet"; it stays
+        ``working`` until the protecting backup is committed.  ``pipelineStatus``
+        answers "did the pipeline itself finish", so a snapshot whose top-level
+        steps are all ``completed`` no longer reads as unfinished.
+        """
+        status = _string_or_none(self._snapshot.get("status"))
+        if status in _TERMINAL_SNAPSHOT_STATUSES:
+            self._snapshot["pipelineStatus"] = status
+        elif _string_or_none(self._snapshot.get("pipelineStatus")) not in _TERMINAL_SNAPSHOT_STATUSES:
+            self._snapshot["pipelineStatus"] = _pending_terminal_status(self._snapshot)
+        self._snapshot["backupState"] = _backup_state(self._snapshot)
 
     def _merge_pipeline_identity(self, event: dict[str, Any]) -> None:
         for key in ("pipelineRunId", "taskId", "contextId", "pipelineName"):
@@ -549,6 +581,7 @@ class _PipelineSnapshotReducer:
         self._snapshot["normalHandoff"] = None
         self._snapshot["pendingNormalHandoff"] = None
         self._snapshot["pendingTerminal"] = None
+        self._snapshot["pipelineStatus"] = None
         control = self._snapshot["control"]
         if "totalSteps" in data:
             control["totalSteps"] = data["totalSteps"]
@@ -1197,6 +1230,27 @@ def _pending_backup_publications_from_snapshot(snapshot: dict[str, Any]) -> list
     return publications
 
 
+def _pending_terminal_status(snapshot: dict[str, Any]) -> str | None:
+    """Terminal outcome carried by a ``pending_backup`` terminal publication."""
+    pending_terminal = _dict_or_none(snapshot.get("pendingTerminal"))
+    if pending_terminal is None:
+        return None
+    status = _normalized_status(pending_terminal.get("status"))
+    if status in _TERMINAL_SNAPSHOT_STATUSES:
+        return status
+    return _TERMINAL_STATUS_BY_EVENT_TYPE.get(_string_or_none(pending_terminal.get("eventType")) or "")
+
+
+def _backup_state(snapshot: dict[str, Any]) -> str:
+    if _pending_backup_publications_from_snapshot(snapshot):
+        return _BACKUP_STATE_PENDING
+    if _string_or_none(snapshot.get("status")) in _TERMINAL_SNAPSHOT_STATUSES:
+        return _BACKUP_STATE_COMMITTED
+    if _dict_or_none(snapshot.get("normalHandoff")) is not None:
+        return _BACKUP_STATE_COMMITTED
+    return _BACKUP_STATE_NONE
+
+
 def _event_matches_snapshot_task_context(event: dict[str, Any], snapshot: dict[str, Any]) -> bool:
     context_id = _string_or_none(snapshot.get("contextId"))
     if context_id is not None and event.get("contextId") != context_id:
@@ -1289,6 +1343,8 @@ def _empty_snapshot() -> dict[str, Any]:
         "contextId": None,
         "pipelineName": None,
         "status": "working",
+        "pipelineStatus": None,
+        "backupState": _BACKUP_STATE_NONE,
         "lastSequence": 0,
         "generatedAt": _utc_now(),
         "steps": [],
@@ -1397,6 +1453,8 @@ def _snapshot_from_existing(existing_snapshot: dict[str, Any] | None) -> dict[st
     snapshot["pendingTerminal"] = (
         _sanitize_cleanup_private_fields(pending_terminal) if isinstance(pending_terminal, dict) else None
     )
+    pipeline_status = _normalized_status(snapshot.get("pipelineStatus"))
+    snapshot["pipelineStatus"] = pipeline_status if pipeline_status in _TERMINAL_SNAPSHOT_STATUSES else None
     cleanup = snapshot.get("cleanup")
     if not isinstance(cleanup, dict):
         cleanup = {}

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -1478,5 +1478,135 @@ def test_store_returns_none_for_invalid_utf8_snapshot(tmp_path) -> None:
 
 
 def test_snapshot_schema_version_is_exported() -> None:
-    assert SNAPSHOT_SCHEMA_VERSION == "1.1"
+    assert SNAPSHOT_SCHEMA_VERSION == "1.2"
     assert "SNAPSHOT_SCHEMA_VERSION" in pipeline_snapshot.__all__
+
+
+_TOP_LEVEL_STEP_IDS = (
+    "intent_parsing",
+    "architecture_planning",
+    "evaluate_candidates",
+    "confirm_and_select",
+    "deploying",
+)
+
+
+def _completed_top_level_step_events() -> list[dict]:
+    events = [_base("evt-started", 1, "pipeline_started")]
+    events[0]["data"] = {"totalSteps": len(_TOP_LEVEL_STEP_IDS)}
+    sequence = 2
+    for index, step_id in enumerate(_TOP_LEVEL_STEP_IDS, start=1):
+        coordinate = {
+            "runId": f"{step_id}-1",
+            "id": step_id,
+            "index": index,
+            "total": len(_TOP_LEVEL_STEP_IDS),
+            "attempt": 1,
+        }
+        started = _base(f"evt-{step_id}-started", sequence, "step_started", scope="step")
+        started["step"] = coordinate
+        completed = _base(f"evt-{step_id}-completed", sequence + 1, "step_completed", scope="step")
+        completed["step"] = dict(coordinate)
+        events.extend([started, completed])
+        sequence += 2
+    return events
+
+
+def _pending_backup_terminal(event_id: str, sequence: int, event_type: str, status: str) -> dict:
+    event = _base(event_id, sequence, event_type, status=status)
+    event["visibility"] = "pending_backup"
+    return event
+
+
+def test_pending_backup_terminal_keeps_status_working_but_reports_pipeline_completed() -> None:
+    events = _completed_top_level_step_events()
+    pending_terminal = _pending_backup_terminal("evt-terminal-pending", 100, "pipeline_completed", "completed")
+    pending_handoff = _pending_backup_terminal("evt-handoff-pending", 101, "pipeline_handoff_ready", "completed")
+    pending_handoff["data"] = {
+        "action": "switch_to_normal",
+        "targetMode": "normal",
+        "outcome": "completed",
+        "summary": "[Pipeline Handoff Context]",
+    }
+
+    snapshot = reduce_pipeline_events([*events, pending_terminal, pending_handoff])
+
+    assert [step["status"] for step in snapshot["steps"]] == ["completed"] * len(_TOP_LEVEL_STEP_IDS)
+    # ``status`` still gates the A2A task on the backup_committed ack ...
+    assert snapshot["status"] == "working"
+    # ... while the pipeline outcome is no longer indistinguishable from "still running".
+    assert snapshot["pipelineStatus"] == "completed"
+    assert snapshot["backupState"] == "pending_backup"
+    assert snapshot["pendingTerminal"]["eventType"] == "pipeline_completed"
+    assert snapshot["pendingNormalHandoff"]["summary"] == "[Pipeline Handoff Context]"
+
+
+def test_committed_backup_ack_converges_status_and_pipeline_status() -> None:
+    events = _completed_top_level_step_events()
+    pending_terminal = _pending_backup_terminal("evt-terminal-pending", 100, "pipeline_completed", "completed")
+    committed_terminal = dict(pending_terminal)
+    committed_terminal["eventId"] = "evt-terminal-committed"
+    committed_terminal["sequence"] = 101
+    committed_terminal["visibility"] = "committed"
+    ack = _base("evt-ack", 102, "backup_committed", status=None)
+    ack["data"] = {
+        "committedEventId": "evt-terminal-committed",
+        "committedEventType": "pipeline_completed",
+        "committedSequence": 101,
+    }
+
+    snapshot = reduce_pipeline_events([*events, pending_terminal, committed_terminal, ack])
+
+    assert snapshot["status"] == "completed"
+    assert snapshot["pipelineStatus"] == "completed"
+    assert snapshot["backupState"] == "committed"
+    assert snapshot["pendingTerminal"] is None
+
+
+def test_in_progress_snapshot_has_no_terminal_pipeline_status() -> None:
+    events = _completed_top_level_step_events()[:4]
+
+    snapshot = reduce_pipeline_events(events)
+
+    assert snapshot["status"] == "working"
+    assert snapshot["pipelineStatus"] is None
+    assert snapshot["backupState"] == "none"
+
+
+def test_pending_backup_failed_and_canceled_report_their_own_outcome() -> None:
+    for event_type, status in (("pipeline_failed", "failed"), ("pipeline_canceled", "canceled")):
+        events = _completed_top_level_step_events()
+        pending_terminal = _pending_backup_terminal("evt-terminal-pending", 100, event_type, status)
+
+        snapshot = reduce_pipeline_events([*events, pending_terminal])
+
+        assert snapshot["status"] == "working"
+        assert snapshot["pipelineStatus"] == status
+        assert snapshot["backupState"] == "pending_backup"
+
+
+def test_backup_blocked_clears_derived_pipeline_status() -> None:
+    events = _completed_top_level_step_events()
+    pending_terminal = _pending_backup_terminal("evt-terminal-pending", 100, "pipeline_completed", "completed")
+    blocked = _base("evt-blocked", 101, "backup_blocked", status="waiting_input")
+    blocked["data"] = {"reason": "terminal", "recoverable": True}
+
+    snapshot = reduce_pipeline_events([*events, pending_terminal, blocked])
+
+    assert snapshot["status"] == "waiting_input"
+    assert snapshot["pipelineStatus"] is None
+    assert snapshot["backupState"] == "none"
+    assert snapshot["pendingTerminal"] is None
+
+
+def test_legacy_snapshot_without_derived_fields_is_rehydrated() -> None:
+    legacy = reduce_pipeline_events(_completed_top_level_step_events())
+    legacy.pop("pipelineStatus")
+    legacy.pop("backupState")
+    pending_terminal = _pending_backup_terminal("evt-terminal-pending", 100, "pipeline_completed", "completed")
+
+    snapshot = reduce_pipeline_events([pending_terminal], legacy)
+
+    assert snapshot["status"] == "working"
+    assert snapshot["pipelineStatus"] == "completed"
+    assert snapshot["backupState"] == "pending_backup"

--- a/tests/a2a/test_pipeline_stream.py
+++ b/tests/a2a/test_pipeline_stream.py
@@ -18,7 +18,7 @@ from iac_code.a2a.exposure import A2AExposureType
 from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
 from iac_code.a2a.pipeline_journal import A2APipelineJournal
 from iac_code.a2a.pipeline_performance import A2A_EXTREME_PERFORMANCE_ENV
-from iac_code.a2a.pipeline_snapshot import A2APipelineSnapshotStore
+from iac_code.a2a.pipeline_snapshot import SNAPSHOT_SCHEMA_VERSION, A2APipelineSnapshotStore
 from iac_code.a2a.pipeline_stream import (
     PipelineA2AEventPublisher,
     PipelineA2APersistenceError,
@@ -353,7 +353,7 @@ async def test_publish_rebuilds_stale_schema_snapshot_from_journal_history(tmp_p
 
     snapshot = publisher.snapshot_store.load()
     assert snapshot is not None
-    assert snapshot["schemaVersion"] == "1.1"
+    assert snapshot["schemaVersion"] == SNAPSHOT_SCHEMA_VERSION
     assert snapshot["display"]["messages"][0]["text"] == "old new"
 
 


### PR DESCRIPTION
## 问题

`pipeline_snapshot.status=working` 与全部顶层步骤 `completed` 语义不一致。

证据 Session `d10910d359354a6891f4d3efad68e3e2`：5 个顶层步骤（`intent_parsing` / `architecture_planning` / `evaluate_candidates` / `confirm_and_select` / `deploying`）全部 `status=completed`，但 `pipeline_snapshot.status` 仍为 `working`，下游（监控、交接、报表）据此误读为 Pipeline 未完成。

## 根因

`src/iac_code/a2a/pipeline_snapshot.py` 的 `_PipelineSnapshotReducer._apply()`：终态事件（`pipeline_completed` / `pipeline_failed` / `pipeline_canceled`）若处于 `visibility=pending_backup`，只写入 `pendingTerminal`，并被显式排除在 `_apply_event_status()` 之外，因此 `snapshot["status"]` 停留在初始值 `working`。

状态映射未区分两种语义：

- 「步骤已完成，仅交接事件待备份」
- 「步骤仍在进行中」

## 方案

`status` 是 A2A task state 的权威来源，被 `_task_state_from_snapshot()`、`_TERMINAL_SNAPSHOT_STATUSES`、`_snapshot_has_conflicting_terminal_status()` 消费。备份未 durable 前必须保持 `working`，否则会破坏 `backup_committed` 门控。因此**不改写 `status`**，改为新增两个派生字段（对应需求中「保留独立备份子状态字段而非整体 working」的建议）：

| 字段 | 语义 |
| --- | --- |
| `pipelineStatus` | Pipeline 本体终态。终态事件即使处于 `pending_backup` 也据事件类型映射为 `completed` / `failed` / `canceled` |
| `backupState` | 备份子状态：`none` / `pending_backup` / `committed` |

- `pipeline_started`、`backup_blocked`、`terminal_publication_unavailable` 路径与现有 pending 字段一同重置这两个字段。
- 旧快照缺失字段时按现存 `status` / `pendingTerminal` 自动推导补齐。
- `SNAPSHOT_SCHEMA_VERSION` 由 `1.1` 升到 `1.2`，让存量快照经 journal 重建出新字段。

修复后同一场景：`status=working`（门控不破）、`pipelineStatus=completed`、`backupState=pending_backup`；`backup_committed` ack 到达后三者收敛为 `completed` / `completed` / `committed`。

## 测试

`tests/a2a/test_pipeline_snapshot.py` 新增 6 个用例：

- 全部顶层步骤 `completed` + `pendingTerminal` 为 `pending_backup` → `pipelineStatus=completed`、`backupState=pending_backup`、`status` 仍 `working`
- `backup_committed` ack 后三字段收敛一致、`pendingTerminal` 清空
- 步骤进行中 → `pipelineStatus is None`、`backupState=none`
- `pipeline_failed` / `pipeline_canceled` 的 pending_backup 变体映射到各自终态
- `backup_blocked` 清空派生终态
- 旧快照（无新字段）重新 reduce 后正确补齐

回归结果：`tests/a2a` + `tests/web` 共 2913 项全部通过；`ruff check` 与 `ty check src/` 全部通过。全量 `pytest tests` 有 15 项失败，均在基线 commit `88ed89c` 上同样复现（`tests/test_i18n.py` 依赖 `make translate` 生成的 `.pot`/`.mo` 产物，`tests/pipeline/engine/test_prerequisites.py` 与 `tests/repl_e2e` 为环境相关），与本次变更无关。

---

Harness work item: `10fb7097-8aba-426f-8507-c9e841a325a8`
Aone: https://project.aone.alibaba-inc.com/v2/project/2169409/req/85634109
