### PR TITLE
fix(pipeline): enforce template output contract in template_generating

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -3999,6 +3999,30 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"template_generating must write the generated template to file_path with "
+"write_file before completing the step."
+msgstr "template_generating muss die generierte Vorlage mit write_file in file_path schreiben, bevor der Schritt abgeschlossen wird."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr "template_generating muss die generierte Vorlage mit ros_validate_template für denselben file_path validieren."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating ran write_file/edit_file after ros_validate_template;"
+" rerun ros_validate_template for the same file_path."
+msgstr "template_generating hat write_file/edit_file nach ros_validate_template ausgeführt; führe ros_validate_template für denselben file_path erneut aus."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must submit the final template content together with "
+"its sha256 hash."
+msgstr "template_generating muss den endgültigen Vorlageninhalt zusammen mit seinem sha256-Hash übermitteln."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "reviewing ran write_file/edit_file after ros_validate_template; rerun "
 "ros_validate_template and infraguard_scan for the same file_path."
 msgstr ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -3978,6 +3978,30 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"template_generating must write the generated template to file_path with "
+"write_file before completing the step."
+msgstr "template_generating debe escribir la plantilla generada en file_path con write_file antes de completar el paso."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr "template_generating debe validar la plantilla generada con ros_validate_template para el mismo file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating ran write_file/edit_file after ros_validate_template;"
+" rerun ros_validate_template for the same file_path."
+msgstr "template_generating ejecutó write_file/edit_file después de ros_validate_template; vuelve a ejecutar ros_validate_template para el mismo file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must submit the final template content together with "
+"its sha256 hash."
+msgstr "template_generating debe enviar el contenido final de la plantilla junto con su hash sha256."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "reviewing ran write_file/edit_file after ros_validate_template; rerun "
 "ros_validate_template and infraguard_scan for the same file_path."
 msgstr ""

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -3986,6 +3986,30 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"template_generating must write the generated template to file_path with "
+"write_file before completing the step."
+msgstr "template_generating doit écrire le modèle généré dans file_path avec write_file avant de terminer l'étape."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr "template_generating doit valider le modèle généré avec ros_validate_template pour le même file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating ran write_file/edit_file after ros_validate_template;"
+" rerun ros_validate_template for the same file_path."
+msgstr "template_generating a exécuté write_file/edit_file après ros_validate_template ; relancez ros_validate_template pour le même file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must submit the final template content together with "
+"its sha256 hash."
+msgstr "template_generating doit soumettre le contenu final du modèle ainsi que son hachage sha256."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "reviewing ran write_file/edit_file after ros_validate_template; rerun "
 "ros_validate_template and infraguard_scan for the same file_path."
 msgstr ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3808,6 +3808,30 @@ msgstr "{count} 件のロールバッククリーンアップリソースを検�
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"template_generating must write the generated template to file_path with "
+"write_file before completing the step."
+msgstr "template_generating はステップを完了する前に、生成したテンプレートを write_file で file_path に書き込む必要があります。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr "template_generating は生成したテンプレートを同じ file_path で ros_validate_template により検証する必要があります。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating ran write_file/edit_file after ros_validate_template;"
+" rerun ros_validate_template for the same file_path."
+msgstr "template_generating は ros_validate_template の後に write_file/edit_file を実行しました。同じ file_path に対して ros_validate_template を再実行してください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must submit the final template content together with "
+"its sha256 hash."
+msgstr "template_generating は最終的なテンプレート内容とその sha256 ハッシュを併せて提出する必要があります。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "reviewing ran write_file/edit_file after ros_validate_template; rerun "
 "ros_validate_template and infraguard_scan for the same file_path."
 msgstr ""

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -3960,6 +3960,30 @@ msgstr "{count} recursos de limpeza de rollback detectados; iniciando limpeza."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"template_generating must write the generated template to file_path with "
+"write_file before completing the step."
+msgstr "template_generating deve gravar o modelo gerado em file_path com write_file antes de concluir a etapa."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr "template_generating deve validar o modelo gerado com ros_validate_template para o mesmo file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating ran write_file/edit_file after ros_validate_template;"
+" rerun ros_validate_template for the same file_path."
+msgstr "template_generating executou write_file/edit_file após ros_validate_template; execute ros_validate_template novamente para o mesmo file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must submit the final template content together with "
+"its sha256 hash."
+msgstr "template_generating deve enviar o conteúdo final do modelo junto com o seu hash sha256."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "reviewing ran write_file/edit_file after ros_validate_template; rerun "
 "ros_validate_template and infraguard_scan for the same file_path."
 msgstr ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3774,6 +3774,30 @@ msgstr "检测到 {count} 个回滚清理资源；开始清理。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"template_generating must write the generated template to file_path with "
