### PR TITLE
fix(pipeline): reject implausible contract price in cost_estimating

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4088,6 +4088,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"A positive list price cannot be paired with a zero or implausible "
+"contract price; report the list price alone when the contract discount "
+"does not apply."
+msgstr "Ein positiver Listenpreis darf nicht mit einem Vertragspreis von null oder einem unplausiblen Vertragspreis kombiniert werden; geben Sie nur den Listenpreis an, wenn der Vertragsrabatt nicht gilt."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4193,6 +4200,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion muss eines dieser Felder enthalten: "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} Validation issue: {code} ({detail}) in "
+"complete_step.conclusion.{field}."
+msgstr "{message} Validierungsproblem: {code} ({detail}) in complete_step.conclusion.{field}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4065,6 +4065,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"A positive list price cannot be paired with a zero or implausible "
+"contract price; report the list price alone when the contract discount "
+"does not apply."
+msgstr "Un precio de lista positivo no puede combinarse con un precio contractual nulo o inverosímil; informe solo el precio de lista cuando el descuento contractual no se aplique."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4167,6 +4174,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion debe incluir uno de estos campos: "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} Validation issue: {code} ({detail}) in "
+"complete_step.conclusion.{field}."
+msgstr "{message} Problema de validación: {code} ({detail}) en complete_step.conclusion.{field}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4074,6 +4074,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"A positive list price cannot be paired with a zero or implausible "
+"contract price; report the list price alone when the contract discount "
+"does not apply."
+msgstr "Un prix catalogue positif ne peut pas être associé à un prix contractuel nul ou invraisemblable ; indiquez uniquement le prix catalogue lorsque la remise contractuelle ne s'applique pas."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4174,6 +4181,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion doit inclure l’un de ces champs : "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} Validation issue: {code} ({detail}) in "
+"complete_step.conclusion.{field}."
+msgstr "{message} Problème de validation : {code} ({detail}) dans complete_step.conclusion.{field}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3876,6 +3876,13 @@ msgstr "ユーザーが明示した各ハード制約は、パラメーターと
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"A positive list price cannot be paired with a zero or implausible "
+"contract price; report the list price alone when the contract discount "
+"does not apply."
+msgstr "定価が正の値のとき、契約価格を 0 や不合理な値にすることはできません。契約割引が適用されない場合は定価のみを報告してください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3966,6 +3973,13 @@ msgid ""
 "{message} complete_step.conclusion must include one of these fields: "
 "{fields}."
 msgstr "{message} complete_step.conclusion には次のいずれかのフィールドが必要です: {fields}。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} Validation issue: {code} ({detail}) in "
+"complete_step.conclusion.{field}."
+msgstr "{message} 検証の問題: {code}（{detail}）complete_step.conclusion.{field} にあります。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4046,6 +4046,13 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"A positive list price cannot be paired with a zero or implausible "
+"contract price; report the list price alone when the contract discount "
+"does not apply."
+msgstr "Um preço de tabela positivo não pode ser combinado com um preço contratual zero ou implausível; informe apenas o preço de tabela quando o desconto contratual não se aplicar."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4143,6 +4150,13 @@ msgid ""
 msgstr ""
 "{message} complete_step.conclusion deve incluir um destes campos: "
 "{fields}."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} Validation issue: {code} ({detail}) in "
+"complete_step.conclusion.{field}."
+msgstr "{message} Problema de validação: {code} ({detail}) em complete_step.conclusion.{field}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3840,6 +3840,13 @@ msgstr "每个用户明确提出的硬约束都必须由一条状态为满足的
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"A positive list price cannot be paired with a zero or implausible "
+"contract price; report the list price alone when the contract discount "
+"does not apply."
+msgstr "列表价为正数时，不能搭配为零或不合理的合同优惠后价格；合同优惠不适用时只报告列表价。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr "调用此工具提交结论以完成当前步骤。如需回滚到较早步骤，请设置 rollback_request。"
@@ -3928,6 +3935,13 @@ msgid ""
 "{message} complete_step.conclusion must include one of these fields: "
 "{fields}."
 msgstr "{message} complete_step.conclusion 必须包含以下字段之一: {fields}。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message} Validation issue: {code} ({detail}) in "
