### PR TITLE
feat(session): stamp per-message createdAt into session.jsonl rows

### DIFF
--- a/src/iac_code/pipeline/engine/transcript_storage.py
+++ b/src/iac_code/pipeline/engine/transcript_storage.py
@@ -12,7 +12,12 @@ from iac_code import __version__
 from iac_code.agent.message import Message
 from iac_code.services.session_layout import ensure_session_owned_parent, require_supported_session_layout
 from iac_code.services.session_metadata import SESSION_JSONL_FILENAME, session_metadata_entry_exists
-from iac_code.services.session_storage import SessionStorage, merge_preserved_cleanup_prompts
+from iac_code.services.session_storage import (
+    SessionStorage,
+    ensure_message_created_at,
+    merge_preserved_cleanup_prompts,
+    stamp_meta_row_created_at,
+)
 from iac_code.utils.file_security import ensure_private_dir, ensure_private_file
 from iac_code.utils.state_io import append_jsonl_locked, open_text_no_follow, write_text_no_follow
 
@@ -62,6 +67,7 @@ class PipelineTranscriptStorage:
     ) -> None:
         path = self.session_path(cwd, session_id)
         self._ensure_transcript_parent(path)
+        ensure_message_created_at(message)
         data = self._stamp(message.to_dict(), cwd, session_id, git_branch)
         append_jsonl_locked(path, [data])
         ensure_private_file(path)
@@ -73,6 +79,7 @@ class PipelineTranscriptStorage:
         self._ensure_transcript_parent(path)
         entry = dict(meta_entry)
         entry["session_id"] = session_id
+        stamp_meta_row_created_at(entry)
         append_jsonl_locked(path, [entry])
         ensure_private_file(path)
 
@@ -89,6 +96,8 @@ class PipelineTranscriptStorage:
             messages = merge_preserved_cleanup_prompts(self.load(cwd, session_id), messages)
         path = self.session_path(cwd, session_id)
         self._ensure_transcript_parent(path)