+"write_file before completing the step."
+msgstr "template_generating 必须先用 write_file 把生成的模板写入 file_path，然后才能完成该步骤。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr "template_generating 必须使用 ros_validate_template 校验生成的模板，且 file_path 必须一致。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating ran write_file/edit_file after ros_validate_template;"
+" rerun ros_validate_template for the same file_path."
+msgstr "template_generating 在 ros_validate_template 之后运行了 write_file/edit_file；请对同一 file_path 重新运行 ros_validate_template。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must submit the final template content together with "
+"its sha256 hash."
+msgstr "template_generating 必须同时提交最终模板内容及其 sha256 摘要。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "reviewing ran write_file/edit_file after ros_validate_template; rerun "
 "ros_validate_template and infraguard_scan for the same file_path."
 msgstr ""

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -26,6 +26,21 @@ logger = logging.getLogger(__name__)
 MAX_PARALLEL_CANDIDATES = 5
 MAX_ROLLBACK_TARGETS = 5
 _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
+    "template_generating_write_file_required": (
+        "template_generating must write the generated template to file_path with write_file "
+        "before completing the step."
+    ),
+    "template_generating_validate_template_required": (
+        "template_generating must validate the generated template with ros_validate_template "
+        "for the same file_path."
+    ),
+    "template_generating_rerun_after_validate_template_write": (
+        "template_generating ran write_file/edit_file after ros_validate_template; "
+        "rerun ros_validate_template for the same file_path."
+    ),
+    "template_generating_template_sha256_required": (
+        "template_generating must submit the final template content together with its sha256 hash."
+    ),
     "reviewing_rerun_after_validate_template_write": (
         "reviewing ran write_file/edit_file after ros_validate_template; "
         "rerun ros_validate_template and infraguard_scan for the same file_path."
@@ -72,6 +87,19 @@ def _completion_guard_message_from_key(key: str) -> str | None:
 def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
     """Keep YAML-selected completion guard messages visible to Babel."""
     return (
+        _(
+            "template_generating must write the generated template to file_path with write_file "
+            "before completing the step."
+        ),
+        _(
+            "template_generating must validate the generated template with ros_validate_template "
+            "for the same file_path."
+        ),
+        _(
+            "template_generating ran write_file/edit_file after ros_validate_template; "
+            "rerun ros_validate_template for the same file_path."
+        ),
+        _("template_generating must submit the final template content together with its sha256 hash."),
         _(
             "reviewing ran write_file/edit_file after ros_validate_template; "
             "rerun ros_validate_template and infraguard_scan for the same file_path."

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -149,6 +149,29 @@ sub_pipelines:
         skill: iac-aliyun-template-generating
         prompt: prompts/template_generating.md
         context_fields: [candidate]
+        completion_guards:
+          - always: true
+            require_tool_result:
+              tool: write_file
+              match_conclusion_field: file_path
+              match_result_field: result.file_path
+            message_key: template_generating_write_file_required
+          - always: true
+            require_tool_result:
+              tool: ros_validate_template
+              match_conclusion_field: file_path
+              match_result_field: input.template_url
+              disallow_tool_results_after_match:
+                - tools: [write_file, edit_file]
+                  match_conclusion_field: file_path
+                  match_result_field: result.file_path
+                  message_key: template_generating_rerun_after_validate_template_write
+            message_key: template_generating_validate_template_required
+          - always: true
+            require_conclusion_sha256:
+              content_field: template
+              sha256_field: template_sha256
+            message_key: template_generating_template_sha256_required
         tools:
           include: []
           exclude:

--- a/src/iac_code/pipeline/selling/prompts/template_generating.md
+++ b/src/iac_code/pipeline/selling/prompts/template_generating.md
@@ -23,6 +23,11 @@
 ## 输出
 文件写入完成后调用 `complete_step` 提交结论。
 
+结论必须携带模板本身，不能只描述已完成的工作：
+- `template`：非空，与 `{candidate.output_path}` 文件的最终内容逐字节一致
+- `template_sha256`：`template` 内容按 UTF-8 编码的 sha256 十六进制摘要
+- `file_path`：实际写入并已通过 `ros_validate_template` 校验的路径
+
 > 注意：`template` 字段为 YAML 字符串（与磁盘文件内容一致），不是 JSON 对象。
 
 ## 注意事项

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -5,12 +5,16 @@ when_to_use: 当需要根据架构方案生成阿里云 ROS 模板时
 user_invocable: false
 conclusion_schema:
   type: object
-  required: [template, file_path, region, description]
+  required: [template, template_sha256, file_path, region, description]
   additionalProperties: false
   properties:
     template:
       type: string
-      description: 与写入文件相同的 YAML 字符串
+      minLength: 1
+      description: 与写入文件相同的 YAML 字符串，不能为空
+    template_sha256:
+      type: string
+      description: template 字段内容的 sha256 十六进制摘要
     file_path:
       type: string
       description: 模板文件路径
@@ -48,7 +52,17 @@ conclusion_schema:
    - 生成的模板默认放在当前工作目录；仅当用户指定其他路径时才写入该路径，不要默认使用 `/tmp` 等工作目录外路径
 5. 调用 `ros_validate_template` 校验；`template_url` 使用刚写入的模板文件路径，已有具体地域时传 `region_id`，否则使用工具默认地域
 6. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
-7. 校验通过 → 完成
+7. 校验通过 → 回传结论：`template` 为最终落盘内容，`template_sha256` 为该内容的 sha256 摘要，`file_path` 为实际写入路径
+
+## 产出协议
+
+结论不是对工作过程的描述，而是模板本身。以下三条由引擎强制校验，不满足会被拒绝并要求重试：
+
+- `template` 必须非空，且与 `file_path` 指向文件的最终内容逐字节一致。
+- `template_sha256` 必须等于 `template` 内容按 UTF-8 编码的 sha256 十六进制摘要。
+- `file_path` 必须是本步骤实际写入的路径，且该路径必须已通过 `ros_validate_template` 校验。校验通过后又修改了文件，必须重新校验。
+
+不要在未产出模板文件的情况下提交结论，也不要用摘要、说明文字或空串代替 `template` 内容。
 
 > **模板路径支持本地文件**：`ros_validate_template` 的 `template_url` 可传当前工作目录内的本地文件路径（如 `./template.yml`）。避免将大模板内容直接作为参数传递。
 

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1460,6 +1460,34 @@ class TestCompletionGuards:
         assert result.is_error
         assert "rerun validation" in result.content
 
+    @pytest.mark.asyncio
+    async def test_template_generating_message_keys_render_actionable_text(self):
+        config = StepConfig(step_id="template_generating", conclusion_field="template", forward=None)
+        keys_to_expected = {
+            "template_generating_write_file_required": "write_file",
+            "template_generating_validate_template_required": "ros_validate_template",
+            "template_generating_template_sha256_required": "sha256",
+        }
+
+        for message_key, expected in keys_to_expected.items():
+            tool = CompleteStepTool(
+                config,
+                completion_guards=[
+                    {
+                        "always": True,
+                        "required_conclusion_field": "template",
+                        "message_key": message_key,
+                    }
+                ],
+            )
+
+            result = await tool.execute(tool_input={"conclusion": {"file_path": "t.yml"}}, context=ToolContext())
+
+            assert result.is_error
+            assert expected in result.content
+            assert message_key not in result.content
+
+
 
 class TestSchemaValidation:
     def test_missing_conclusion_validation_error_includes_current_step_schema(self):

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -51,6 +51,33 @@ class TestSkillFrontmatter:
         fm = _parse_frontmatter(content)
         assert "ROS" in fm["description"]
 
+    def test_conclusion_schema_rejects_empty_template_and_requires_sha256(self):
+        fm = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))
+        schema = fm["conclusion_schema"]
+
+        assert schema["required"] == ["template", "template_sha256", "file_path", "region", "description"]
+        assert schema["properties"]["template"]["minLength"] == 1
+        assert schema["properties"]["template_sha256"]["type"] == "string"
+        assert schema["additionalProperties"] is False
+
+    def test_conclusion_schema_validates_template_emptiness(self):
+        import jsonschema
+
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        valid = {
+            "template": "ROSTemplateFormatVersion: 2015-09-01\n",
+            "template_sha256": "a" * 64,
+            "file_path": "template.yml",
+            "region": "cn-hangzhou",
+            "description": "demo",
+        }
+        jsonschema.validate(valid, schema)
+
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({**valid, "template": ""}, schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({key: value for key, value in valid.items() if key != "template_sha256"}, schema)
+
 
 class TestSkillContentRosOnly:
     @pytest.fixture()
@@ -109,6 +136,13 @@ class TestSkillContentRosOnly:
 
     def test_contains_error_handling(self, body):
         assert "校验失败" in body
+
+    def test_states_output_contract_for_template_content(self, body):
+        assert "## 产出协议" in body
+        assert "template_sha256" in body
+        assert "sha256" in body
+        assert "逐字节一致" in body
+        assert "不要在未产出模板文件的情况下提交结论" in body
 
     def test_honors_candidate_resource_lifecycle_contract(self, body):
         assert "resource_intents" in body
@@ -176,6 +210,13 @@ class TestSkillPromptRendering:
         assert "如果 `templates/` 目录不存在，先创建它" not in body
         assert "mkdir" not in body.lower()
         assert "bash" not in body.lower()
+
+    def test_prompt_requires_template_content_and_sha256_in_conclusion(self):
+        body = TEMPLATE_PROMPT_MD.read_text(encoding="utf-8")
+        assert "`template_sha256`" in body
+        assert "sha256" in body
+        assert "逐字节一致" in body
+        assert "已通过 `ros_validate_template` 校验的路径" in body
 
     def test_prompt_passes_full_candidate_without_repeating_skill_constraints(self):
         body = TEMPLATE_PROMPT_MD.read_text(encoding="utf-8")
@@ -267,3 +308,129 @@ class TestEvalsJson:
             for assertion in ev["assertions"]:
                 assert "name" in assertion
                 assert "check" in assertion
+
+
+class TestTemplateGeneratingOutputEnforcement:
+    """The real pipeline guards must reject conclusions without a written, validated template."""
+
+    TEMPLATE = "ROSTemplateFormatVersion: '2015-09-01'\nResources: {}\n"
+
+    @staticmethod
+    def _sha256(value: str) -> str:
+        import hashlib
+
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    @pytest.fixture()
+    def step(self):
+        from iac_code.pipeline.engine.loader import load_pipeline_dir
+
+        loaded = load_pipeline_dir(SKILL_DIR.parents[1])
+        return next(s for s in loaded.sub_pipelines["evaluate_candidate"].steps if s.step_id == "template_generating")
+
+    def _tool(self, step, tool_calls, cwd):
+        from iac_code.pipeline.engine.complete_step_tool import CompleteStepTool
+        from iac_code.pipeline.engine.completion_guard_state import record_completion_guard_tool_result
+        from iac_code.pipeline.engine.types import StepConfig
+
+        state: dict = {}
+        for tool_name, tool_input, content in tool_calls:
+            record_completion_guard_tool_result(
+                state,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                content=content,
+                is_error=False,
+                cwd=cwd,
+            )
+        config = StepConfig(
+            step_id=step.step_id,
+            conclusion_field=step.conclusion_field,
+            forward=step.forward,
+            conclusion_schema=step.conclusion_schema,
+        )
+        return CompleteStepTool(config, completion_guards=step.completion_guards, completion_guard_state=state)
+
+    def _write_call(self):
+        return ("write_file", {"path": "template.yml", "content": self.TEMPLATE}, None)
+
+    def _validate_call(self):
+        return ("ros_validate_template", {"template_url": "template.yml"}, json.dumps({"Parameters": {}}))
+
+    def _conclusion(self, **overrides):
+        conclusion = {
+            "template": self.TEMPLATE,
+            "template_sha256": self._sha256(self.TEMPLATE),
+            "file_path": "template.yml",
+            "region": "cn-hangzhou",
+            "description": "demo",
+        }
+        conclusion.update(overrides)
+        return conclusion
+
+    @pytest.mark.asyncio
+    async def test_written_and_validated_template_completes_step(self, step, tmp_path):
+        from iac_code.tools.base import ToolContext
+
+        tool = self._tool(step, [self._write_call(), self._validate_call()], str(tmp_path))
+
+        result = await tool.execute(tool_input={"conclusion": self._conclusion()}, context=ToolContext())
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_empty_template_is_rejected(self, step, tmp_path):
+        from iac_code.tools.base import ToolContext
+
+        tool = self._tool(step, [self._write_call(), self._validate_call()], str(tmp_path))
+        conclusion = self._conclusion(template="", template_sha256=self._sha256(""))
+
+        result = await tool.execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_template_without_write_file_is_rejected(self, step, tmp_path):
+        from iac_code.tools.base import ToolContext
+
+        tool = self._tool(step, [self._validate_call()], str(tmp_path))
+
+        result = await tool.execute(tool_input={"conclusion": self._conclusion()}, context=ToolContext())
+
+        assert result.is_error
+        assert "write_file" in result.content
+
+    @pytest.mark.asyncio
+    async def test_template_without_validation_is_rejected(self, step, tmp_path):
+        from iac_code.tools.base import ToolContext
+
+        tool = self._tool(step, [self._write_call()], str(tmp_path))
+
+        result = await tool.execute(tool_input={"conclusion": self._conclusion()}, context=ToolContext())
+
+        assert result.is_error
+        assert "ros_validate_template" in result.content
+
+    @pytest.mark.asyncio
+    async def test_rewrite_after_validation_is_rejected(self, step, tmp_path):
+        from iac_code.tools.base import ToolContext
+
+        tool_calls = [self._write_call(), self._validate_call(), self._write_call()]
+        tool = self._tool(step, tool_calls, str(tmp_path))
+
+        result = await tool.execute(tool_input={"conclusion": self._conclusion()}, context=ToolContext())
+
+        assert result.is_error
+        assert "ros_validate_template" in result.content
+
+    @pytest.mark.asyncio
+    async def test_template_hash_mismatch_is_rejected(self, step, tmp_path):
+        from iac_code.tools.base import ToolContext
+
+        tool = self._tool(step, [self._write_call(), self._validate_call()], str(tmp_path))
+        conclusion = self._conclusion(template_sha256=self._sha256("stale template\n"))
+
+        result = await tool.execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+
+        assert result.is_error
+        assert "template_sha256" in result.content

--- a/tests/pipeline/selling/test_pipeline_reviewing.py
+++ b/tests/pipeline/selling/test_pipeline_reviewing.py
@@ -248,6 +248,51 @@ def test_review_disabled_removes_review_step_and_generated_template_remains_fina
     assert cost_step.context_fields == ["candidate", "template"]
 
 
+def test_template_generating_guards_require_written_and_validated_template() -> None:
+    loaded = _load_selling(enable_reviewing=False)
+    template_step = loaded.sub_pipelines["evaluate_candidate"].steps[0]
+
+    assert template_step.completion_guards == [
+        {
+            "always": True,
+            "require_tool_result": {
+                "tool": "write_file",
+                "match_conclusion_field": "file_path",
+                "match_result_field": "result.file_path",
+            },
+            "message_key": "template_generating_write_file_required",
+        },
+        {
+            "always": True,
+            "require_tool_result": {
+                "tool": "ros_validate_template",
+                "match_conclusion_field": "file_path",
+                "match_result_field": "input.template_url",
+                "disallow_tool_results_after_match": [
+                    {
+                        "tools": ["write_file", "edit_file"],
+                        "match_conclusion_field": "file_path",
+                        "match_result_field": "result.file_path",
+                        "message_key": "template_generating_rerun_after_validate_template_write",
+                    }
+                ],
+            },
+            "message_key": "template_generating_validate_template_required",
+        },
+        {
+            "always": True,
+            "require_conclusion_sha256": {
+                "content_field": "template",
+                "sha256_field": "template_sha256",
+            },
+            "message_key": "template_generating_template_sha256_required",
+        },
+    ]
+    assert template_step.conclusion_schema is not None
+    assert template_step.conclusion_schema["properties"]["template"]["minLength"] == 1
+    assert "template_sha256" in template_step.conclusion_schema["required"]
+
+
 def test_cost_prompt_injects_only_required_candidate_fields() -> None:
     from iac_code.pipeline.engine.context import PipelineContext
 


### PR DESCRIPTION
## 背景

selling pipeline 的 `template_generating` 步骤可能在**完全没有产出模板**的情况下被判定为 COMPLETED。

技能 frontmatter 的 `conclusion_schema` 只要求 `template` 是 `string`，因此空字符串 `""` 能通过校验；同时该步骤没有声明任何 `completion_guards`，没有任何机制把结论绑定到真实的 `write_file` 结果或 `ros_validate_template` 调用上。

`reviewing` 步骤已经用 `require_tool_result` + `require_conclusion_sha256` 把这条链锁死，但它受 `enable_reviewing` 门控（默认 `false`）——所以**默认配置下，`evaluate_candidate` 子流程里没有任何一步强制模板真实落盘**。

结果是弱模型跑完整个步骤、调用 `complete_step`「成功」提交一个空的或叙述性的 `template`，而 `step_executor` 的 nudge/recovery 机制只在 `complete_step` 调用失败或未调用时触发，因此永不介入。评测侧观察到的现象就是 `content_nonempty=true` 但 `template_nonempty=false`。

## 改动

把 `reviewing` 已验证的产出协议下沉到 `template_generating`，用引擎强制替代提示词劝导：

- **`conclusion_schema`**：`template` 增加 `minLength: 1`，新增必填 `template_sha256` —— 空模板与缺失内容在 schema 层被拒绝。
- **`completion_guards`**（3 条，全部复用 loader 白名单内已有能力，未扩展引擎语义）：
  - 要求存在 `write_file` 结果且其 `result.file_path` 与 `conclusion.file_path` 对齐 → 模板必须真实落盘到声明路径。
  - 要求对同一路径存在 `ros_validate_template` 结果（`input.template_url` 对齐），并用 `disallow_tool_results_after_match` 拦截「校验通过后又改写文件」。
  - 要求 `conclusion.template` 与 `conclusion.template_sha256` 自洽 → 结论、磁盘文件、对外 A2A 产物三方一致。
- **提示词与 SKILL.md**：补充产出协议说明（含 sha256 如何计算），让模型知道怎么满足新约束，而不是盲目重试。

guard 失败时 `complete_step` 返回可执行的错误提示，并消耗既有的 `max_conclusion_retries` 预算，而不是静默交付一个空模板。

## 影响范围

改动集中在 selling pipeline 配置、技能 frontmatter 与步骤提示词，不触碰 agent loop、provider 适配或云 API 调用路径。

新约束对所有模型一致生效，不是针对某个变体的分支逻辑：本来就在「写文件 + 校验」的模型行为不变；此前静默空产出的模型现在会被拦下并重试。

`template` / `file_path` / `region` / `description` 语义未变，`reviewing` 与 `cost_estimating` 通过 `context_fields` 读取的字段不受影响。

## 验证

- 新增 14 项用例：schema 边界（空 `template`、缺 `template_sha256`）、guard 配置断言、message key 渲染，以及 6 个失败模式的端到端拦截（未写文件 / 未校验 / 校验后改写 / 哈希不一致 / 空模板）+ happy path。
- `tests/pipeline` + `tests/skills` + `tests/a2a`：3330 项中 3329 通过。
- 唯一失败 `test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` 已在未改动的 base commit 上复现，属沙箱网络导致 urllib 抛 `HTTPError` 而非 `InvalidURL` 的既有环境相关失败，与本次改动无关。
- `ruff check src/ tests/` 与 `ty check src/` 均通过。
- 新增的 4 条 guard 文案已通过 `make translate` 补齐到全部 6 个 locale，并验证 `translate_message` 在 6 个语言下均正常解析、无 fallback 与 fuzzy 标记。