+"complete_step.conclusion.{field}."
+msgstr "{message} 校验问题：{code}（{detail}），位于 complete_step.conclusion.{field}。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A completion guard is misconfigured."

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -13,6 +13,7 @@ import jsonschema
 
 from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
+from iac_code.pipeline.engine.cost_estimate import validate_monthly_estimate
 from iac_code.pipeline.engine.hard_constraints import collect_hard_constraints, validate_hard_constraint_checks
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
@@ -60,6 +61,10 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
     ),
+    "monthly_estimate_plausibility_required": (
+        "A positive list price cannot be paired with a zero or implausible contract price; report the list price "
+        "alone when the contract discount does not apply."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -99,6 +104,10 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
         _(
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
+        ),
+        _(
+            "A positive list price cannot be paired with a zero or implausible contract price; report the list price "
+            "alone when the contract discount does not apply."
         ),
     )
 
@@ -324,6 +333,7 @@ class CompleteStepTool(Tool):
             required_tool_result = guard.get("require_tool_result")
             required_conclusion_sha256 = guard.get("require_conclusion_sha256")
             required_constraint_coverage = guard.get("require_context_constraint_coverage")
+            required_monthly_estimate = guard.get("require_monthly_estimate_plausibility")
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
@@ -383,7 +393,43 @@ class CompleteStepTool(Tool):
                 )
                 if validation_error is not None:
                     return validation_error
+            if isinstance(required_monthly_estimate, dict):
+                validation_error = self._validate_monthly_estimate_plausibility(
+                    required_monthly_estimate,
+                    conclusion,
+                    self._completion_guard_message(guard, None),
+                )
+                if validation_error is not None:
+                    return validation_error
         return None
