### PR TITLE
fix(pipeline): 强制 cost_estimating 分离列表价与合同优惠后价

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4088,6 +4088,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The monthly estimate must keep the list price and the contract-discounted"
+" price separated; when both are equal, declare that no discount applied "
+"and explain why."
+msgstr "Die monatliche Schätzung muss den Listenpreis und den vertraglich rabattierten Preis getrennt ausweisen; wenn beide gleich sind, geben Sie an, dass kein Rabatt angewendet wurde, und erläutern Sie den Grund."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4193,6 +4200,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion muss eines dieser Felder enthalten: "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} complete_step.conclusion.{breakdown_field} validation issue: "
+"{code} ({detail})."
+msgstr "{message} Validierungsproblem bei complete_step.conclusion.{breakdown_field}: {code} ({detail})."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4065,6 +4065,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The monthly estimate must keep the list price and the contract-discounted"
+" price separated; when both are equal, declare that no discount applied "
+"and explain why."
+msgstr "La estimación mensual debe mantener separados el precio de lista y el precio con descuento contractual; cuando ambos sean iguales, declare que no se aplicó ningún descuento y explique por qué."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4167,6 +4174,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion debe incluir uno de estos campos: "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} complete_step.conclusion.{breakdown_field} validation issue: "
+"{code} ({detail})."
+msgstr "{message} Problema de validación de complete_step.conclusion.{breakdown_field}: {code} ({detail})."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4074,6 +4074,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The monthly estimate must keep the list price and the contract-discounted"
+" price separated; when both are equal, declare that no discount applied "
+"and explain why."
+msgstr "L'estimation mensuelle doit conserver séparément le prix catalogue et le prix après remise contractuelle ; lorsque les deux sont égaux, déclarez qu'aucune remise n'a été appliquée et expliquez pourquoi."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4174,6 +4181,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion doit inclure l’un de ces champs : "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} complete_step.conclusion.{breakdown_field} validation issue: "
+"{code} ({detail})."
+msgstr "{message} Problème de validation de complete_step.conclusion.{breakdown_field} : {code} ({detail})."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3876,6 +3876,13 @@ msgstr "ユーザーが明示した各ハード制約は、パラメーターと
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The monthly estimate must keep the list price and the contract-discounted"
+" price separated; when both are equal, declare that no discount applied "
+"and explain why."
+msgstr "月額見積もりでは、定価と契約割引後価格を分けて示す必要があります。両者が同一の場合は、割引が適用されなかったことを明示し、その理由を説明してください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3966,6 +3973,13 @@ msgid ""
 "{message} complete_step.conclusion must include one of these fields: "
 "{fields}."
 msgstr "{message} complete_step.conclusion には次のいずれかのフィールドが必要です: {fields}。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} complete_step.conclusion.{breakdown_field} validation issue: "
+"{code} ({detail})."
+msgstr "{message} complete_step.conclusion.{breakdown_field} の検証エラー: {code} ({detail})。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4046,6 +4046,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The monthly estimate must keep the list price and the contract-discounted"
+" price separated; when both are equal, declare that no discount applied "
+"and explain why."
+msgstr "A estimativa mensal deve manter separados o preço de tabela e o preço com desconto contratual; quando ambos forem iguais, declare que nenhum desconto foi aplicado e explique o motivo."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4143,6 +4150,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion deve incluir um destes campos: "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} complete_step.conclusion.{breakdown_field} validation issue: "
+"{code} ({detail})."
+msgstr "{message} Problema de validação de complete_step.conclusion.{breakdown_field}: {code} ({detail})."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3840,6 +3840,13 @@ msgstr "每个用户明确提出的硬约束都必须由一条状态为满足的
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The monthly estimate must keep the list price and the contract-discounted"
+" price separated; when both are equal, declare that no discount applied "
+"and explain why."
+msgstr "月度费用估算必须将列表价与合同优惠后价分开呈现；两者相同时，必须声明未享受折扣并说明原因。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr "调用此工具提交结论以完成当前步骤。如需回滚到较早步骤，请设置 rollback_request。"
@@ -3928,6 +3935,13 @@ msgid ""
 "{message} complete_step.conclusion must include one of these fields: "
 "{fields}."
 msgstr "{message} complete_step.conclusion 必须包含以下字段之一: {fields}。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} complete_step.conclusion.{breakdown_field} validation issue: "
+"{code} ({detail})."
+msgstr "{message} complete_step.conclusion.{breakdown_field} 校验问题：{code}（{detail}）。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -14,6 +14,7 @@ import jsonschema
 from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
 from iac_code.pipeline.engine.hard_constraints import collect_hard_constraints, validate_hard_constraint_checks
