### PR TITLE
fix(pipeline): reject unexplained zeroed contract discount in cost estimate

### DIFF
--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -13,6 +13,7 @@ import jsonschema
 
 from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
+from iac_code.pipeline.engine.cost_estimate import validate_cost_estimate_sanity
 from iac_code.pipeline.engine.hard_constraints import collect_hard_constraints, validate_hard_constraint_checks
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
@@ -60,6 +61,9 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
     ),
+    "cost_estimate_zero_discount_basis_required": (
+        "A discounted monthly price that drops to zero must state its discount basis or fall back to the list price."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -99,6 +103,10 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
         _(
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
+        ),
+        _(
+            "A discounted monthly price that drops to zero must state its discount basis or fall back to the "
+            "list price."
         ),
     )
 
@@ -324,6 +332,7 @@ class CompleteStepTool(Tool):
             required_tool_result = guard.get("require_tool_result")
             required_conclusion_sha256 = guard.get("require_conclusion_sha256")
             required_constraint_coverage = guard.get("require_context_constraint_coverage")
+            required_cost_estimate_sanity = guard.get("require_cost_estimate_sanity")
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
@@ -383,7 +392,41 @@ class CompleteStepTool(Tool):
                 )
                 if validation_error is not None:
                     return validation_error
+            if isinstance(required_cost_estimate_sanity, dict):
+                validation_error = self._validate_cost_estimate_sanity(
+                    required_cost_estimate_sanity,
+                    conclusion,
+                    self._completion_guard_message(guard, None),
+                )
+                if validation_error is not None:
+                    return validation_error
         return None