+
+    def _validate_monthly_estimate_plausibility(
+        self,
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        message: str | None,
+    ) -> str | None:
+        field = str(requirement.get("field") or "monthly_estimate")
+        value = self._resolve_dotted(conclusion, field)
+        if value is None:
+            return None
+        skip_values = self._string_set(requirement.get("skip_values")) or {"询价失败"}
+        if isinstance(value, str) and value.strip() in skip_values:
+            return None
+        issues = validate_monthly_estimate(value)
+        if not issues:
+            return None
+        base_message = message or _(
+            "A positive list price cannot be paired with a zero or implausible contract price; report the list price "
+            "alone when the contract discount does not apply."
+        )
+        issue = issues[0]
+        return _("{message} Validation issue: {code} ({detail}) in complete_step.conclusion.{field}.").format(
+            message=base_message,
+            code=issue.code,
+            detail=issue.detail or field,
+            field=field,
+        )
 
     def _validate_context_constraint_coverage(
         self,

--- a/src/iac_code/pipeline/engine/cost_estimate.py
+++ b/src/iac_code/pipeline/engine/cost_estimate.py
@@ -1,0 +1,81 @@
+"""Deterministic plausibility checks for pipeline cost estimate conclusions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from decimal import Decimal, DecimalException
+
+# ROS pricing returns OriginalAmount (list price) and TradeAmount (contract price).
+# Real Alibaba Cloud contract discounts never drive a positive list price down to
+# a rounding-level residue, so a discounted price below this ratio means the model
+# mishandled a missing/zero TradeAmount instead of reporting a real price.
+MIN_DISCOUNTED_RATIO = Decimal("0.01")
+
+_AMOUNT_PATTERN = re.compile(r"(?:¥|￥|CNY\s*|RMB\s*)\s*(\d+(?:,\d{3})*(?:\.\d+)?)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class MonthlyEstimateIssue:
+    code: str
+    detail: str = ""
+
+
+def parse_monthly_amounts(monthly_estimate: str) -> list[Decimal]:
+    """Extract the currency amounts from a monthly estimate string, in text order."""
+
+    amounts: list[Decimal] = []
+    for raw in _AMOUNT_PATTERN.findall(monthly_estimate):
+        try:
+            amounts.append(Decimal(raw.replace(",", "")))
+        except (DecimalException, ValueError):
+            continue
+    return amounts
+
+
+def validate_monthly_estimate(
+    monthly_estimate: object,
+    *,
+    min_discounted_ratio: Decimal = MIN_DISCOUNTED_RATIO,
+) -> list[MonthlyEstimateIssue]:
+    """Validate the list/discounted price pair carried by ``monthly_estimate``.
+
+    Only the dual-price form is constrained: when a positive list price is reported
+    together with a discounted price, the discounted price must be positive, must not
+    exceed the list price, and must stay above ``min_discounted_ratio`` of it. Single
+    prices, genuinely free templates and the ``"询价失败"`` form stay valid.
+    """
+
+    if not isinstance(monthly_estimate, str) or not monthly_estimate.strip():
+        return [MonthlyEstimateIssue("invalid_monthly_estimate")]
+
+    amounts = parse_monthly_amounts(monthly_estimate)
+    if len(amounts) < 2:
+        return []
+
+    list_price, discounted_price = amounts[0], amounts[1]
+    if list_price <= 0:
+        return []
+
+    if discounted_price <= 0:
+        return [
+            MonthlyEstimateIssue(
+                "discounted_monthly_price_not_positive",
+                "list={} discounted={}".format(list_price, discounted_price),
+            )
+        ]
+    if discounted_price > list_price:
+        return [
+            MonthlyEstimateIssue(
+                "discounted_monthly_price_above_list_price",
+                "list={} discounted={}".format(list_price, discounted_price),
+            )
+        ]
+    if discounted_price < list_price * min_discounted_ratio:
+        return [
+            MonthlyEstimateIssue(
+                "discounted_monthly_price_implausible_ratio",
+                "list={} discounted={} min_ratio={}".format(list_price, discounted_price, min_discounted_ratio),
+            )
+        ]
+    return []

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -43,6 +43,7 @@ _SUPPORTED_COMPLETION_GUARD_KEYS = {
     "message_key",
     "require_conclusion_sha256",
     "require_context_constraint_coverage",
+    "require_monthly_estimate_plausibility",
     "require_tool",
     "require_tool_result",
     "required_conclusion_any_of",

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -356,6 +356,10 @@ sub_pipelines:
               checks_field: hard_constraint_checks
               deployment_parameters_field: deployment_parameters
             message_key: hard_constraint_verification_required
+          - always: true
+            require_monthly_estimate_plausibility:
+              field: monthly_estimate
+            message_key: monthly_estimate_plausibility_required
         tools:
           include: []
           exclude:

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -39,7 +39,8 @@ API 调用完成后调用 `complete_step` 提交费用预估。
 `complete_step.conclusion.monthly_estimate` 必须保留两个价格口径：
 - `OriginalAmount` 是原价，按统一月度周期换算并汇总为列表价。
 - `TradeAmount` 是合同优惠后的最终价，按与原价相同的月度周期换算并汇总。
-- 两个字段都存在时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
+- 两个字段都存在且换算后的最终价为正数时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
+- 列表价为正数时，后优惠价必须为正数、不得高于列表价，也不得低于列表价的合理比例（低于 1% 视为异常）。`TradeAmount` 缺失、为 0 或换算后不是正数，说明合同优惠不适用于本次询价：此时回退为只展示列表价 `¥<原价>/月（列表价）`，并在 `api_raw_summary` 说明该字段缺失或为零，**不得**输出 `合同优惠后约¥0.00/月`。
 - 任一字段缺失时只展示可用价格，并在 `api_raw_summary` 中说明缺失字段；询价失败时仍填写 `"询价失败"`。
 
 若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -17,7 +17,7 @@ conclusion_schema:
   properties:
     monthly_estimate:
       type: string
-      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"
+      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 且换算后的合同优惠后价格为正数时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；TradeAmount 缺失、为 0 或换算后不是正数时，只展示列表价并在 api_raw_summary 说明，不得写出 ¥0/月 的后优惠价；询价失败时填 "询价失败"
     currency:
       type: string
       enum: [CNY]
@@ -300,6 +300,7 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 
 补充说明：
 - `cost` 字段为字符串，包含金额和计费周期（如 "¥800/月"、"¥0.5/小时"、"¥0"）
+- 列表价为正数时，`monthly_estimate` 中的合同优惠后价格必须为正数且不高于列表价；`TradeAmount` 缺失或为 0 时回退为只展示列表价，并在 `api_raw_summary` 说明，不得输出 ¥0/月 的后优惠价
 - 若修复了模板，设置 `template_fixed: true` 并在 `fix_summary` 中说明修复内容；仅形成或输出 `deployment_parameters` 不算模板修复
 - `deployment_parameters` 填当前已选、已验证或已用于 `ros_estimate_template_cost` 的参数字典；PreviewStack 成功但询价失败时仍填该参数集；没有任何可用参数时填 `{}`
 - 没有硬约束时，`hard_constraint_checks` 填 `[]`；不要输出 `hard_constraints_verified`

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -466,6 +466,71 @@ class TestCompletionGuards:
         assert "missing_constraint_check" in terminal.metadata["step_result"].error
 
     @staticmethod
+    def _monthly_estimate_guard() -> dict:
+        return {
+            "always": True,
+            "require_monthly_estimate_plausibility": {"field": "monthly_estimate"},
+            "message_key": "monthly_estimate_plausibility_required",
+        }
+
+    def _monthly_estimate_tool(self) -> CompleteStepTool:
+        return CompleteStepTool(
+            StepConfig(step_id="cost_estimating", conclusion_field="cost", forward=None),
+            completion_guards=[self._monthly_estimate_guard()],
+        )
+
+    def test_rejects_zero_contract_price_when_list_price_is_positive(self):
+        tool = self._monthly_estimate_tool()
+
+        error = tool.validate_completion_input(
+            {"conclusion": {"monthly_estimate": "¥289.81/月（列表价，合同优惠后约¥0.00/月）"}}
+        )
+
+        assert error is not None
+        assert "discounted_monthly_price_not_positive" in error
+        assert "monthly_estimate" in error
+
+    def test_accepts_plausible_contract_price_and_list_price_only_fallback(self):
+        tool = self._monthly_estimate_tool()
+
+        assert (
+            tool.validate_completion_input(
+                {"conclusion": {"monthly_estimate": "¥289.81/月（列表价，合同优惠后约¥41.20/月）"}}
+            )
+            is None
+        )
+        assert tool.validate_completion_input({"conclusion": {"monthly_estimate": "¥289.81/月（列表价）"}}) is None
+        assert tool.validate_completion_input({"conclusion": {"monthly_estimate": "询价失败"}}) is None
+
+    @pytest.mark.asyncio
+    async def test_monthly_estimate_guard_returns_repairable_error(self):
+        tool = CompleteStepTool(
+            StepConfig(
+                step_id="cost_estimating",
+                conclusion_field="cost",
+                forward=None,
+                max_conclusion_retries=2,
+            ),
+            completion_guards=[self._monthly_estimate_guard()],
+        )
+
+        rejected = await tool.execute(
+            tool_input={"conclusion": {"monthly_estimate": "¥289.81/月（列表价，合同优惠后约¥0.00/月）"}},
+            context=ToolContext(),
+        )
+
+        assert rejected.is_error is True
+        assert rejected.metadata is None
+        assert "fix it and call complete_step again" in rejected.content
+
+        repaired = await tool.execute(
+            tool_input={"conclusion": {"monthly_estimate": "¥289.81/月（列表价）"}},
+            context=ToolContext(),
+        )
+
+        assert repaired.is_error is False
+
+    @staticmethod
     def _deploying_success_guard() -> dict:
         return {
             "when_conclusion_field_equals": {"status": "success"},

--- a/tests/pipeline/engine/test_cost_estimate.py
+++ b/tests/pipeline/engine/test_cost_estimate.py
@@ -1,0 +1,63 @@
+"""Tests for deterministic monthly cost estimate plausibility checks."""
+
+from decimal import Decimal
+
+from iac_code.pipeline.engine.cost_estimate import (
+    MIN_DISCOUNTED_RATIO,
+    parse_monthly_amounts,
+    validate_monthly_estimate,
+)
+
+
+class TestParseMonthlyAmounts:
+    def test_parses_list_and_discounted_prices_in_order(self):
+        amounts = parse_monthly_amounts("¥289.81/月（列表价，合同优惠后约¥13.76/月）")
+
+        assert amounts == [Decimal("289.81"), Decimal("13.76")]
+
+    def test_parses_thousands_separator_and_alternate_symbols(self):
+        assert parse_monthly_amounts("￥1,234.50/月") == [Decimal("1234.50")]
+        assert parse_monthly_amounts("CNY 96.80/月") == [Decimal("96.80")]
+
+    def test_ignores_text_without_currency_amounts(self):
+        assert parse_monthly_amounts("询价失败") == []
+
+
+class TestValidateMonthlyEstimate:
+    def test_rejects_zero_discounted_price_reported_from_the_session(self):
+        issues = validate_monthly_estimate("¥289.81/月（列表价，合同优惠后约¥0.00/月）")
+
+        assert [issue.code for issue in issues] == ["discounted_monthly_price_not_positive"]
+        assert "289.81" in issues[0].detail
+
+    def test_rejects_discounted_price_above_list_price(self):
+        issues = validate_monthly_estimate("¥96.80/月（列表价，合同优惠后约¥120.00/月）")
+
+        assert [issue.code for issue in issues] == ["discounted_monthly_price_above_list_price"]
+
+    def test_rejects_discounted_price_below_plausible_ratio(self):
+        issues = validate_monthly_estimate("¥1000.00/月（列表价，合同优惠后约¥1.00/月）")
+
+        assert [issue.code for issue in issues] == ["discounted_monthly_price_implausible_ratio"]
+
+    def test_accepts_real_contract_discount(self):
+        assert validate_monthly_estimate("¥96.80/月（列表价，合同优惠后约¥13.76/月）") == []
+
+    def test_accepts_identical_list_and_discounted_prices(self):
+        assert validate_monthly_estimate("¥96.80/月（列表价，合同优惠后约¥96.80/月）") == []
+
+    def test_accepts_single_price_and_pricing_failure(self):
+        assert validate_monthly_estimate("¥289.81/月（列表价）") == []
+        assert validate_monthly_estimate("询价失败") == []
+
+    def test_accepts_genuinely_free_template(self):
+        assert validate_monthly_estimate("¥0/月（列表价，合同优惠后约¥0/月）") == []
+
+    def test_rejects_missing_or_empty_estimate(self):
+        assert [issue.code for issue in validate_monthly_estimate(None)] == ["invalid_monthly_estimate"]
+        assert [issue.code for issue in validate_monthly_estimate("   ")] == ["invalid_monthly_estimate"]
+
+    def test_ratio_boundary_is_inclusive(self):
+        boundary = Decimal("1000") * MIN_DISCOUNTED_RATIO
+
+        assert validate_monthly_estimate("¥1000.00/月（列表价，合同优惠后约¥{}/月）".format(boundary)) == []

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -172,6 +172,14 @@ class TestSkillFrontmatter:
         assert "OriginalAmount" in description
         assert "TradeAmount" in description
 
+    def test_monthly_estimate_schema_forbids_zero_discounted_price(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        description = schema["properties"]["monthly_estimate"]["description"]
+
+        assert "为正数时" in description
+        assert "只展示列表价" in description
+        assert "¥0/月" in description
+
     def test_conclusion_schema_requires_full_preview_validation_when_succeeded(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         fm = _parse_frontmatter(content)
@@ -538,6 +546,14 @@ class TestCostPrompt:
         assert "列表价" in body
         assert "合同优惠后" in body
         assert "monthly_estimate" in body
+
+    def test_prompt_falls_back_to_list_price_when_contract_discount_is_missing(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+
+        assert "后优惠价必须为正数" in body
+        assert "不得高于列表价" in body
+        assert "合同优惠后约¥0.00/月" in body
+        assert "api_raw_summary" in body
 
     def test_prompt_receives_only_required_candidate_fields_without_repeating_skill_rules(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")

--- a/tests/pipeline/selling/test_pipeline_reviewing.py
+++ b/tests/pipeline/selling/test_pipeline_reviewing.py
@@ -44,7 +44,12 @@ def test_review_enabled_loads_infraguard_repair_step_before_cost() -> None:
                 "deployment_parameters_field": "deployment_parameters",
             },
             "message_key": "hard_constraint_verification_required",
-        }
+        },
+        {
+            "always": True,
+            "require_monthly_estimate_plausibility": {"field": "monthly_estimate"},
+            "message_key": "monthly_estimate_plausibility_required",
+        },
     ]
 
     assert review_step.tools is not None


### PR DESCRIPTION
## 问题

`cost_estimating` 步骤会把 ROS 询价返回的 `OriginalAmount` / `TradeAmount` 汇总成「列表价 + 合同优惠后价格」双口径写入 `monthly_estimate`。

当 `TradeAmount` 缺失或为 0 时：

- Skill/Prompt 仍要求「即使数值相同也保留两个价格口径」；
- `cost_estimating` 的 completion guard 只校验硬约束覆盖，对金额零校验。

结果是 `¥289.81/月（列表价，合同优惠后约¥0.00/月）` 这类结论直接通过 `complete_step`，并经 `candidate_completed.conclusions.cost` 透传到 `confirm_and_select` 与 Web 输出面板，用户看到不合理的 ¥0/月 实际月成本。

## 改动

- 新增 `src/iac_code/pipeline/engine/cost_estimate.py`：解析双价口径并做确定性校验。列表价为正时，后优惠价必须为正、不高于列表价，且不低于列表价的 1%。
- 新增 `require_monthly_estimate_plausibility` completion guard（`loader.py` 白名单 + `complete_step_tool.py` 校验分支 + message key），挂到 `cost_estimating`。校验失败返回可修复错误，模型在既有 `max_conclusion_retries: 4` 预算内改正。
- `iac-aliyun-cost` SKILL.md 与 `prompts/cost_estimating.md`：明确合同优惠不适用时回退为只展示列表价并在 `api_raw_summary` 说明，不再写出 ¥0/月 的后优惠价。
- 同步 6 个语言的 `messages.po`。

## 兼容性

单价口径、真实合同折扣、列表价本身为 0 的免费模板与 `"询价失败"` 均不受影响。

## 验证

- 新增 `tests/pipeline/engine/test_cost_estimate.py`（12 项）覆盖 ¥0、超列表价、比例过低、真实折扣、免费模板与询价失败。
- `tests/pipeline/engine/test_complete_step_tool.py` 新增 guard 分支测试（含可修复错误路径）。
- `tests/pipeline/selling/` 同步 pipeline.yaml guard 断言与 Skill/Prompt 文本断言。
- `uv run pytest tests/pipeline/engine/test_cost_estimate.py tests/pipeline/engine/test_complete_step_tool.py tests/pipeline/selling/ -q` → 454 passed。
- `uv run ruff check src/ tests/`、`uv run ty check src/` 均通过。