+from iac_code.pipeline.engine.monthly_price import validate_monthly_price_breakdown
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.utils.public_errors import sanitize_strict_text
@@ -60,6 +61,10 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
     ),
+    "monthly_price_disclosure_required": (
+        "The monthly estimate must keep the list price and the contract-discounted price separated; "
+        "when both are equal, declare that no discount applied and explain why."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -99,6 +104,10 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
         _(
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
+        ),
+        _(
+            "The monthly estimate must keep the list price and the contract-discounted price separated; "
+            "when both are equal, declare that no discount applied and explain why."
         ),
     )
 
@@ -324,6 +333,7 @@ class CompleteStepTool(Tool):
             required_tool_result = guard.get("require_tool_result")
             required_conclusion_sha256 = guard.get("require_conclusion_sha256")
             required_constraint_coverage = guard.get("require_context_constraint_coverage")
+            required_price_disclosure = guard.get("require_monthly_price_disclosure")
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
@@ -383,7 +393,42 @@ class CompleteStepTool(Tool):
                 )
                 if validation_error is not None:
                     return validation_error
+            if isinstance(required_price_disclosure, dict):
+                validation_error = self._validate_monthly_price_disclosure(
+                    required_price_disclosure,
+                    conclusion,
+                    self._completion_guard_message(guard, None),
+                )
+                if validation_error is not None:
+                    return validation_error
         return None