+
+    def _validate_cost_estimate_sanity(
+        self,
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        message: str | None,
+    ) -> str | None:
+        issues = validate_cost_estimate_sanity(
+            conclusion,
+            monthly_estimate_field=str(requirement.get("monthly_estimate_field") or "monthly_estimate"),
+            discount_basis_field=str(requirement.get("discount_basis_field") or "discount_basis"),
+            api_raw_summary_field=str(requirement.get("api_raw_summary_field") or "api_raw_summary"),
+        )
+        if not issues:
+            return None
+        base_message = message or _(
+            "A discounted monthly price that drops to zero must state its discount basis or fall back to the "
+            "list price."
+        )
+        issue_summaries = [f"{issue.code}[{issue.detail}]" if issue.detail else issue.code for issue in issues]
+        code = issues[0].code if len(issues) == 1 else "multiple_cost_estimate_issues"
+        return _("{message} Validation issue: {code} ({detail}).").format(
+            message=base_message,
+            code=code,
+            detail="; ".join(issue_summaries),
+        )
 
     def _validate_context_constraint_coverage(
         self,

--- a/src/iac_code/pipeline/engine/cost_estimate.py
+++ b/src/iac_code/pipeline/engine/cost_estimate.py
@@ -1,0 +1,135 @@
+"""Sanity validation for the cost step's list-price / discounted-price monthly estimate."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+# A discounted monthly price below this share of the list price is treated as suspicious.
+# Real contract discounts stay well above it, while a mis-read discount field collapses to ~0.
+SUSPICIOUS_DISCOUNT_RATIO = Decimal("0.01")
+
+_PRICING_FAILED_MARKERS = ("询价失败", "pricing failed", "estimate failed")
+_AMOUNT_PATTERN = re.compile(r"(?:¥|￥|CNY|RMB)\s*(-?\d+(?:,\d{3})*(?:\.\d+)?)", re.IGNORECASE)
+_DISCOUNTED_MARKERS = ("合同优惠后", "优惠后", "discounted", "after discount")
+
+
+@dataclass(frozen=True)
+class CostEstimateIssue:
+    code: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {key: value for key, value in asdict(self).items() if value}
+
+
+@dataclass(frozen=True)
+class MonthlyEstimatePrices:
+    """Amounts parsed out of a ``monthly_estimate`` string."""
+
+    list_price: Decimal | None = None
+    discounted_price: Decimal | None = None
+    pricing_failed: bool = False
+
+    @property
+    def has_both_prices(self) -> bool:
+        return self.list_price is not None and self.discounted_price is not None
+
+
+def parse_monthly_estimate(monthly_estimate: Any) -> MonthlyEstimatePrices:
+    """Parse the list price and the contract-discounted price out of ``monthly_estimate``.
+
+    The field is free-form text produced by the cost step, for example
+    ``¥289.81/月（列表价，合同优惠后约¥0.00/月）``. Only amounts are extracted; when the
+    step reports a pricing failure or no amount is present, the corresponding price stays
+    ``None`` so callers can skip validation instead of guessing.
+    """
+
+    if not isinstance(monthly_estimate, str) or not monthly_estimate.strip():
+        return MonthlyEstimatePrices()
+
+    text = monthly_estimate.strip()
+    if any(marker in text.casefold() for marker in _PRICING_FAILED_MARKERS):
+        return MonthlyEstimatePrices(pricing_failed=True)
+
+    matches = list(_AMOUNT_PATTERN.finditer(text))
+    if not matches:
+        return MonthlyEstimatePrices()
+
+    amounts = [_decimal_or_none(match.group(1).replace(",", "")) for match in matches]
+    if amounts[0] is None:
+        return MonthlyEstimatePrices()
+    if len(amounts) == 1:
+        # A single amount carries only one gauge; a discount marker means it is already the
+        # final price, otherwise treat it as the list price.
+        if _is_discounted_amount(text, matches[0].start()):
+            return MonthlyEstimatePrices(discounted_price=amounts[0])
+        return MonthlyEstimatePrices(list_price=amounts[0])
+
+    discounted = next(
+        (
+            amount
+            for amount, match in zip(amounts[1:], matches[1:])
+            if amount is not None and _is_discounted_amount(text, match.start())
+        ),
+        None,
+    )
+    return MonthlyEstimatePrices(list_price=amounts[0], discounted_price=discounted)
+
+
+def validate_cost_estimate_sanity(
+    conclusion: Any,
+    *,
+    monthly_estimate_field: str = "monthly_estimate",
+    discount_basis_field: str = "discount_basis",
+    api_raw_summary_field: str = "api_raw_summary",
+) -> list[CostEstimateIssue]:
+    """Reject a zeroed-out discounted monthly price that has no basis and no list-price fallback.
+
+    A contract discount that collapses a running deployment's monthly cost to zero is either
+    backed by an explicit basis or a mis-read discount field. Without a basis the step must
+    fall back to the list price rather than reporting a free deployment.
+    """
+
+    if not isinstance(conclusion, dict):
+        return [CostEstimateIssue("invalid_cost_conclusion")]
+
+    monthly_estimate = conclusion.get(monthly_estimate_field)
+    prices = parse_monthly_estimate(monthly_estimate)
+    if prices.pricing_failed or not prices.has_both_prices:
+        return []
+
+    list_price = prices.list_price
+    discounted_price = prices.discounted_price
+    assert list_price is not None and discounted_price is not None  # noqa: S101 - narrowed by has_both_prices
+
+    if discounted_price < 0 or list_price < 0:
+        return [CostEstimateIssue("negative_monthly_estimate", str(monthly_estimate))]
+    if list_price <= 0 or discounted_price > list_price * SUSPICIOUS_DISCOUNT_RATIO:
+        return []
+    if _has_discount_basis(conclusion, discount_basis_field, api_raw_summary_field):
+        return []
+    return [CostEstimateIssue("discounted_monthly_estimate_zeroed", str(monthly_estimate))]
+
+
+def _has_discount_basis(conclusion: dict[str, Any], discount_basis_field: str, api_raw_summary_field: str) -> bool:
+    for field in (discount_basis_field, api_raw_summary_field):
+        value = conclusion.get(field)
+        if isinstance(value, str) and value.strip():
+            return True
+    return False
+
+
+def _is_discounted_amount(text: str, amount_start: int) -> bool:
+    preceding = text[:amount_start].casefold()
+    return any(marker in preceding for marker in _DISCOUNTED_MARKERS)
+
+
+def _decimal_or_none(value: str) -> Decimal | None:
+    try:
+        number = Decimal(value)
+    except InvalidOperation:
+        return None
+    return number if number.is_finite() else None

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -43,6 +43,7 @@ _SUPPORTED_COMPLETION_GUARD_KEYS = {
     "message_key",
     "require_conclusion_sha256",
     "require_context_constraint_coverage",
+    "require_cost_estimate_sanity",
     "require_tool",
     "require_tool_result",
     "required_conclusion_any_of",

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -356,6 +356,12 @@ sub_pipelines:
               checks_field: hard_constraint_checks
               deployment_parameters_field: deployment_parameters
             message_key: hard_constraint_verification_required
+          - always: true
+            require_cost_estimate_sanity:
+              monthly_estimate_field: monthly_estimate
+              discount_basis_field: discount_basis
+              api_raw_summary_field: api_raw_summary
+            message_key: cost_estimate_zero_discount_basis_required
         tools:
           include: []
           exclude:

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -40,6 +40,7 @@ API 调用完成后调用 `complete_step` 提交费用预估。
 - `OriginalAmount` 是原价，按统一月度周期换算并汇总为列表价。
 - `TradeAmount` 是合同优惠后的最终价，按与原价相同的月度周期换算并汇总。
 - 两个字段都存在时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
+- 优惠后月费归零或异常低于列表价时，必须在 `discount_basis` 写明可核对依据（询价结果中的折扣字段路径、代金券或免费额度）；无依据时把优惠后价格回退为列表价，不要输出无依据的 ¥0.00/月。
 - 任一字段缺失时只展示可用价格，并在 `api_raw_summary` 中说明缺失字段；询价失败时仍填写 `"询价失败"`。
 
 若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -17,7 +17,10 @@ conclusion_schema:
   properties:
     monthly_estimate:
       type: string
-      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"
+      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；合同优惠后价格归零或异常低于列表价时，必须在 discount_basis 说明依据，否则回退为列表价；询价失败时填 "询价失败"
+    discount_basis:
+      type: string
+      description: 合同优惠后价格归零或异常低于列表价时的折扣依据，如询价结果中的折扣字段路径、代金券或免费额度说明；无依据时不要填写，改为把优惠后价格回退为列表价
     currency:
       type: string
       enum: [CNY]
@@ -307,3 +310,4 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 - `missing_deployment_parameters` 填完整部署或 PreviewStack 仍缺少的参数及原因；没有缺口时可省略或填 `[]`
 - `parameter_set_summary` 可简要说明参数来源、可用性筛选、PreviewStack 验证结果以及是否使用软门禁继续询价
 - 询价失败时 `monthly_estimate` 填 "询价失败"，`resources` 为空数组，`error` 说明原因
+- 合同优惠后月费归零或异常低于列表价（低于列表价 1%）时，必须在 `discount_basis` 给出可核对依据（询价结果中的折扣字段路径、代金券或免费额度说明）；无依据时把优惠后价格回退为列表价。运行中的基础设施月费为零不合常理，代码会在 `complete_step` 拦截无依据的归零并要求修正

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1461,6 +1461,94 @@ class TestCompletionGuards:
         assert "rerun validation" in result.content
 
 
+class TestCostEstimateSanityGuard:
+    ZEROED = "¥289.81/月（列表价，合同优惠后约¥0.00/月）"
+
+    def _cost_tool(self):
+        config = StepConfig(
+            step_id="cost_estimating",
+            conclusion_field="cost",
+            forward=None,
+        )
+        return CompleteStepTool(
+            config,
+            completion_guards=[
+                {
+                    "always": True,
+                    "require_cost_estimate_sanity": {
+                        "monthly_estimate_field": "monthly_estimate",
+                        "discount_basis_field": "discount_basis",
+                        "api_raw_summary_field": "api_raw_summary",
+                    },
+                    "message_key": "cost_estimate_zero_discount_basis_required",
+                }
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_zeroed_discount_without_basis(self):
+        result = await self._cost_tool().execute(
+            tool_input={"conclusion": {"monthly_estimate": self.ZEROED, "currency": "CNY"}},
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "discount basis" in result.content
+        assert "discounted_monthly_estimate_zeroed" in result.content
+
+    @pytest.mark.asyncio
+    async def test_accepts_zeroed_discount_with_basis(self):
+        result = await self._cost_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": self.ZEROED,
+                    "currency": "CNY",
+                    "discount_basis": "Result.TradeAmount=0，账号命中免费额度",
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_accepts_list_price_fallback(self):
+        result = await self._cost_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": "¥289.81/月（列表价，合同优惠后约¥289.81/月）",
+                    "currency": "CNY",
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_accepts_normal_discount(self):
+        result = await self._cost_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "monthly_estimate": "¥289.81/月（列表价，合同优惠后约¥13.76/月）",
+                    "currency": "CNY",
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_does_not_block_pricing_failure(self):
+        result = await self._cost_tool().execute(
+            tool_input={"conclusion": {"monthly_estimate": "询价失败", "error": "GetTemplateEstimateCost 报错"}},
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+
 class TestSchemaValidation:
     def test_missing_conclusion_validation_error_includes_current_step_schema(self):
         config = StepConfig(

--- a/tests/pipeline/engine/test_cost_estimate.py
+++ b/tests/pipeline/engine/test_cost_estimate.py
@@ -1,0 +1,161 @@
+"""Tests for cost-step monthly estimate parsing and zeroed-discount sanity validation."""
+
+from decimal import Decimal
+
+from iac_code.pipeline.engine.cost_estimate import (
+    parse_monthly_estimate,
+    validate_cost_estimate_sanity,
+)
+
+ZEROED_ESTIMATE = "¥289.81/月（列表价，合同优惠后约¥0.00/月）"
+NORMAL_ESTIMATE = "¥289.81/月（列表价，合同优惠后约¥13.76/月）"
+
+
+def _conclusion(monthly_estimate: str, **extra) -> dict:
+    return {
+        "monthly_estimate": monthly_estimate,
+        "currency": "CNY",
+        "resources": [{"type": "ALIYUN::ECS::InstanceGroup", "cost": "¥289.81/月"}],
+        "template_fixed": False,
+        "deployment_parameters": {"ZoneId": "cn-hangzhou-k"},
+        "hard_constraint_checks": [],
+        "preview_validation": {"succeeded": False, "error": "missing VpcId"},
+        **extra,
+    }
+
+
+class TestParseMonthlyEstimate:
+    def test_parses_both_price_gauges(self):
+        prices = parse_monthly_estimate(NORMAL_ESTIMATE)
+
+        assert prices.list_price == Decimal("289.81")
+        assert prices.discounted_price == Decimal("13.76")
+        assert prices.has_both_prices is True
+        assert prices.pricing_failed is False
+
+    def test_parses_zeroed_discounted_price(self):
+        prices = parse_monthly_estimate(ZEROED_ESTIMATE)
+
+        assert prices.list_price == Decimal("289.81")
+        assert prices.discounted_price == Decimal("0.00")
+
+    def test_parses_thousands_separator(self):
+        prices = parse_monthly_estimate("¥12,345.60/月（列表价，合同优惠后约¥1,234.56/月）")
+
+        assert prices.list_price == Decimal("12345.60")
+        assert prices.discounted_price == Decimal("1234.56")
+
+    def test_single_amount_is_the_list_price(self):
+        prices = parse_monthly_estimate("¥289.81/月")
+
+        assert prices.list_price == Decimal("289.81")
+        assert prices.discounted_price is None
+        assert prices.has_both_prices is False
+
+    def test_single_amount_after_discount_marker_is_the_final_price(self):
+        prices = parse_monthly_estimate("合同优惠后约¥13.76/月")
+
+        assert prices.list_price is None
+        assert prices.discounted_price == Decimal("13.76")
+
+    def test_pricing_failure_is_reported(self):
+        prices = parse_monthly_estimate("询价失败")
+
+        assert prices.pricing_failed is True
+        assert prices.has_both_prices is False
+
+    def test_missing_or_unparsable_values_yield_no_prices(self):
+        for value in (None, "", "   ", 289.81, "价格未知"):
+            prices = parse_monthly_estimate(value)
+
+            assert prices.list_price is None
+            assert prices.discounted_price is None
+            assert prices.pricing_failed is False
+
+
+class TestValidateCostEstimateSanity:
+    def test_rejects_zeroed_discount_without_basis(self):
+        issues = validate_cost_estimate_sanity(_conclusion(ZEROED_ESTIMATE))
+
+        assert [issue.code for issue in issues] == ["discounted_monthly_estimate_zeroed"]
+        assert issues[0].detail == ZEROED_ESTIMATE
+
+    def test_accepts_zeroed_discount_with_discount_basis(self):
+        conclusion = _conclusion(ZEROED_ESTIMATE, discount_basis="Result.TradeAmount=0，账号命中 100% 合同折扣")
+
+        assert validate_cost_estimate_sanity(conclusion) == []
+
+    def test_accepts_zeroed_discount_explained_in_api_raw_summary(self):
+        conclusion = _conclusion(ZEROED_ESTIMATE, api_raw_summary="TradeAmount 为 0，来源为免费额度")
+
+        assert validate_cost_estimate_sanity(conclusion) == []
+
+    def test_blank_basis_does_not_count_as_explanation(self):
+        conclusion = _conclusion(ZEROED_ESTIMATE, discount_basis="   ", api_raw_summary="")
+
+        assert [issue.code for issue in validate_cost_estimate_sanity(conclusion)] == [
+            "discounted_monthly_estimate_zeroed"
+        ]
+
+    def test_accepts_fallback_to_list_price(self):
+        conclusion = _conclusion("¥289.81/月（列表价，合同优惠后约¥289.81/月）")
+
+        assert validate_cost_estimate_sanity(conclusion) == []
+
+    def test_accepts_normal_contract_discount(self):
+        assert validate_cost_estimate_sanity(_conclusion(NORMAL_ESTIMATE)) == []
+
+    def test_rejects_suspiciously_low_discount_without_basis(self):
+        conclusion = _conclusion("¥289.81/月（列表价，合同优惠后约¥1.00/月）")
+
+        assert [issue.code for issue in validate_cost_estimate_sanity(conclusion)] == [
+            "discounted_monthly_estimate_zeroed"
+        ]
+
+    def test_accepts_discount_just_above_the_suspicious_ratio(self):
+        conclusion = _conclusion("¥289.81/月（列表价，合同优惠后约¥5.00/月）")
+
+        assert validate_cost_estimate_sanity(conclusion) == []
+
+    def test_rejects_negative_amounts(self):
+        conclusion = _conclusion("¥289.81/月（列表价，合同优惠后约¥-1.00/月）")
+
+        assert [issue.code for issue in validate_cost_estimate_sanity(conclusion)] == ["negative_monthly_estimate"]
+
+    def test_pricing_failure_is_not_flagged(self):
+        conclusion = _conclusion("询价失败", error="GetTemplateEstimateCost 报错")
+
+        assert validate_cost_estimate_sanity(conclusion) == []
+
+    def test_single_price_gauge_is_not_flagged(self):
+        assert validate_cost_estimate_sanity(_conclusion("¥289.81/月")) == []
+
+    def test_free_tier_list_price_is_not_flagged(self):
+        conclusion = _conclusion("¥0.00/月（列表价，合同优惠后约¥0.00/月）")
+
+        assert validate_cost_estimate_sanity(conclusion) == []
+
+    def test_non_dict_conclusion_is_reported(self):
+        assert [issue.code for issue in validate_cost_estimate_sanity("¥0/月")] == ["invalid_cost_conclusion"]
+
+    def test_custom_field_names_are_honored(self):
+        conclusion = {"cost_text": ZEROED_ESTIMATE, "basis": "TradeAmount=0，免费额度"}
+
+        assert validate_cost_estimate_sanity(
+            conclusion,
+            monthly_estimate_field="cost_text",
+            discount_basis_field="basis",
+        ) == []
+        assert [
+            issue.code
+            for issue in validate_cost_estimate_sanity(
+                {"cost_text": ZEROED_ESTIMATE},
+                monthly_estimate_field="cost_text",
+                discount_basis_field="basis",
+            )
+        ] == ["discounted_monthly_estimate_zeroed"]
+
+    def test_issue_to_dict_omits_empty_detail(self):
+        issues = validate_cost_estimate_sanity("not-a-dict")
+
+        assert issues[0].to_dict() == {"code": "invalid_cost_conclusion"}

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -172,6 +172,21 @@ class TestSkillFrontmatter:
         assert "OriginalAmount" in description
         assert "TradeAmount" in description
 
+    def test_conclusion_schema_carries_discount_basis_for_zeroed_prices(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        discount_basis = schema["properties"]["discount_basis"]
+
+        assert discount_basis["type"] == "string"
+        assert "折扣依据" in discount_basis["description"]
+        assert "discount_basis" not in schema["required"]
+
+    def test_monthly_estimate_schema_requires_basis_or_list_price_fallback(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        description = schema["properties"]["monthly_estimate"]["description"]
+
+        assert "discount_basis" in description
+        assert "回退" in description
+
     def test_conclusion_schema_requires_full_preview_validation_when_succeeded(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         fm = _parse_frontmatter(content)
@@ -538,6 +553,13 @@ class TestCostPrompt:
         assert "列表价" in body
         assert "合同优惠后" in body
         assert "monthly_estimate" in body
+
+    def test_prompt_requires_basis_or_list_price_fallback_for_zeroed_discount(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+
+        assert "discount_basis" in body
+        assert "归零" in body
+        assert "回退为列表价" in body
 
     def test_prompt_receives_only_required_candidate_fields_without_repeating_skill_rules(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")

--- a/tests/pipeline/selling/test_pipeline_reviewing.py
+++ b/tests/pipeline/selling/test_pipeline_reviewing.py
@@ -44,7 +44,16 @@ def test_review_enabled_loads_infraguard_repair_step_before_cost() -> None:
                 "deployment_parameters_field": "deployment_parameters",
             },
             "message_key": "hard_constraint_verification_required",
-        }
+        },
+        {
+            "always": True,
+            "require_cost_estimate_sanity": {
+                "monthly_estimate_field": "monthly_estimate",
+                "discount_basis_field": "discount_basis",
+                "api_raw_summary_field": "api_raw_summary",
+            },
+            "message_key": "cost_estimate_zero_discount_basis_required",
+        },
     ]
 
     assert review_step.tools is not None


### PR DESCRIPTION
## 问题

成本估算对同一候选方案同时报出「列表价 ¥289.81/月」与「合同优惠后约 ¥0.00/月」。运行中的基础设施月费归零不合常理，会让用户误判长期成本，影响选型与预算决策。

证据：`pipeline_snapshot.steps.2.candidates.0.steps.1`（`evaluate_candidate` 子流程的 `cost_estimating` 步骤）。

## 根因

`monthly_estimate` 是由步骤 LLM 自行摘取询价结果后写入的自由文本，而 `ros_estimate_template_cost` 是透传工具、不解析金额。`cost_estimating` 原有唯一的 completion guard 只校验硬约束覆盖（`require_context_constraint_coverage`），**对价格口径零校验**。因此 LLM 误取折扣字段导致优惠后价归零时，列表价与优惠后价之间的内部矛盾无人拦截，既不要求标注折扣依据，也不回退到列表价。

## 改动

新增 `pipeline/engine/cost_estimate.py`（纯函数，无 IO）：

- `parse_monthly_estimate` 解析列表价与合同优惠后价两个口径，兼容千分位、单一价格、`询价失败` 等形态
- `validate_cost_estimate_sanity`：列表价为正而优惠后价归零或低于列表价 1% 时，要求 conclusion 给出折扣依据（`discount_basis` 或 `api_raw_summary`），否则必须回退为列表价

通过新的 `require_cost_estimate_sanity` completion guard 接入 `complete_step`，校验不通过时返回带校验码的错误，LLM 在既有 `max_conclusion_retries: 4` 预算内修正。同步在 `iac-aliyun-cost` SKILL.md 增加可选 `discount_basis` 字段，并更新 `cost_estimating.md` 说明。

不误报的场景：询价失败、只有单一价格口径、列表价本身为 0（免费资源）、正常折扣。

## 测试

- 新增 `tests/pipeline/engine/test_cost_estimate.py`（22 项）覆盖解析与校验，含归零无依据被拦截 / 有依据放行 / 回退列表价放行 / 负数 / 自定义字段名
- `test_complete_step_tool.py` 新增 5 项 guard 集成用例
- `test_iac_aliyun_cost_skill.py` 新增 schema 与文案断言
- `pytest tests/pipeline/` 1638 passed；全量 `pytest tests/` 14334 passed
- `ruff check` 改动文件全绿，`ty check src/` 全绿

> 全量运行中另有 2 项失败（`test_prerequisites` 直连下载 URL、`repl_e2e` sidecar 嵌套布局）与 13 项 `test_i18n` 失败，在未改动的 `main` 基线上同样失败，属沙箱网络/缺少编译 `.mo` 产物导致的既有问题，与本改动无关。