+        for message in messages:
+            ensure_message_created_at(message)
         content = "".join(
             json.dumps(self._stamp(message.to_dict(), cwd, session_id, git_branch), ensure_ascii=False) + "\n"
             for message in messages

--- a/src/iac_code/services/session_storage.py
+++ b/src/iac_code/services/session_storage.py
@@ -12,12 +12,17 @@ Each ``session.jsonl`` file is a stream of two kinds of JSONL lines:
 
 * **Message rows** — one per :class:`Message`, with extra stamp fields
   (``session_id``, ``cwd``, ``git_branch``, ``version``) appended at write
-  time. ``Message.from_dict`` ignores unknown fields, so loading is
-  schema-agnostic.
+  time, plus a ``metadata.createdAt`` timestamp. ``Message.from_dict``
+  ignores unknown fields, so loading is schema-agnostic.
 
 * **Lite-meta rows** — special rows without a ``role``, identified by a
   ``type`` field (``last-prompt``, …). They are appended for the picker
-  to read via tail-scan, without being part of the conversation.
+  to read via tail-scan, without being part of the conversation. They
+  carry a top-level ``createdAt`` timestamp.
+
+Every row therefore carries its own timestamp, so a session transcript can
+be attributed to an analysis time window per message rather than only at
+session granularity.
 """
 
 from __future__ import annotations
@@ -59,6 +64,33 @@ from iac_code.utils.state_io import append_jsonl_locked, atomic_write_text, safe
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+CREATED_AT_KEY = "createdAt"
+
+
+def ensure_message_created_at(message: Message) -> str:
+    """Stamp ``message.metadata['createdAt']`` if missing, returning the timestamp.
+
+    The timestamp is written onto the message itself rather than only onto the
+    serialized row, so that rewrites (``save`` after compaction) and reloads
+    keep the moment the message was first persisted instead of drifting to the
+    rewrite time.
+    """
+    existing = message.metadata.get(CREATED_AT_KEY)
+    if isinstance(existing, str) and existing:
+        return existing
+    created_at = _utc_now()
+    message.metadata[CREATED_AT_KEY] = created_at
+    return created_at
+
+
+def stamp_meta_row_created_at(entry: dict[str, Any]) -> dict[str, Any]:
+    """Stamp a lite-meta row with ``createdAt`` unless the caller supplied one."""
+    existing = entry.get(CREATED_AT_KEY)
+    if not isinstance(existing, str) or not existing:
+        entry[CREATED_AT_KEY] = _utc_now()
+    return entry
 
 
 def _long_project_dir_hash_suffix(project_dir: Path) -> str | None:
@@ -667,6 +699,7 @@ class SessionStorage:
         """Append a single message (real-time persistence)."""
         path, was_new = self._prepare_session_write(cwd, session_id)
         ensure_private_dir(path.parent)
+        ensure_message_created_at(message)
         data = self._stamp(message.to_dict(), cwd, session_id, git_branch)
         append_jsonl_locked(path, [data])
         ensure_private_file(path)
@@ -680,6 +713,7 @@ class SessionStorage:
         ensure_private_dir(path.parent)
         entry = dict(meta_entry)
         entry["session_id"] = session_id
+        stamp_meta_row_created_at(entry)
         append_jsonl_locked(path, [entry])
         ensure_private_file(path)
         self._ensure_new_session_metadata(cwd, session_id, git_branch=None, was_new=was_new)
@@ -700,6 +734,7 @@ class SessionStorage:
         ensure_private_dir(path.parent)
         lines = []
         for msg in messages:
+            ensure_message_created_at(msg)
             data = self._stamp(msg.to_dict(), cwd, session_id, git_branch)
             lines.append(json.dumps(data, ensure_ascii=False) + "\n")
         atomic_write_text(path, "".join(lines), durable=True)

--- a/tests/pipeline/engine/test_transcript_storage.py
+++ b/tests/pipeline/engine/test_transcript_storage.py
@@ -174,6 +174,24 @@ def test_append_stamps_required_fields(tmp_path: Path):
     assert row["cwd"] == "/repo"
     assert row["git_branch"] == "main"
     assert row["version"] == __version__
+    assert row["metadata"]["createdAt"].endswith("Z")
+
+
+def test_save_stamps_created_at_on_every_message(tmp_path: Path):
+    storage = PipelineTranscriptStorage(tmp_path / "pipeline")
+
+    storage.save(
+        "/repo",
+        "transcript_att_0001",
+        [Message(role="user", content="one"), Message(role="assistant", content="two")],
+        git_branch="main",
+    )
+
+    lines = storage.session_path("/repo", "transcript_att_0001").read_text(encoding="utf-8").splitlines()
+    rows = [json.loads(line) for line in lines if line]
+    assert len(rows) == 2
+    for row in rows:
+        assert row["metadata"]["createdAt"].endswith("Z")
 
 
 def test_append_meta_requires_type(tmp_path: Path):
@@ -193,7 +211,9 @@ def test_append_meta_stamps_session_and_is_skipped_by_load(tmp_path: Path):
     storage.append_meta("/repo", "transcript_att_0001", {"type": "pipeline_init"})
 
     row = json.loads(storage.session_path("/repo", "transcript_att_0001").read_text(encoding="utf-8"))
-    assert row == {"type": "pipeline_init", "session_id": "transcript_att_0001"}
+    assert row["type"] == "pipeline_init"
+    assert row["session_id"] == "transcript_att_0001"
+    assert row["createdAt"].endswith("Z")
     assert storage.load("/repo", "transcript_att_0001") == []
 
 

--- a/tests/services/test_session_storage.py
+++ b/tests/services/test_session_storage.py
@@ -138,6 +138,58 @@ class TestSessionStorage:
         assert obj["git_branch"] == "dev"
         assert "version" in obj
 
+    def test_every_message_row_carries_created_at(self, storage, sample_messages):
+        storage.append(CWD, "created-at", Message(role="user", content="appended"), git_branch="main")
+        storage.save(CWD, "created-at", sample_messages, git_branch="main")
+        storage.append(CWD, "created-at", Message(role="assistant", content="after save"), git_branch="main")
+
+        path = storage.session_path(CWD, "created-at")
+        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+        assert len(rows) == len(sample_messages) + 1
+        for row in rows:
+            created_at = row["metadata"]["createdAt"]
+            assert isinstance(created_at, str) and created_at.endswith("Z")
+
+    def test_meta_rows_carry_created_at(self, storage):
+        storage.append_meta(CWD, "created-at-meta", {"type": "last-prompt", "last_prompt": "hi"})
+
+        path = storage.session_path(CWD, "created-at-meta")
+        row = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+
+        assert isinstance(row["createdAt"], str) and row["createdAt"].endswith("Z")
+
+    def test_meta_row_created_at_is_not_overwritten(self, storage):
+        storage.append_meta(
+            CWD,
+            "created-at-meta-explicit",
+            {"type": "pipeline_init", "createdAt": "2026-08-19T06:30:00Z"},
+        )
+
+        path = storage.session_path(CWD, "created-at-meta-explicit")
+        row = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+
+        assert row["createdAt"] == "2026-08-19T06:30:00Z"
+
+    def test_save_preserves_original_created_at_on_rewrite(self, storage):
+        message = Message(role="user", content="first")
+        storage.append(CWD, "created-at-rewrite", message, git_branch="main")
+        original = message.metadata["createdAt"]
+
+        storage.save(CWD, "created-at-rewrite", storage.load(CWD, "created-at-rewrite"), git_branch="main")
+
+        path = storage.session_path(CWD, "created-at-rewrite")
+        row = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+
+        assert row["metadata"]["createdAt"] == original
+
+    def test_created_at_survives_load_round_trip(self, storage):
+        storage.append(CWD, "created-at-roundtrip", Message(role="user", content="hi"), git_branch=None)
+
+        loaded = storage.load(CWD, "created-at-roundtrip")
+
+        assert loaded[0].metadata["createdAt"]
+
     def test_tool_use_preserved(self, storage, sample_messages):
         storage.save(CWD, "tools", sample_messages, git_branch=None)
         loaded = storage.load(CWD, "tools")
@@ -293,7 +345,8 @@ def test_new_session_uses_directory_format(storage):
     assert session_dir.is_dir()
     assert (session_dir / SESSION_JSONL_FILENAME).exists()
     assert not legacy_path.exists()
-    assert storage.load(CWD, "dir-session") == [Message(role="user", content="hi")]
+    loaded = storage.load(CWD, "dir-session")
+    assert [(message.role, message.content) for message in loaded] == [("user", "hi")]
 
 
 def test_recalled_memory_metadata_round_trips(tmp_path):

--- a/tests/web/test_session_manager.py
+++ b/tests/web/test_session_manager.py
@@ -1486,7 +1486,8 @@ def test_persist_pipeline_user_prompt_tags_normal_chat(tmp_path) -> None:
     stored = manager.load_resume_messages(session.session_id, cwd=cwd)
     prompts = [msg for msg in stored if msg.role == "user"]
     assert [msg.get_text() for msg in prompts] == ["流水线回合 prompt", "交接后普通对话 prompt"]
-    assert prompts[0].metadata == {"source": "pipeline"}
+    assert prompts[0].metadata.get("source") == "pipeline"
+    assert prompts[0].metadata.get("normalChat") is None
     assert prompts[1].metadata.get("source") == "pipeline"
     assert prompts[1].metadata.get("normalChat") is True
 


### PR DESCRIPTION
## 背景

`session.jsonl` 的每一行只带 `session_id` / `cwd` / `git_branch` / `version`，普通对话消息的 `Message.metadata` 默认是空对象，没有逐条时间戳。

会话分析因此无法把 Normal 段消息精确归属到分析窗口，报告只能以 Session 级口径统计并显式声明降级（参考 Session `d10910d359354a6891f4d3efad68e3e2`：110 行的 `metadata` 全为 `{}`）。

## 改动

落盘时补齐逐条 UTC 时间戳：

- `SessionStorage._stamp()` — 消息行写入 `metadata.createdAt`
- `SessionStorage.append_meta()` — lite-meta / Pipeline 标记行写入顶层 `createdAt`
- `PipelineTranscriptStorage` 的同源实现对齐，避免 sidecar transcript 成为盲区

时间戳写在 `Message` 自身上且**不覆盖**已有值，因此压缩后的 `save()` 重写会保留消息首次落盘的时刻，而不是漂移到重写时间。旧会话行缺少该字段时读取路径不受影响，不做数据迁移。

## 验证

- 新增用例：`append` / `save` / `append_meta` 三条写路径的每一行都带非空 `createdAt`；`save()` 重写保留原始时间戳；`createdAt` 可经 load 往返
- `make lint` 全绿（ruff + ty）
- `uv run pytest tests/ -n auto`：14327 passed / 5 skipped；剩余 15 个失败在本改动前的 `main` 上即可复现（13 个 `tests/test_i18n.py` 需 `make translate` 产物、1 个 mtime 敏感的 repl_e2e 用例、1 个 urllib `InvalidURL` 行为差异）

Aone: https://project.aone.alibaba-inc.com/v2/project/2169409/req/85634111
