### PR TITLE
perf(providers): bound qwen3.7-max thinking budget to cut tail latency

### DIFF
--- a/src/iac_code/providers/thinking.py
+++ b/src/iac_code/providers/thinking.py
@@ -229,6 +229,18 @@ _DASHSCOPE_KIMI_K27_CODE_SPEC = ThinkingSpec(
     use_max_completion_tokens=True,
 )
 
+# qwen3.7-max is the strongest Bailian variant but leaves thinking length to the
+# server, which produced ~12-minute thinking phases (p99 728,878ms) inside
+# ~17-minute end-to-end executions. Declaring a bounded budget makes
+# ``dashscope_provider`` send ``extra_body.thinking_budget`` so the thinking
+# stage has a hard ceiling, and lets callers raise it per request through the
+# existing Web/A2A budget path when a task genuinely needs deeper reasoning.
+_DASHSCOPE_QWEN37_MAX_SPEC = ThinkingSpec(
+    ThinkingFamily.DASHSCOPE,
+    default_thinking_budget=8192,
+    supports_thinking_budget=True,
+)
+
 _DASHSCOPE_GLM52_SPEC = ThinkingSpec(
     ThinkingFamily.DASHSCOPE,
     _GLM_EFFORTS,
@@ -362,7 +374,7 @@ MODEL_THINKING: dict[str, dict[str, ThinkingSpec]] = {
     },
     "dashscope": {
         "qwen3.8-max": _DASHSCOPE_QWEN38_SPEC,
-        "qwen3.7-max": ThinkingSpec(ThinkingFamily.DASHSCOPE),
+        "qwen3.7-max": _DASHSCOPE_QWEN37_MAX_SPEC,
         "qwen3.7-plus": ThinkingSpec(ThinkingFamily.DASHSCOPE),
         "qwen3.7-flash": ThinkingSpec(ThinkingFamily.DASHSCOPE),
         "qwen3.6-max-preview": ThinkingSpec(ThinkingFamily.DASHSCOPE),
@@ -410,7 +422,7 @@ MODEL_THINKING: dict[str, dict[str, ThinkingSpec]] = {
     "dashscope_token_plan": {
         "qwen3.8-max": _DASHSCOPE_QWEN38_SPEC,
         "qwen3.8-max-preview": _DASHSCOPE_QWEN38_PREVIEW_SPEC,
-        "qwen3.7-max": ThinkingSpec(ThinkingFamily.DASHSCOPE),
+        "qwen3.7-max": _DASHSCOPE_QWEN37_MAX_SPEC,
         "qwen3.7-plus": ThinkingSpec(ThinkingFamily.DASHSCOPE),
         "qwen3.6-plus": ThinkingSpec(ThinkingFamily.DASHSCOPE),
         "qwen3.6-flash": ThinkingSpec(ThinkingFamily.DASHSCOPE),

--- a/tests/providers/test_dashscope_provider.py
+++ b/tests/providers/test_dashscope_provider.py
@@ -254,7 +254,9 @@ class TestDashScopeThinkingBudgetRequestPolicy:
             ),
         ]
         client = FakeOpenAIClient(stream_chunks=chunks)
-        provider = DashScopeProvider(model="qwen3.7-max", api_key="k")
+        # qwen3.7-plus 仍是无界思考的 qwen,用它守住「普通 qwen 不下发预算」的基线;
+        # qwen3.7-max 的有界预算由下面的专项用例覆盖。
+        provider = DashScopeProvider(model="qwen3.7-plus", api_key="k")
         provider._client = client
 
         _ = [event async for event in provider.stream(messages=[Message.user("hi")], system="", max_tokens=8192)]
@@ -263,6 +265,61 @@ class TestDashScopeThinkingBudgetRequestPolicy:
         assert call_kwargs["max_tokens"] == 8192
         assert "max_completion_tokens" not in call_kwargs
         assert call_kwargs["extra_body"] == {"enable_thinking": True, "preserve_thinking": True}
+
+    async def test_qwen37_max_sends_bounded_thinking_budget_without_changing_token_limit(self):
+        chunks = [
+            ns(
+                usage=ns(prompt_tokens=1, completion_tokens=1),
+                choices=[ns(finish_reason="stop", delta=ns(content="ok", tool_calls=None))],
+            ),
+        ]
+        client = FakeOpenAIClient(stream_chunks=chunks)
+        provider = DashScopeProvider(model="qwen3.7-max", api_key="k")
+        provider._client = client
+
+        _ = [event async for event in provider.stream(messages=[Message.user("hi")], system="", max_tokens=8192)]
+
+        call_kwargs = client.chat.completions.calls[0]
+        # 思考预算走 extra_body,可见输出上限仍是 max_tokens(未切到 max_completion_tokens)。
+        assert call_kwargs["max_tokens"] == 8192
+        assert "max_completion_tokens" not in call_kwargs
+        assert call_kwargs["extra_body"] == {
+            "enable_thinking": True,
+            "preserve_thinking": True,
+            "thinking_budget": 8192,
+        }
+
+    async def test_qwen37_max_honors_caller_supplied_thinking_budget(self):
+        chunks = [
+            ns(
+                usage=ns(prompt_tokens=1, completion_tokens=1),
+                choices=[ns(finish_reason="stop", delta=ns(content="ok", tool_calls=None))],
+            ),
+        ]
+        client = FakeOpenAIClient(stream_chunks=chunks)
+        provider = DashScopeProvider(model="qwen3.7-max", api_key="k", thinking_budget=20000)
+        provider._client = client
+
+        _ = [event async for event in provider.stream(messages=[Message.user("hi")], system="", max_tokens=8192)]
+
+        call_kwargs = client.chat.completions.calls[0]
+        assert call_kwargs["extra_body"]["thinking_budget"] == 20000
+
+    async def test_qwen37_max_disabled_thinking_omits_budget(self):
+        response = ns(
+            id="cmpl_qwen37",
+            choices=[ns(finish_reason="stop", message=ns(content="ok", tool_calls=None))],
+            usage=ns(prompt_tokens=1, completion_tokens=1),
+        )
+        client = FakeOpenAIClient(create_response=response)
+        provider = DashScopeProvider(model="qwen3.7-max", api_key="k", thinking_enabled=False)
+        provider._client = client
+
+        await provider.complete(messages=[Message.user("hi")], system="", max_tokens=8192)
+
+        call_kwargs = client.chat.completions.calls[0]
+        assert call_kwargs["extra_body"] == {"enable_thinking": False}
+        assert call_kwargs["max_tokens"] == 8192
 
     async def test_token_plan_glm52_uses_same_budget_free_request_policy(self):
         chunks = [

--- a/tests/providers/test_thinking_registry.py
+++ b/tests/providers/test_thinking_registry.py
@@ -202,6 +202,26 @@ class TestGetThinkingSpec:
         assert kimi.use_max_completion_tokens is True
         assert kimi.uses_reasoning_effort_param is False
 
+    def test_qwen37_max_has_bounded_thinking_budget_on_both_endpoints(self):
+        # 长尾治理契约:qwen3.7-max 的思考阶段必须有硬预算上限,否则服务端可能
+        # 产出 ~12 分钟级 thinking(实测 p99 728,878ms)。两个 endpoint 必须一致,
+        # 只治一个入口等于没治。
+        for provider_key in ("dashscope", "dashscope_token_plan"):
+            spec = get_thinking_spec(provider_key, "qwen3.7-max")
+            assert spec.family is ThinkingFamily.DASHSCOPE, provider_key
+            assert spec.supports_thinking_budget is True, provider_key
+            assert spec.default_thinking_budget == 8192, provider_key
+            # 预算走 extra_body.thinking_budget,不改 max_tokens 语义。
+            assert spec.use_max_completion_tokens is False, provider_key
+            assert spec.allowed_efforts == (), provider_key
+
+    def test_qwen37_siblings_keep_unbounded_thinking(self):
+        # 收敛范围校验:只有 qwen3.7-max 被声明有界,同代其他模型不受影响。
+        for model in ("qwen3.7-plus", "qwen3.7-flash"):
+            spec = get_thinking_spec("dashscope", model)
+            assert spec.supports_thinking_budget is False, model
+            assert spec.default_thinking_budget is None, model
+
     def test_thinking_budget_capability_false_for_effort_families(self):
         # UI gating contract: the 思考预算 field must NOT appear for effort-driven
         # families (Anthropic/OpenAI/Gemini). Lock the negative side so a registry
@@ -269,6 +289,8 @@ class TestGetThinkingSpec:
                 if (provider_key, model) in {
                     ("dashscope", "kimi-k2.7-code"),
                     ("dashscope_token_plan", "kimi-k2.7-code"),
+                    ("dashscope", "qwen3.7-max"),
+                    ("dashscope_token_plan", "qwen3.7-max"),
                 }:
                     continue
                 assert spec.default_thinking_budget is None, (provider_key, model)


### PR DESCRIPTION
## 问题

评测报告显示 `qwen3.7-max` 变体虽然 10/10 全部成功、template_coverage=1.0，但存在严重长尾时延：p99 latency=1,011,589ms、单次最长 1,025,586ms（约 17 分钟），其中 `stage_summary_ms.llm_thinking` p99=728,878ms，占总时延约 72%。

## 根因

`providers/thinking.py` 把 `qwen3.7-max` 注册为裸 spec `ThinkingSpec(ThinkingFamily.DASHSCOPE)`，即 `supports_thinking_budget=False`。
于是 `openai_provider._effective_thinking_budget_for_spec()` 直接返回 `None`，`dashscope_provider._build_thinking_kwargs()` 只会下发 `extra_body={"enable_thinking": True, "preserve_thinking": True}` —— **思考阶段在 wire 层没有任何上限**，长度完全交由服务端收敛。

现有的 `stream_idle_timeout`(90s) + `StreamWatchdog` 不覆盖该场景：长思考期间 token 持续流出，空闲计时器永远不会触发。

`thinkingBudget` 的配置通路（Web 设置 → `ProviderRequestPolicy`；A2A `metadata.iac_code.thinking.budget` → `a2a/thinking_metadata.py`）本身是完整的，但因为能力声明为 False，上游即便传了 budget 也会被丢弃。

## 改动

为 `qwen3.7-max` 声明有界思考预算 spec（`default_thinking_budget=8192`、`supports_thinking_budget=True`），`dashscope` 与 `dashscope_token_plan` 两个 provider key 下都替换，避免只治好一个入口。

- 无需改动 provider 实现：既有 `_effective_thinking_budget()` 在能力为 True 后会自动把 `thinking_budget` 注入 `extra_body`。
- `use_max_completion_tokens` 保持 False：可见输出上限仍走 `max_tokens`，只给思考阶段加顶。
- 正向副作用：Web 模型设置页对该模型显示「思考预算」输入框，上游也可通过 A2A metadata 按请求调高，无需再改代码。

## 预算取值依据（8192）

thinking p99 728,878ms、总 p99 1,011,589ms → 非思考部分约 283,000ms；验收要求 ≤600,000ms，故思考需压到约 300,000ms 内。按 qwen-max 级模型约 40 tok/s 思考产出估算，728,878ms ≈ 29,000 token，压到 ~300,000ms 需约 12,000 token 内。取 8192（≈205s 思考 + ~283s 其余 ≈ 490s，留安全余量），并与仓库内既有唯一一处有界思考策略 `kimi-k2.7-code` 的 8192 保持一致。

## 核查后未改动的部分

需求建议里的「可并行工具调用从串行改为并行」在当前代码中已实现：`tools/tool_executor.py:execute_batch()` 已按 read/write 分区，连续 concurrency-safe 只读调用经 `asyncio.gather` + `Semaphore(10)` 并行，写操作作为顺序屏障。本次不动执行器语义。

## 测试

- `uv run pytest tests/providers -q` → 557 passed，含新增：
  - 两个 endpoint 均声明有界预算、`use_max_completion_tokens` 仍为 False
  - 兄弟模型 `qwen3.7-plus` / `qwen3.7-flash` 未受影响
  - 默认 budget 实际进入 wire `extra_body.thinking_budget`
  - 调用方显式 budget 可覆盖默认值
  - `thinking_enabled=False` 时不下发 budget，`max_tokens` 语义不变
- `tests/web/test_settings.py`、`tests/a2a/test_thinking_metadata.py`、`tests/services` 全绿
- `ruff check` + `ty check src/` 通过
- 全量 `pytest tests/ -n auto`：14326 passed / 5 skipped / 15 failed，15 条失败在 base commit 上同样失败（未生成 `messages.pot` 的 i18n 组、沙箱网络导致的 prerequisites URL 断言、sidecar 布局 e2e），与本改动无关。

## 已知限制

硬上限可能在极复杂任务上削减思考深度。验收需重跑 10 条共同任务确认 p99/max ≤600,000ms 且 success 不下降（≥10/10）；若出现能力回退，可通过 A2A metadata 或 Web 设置调高 budget，无需改代码。
