### PR TITLE
feat(a2a): bound raw thinking_delta in durable pipeline journal

### DIFF
--- a/src/iac_code/a2a/pipeline_stream.py
+++ b/src/iac_code/a2a/pipeline_stream.py
@@ -110,6 +110,54 @@ _EXTREME_JOURNAL_FLUSH_EVENTS = 512
 _RECOVERY_STATE_SCOPES = {"step", "candidate", "candidateStep", "candidate_step"}
 _RECOVERY_STATE_STATUSES = {"working"}
 
+# raw thinking is display-only: the snapshot reducer and recovery hydration never read
+# ``thinking_delta`` text, yet the journal used to persist every increment verbatim. On
+# reasoning-heavy sessions these deltas dominate the durable ``a2a-events.jsonl`` (and the
+# audit surface derived from it). We therefore project ``thinking_delta`` down to a bounded
+# summary before it reaches the journal, keeping ``rawThinkingChars`` so the original volume
+# stays traceable. The transport/live-stream copy is untouched, so remote A2A clients and the
+# Web "思考完成" indicator still receive the full text.
+A2A_JOURNAL_RAW_THINKING_MAX_CHARS_ENV = "IAC_CODE_A2A_JOURNAL_RAW_THINKING_MAX_CHARS"
+_DEFAULT_A2A_JOURNAL_RAW_THINKING_MAX_CHARS = 0
+
+
+def _a2a_journal_raw_thinking_max_chars() -> int:
+    raw = os.environ.get(A2A_JOURNAL_RAW_THINKING_MAX_CHARS_ENV)
+    if raw is None or raw.strip() == "":
+        return _DEFAULT_A2A_JOURNAL_RAW_THINKING_MAX_CHARS
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return _DEFAULT_A2A_JOURNAL_RAW_THINKING_MAX_CHARS
+    return value if value >= 0 else _DEFAULT_A2A_JOURNAL_RAW_THINKING_MAX_CHARS
+
+
+def _project_thinking_delta_for_journal(envelope: dict[str, Any], *, max_chars: int) -> dict[str, Any]:
+    """Return a journal-bound copy of a ``thinking_delta`` envelope with bounded raw text.
+
+    Non ``thinking_delta`` envelopes are returned unchanged. For ``thinking_delta`` the
+    ``data.text`` is truncated to ``max_chars`` (``0`` stores no raw text at all) and the
+    original character count is preserved under ``data.rawThinkingChars`` with a
+    ``data.thinkingTruncated`` flag so the reduction stays auditable.
+    """
+    if envelope.get("eventType") != "thinking_delta":
+        return envelope
+    data = envelope.get("data")
+    if not isinstance(data, dict):
+        return envelope
+    text = data.get("text")
+    if not isinstance(text, str) or not text:
+        return envelope
+    if len(text) <= max_chars and not data.get("thinkingTruncated"):
+        return envelope
+    projected = dict(envelope)
+    projected_data = dict(data)
+    projected_data["rawThinkingChars"] = len(text)
+    projected_data["thinkingTruncated"] = len(text) > max_chars
+    projected_data["text"] = text[:max_chars] if max_chars > 0 else ""
+    projected["data"] = projected_data
+    return projected
+
 
 def backup_committed_delivery_envelope(
     ack_envelope: dict[str, Any],
@@ -187,6 +235,7 @@ class PipelineA2AEventPublisher:
         self.extreme_performance = (
             a2a_extreme_performance_enabled() if extreme_performance is None else extreme_performance
         )
+        self._journal_raw_thinking_max_chars = _a2a_journal_raw_thinking_max_chars()
         self._extreme_snapshot_loaded = False
         self._extreme_snapshot_cache: dict[str, Any] | None = None
         self._extreme_pending_journal_events: list[dict[str, Any]] = []
@@ -737,7 +786,7 @@ class PipelineA2AEventPublisher:
             journal_persisted = False
             snapshot_persisted = False
             try:
-                self.journal.append(safe_envelope, durable=durable_required)
+                self.journal.append(self._journal_envelope(safe_envelope), durable=durable_required)
                 journal_persisted = True
             except Exception as exc:
                 logger.warning(
@@ -764,6 +813,19 @@ class PipelineA2AEventPublisher:
                 return None
         return safe_envelope
 
+    def _journal_envelope(self, safe_envelope: dict[str, Any]) -> dict[str, Any]:
+        """Project an outbound envelope into its journal-bound form.
+
+        Only ``thinking_delta`` is affected: its verbatim raw thinking is bounded to
+        ``self._journal_raw_thinking_max_chars`` so the durable journal stops carrying the
+        bulk of reasoning-heavy sessions. The transport copy (``safe_envelope``) is left
+        untouched for remote A2A delivery and the Web loopback sink.
+        """
+        return _project_thinking_delta_for_journal(
+            safe_envelope,
+            max_chars=self._journal_raw_thinking_max_chars,
+        )
+
     def _persist_envelope_extreme(
         self,
         safe_envelope: dict[str, Any],
@@ -778,7 +840,7 @@ class PipelineA2AEventPublisher:
             durable_required=durable_required,
             require_journal_metadata=require_journal_metadata,
         ):
-            self._extreme_pending_journal_events.append(safe_envelope)
+            self._extreme_pending_journal_events.append(self._journal_envelope(safe_envelope))
             self._extreme_pending_snapshot_events.append(safe_envelope)
             if len(self._extreme_pending_journal_events) >= _EXTREME_JOURNAL_FLUSH_EVENTS:
                 self._flush_extreme_journal_events()
@@ -788,7 +850,7 @@ class PipelineA2AEventPublisher:
         snapshot_persisted = False
         self._flush_extreme_journal_events()
         try:
-            self.journal.append(safe_envelope, durable=False)
+            self.journal.append(self._journal_envelope(safe_envelope), durable=False)
             journal_persisted = True
         except Exception as exc:
             logger.warning(

--- a/src/iac_code/web/pipeline_transcript.py
+++ b/src/iac_code/web/pipeline_transcript.py
@@ -756,9 +756,17 @@ class PipelineTranscriptTranslator:
         message_id = self._text_message_id(env)
         if not message_id:
             return []
-        text = str(_as_mapping(env.get("data")).get("text") or "")
+        data = _as_mapping(env.get("data"))
+        text = str(data.get("text") or "")
         if not text:
-            return []
+            # The durable journal may bound (or drop) raw thinking to control storage cost
+            # (see ``pipeline_stream._project_thinking_delta_for_journal``). When the text was
+            # elided but the envelope still records that thinking occurred, emit a minimal
+            # placeholder so a reloaded transcript keeps showing 思考完成 instead of losing the
+            # thinking bubble entirely. The live/transport copy keeps the full text untouched.
+            if not _optional_int(data.get("rawThinkingChars")):
+                return []
+            text = "…"
         events = self._ensure_started(message_id)
         events.append({"type": "assistant.thinking.delta", "payload": {"messageId": message_id, "delta": text}})
         return events

--- a/tests/a2a/test_pipeline_stream.py
+++ b/tests/a2a/test_pipeline_stream.py
@@ -394,8 +394,45 @@ async def test_publish_thinking_delta_writes_pipeline_metadata_when_exposed(tmp_
     assert "message" not in dumped["status"]
     envelope = dumped["metadata"]["iac_code"]["pipeline"]
     assert envelope["eventType"] == "thinking_delta"
+    # The transport copy keeps the full raw thinking so remote A2A / Web stay unchanged.
     assert envelope["data"] == {"type": "raw_thinking", "text": "visible reasoning"}
-    assert publisher.journal.read_all()[0]["data"] == {"type": "raw_thinking", "text": "visible reasoning"}
+    # The durable journal bounds raw thinking (default: drop text, keep the length) so a
+    # reasoning-heavy session stops inflating a2a-events.jsonl / the audit surface.
+    assert publisher.journal.read_all()[0]["data"] == {
+        "type": "raw_thinking",
+        "text": "",
+        "rawThinkingChars": len("visible reasoning"),
+        "thinkingTruncated": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_thinking_delta_journal_respects_char_limit(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv(pipeline_stream.A2A_JOURNAL_RAW_THINKING_MAX_CHARS_ENV, "4")
+    publisher, queue = _publisher(tmp_path, exposure_types=[A2AExposureType.RAW_THINKING])
+
+    await publisher.publish(ThinkingDeltaEvent(text="abcdefgh"))
+
+    # Transport keeps the full text; journal is truncated to the configured limit.
+    transport = dump(queue.events[0])["metadata"]["iac_code"]["pipeline"]
+    assert transport["data"]["text"] == "abcdefgh"
+    assert publisher.journal.read_all()[0]["data"] == {
+        "type": "raw_thinking",
+        "text": "abcd",
+        "rawThinkingChars": 8,
+        "thinkingTruncated": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_thinking_delta_journal_keeps_short_text_under_limit(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv(pipeline_stream.A2A_JOURNAL_RAW_THINKING_MAX_CHARS_ENV, "16")
+    publisher, queue = _publisher(tmp_path, exposure_types=[A2AExposureType.RAW_THINKING])
+
+    await publisher.publish(ThinkingDeltaEvent(text="short"))
+
+    # Within the limit: journal keeps the text verbatim and adds no bookkeeping fields.
+    assert publisher.journal.read_all()[0]["data"] == {"type": "raw_thinking", "text": "short"}
 
 
 @pytest.mark.asyncio
@@ -489,7 +526,31 @@ async def test_publish_batch_extreme_mode_defers_delta_sidecar_persistence_until
 
 
 @pytest.mark.asyncio
-async def test_publish_batch_holds_delivery_lock_while_before_enqueue_waits(tmp_path: Path) -> None:
+async def test_publish_batch_extreme_mode_bounds_journaled_thinking_delta(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(A2A_EXTREME_PERFORMANCE_ENV, raising=False)
+    publisher, queue = _publisher(tmp_path, exposure_types=[A2AExposureType.RAW_THINKING])
+
+    await publisher.publish_batch([ThinkingDeltaEvent(text="deferred reasoning")])
+    # Deferred deltas flush to the journal only once a semantic event lands.
+    await publisher.publish_manual("pipeline_warning", "pipeline", data={"message": "flush"})
+
+    journal = publisher.journal.read_all()
+    thinking = next(event for event in journal if event["eventType"] == "thinking_delta")
+    assert thinking["data"] == {
+        "type": "raw_thinking",
+        "text": "",
+        "rawThinkingChars": len("deferred reasoning"),
+        "thinkingTruncated": True,
+    }
+    # Transport still carried the full text.
+    transport = dump(queue.events[0])["metadata"]["iac_code"]["pipeline"]
+    assert transport["data"]["text"] == "deferred reasoning"
+
+
+
     publisher, queue = _publisher(tmp_path)
     hook_started = asyncio.Event()
     release_hook = asyncio.Event()

--- a/tests/web/test_pipeline_transcript.py
+++ b/tests/web/test_pipeline_transcript.py
@@ -1291,6 +1291,26 @@ def test_translator_skips_empty_thinking_delta():
     assert not any(e["type"] == "assistant.thinking.delta" for e in events)
 
 
+def test_translator_keeps_thinking_indicator_when_journal_elided_raw_text():
+    # The durable journal may drop raw thinking text (rawThinkingChars records the original
+    # length). Reload must still surface a thinking bubble so 思考完成 shows instead of nothing.
+    step = {"id": "s", "runId": "r-10b", "index": 1, "total": 3}
+    events = PipelineTranscriptTranslator().translate_all(
+        [
+            _envelope("step_started", "step", 1, step=step),
+            _envelope(
+                "thinking_delta",
+                "step",
+                2,
+                step=step,
+                data={"type": "raw_thinking", "text": "", "rawThinkingChars": 42, "thinkingTruncated": True},
+            ),
+        ]
+    )
+    thinking = next(e for e in events if e["type"] == "assistant.thinking.delta")
+    assert thinking["payload"]["delta"] == "…"
+
+
 def test_build_rows_accumulate_thinking_into_message_row():
     step = {"id": "s", "runId": "r-11", "index": 1, "total": 3}
     rows = build_pipeline_transcript_rows(


### PR DESCRIPTION
## 背景
关联需求 #85718893（Session `9dc515b2084a4da49a24ede6a624372b`）：a2a 事件流中 `thinking_delta` 占 94.3%（4629/4909），被全量持久化，推高存储与审计成本。

## 根因
A2A pipeline 持久化层 (`PipelineA2AEventPublisher.persist_envelope`) 会把每个事件信封写入持久化 journal `a2a-events.jsonl`。`thinking_delta` 携带完整 raw thinking 文本被逐条全量落盘，但它是 display-only 事件：快照 reducer 与恢复 hydration 均不消费其文本。

## 修改
- journal 落盘前对 `thinking_delta` 的 `data.text` 按可配置上限裁剪（默认清空正文，仅保留 `rawThinkingChars`/`thinkingTruncated` 元数据保证可追溯）。
- 传输/实时流（远端 A2A、Web loopback）保持完整正文不变。
- Web 重载 transcript：正文被裁剪但存在 `rawThinkingChars` 时仍产出占位 thinking，保证「思考完成」显示。
- 上限可通过 env `IAC_CODE_A2A_JOURNAL_RAW_THINKING_MAX_CHARS` 配置（默认 0）。覆盖标准与 extreme 两条 journal 路径。

## 影响与验收
- 仅 iac-code；快照/恢复语义与非 thinking 事件不受影响。
- 新增单测覆盖 journal 裁剪（含 extreme 路径）与 Web 重载占位；`tests/a2a` + `tests/web` 全量 2910 通过，ruff/ty 通过。