+
+    def _validate_monthly_price_disclosure(
+        self,
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        message: str | None,
+    ) -> str | None:
+        estimate_field = str(requirement.get("estimate_field") or "monthly_estimate")
+        breakdown_field = str(requirement.get("breakdown_field") or "monthly_price_breakdown")
+        issues = validate_monthly_price_breakdown(
+            self._resolve_dotted(conclusion, estimate_field),
+            self._resolve_dotted(conclusion, breakdown_field),
+        )
+        if not issues:
+            return None
+        base_message = message or _(
+            "The monthly estimate must keep the list price and the contract-discounted price separated; "
+            "when both are equal, declare that no discount applied and explain why."
+        )
+        summaries = [f"{issue.code}[{issue.detail}]" if issue.detail else issue.code for issue in issues]
+        code = issues[0].code if len(issues) == 1 else "multiple_price_issues"
+        return _("{message} complete_step.conclusion.{breakdown_field} validation issue: {code} ({detail}).").format(
+            message=base_message,
+            breakdown_field=breakdown_field,
+            code=code,
+            detail="; ".join(summaries),
+        )
 
     def _validate_context_constraint_coverage(
         self,

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -43,6 +43,7 @@ _SUPPORTED_COMPLETION_GUARD_KEYS = {
     "message_key",
     "require_conclusion_sha256",
     "require_context_constraint_coverage",
+    "require_monthly_price_disclosure",
     "require_tool",
     "require_tool_result",
     "required_conclusion_any_of",

--- a/src/iac_code/pipeline/engine/monthly_price.py
+++ b/src/iac_code/pipeline/engine/monthly_price.py
@@ -1,0 +1,131 @@
+"""Generic validation for the cost step's list price vs contract-discounted price disclosure."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+PRICING_FAILED_ESTIMATE = "询价失败"
+
+_AMOUNT_RE = re.compile(r"\d+(?:,\d{3})*(?:\.\d+)?")
+
+
+@dataclass(frozen=True)
+class PriceValidationIssue:
+    code: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {key: value for key, value in asdict(self).items() if value}
+
+
+def validate_monthly_price_breakdown(monthly_estimate: Any, breakdown: Any) -> list[PriceValidationIssue]:
+    """Validate that the list price and contract-discounted price are truly separated.
+
+    The cost step reports ``monthly_estimate`` as display text, so identical list and
+    discounted prices are only acceptable when the step explicitly states that no
+    discount applied. This keeps a zero discount distinguishable from a discounted
+    price that was silently overwritten with the list price.
+    """
+
+    if isinstance(monthly_estimate, str) and monthly_estimate.strip() == PRICING_FAILED_ESTIMATE:
+        return []
+    if not isinstance(monthly_estimate, str) or not monthly_estimate.strip():
+        return [PriceValidationIssue("invalid_monthly_estimate")]
+    if not isinstance(breakdown, dict):
+        return [PriceValidationIssue("missing_monthly_price_breakdown")]
+
+    list_price = _decimal_or_none(breakdown.get("list_price"))
+    discounted_price = _decimal_or_none(breakdown.get("discounted_price"))
+    issues: list[PriceValidationIssue] = []
+    if list_price is None or list_price < 0:
+        issues.append(PriceValidationIssue("invalid_list_price", _text(breakdown.get("list_price"))))
+    if discounted_price is None or discounted_price < 0:
+        issues.append(PriceValidationIssue("invalid_discounted_price", _text(breakdown.get("discounted_price"))))
+    if issues:
+        return issues
+
+    assert list_price is not None and discounted_price is not None
+    if discounted_price > list_price:
+        return [
+            PriceValidationIssue(
+                "discounted_price_above_list_price",
+                "{} > {}".format(_text(discounted_price), _text(list_price)),
+            )
+        ]
+
+    discount_applied = breakdown.get("discount_applied")
+    if not isinstance(discount_applied, bool):
+        return [PriceValidationIssue("invalid_discount_applied", _text(discount_applied))]
+
+    same_price = discounted_price == list_price
+    same_price_reason = breakdown.get("same_price_reason")
+    if same_price:
+        if discount_applied:
+            issues.append(PriceValidationIssue("discount_applied_without_price_difference"))
+        if not isinstance(same_price_reason, str) or not same_price_reason.strip():
+            issues.append(PriceValidationIssue("missing_same_price_reason"))
+    elif not discount_applied:
+        issues.append(PriceValidationIssue("discount_not_declared_despite_price_difference"))
+
+    issues.extend(_estimate_text_issues(monthly_estimate, list_price, discounted_price, same_price=same_price))
+    return issues
+
+
+def _estimate_text_issues(
+    monthly_estimate: str,
+    list_price: Decimal,
+    discounted_price: Decimal,
+    *,
+    same_price: bool,
+) -> list[PriceValidationIssue]:
+    amounts = _amounts_in_text(monthly_estimate)
+    if not amounts:
+        return [PriceValidationIssue("monthly_estimate_missing_amount", monthly_estimate)]
+    if list_price not in amounts:
+        return [
+            PriceValidationIssue(
+                "monthly_estimate_list_price_mismatch",
+                "{} not in {}".format(_text(list_price), monthly_estimate),
+            )
+        ]
+    if not same_price and discounted_price not in amounts:
+        return [
+            PriceValidationIssue(
+                "monthly_estimate_discounted_price_mismatch",
+                "{} not in {}".format(_text(discounted_price), monthly_estimate),
+            )
+        ]
+    return []
+
+
+def _amounts_in_text(text: str) -> set[Decimal]:
+    amounts: set[Decimal] = set()
+    for match in _AMOUNT_RE.finditer(text):
+        number = _decimal_or_none(match.group(0).replace(",", ""))
+        if number is not None:
+            amounts.add(number)
+    return amounts
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float, Decimal, str)):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        number = Decimal(text)
+    except InvalidOperation:
+        return None
+    return number if number.is_finite() else None
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, Decimal):
+        return format(value.normalize(), "f")
+    return "" if value is None else str(value)

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -356,6 +356,11 @@ sub_pipelines:
               checks_field: hard_constraint_checks
               deployment_parameters_field: deployment_parameters
             message_key: hard_constraint_verification_required
+          - always: true
+            require_monthly_price_disclosure:
+              estimate_field: monthly_estimate
+              breakdown_field: monthly_price_breakdown
+            message_key: monthly_price_disclosure_required
         tools:
           include: []
           exclude:

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -42,6 +42,8 @@ API 调用完成后调用 `complete_step` 提交费用预估。
 - 两个字段都存在时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
 - 任一字段缺失时只展示可用价格，并在 `api_raw_summary` 中说明缺失字段；询价失败时仍填写 `"询价失败"`。
 
+同时必须在 `complete_step.conclusion.monthly_price_breakdown` 写入结构化价格口径：`list_price` 填列表价数值、`discounted_price` 填合同优惠后价数值。**不得用列表价直接填充 `discounted_price`。** 两价相同时 `discount_applied` 填 `false`，并在 `same_price_reason` 显式说明折扣为 0 或未取到优惠信息的原因；两价不同时 `discount_applied` 填 `true`。该字段由代码校验，数值必须与 `monthly_estimate` 文案一致。
+
 若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。
 
 ## 注意事项

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -7,6 +7,7 @@ conclusion_schema:
   type: object
   required:
     - monthly_estimate
+    - monthly_price_breakdown
     - currency
     - resources
     - template_fixed
@@ -18,6 +19,26 @@ conclusion_schema:
     monthly_estimate:
       type: string
       description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"
+    monthly_price_breakdown:
+      type: object
+      required: [list_price, discounted_price, discount_applied]
+      additionalProperties: false
+      description: monthly_estimate 的结构化价格口径；complete_step 由代码校验两价分离、折扣声明与文案数值一致；询价失败时列表价与优惠后价均填 0、discount_applied 填 false、same_price_reason 填 "询价失败"
+      properties:
+        list_price:
+          type: number
+          minimum: 0
+          description: 按统一月度周期换算并汇总的列表价，来自询价结果的 OriginalAmount
+        discounted_price:
+          type: number
+          minimum: 0
+          description: 按与列表价相同月度周期换算并汇总的合同优惠后价，来自询价结果的 TradeAmount；不得直接用列表价填充，也不得高于列表价
+        discount_applied:
+          type: boolean
+          description: 是否真实存在合同优惠；两价相同时必须为 false，两价不同时必须为 true
+        same_price_reason:
+          type: string
+          description: 两价相同时必填的显式说明，例如"当前账号无合同优惠，折扣为 0"或"询价未返回 TradeAmount"
     currency:
       type: string
       enum: [CNY]
@@ -307,3 +328,4 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 - `missing_deployment_parameters` 填完整部署或 PreviewStack 仍缺少的参数及原因；没有缺口时可省略或填 `[]`
 - `parameter_set_summary` 可简要说明参数来源、可用性筛选、PreviewStack 验证结果以及是否使用软门禁继续询价
 - 询价失败时 `monthly_estimate` 填 "询价失败"，`resources` 为空数组，`error` 说明原因
+- `monthly_price_breakdown` 是 `monthly_estimate` 的结构化价格口径，`list_price` 取 `OriginalAmount`、`discounted_price` 取 `TradeAmount`，两者按同一月度周期换算汇总。**禁止直接用列表价填充优惠后价字段**：询价未返回 `TradeAmount` 或折扣为 0 时，`discount_applied` 填 `false` 并在 `same_price_reason` 显式说明折扣为 0 的原因；两价不同时 `discount_applied` 填 `true`。`complete_step` 会用代码逐条校验两价合法性、折扣声明与 `monthly_estimate` 文案数值的一致性，两价相同却没有说明会被拒绝，不得通过删除字段绕过

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1461,6 +1461,112 @@ class TestCompletionGuards:
         assert "rerun validation" in result.content
 
 
+class TestMonthlyPriceDisclosureGuard:
+    GUARD = {
+        "always": True,
+        "require_monthly_price_disclosure": {
+            "estimate_field": "monthly_estimate",
+            "breakdown_field": "monthly_price_breakdown",
+        },
+        "message_key": "monthly_price_disclosure_required",
+    }
+
+    def _tool(self) -> CompleteStepTool:
+        return CompleteStepTool(
+            StepConfig(step_id="cost_estimating", conclusion_field="cost", forward=None),
+            completion_guards=[self.GUARD],
+            completion_guard_state={},
+        )
+
+    def test_identical_prices_without_zero_discount_statement_are_rejected(self):
+        conclusion = {
+            "monthly_estimate": "¥373.54/月（列表价，合同优惠后约¥373.54/月）",
+            "monthly_price_breakdown": {
+                "list_price": 373.54,
+                "discounted_price": 373.54,
+                "discount_applied": True,
+            },
+        }
+
+        error = self._tool().validate_completion_input({"conclusion": conclusion})
+
+        assert error is not None
+        assert "discount_applied_without_price_difference" in error
+        assert "missing_same_price_reason" in error
+
+    def test_identical_prices_with_zero_discount_statement_pass(self):
+        conclusion = {
+            "monthly_estimate": "¥373.54/月（列表价，合同优惠后约¥373.54/月）",
+            "monthly_price_breakdown": {
+                "list_price": 373.54,
+                "discounted_price": 373.54,
+                "discount_applied": False,
+                "same_price_reason": "当前账号无合同优惠，折扣为 0",
+            },
+        }
+
+        assert self._tool().validate_completion_input({"conclusion": conclusion}) is None
+
+    def test_real_discount_passes(self):
+        conclusion = {
+            "monthly_estimate": "¥96.80/月（列表价，合同优惠后约¥13.76/月）",
+            "monthly_price_breakdown": {
+                "list_price": 96.80,
+                "discounted_price": 13.76,
+                "discount_applied": True,
+            },
+        }
+
+        assert self._tool().validate_completion_input({"conclusion": conclusion}) is None
+
+    def test_missing_breakdown_is_rejected(self):
+        conclusion = {"monthly_estimate": "¥373.54/月"}
+
+        error = self._tool().validate_completion_input({"conclusion": conclusion})
+
+        assert error is not None
+        assert "missing_monthly_price_breakdown" in error
+
+    def test_estimate_text_must_match_breakdown(self):
+        conclusion = {
+            "monthly_estimate": "¥500/月（列表价，合同优惠后约¥13.76/月）",
+            "monthly_price_breakdown": {
+                "list_price": 96.80,
+                "discounted_price": 13.76,
+                "discount_applied": True,
+            },
+        }
+
+        error = self._tool().validate_completion_input({"conclusion": conclusion})
+
+        assert error is not None
+        assert "monthly_estimate_list_price_mismatch" in error
+
+    def test_pricing_failure_is_exempt(self):
+        conclusion = {"monthly_estimate": "询价失败", "error": "GetTemplateEstimateCost failed"}
+
+        assert self._tool().validate_completion_input({"conclusion": conclusion}) is None
+
+    @pytest.mark.asyncio
+    async def test_execute_rejects_then_accepts_corrected_breakdown(self):
+        tool = self._tool()
+        breakdown = {"list_price": 373.54, "discounted_price": 373.54, "discount_applied": True}
+        conclusion = {
+            "monthly_estimate": "¥373.54/月（列表价，合同优惠后约¥373.54/月）",
+            "monthly_price_breakdown": breakdown,
+        }
+
+        rejected = await tool.execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+        assert rejected.is_error
+        assert "monthly_price_breakdown" in rejected.content
+
+        breakdown["discount_applied"] = False
+        breakdown["same_price_reason"] = "询价未返回 TradeAmount，折扣为 0"
+        accepted = await tool.execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+        assert not accepted.is_error
+        assert accepted.metadata["step_result"].status == StepStatus.COMPLETED
+
+
 class TestSchemaValidation:
     def test_missing_conclusion_validation_error_includes_current_step_schema(self):
         config = StepConfig(

--- a/tests/pipeline/engine/test_monthly_price.py
+++ b/tests/pipeline/engine/test_monthly_price.py
@@ -1,0 +1,129 @@
+"""Tests for the monthly list price vs contract-discounted price validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from iac_code.pipeline.engine.monthly_price import validate_monthly_price_breakdown
+
+LIST_AND_DISCOUNTED_TEXT = "¥96.80/月（列表价，合同优惠后约¥13.76/月）"
+SAME_PRICE_TEXT = "¥373.54/月（列表价，合同优惠后约¥373.54/月）"
+
+
+def _codes(monthly_estimate, breakdown) -> list[str]:
+    return [issue.code for issue in validate_monthly_price_breakdown(monthly_estimate, breakdown)]
+
+
+class TestAcceptedDisclosures:
+    def test_real_discount_passes(self):
+        breakdown = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": True}
+        assert validate_monthly_price_breakdown(LIST_AND_DISCOUNTED_TEXT, breakdown) == []
+
+    def test_zero_discount_with_explicit_reason_passes(self):
+        breakdown = {
+            "list_price": 373.54,
+            "discounted_price": 373.54,
+            "discount_applied": False,
+            "same_price_reason": "当前账号无合同优惠，折扣为 0",
+        }
+        assert validate_monthly_price_breakdown(SAME_PRICE_TEXT, breakdown) == []
+
+    def test_pricing_failure_is_exempt(self):
+        assert validate_monthly_price_breakdown("询价失败", None) == []
+        assert validate_monthly_price_breakdown("  询价失败  ", {"list_price": "x"}) == []
+
+    def test_string_amounts_are_accepted(self):
+        breakdown = {"list_price": "96.80", "discounted_price": "13.76", "discount_applied": True}
+        assert validate_monthly_price_breakdown(LIST_AND_DISCOUNTED_TEXT, breakdown) == []
+
+    def test_thousands_separator_in_text_is_matched(self):
+        breakdown = {"list_price": 1234.50, "discounted_price": 1000, "discount_applied": True}
+        text = "¥1,234.50/月（列表价，合同优惠后约¥1,000/月）"
+        assert validate_monthly_price_breakdown(text, breakdown) == []
+
+
+class TestRejectedDisclosures:
+    def test_identical_prices_without_reason_are_rejected(self):
+        """The reported regression: both prices equal and no zero-discount explanation."""
+        breakdown = {"list_price": 373.54, "discounted_price": 373.54, "discount_applied": True}
+        codes = _codes(SAME_PRICE_TEXT, breakdown)
+        assert "discount_applied_without_price_difference" in codes
+        assert "missing_same_price_reason" in codes
+
+    def test_identical_prices_with_blank_reason_are_rejected(self):
+        breakdown = {
+            "list_price": 373.54,
+            "discounted_price": 373.54,
+            "discount_applied": False,
+            "same_price_reason": "   ",
+        }
+        assert _codes(SAME_PRICE_TEXT, breakdown) == ["missing_same_price_reason"]
+
+    def test_price_difference_must_declare_discount(self):
+        breakdown = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": False}
+        assert _codes(LIST_AND_DISCOUNTED_TEXT, breakdown) == ["discount_not_declared_despite_price_difference"]
+
+    def test_discounted_price_above_list_price_is_rejected(self):
+        breakdown = {"list_price": 10, "discounted_price": 20, "discount_applied": True}
+        text = "¥10/月（列表价，合同优惠后约¥20/月）"
+        assert _codes(text, breakdown) == ["discounted_price_above_list_price"]
+
+    def test_missing_breakdown_is_rejected(self):
+        assert _codes("¥96.80/月", None) == ["missing_monthly_price_breakdown"]
+
+    @pytest.mark.parametrize("estimate", ["", "   ", None, 96.8])
+    def test_invalid_monthly_estimate_is_rejected(self, estimate):
+        breakdown = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": True}
+        assert _codes(estimate, breakdown) == ["invalid_monthly_estimate"]
+
+    @pytest.mark.parametrize("value", [None, "", "abc", -1, True, [96.8]])
+    def test_invalid_list_price_is_rejected(self, value):
+        breakdown = {"list_price": value, "discounted_price": 13.76, "discount_applied": True}
+        assert "invalid_list_price" in _codes(LIST_AND_DISCOUNTED_TEXT, breakdown)
+
+    @pytest.mark.parametrize("value", [None, "", "abc", -1, True])
+    def test_invalid_discounted_price_is_rejected(self, value):
+        breakdown = {"list_price": 96.80, "discounted_price": value, "discount_applied": True}
+        assert "invalid_discounted_price" in _codes(LIST_AND_DISCOUNTED_TEXT, breakdown)
+
+    @pytest.mark.parametrize("value", [None, "true", 1, "yes"])
+    def test_non_boolean_discount_applied_is_rejected(self, value):
+        breakdown = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": value}
+        assert _codes(LIST_AND_DISCOUNTED_TEXT, breakdown) == ["invalid_discount_applied"]
+
+    def test_text_without_any_amount_is_rejected(self):
+        breakdown = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": True}
+        assert _codes("费用待确认", breakdown) == ["monthly_estimate_missing_amount"]
+
+    def test_text_list_price_must_match_breakdown(self):
+        breakdown = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": True}
+        text = "¥500/月（列表价，合同优惠后约¥13.76/月）"
+        assert _codes(text, breakdown) == ["monthly_estimate_list_price_mismatch"]
+
+    def test_text_discounted_price_must_match_breakdown(self):
+        breakdown = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": True}
+        text = "¥96.80/月（列表价，合同优惠后约¥50/月）"
+        assert _codes(text, breakdown) == ["monthly_estimate_discounted_price_mismatch"]
+
+    def test_single_amount_text_is_accepted_only_when_prices_are_equal(self):
+        equal = {
+            "list_price": 373.54,
+            "discounted_price": 373.54,
+            "discount_applied": False,
+            "same_price_reason": "折扣为 0",
+        }
+        assert validate_monthly_price_breakdown("¥373.54/月", equal) == []
+
+        differing = {"list_price": 96.80, "discounted_price": 13.76, "discount_applied": True}
+        assert _codes("¥96.80/月", differing) == ["monthly_estimate_discounted_price_mismatch"]
+
+
+class TestIssueSerialization:
+    def test_issue_to_dict_drops_empty_detail(self):
+        issues = validate_monthly_price_breakdown("¥96.80/月", None)
+        assert [issue.to_dict() for issue in issues] == [{"code": "missing_monthly_price_breakdown"}]
+
+    def test_issue_to_dict_keeps_detail(self):
+        breakdown = {"list_price": 10, "discounted_price": 20, "discount_applied": True}
+        issue = validate_monthly_price_breakdown("¥10/月 ¥20/月", breakdown)[0]
+        assert issue.to_dict() == {"code": "discounted_price_above_list_price", "detail": "20 > 10"}

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -112,6 +112,12 @@ class TestSkillFrontmatter:
         }
         conclusion = {
             "monthly_estimate": "¥100/月",
+            "monthly_price_breakdown": {
+                "list_price": 100,
+                "discounted_price": 100,
+                "discount_applied": False,
+                "same_price_reason": "无合同优惠",
+            },
             "currency": "CNY",
             "resources": [{"type": "ALIYUN::RDS::DBInstance", "cost": "¥100/月"}],
             "template_fixed": False,
@@ -172,12 +178,69 @@ class TestSkillFrontmatter:
         assert "OriginalAmount" in description
         assert "TradeAmount" in description
 
+    def test_conclusion_schema_requires_structured_monthly_price_breakdown(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        breakdown = schema["properties"]["monthly_price_breakdown"]
+
+        assert "monthly_price_breakdown" in schema["required"]
+        assert breakdown["type"] == "object"
+        assert set(breakdown["required"]) == {"list_price", "discounted_price", "discount_applied"}
+        assert breakdown["properties"]["list_price"]["type"] == "number"
+        assert breakdown["properties"]["discounted_price"]["type"] == "number"
+        assert breakdown["properties"]["discount_applied"]["type"] == "boolean"
+        assert breakdown["properties"]["same_price_reason"]["type"] == "string"
+        assert all(value.get("description") for value in breakdown["properties"].values())
+
+    def test_monthly_price_breakdown_rejects_missing_and_extra_fields(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        conclusion = {
+            "monthly_estimate": "¥96.80/月（列表价，合同优惠后约¥13.76/月）",
+            "monthly_price_breakdown": {
+                "list_price": 96.80,
+                "discounted_price": 13.76,
+                "discount_applied": True,
+            },
+            "currency": "CNY",
+            "resources": [{"type": "ALIYUN::ECS::InstanceGroup", "cost": "¥96.80/月"}],
+            "template_fixed": False,
+            "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+            "hard_constraint_checks": [],
+            "preview_validation": {"succeeded": False, "error": "missing VpcId"},
+        }
+
+        jsonschema.validate(conclusion, schema)
+
+        missing_breakdown = {key: value for key, value in conclusion.items() if key != "monthly_price_breakdown"}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(missing_breakdown, schema)
+
+        missing_discount_flag = json.loads(json.dumps(conclusion, ensure_ascii=False))
+        del missing_discount_flag["monthly_price_breakdown"]["discount_applied"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(missing_discount_flag, schema)
+
+        negative_price = json.loads(json.dumps(conclusion, ensure_ascii=False))
+        negative_price["monthly_price_breakdown"]["discounted_price"] = -1
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(negative_price, schema)
+
+        unexpected_field = json.loads(json.dumps(conclusion, ensure_ascii=False))
+        unexpected_field["monthly_price_breakdown"]["discount_rate"] = 0.5
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(unexpected_field, schema)
+
     def test_conclusion_schema_requires_full_preview_validation_when_succeeded(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         fm = _parse_frontmatter(content)
         schema = fm["conclusion_schema"]
         conclusion = {
             "monthly_estimate": "¥100/月",
+            "monthly_price_breakdown": {
+                "list_price": 100,
+                "discounted_price": 100,
+                "discount_applied": False,
+                "same_price_reason": "无合同优惠",
+            },
             "currency": "CNY",
             "resources": [{"type": "ALIYUN::ECS::InstanceGroup", "cost": "¥100/月"}],
             "template_fixed": False,
@@ -204,6 +267,12 @@ class TestSkillFrontmatter:
         schema = fm["conclusion_schema"]
         conclusion = {
             "monthly_estimate": "询价失败",
+            "monthly_price_breakdown": {
+                "list_price": 0,
+                "discounted_price": 0,
+                "discount_applied": False,
+                "same_price_reason": "询价失败",
+            },
             "currency": "CNY",
             "resources": [],
             "template_fixed": False,
@@ -380,6 +449,13 @@ class TestSkillContentRosOnly:
     def test_contains_error_handling(self, body):
         assert "失败" in body
 
+    def test_forbids_filling_discounted_price_with_list_price(self, body):
+        assert "monthly_price_breakdown" in body
+        assert "禁止直接用列表价填充优惠后价字段" in body
+        assert "same_price_reason" in body
+        assert "discount_applied" in body
+        assert "代码逐条校验" in body
+
     def test_emphasizes_write_back(self, body):
         assert "写回原文件路径" in body
 
@@ -538,6 +614,14 @@ class TestCostPrompt:
         assert "列表价" in body
         assert "合同优惠后" in body
         assert "monthly_estimate" in body
+
+    def test_prompt_requires_structured_price_breakdown_without_list_price_fallback(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+
+        assert "monthly_price_breakdown" in body
+        assert "不得用列表价直接填充 `discounted_price`" in body
+        assert "same_price_reason" in body
+        assert "discount_applied" in body
 
     def test_prompt_receives_only_required_candidate_fields_without_repeating_skill_rules(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")

--- a/tests/pipeline/selling/test_pipeline_reviewing.py
+++ b/tests/pipeline/selling/test_pipeline_reviewing.py
@@ -44,7 +44,15 @@ def test_review_enabled_loads_infraguard_repair_step_before_cost() -> None:
                 "deployment_parameters_field": "deployment_parameters",
             },
             "message_key": "hard_constraint_verification_required",
-        }
+        },
+        {
+            "always": True,
+            "require_monthly_price_disclosure": {
+                "estimate_field": "monthly_estimate",
+                "breakdown_field": "monthly_price_breakdown",
+            },
+            "message_key": "monthly_price_disclosure_required",
+        },
     ]
 
     assert review_step.tools is not None


### PR DESCRIPTION
## 问题

`cost_estimating` 的 `monthly_estimate` 此前是**完全由 LLM 自由书写的字符串**，从询价 API 到最终展示的整条链路没有任何代码级校验：

- `conclusion_schema` 里只约束 `{"type": "string"}`，没有 `pattern`，也没有结构化的原价/优惠后价字段；
- `complete_step` 的 completion guard 只覆盖 `hard_constraint_checks`、`preview_validation`、sha256，**没有任何一条校验价格口径**；
- 全仓检索确认 `OriginalAmount` / `TradeAmount` 只出现在 prompt、SKILL.md 和测试断言这些文本里，**没有任何 Python 代码解析询价结果的这两个字段**，下游 `web/outputs.py` 与 `selling/tools/ros_deploy_tool.py` 都是原样透传。

因此当模型汇总出现偏差、或折扣未取到时直接用列表价把优惠后价复述一遍，就会产出 `¥373.54/月（列表价，合同优惠后约¥373.54/月）` 这种**两价相同且毫无说明**的结论。系统无法察觉，用户也无法分辨「折扣确实为 0」和「优惠后价被列表价覆盖」这两种完全不同的情况。

## 改动

把价格口径从自由文本升级为可校验数据，并补上代码兜底：

- **新增结构化字段** `monthly_price_breakdown`（`list_price` / `discounted_price` / `discount_applied` / `same_price_reason`），加入 `conclusion_schema` 的 `required`。
- **新增 `pipeline/engine/monthly_price.py`** 纯函数校验，与既有 `hard_constraints.py` 同风格、可独立单测：
  - 两价必须是合法非负数值；
  - 优惠后价不得高于列表价；
  - **两价相同时必须 `discount_applied: false` 且给出非空 `same_price_reason`**（即"折扣为 0 / 未取到优惠"的显式说明）；
  - 两价不同时必须 `discount_applied: true`，防止反向填错；
  - `monthly_estimate` 文案里的金额必须与 breakdown 数值一致，杜绝"字段填一套、文案写另一套"；
  - `monthly_estimate == "询价失败"` 时整条校验豁免，保持既有失败路径不变。
- **新增 `require_monthly_price_disclosure` completion guard** 并接入 `cost_estimating`，沿用既有 guard 机制；校验失败时返回带校验码的可执行提示，要求模型重填而非放行。
- **prompt / SKILL.md** 把「禁止用列表价填充优惠后价」「折扣为 0 必须显式标注」从建议升级为带字段的硬契约。
- 六个 locale 补齐新增 msgid 的**完整翻译**（无 fuzzy、无空 msgstr）。

## 兼容性

`monthly_estimate` 字符串格式保持不变，`web/outputs.py` 与 `ros_deploy_tool.py` 零改动，Web / A2A 展示不回归。

## 验证

- 新增 42 条测试：`test_monthly_price.py` 35 条纯函数矩阵 + `TestMonthlyPriceDisclosureGuard` 7 条 guard 集成用例，覆盖两价相同无说明被拒（即本次缺陷表现）、两价相同有说明通过、真实折扣通过、优惠后价高于列表价被拒、文案与字段不一致被拒、询价失败豁免。
- `tests/pipeline` + `tests/i18n` + `tests/web` + `tests/a2a` + `tests/skill_bridge`：**4682 passed**。
- `ruff check src/ tests/` 与 `ty check src/` 全部通过；改动文件均已 `ruff format`。
- `tests/test_i18n.py`(13) 与 `repl_e2e`(1) 在未改动的 clean tree 上即失败，已用 `git stash` 对比确认基线一致（14 failed / 18 passed 两侧相同），与本次改动无关。
