### PR TITLE
fix(pipeline): 强制 cost_estimating 结论币种自洽

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4088,6 +4088,12 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The cost conclusion must use a single currency; a different source "
+"currency requires an explicit exchange rate."
+msgstr "Das Kostenergebnis muss eine einzige Währung verwenden; bei einer abweichenden Ausgangswährung ist ein expliziter Wechselkurs erforderlich."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4195,13 +4201,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "Eine Abschlussbedingung ist falsch konfiguriert."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Validierungsproblem: {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "Eine Abschlussbedingung ist falsch konfiguriert."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4065,6 +4065,12 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The cost conclusion must use a single currency; a different source "
+"currency requires an explicit exchange rate."
+msgstr "La conclusión de costes debe usar una sola moneda; si la moneda de origen es distinta, se requiere un tipo de cambio explícito."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4169,13 +4175,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "La guarda de finalización está mal configurada."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Problema de validación: {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "La guarda de finalización está mal configurada."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4074,6 +4074,12 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The cost conclusion must use a single currency; a different source "
+"currency requires an explicit exchange rate."
+msgstr "La conclusion de coût doit utiliser une seule devise ; si la devise source est différente, un taux de change explicite est requis."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4176,13 +4182,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "Une garde de finalisation est mal configurée."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Problème de validation : {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "Une garde de finalisation est mal configurée."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3876,6 +3876,12 @@ msgstr "ユーザーが明示した各ハード制約は、パラメーターと
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The cost conclusion must use a single currency; a different source "
+"currency requires an explicit exchange rate."
+msgstr "コスト結論は単一の通貨を使用しなければなりません。元の通貨が異なる場合は明示的な為替レートが必要です。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3968,13 +3974,13 @@ msgid ""
 msgstr "{message} complete_step.conclusion には次のいずれかのフィールドが必要です: {fields}。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "完了ガードの設定に誤りがあります。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} 検証上の問題: {code} ({detail})。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "完了ガードの設定に誤りがあります。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4046,6 +4046,12 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The cost conclusion must use a single currency; a different source "
+"currency requires an explicit exchange rate."
+msgstr "A conclusão de custo deve usar uma única moeda; se a moeda de origem for diferente, é necessária uma taxa de câmbio explícita."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4145,13 +4151,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "Uma proteção de conclusão está configurada incorretamente."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Problema de validação: {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "Uma proteção de conclusão está configurada incorretamente."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3840,6 +3840,12 @@ msgstr "每个用户明确提出的硬约束都必须由一条状态为满足的
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"The cost conclusion must use a single currency; a different source "
+"currency requires an explicit exchange rate."
+msgstr "成本结论必须使用单一币种；原始币种不同时必须提供明确的汇率。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr "调用此工具提交结论以完成当前步骤。如需回滚到较早步骤，请设置 rollback_request。"
@@ -3930,13 +3936,13 @@ msgid ""
 msgstr "{message} complete_step.conclusion 必须包含以下字段之一: {fields}。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "完成守卫配置错误。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} 校验问题：{code}（{detail}）。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "完成守卫配置错误。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -13,6 +13,7 @@ import jsonschema
 
 from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
+from iac_code.pipeline.engine.currency_consistency import validate_currency_consistency
 from iac_code.pipeline.engine.hard_constraints import collect_hard_constraints, validate_hard_constraint_checks
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
@@ -60,6 +61,10 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
     ),
+    "cost_currency_consistency_required": (
+        "The cost conclusion must use a single currency; a different source currency requires an explicit "
+        "exchange rate."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -99,6 +104,10 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
         _(
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
+        ),
+        _(
+            "The cost conclusion must use a single currency; a different source currency requires an explicit "
+            "exchange rate."
         ),
     )
 
@@ -324,6 +333,7 @@ class CompleteStepTool(Tool):
             required_tool_result = guard.get("require_tool_result")
             required_conclusion_sha256 = guard.get("require_conclusion_sha256")
             required_constraint_coverage = guard.get("require_context_constraint_coverage")
+            required_currency_consistency = guard.get("require_currency_consistency")
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
@@ -383,7 +393,69 @@ class CompleteStepTool(Tool):
                 )
                 if validation_error is not None:
                     return validation_error
+            if isinstance(required_currency_consistency, dict):
+                validation_error = self._validate_currency_consistency(
+                    required_currency_consistency,
+                    conclusion,
+                    self._completion_guard_message(guard, None),
+                )
+                if validation_error is not None:
+                    return validation_error
         return None
+
+    def _validate_currency_consistency(
+        self,
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        message: str | None,
+    ) -> str | None:
+        currency = self._resolve_dotted(conclusion, str(requirement.get("currency_field") or "currency"))
+        source_currency = self._resolve_dotted(
+            conclusion,
+            str(requirement.get("source_currency_field") or "source_currency"),
+        )
+        exchange_rate = self._resolve_dotted(
+            conclusion,
+            str(requirement.get("exchange_rate_field") or "exchange_rate"),
+        )
+        issues = validate_currency_consistency(
+            currency=currency,
+            source_currency=source_currency,
+            exchange_rate=exchange_rate,
+            amount_texts=self._collect_amount_texts(requirement, conclusion),
+        )
+        if not issues:
+            return None
+        base_message = message or _(
+            "The cost conclusion must use a single currency; a different source currency requires an explicit "
+            "exchange rate."
+        )
+        issue_summaries = [f"{issue.code}[{issue.detail}]" if issue.detail else issue.code for issue in issues]
+        code = issues[0].code if len(issues) == 1 else "multiple_currency_issues"
+        return _("{message} Validation issue: {code} ({detail}).").format(
+            message=base_message,
+            code=code,
+            detail="; ".join(issue_summaries),
+        )
+
+    def _collect_amount_texts(self, requirement: dict[str, Any], conclusion: dict[str, Any]) -> list[Any]:
+        raw_fields = requirement.get("amount_fields")
+        fields = raw_fields if isinstance(raw_fields, list) else ["monthly_estimate", "resources[].cost"]
+        texts: list[Any] = []
+        for field in fields:
+            if not isinstance(field, str) or not field:
+                continue
+            list_field, separator, item_field = field.partition("[].")
+            if not separator:
+                texts.append(self._resolve_dotted(conclusion, field))
+                continue
+            items = self._resolve_dotted(conclusion, list_field)
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if isinstance(item, dict):
+                    texts.append(self._resolve_dotted(item, item_field))
+        return [text for text in texts if isinstance(text, str) and text]
 
     def _validate_context_constraint_coverage(
         self,

--- a/src/iac_code/pipeline/engine/currency_consistency.py
+++ b/src/iac_code/pipeline/engine/currency_consistency.py
@@ -1,0 +1,111 @@
+"""Generic validation for pipeline cost conclusions that mix currencies."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+SUPPORTED_CURRENCIES = ("CNY", "USD")
+
+_SYMBOL_CURRENCIES = {
+    "¥": "CNY",
+    "￥": "CNY",
+    "$": "USD",
+}
+_CODE_CURRENCIES = {
+    "CNY": "CNY",
+    "RMB": "CNY",
+    "USD": "USD",
+}
+_CODE_PATTERN = re.compile(r"[A-Za-z]{3}")
+
+
+@dataclass(frozen=True)
+class CurrencyValidationIssue:
+    code: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {key: value for key, value in asdict(self).items() if value}
+
+
+def validate_currency_consistency(
+    *,
+    currency: Any,
+    source_currency: Any,
+    exchange_rate: Any,
+    amount_texts: list[Any],
+) -> list[CurrencyValidationIssue]:
+    """Reject conclusions whose declared currency contradicts amounts or lacks an exchange rate."""
+
+    if not isinstance(currency, str) or currency not in SUPPORTED_CURRENCIES:
+        return [CurrencyValidationIssue("unsupported_currency", str(currency))]
+
+    issues: list[CurrencyValidationIssue] = []
+    if source_currency is not None:
+        if not isinstance(source_currency, str) or source_currency not in SUPPORTED_CURRENCIES:
+            issues.append(CurrencyValidationIssue("unsupported_source_currency", str(source_currency)))
+        elif source_currency != currency and exchange_rate is None:
+            issues.append(CurrencyValidationIssue("missing_exchange_rate", f"{source_currency}->{currency}"))
+
+    if exchange_rate is not None:
+        issues.extend(_validate_exchange_rate(exchange_rate, currency=currency, source_currency=source_currency))
+
+    for text in amount_texts:
+        detected = detect_currencies(text)
+        for detected_currency in sorted(detected - {currency}):
+            issues.append(CurrencyValidationIssue("amount_currency_mismatch", f"{detected_currency}:{text}"))
+    return issues
+
+
+def detect_currencies(text: Any) -> set[str]:
+    """Detect currencies written into a human-readable amount string."""
+
+    if not isinstance(text, str) or not text:
+        return set()
+    detected = {currency for symbol, currency in _SYMBOL_CURRENCIES.items() if symbol in text}
+    for match in _CODE_PATTERN.findall(text):
+        currency = _CODE_CURRENCIES.get(match.upper())
+        if currency is not None:
+            detected.add(currency)
+    return detected
+
+
+def _validate_exchange_rate(
+    exchange_rate: Any,
+    *,
+    currency: str,
+    source_currency: Any,
+) -> list[CurrencyValidationIssue]:
+    if not isinstance(exchange_rate, dict):
+        return [CurrencyValidationIssue("invalid_exchange_rate", str(exchange_rate))]
+
+    issues: list[CurrencyValidationIssue] = []
+    rate_from = exchange_rate.get("from")
+    rate_to = exchange_rate.get("to")
+    if isinstance(source_currency, str) and rate_from != source_currency:
+        issues.append(CurrencyValidationIssue("exchange_rate_source_mismatch", f"{rate_from}!={source_currency}"))
+    if source_currency is None and rate_from not in SUPPORTED_CURRENCIES:
+        issues.append(CurrencyValidationIssue("exchange_rate_source_mismatch", str(rate_from)))
+    if rate_to != currency:
+        issues.append(CurrencyValidationIssue("exchange_rate_target_mismatch", f"{rate_to}!={currency}"))
+    rate = _positive_decimal_or_none(exchange_rate.get("rate"))
+    if rate is None:
+        issues.append(CurrencyValidationIssue("invalid_exchange_rate_value", str(exchange_rate.get("rate"))))
+    elif rate_from == rate_to and rate != Decimal(1):
+        issues.append(CurrencyValidationIssue("invalid_exchange_rate_value", str(exchange_rate.get("rate"))))
+    return issues
+
+
+def _positive_decimal_or_none(value: Any) -> Decimal | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal, str)):
+        return None
+    try:
+        number = Decimal(str(value))
+    except InvalidOperation:
+        return None
+    if not number.is_finite() or number <= 0:
+        return None
+    return number

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -43,6 +43,7 @@ _SUPPORTED_COMPLETION_GUARD_KEYS = {
     "message_key",
     "require_conclusion_sha256",
     "require_context_constraint_coverage",
+    "require_currency_consistency",
     "require_tool",
     "require_tool_result",
     "required_conclusion_any_of",

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -356,6 +356,13 @@ sub_pipelines:
               checks_field: hard_constraint_checks
               deployment_parameters_field: deployment_parameters
             message_key: hard_constraint_verification_required
+          - always: true
+            require_currency_consistency:
+              currency_field: currency
+              source_currency_field: source_currency
+              exchange_rate_field: exchange_rate
+              amount_fields: [monthly_estimate, "resources[].cost"]
+            message_key: cost_currency_consistency_required
         tools:
           include: []
           exclude:

--- a/src/iac_code/pipeline/selling/prompts/cost_estimating.md
+++ b/src/iac_code/pipeline/selling/prompts/cost_estimating.md
@@ -39,8 +39,13 @@ API 调用完成后调用 `complete_step` 提交费用预估。
 `complete_step.conclusion.monthly_estimate` 必须保留两个价格口径：
 - `OriginalAmount` 是原价，按统一月度周期换算并汇总为列表价。
 - `TradeAmount` 是合同优惠后的最终价，按与原价相同的月度周期换算并汇总。
-- 两个字段都存在时，使用 `¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）` 格式；即使数值相同也保留两个价格口径。
+- 两个字段都存在时，使用 `<符号><原价>/月（列表价，合同优惠后约<符号><最终价>/月）` 格式；即使数值相同也保留两个价格口径。符号按 `currency` 取（CNY → `¥`，USD → `$`）。
 - 任一字段缺失时只展示可用价格，并在 `api_raw_summary` 中说明缺失字段；询价失败时仍填写 `"询价失败"`。
+
+`complete_step.conclusion` 的币种必须自洽，具体归一规则按技能执行：
+- `currency` 是 `monthly_estimate` 与 `resources[].cost` 实际使用的币种，必须与书写的金额符号一致。
+- 询价返回 USD 等非 CNY 原始价时，要么按原始币种上报（`currency` = `source_currency`，不填 `exchange_rate`），要么填 `exchange_rate` 按显式汇率换算并在 `api_raw_summary` 记录原始币种与原始金额。
+- 禁止 USD 原始价与 `currency: CNY` 共存于同一结论，也禁止无汇率的跨币种换算。不要联网查汇率。
 
 若 `ros_preview_template` 成功，在 `complete_step.conclusion.preview_validation` 写入 PreviewStack 成功证明：`succeeded: true`、`template_url: "{template.file_path}"`、`parameters: <预览通过的同一参数字典>`；失败或未执行时写入 `succeeded: false`、`error: "<原因>"`。
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -17,10 +17,36 @@ conclusion_schema:
   properties:
     monthly_estimate:
       type: string
-      description: 月度费用估算；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"
+      description: 月度费用估算，金额符号必须与 currency 一致（CNY 用 ¥，USD 用 $）；询价同时返回 OriginalAmount 与 TradeAmount 时，必须同时包含列表价和合同优惠后价格（如 ¥96.80/月（列表价，合同优惠后约¥13.76/月））；询价失败时填 "询价失败"
     currency:
       type: string
-      enum: [CNY]
+      enum: [CNY, USD]
+      description: monthly_estimate 与 resources[].cost 实际使用的币种；必须与实际书写的金额符号一致，不得声明未换算的其他币种
+    source_currency:
+      type: string
+      enum: [CNY, USD]
+      description: 询价 API 原始返回的币种；与 currency 不同时必须提供 exchange_rate 并已完成换算
+    exchange_rate:
+      type: object
+      description: 把 source_currency 金额换算为 currency 时使用的显式汇率；source_currency 与 currency 不一致时必填
+      required: [from, to, rate]
+      additionalProperties: false
+      properties:
+        from:
+          type: string
+          enum: [CNY, USD]
+          description: 换算前币种，必须等于 source_currency
+        to:
+          type: string
+          enum: [CNY, USD]
+          description: 换算后币种，必须等于 currency
+        rate:
+          type: number
+          exclusiveMinimum: 0
+          description: 1 单位 from 币种折算为 to 币种的数值
+        source:
+          type: string
+          description: 汇率来源说明，如询价结果字段或上下文出处
     resources:
       type: array
       items:
@@ -295,11 +321,23 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 - 修复模板后**必须写回原文件路径** — 后续部署步骤直接使用此文件，未写回等于向下游传递错误模板
 - 修改后校验不通过时**不要跳过修复直接询价**，错误模板会导致后续部署失败
 
+## 币种归一
+
+询价结果的原始币种由 API 决定，跨境产品（如 GA）可能返回 USD 而非 CNY。同一结论内不得出现两个币种，只有两条合法路径：
+
+1. **按原始币种上报** — `currency` 填询价返回的币种，`source_currency` 填同一个值，不需要 `exchange_rate`。金额符号按 `currency` 书写（CNY → `¥`，USD → `$`）。
+2. **按显式汇率换算** — `source_currency` 填原始币种，`currency` 填换算后的币种，并在 `exchange_rate` 填 `{"from": <source_currency>, "to": <currency>, "rate": <数值>, "source": "<汇率出处>"}`。`monthly_estimate` 和 `resources[].cost` 写换算后的金额，`api_raw_summary` 必须记录原始币种和原始金额。
+
+硬性要求：
+- `monthly_estimate` 与所有 `resources[].cost` 必须使用同一个币种，且金额符号与 `currency` 一致；不得用 `¥` 书写 USD 原始价，也不得声明 `currency: CNY` 却填未换算的 USD 金额。
+- `source_currency` 与 `currency` 不一致时缺少 `exchange_rate`，或 `exchange_rate.from/to` 与 `source_currency`/`currency` 不对应，`complete_step` 会被代码拒绝。
+- 不要搜索定价文档或联网查汇率。汇率只能来自询价结果字段或当前上下文；拿不到可信汇率时走路径 1，按原始币种上报。
+
 ## 输出
 调用 `complete_step` 提交结论。字段定义见 tool schema。
 
 补充说明：
-- `cost` 字段为字符串，包含金额和计费周期（如 "¥800/月"、"¥0.5/小时"、"¥0"）
+- `cost` 字段为字符串，包含金额和计费周期（如 "¥800/月"、"$0.5/小时"、"¥0"），金额符号与 `currency` 一致
 - 若修复了模板，设置 `template_fixed: true` 并在 `fix_summary` 中说明修复内容；仅形成或输出 `deployment_parameters` 不算模板修复
 - `deployment_parameters` 填当前已选、已验证或已用于 `ros_estimate_template_cost` 的参数字典；PreviewStack 成功但询价失败时仍填该参数集；没有任何可用参数时填 `{}`
 - 没有硬约束时，`hard_constraint_checks` 填 `[]`；不要输出 `hard_constraints_verified`
@@ -307,3 +345,4 @@ aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<�
 - `missing_deployment_parameters` 填完整部署或 PreviewStack 仍缺少的参数及原因；没有缺口时可省略或填 `[]`
 - `parameter_set_summary` 可简要说明参数来源、可用性筛选、PreviewStack 验证结果以及是否使用软门禁继续询价
 - 询价失败时 `monthly_estimate` 填 "询价失败"，`resources` 为空数组，`error` 说明原因
+- `currency`、`source_currency`、`exchange_rate` 按「币种归一」填写；`api_raw_summary` 在发生换算时必须记录原始币种与原始金额

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1461,6 +1461,135 @@ class TestCompletionGuards:
         assert "rerun validation" in result.content
 
 
+class TestCurrencyConsistencyGuard:
+    GUARD = {
+        "always": True,
+        "require_currency_consistency": {
+            "currency_field": "currency",
+            "source_currency_field": "source_currency",
+            "exchange_rate_field": "exchange_rate",
+            "amount_fields": ["monthly_estimate", "resources[].cost"],
+        },
+        "message_key": "cost_currency_consistency_required",
+    }
+
+    def _validate(self, conclusion: dict) -> str | None:
+        tool = CompleteStepTool(
+            StepConfig(step_id="cost_estimating", conclusion_field="cost", forward=None),
+            completion_guards=[self.GUARD],
+        )
+        return tool.validate_completion_input({"conclusion": conclusion})
+
+    def test_rejects_usd_raw_price_declared_as_cny_without_exchange_rate(self):
+        error = self._validate(
+            {
+                "currency": "CNY",
+                "source_currency": "USD",
+                "monthly_estimate": "$68.00/月",
+                "resources": [{"type": "ALIYUN::GA::Accelerator", "cost": "$68.00/月"}],
+            }
+        )
+
+        assert error is not None
+        assert "missing_exchange_rate" in error
+        assert "amount_currency_mismatch" in error
+
+    def test_accepts_reporting_in_the_original_currency(self):
+        assert (
+            self._validate(
+                {
+                    "currency": "USD",
+                    "source_currency": "USD",
+                    "monthly_estimate": "$68.00/月",
+                    "resources": [{"type": "ALIYUN::GA::Accelerator", "cost": "$68.00/月"}],
+                }
+            )
+            is None
+        )
+
+    def test_accepts_conversion_with_an_explicit_exchange_rate(self):
+        assert (
+            self._validate(
+                {
+                    "currency": "CNY",
+                    "source_currency": "USD",
+                    "exchange_rate": {"from": "USD", "to": "CNY", "rate": 7.15, "source": "询价结果附带汇率"},
+                    "monthly_estimate": "¥486.20/月",
+                    "resources": [{"type": "ALIYUN::GA::Accelerator", "cost": "¥486.20/月"}],
+                }
+            )
+            is None
+        )
+
+    def test_rejects_exchange_rate_whose_direction_does_not_match_the_declared_currencies(self):
+        error = self._validate(
+            {
+                "currency": "CNY",
+                "source_currency": "USD",
+                "exchange_rate": {"from": "CNY", "to": "USD", "rate": 7.15},
+                "monthly_estimate": "¥486.20/月",
+                "resources": [],
+            }
+        )
+
+        assert error is not None
+        assert "exchange_rate_source_mismatch" in error
+        assert "exchange_rate_target_mismatch" in error
+
+    def test_rejects_non_positive_exchange_rate(self):
+        error = self._validate(
+            {
+                "currency": "CNY",
+                "source_currency": "USD",
+                "exchange_rate": {"from": "USD", "to": "CNY", "rate": 0},
+                "monthly_estimate": "¥486.20/月",
+                "resources": [],
+            }
+        )
+
+        assert error is not None
+        assert "invalid_exchange_rate_value" in error
+
+    def test_rejects_amount_symbol_that_contradicts_currency_without_source_currency(self):
+        error = self._validate({"currency": "CNY", "monthly_estimate": "$68/月", "resources": []})
+
+        assert error is not None
+        assert "amount_currency_mismatch" in error
+
+    def test_rejects_resource_cost_in_another_currency_than_the_total(self):
+        error = self._validate(
+            {
+                "currency": "CNY",
+                "monthly_estimate": "¥486.20/月",
+                "resources": [{"type": "ALIYUN::GA::Accelerator", "cost": "$68.00/月"}],
+            }
+        )
+
+        assert error is not None
+        assert "amount_currency_mismatch" in error
+
+    def test_accepts_existing_cny_only_conclusions(self):
+        assert (
+            self._validate(
+                {
+                    "currency": "CNY",
+                    "monthly_estimate": "¥96.80/月（列表价，合同优惠后约¥13.76/月）",
+                    "resources": [{"type": "ALIYUN::ECS::InstanceGroup", "cost": "¥96.80/月"}],
+                }
+            )
+            is None
+        )
+
+    def test_accepts_pricing_failure_without_any_amount(self):
+        assert self._validate({"currency": "CNY", "monthly_estimate": "询价失败", "resources": []}) is None
+
+    def test_rejects_unsupported_currency(self):
+        error = self._validate({"currency": "EUR", "monthly_estimate": "€10/月", "resources": []})
+
+        assert error is not None
+        assert "unsupported_currency" in error
+
+
 class TestSchemaValidation:
     def test_missing_conclusion_validation_error_includes_current_step_schema(self):
         config = StepConfig(

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -172,6 +172,58 @@ class TestSkillFrontmatter:
         assert "OriginalAmount" in description
         assert "TradeAmount" in description
 
+    def test_currency_schema_admits_the_pricing_api_currencies(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        currency = schema["properties"]["currency"]
+
+        assert currency["enum"] == ["CNY", "USD"]
+        assert currency.get("description")
+
+    def test_conclusion_schema_carries_source_currency_and_exchange_rate(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        properties = schema["properties"]
+
+        assert properties["source_currency"]["enum"] == ["CNY", "USD"]
+        exchange_rate = properties["exchange_rate"]
+        assert exchange_rate["type"] == "object"
+        assert exchange_rate["required"] == ["from", "to", "rate"]
+        assert exchange_rate["properties"]["from"]["enum"] == ["CNY", "USD"]
+        assert exchange_rate["properties"]["to"]["enum"] == ["CNY", "USD"]
+        assert exchange_rate["properties"]["rate"]["exclusiveMinimum"] == 0
+        assert "source_currency" not in schema["required"]
+        assert "exchange_rate" not in schema["required"]
+
+    def test_conclusion_schema_accepts_both_currency_normalization_paths(self):
+        schema = _parse_frontmatter(SKILL_MD.read_text(encoding="utf-8"))["conclusion_schema"]
+        base = {
+            "monthly_estimate": "$68.00/月",
+            "currency": "USD",
+            "source_currency": "USD",
+            "resources": [{"type": "ALIYUN::GA::Accelerator", "cost": "$68.00/月"}],
+            "template_fixed": False,
+            "deployment_parameters": {},
+            "hard_constraint_checks": [],
+            "preview_validation": {"succeeded": False, "error": "missing BandwidthPackageId"},
+        }
+
+        jsonschema.validate(base, schema)
+
+        converted = dict(
+            base,
+            monthly_estimate="¥486.20/月",
+            currency="CNY",
+            resources=[{"type": "ALIYUN::GA::Accelerator", "cost": "¥486.20/月"}],
+            exchange_rate={"from": "USD", "to": "CNY", "rate": 7.15, "source": "询价结果附带汇率"},
+        )
+        jsonschema.validate(converted, schema)
+
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(dict(base, currency="EUR"), schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(dict(converted, exchange_rate={"from": "USD", "to": "CNY"}), schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(dict(converted, exchange_rate={"from": "USD", "to": "CNY", "rate": 0}), schema)
+
     def test_conclusion_schema_requires_full_preview_validation_when_succeeded(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         fm = _parse_frontmatter(content)
@@ -380,6 +432,14 @@ class TestSkillContentRosOnly:
     def test_contains_error_handling(self, body):
         assert "失败" in body
 
+    def test_normalizes_currency_before_reporting_cost(self, body):
+        assert "## 币种归一" in body
+        assert "source_currency" in body
+        assert "exchange_rate" in body
+        assert "同一结论内不得出现两个币种" in body
+        assert "金额符号与 `currency` 一致" in body
+        assert "不要搜索定价文档或联网查汇率" in body
+
     def test_emphasizes_write_back(self, body):
         assert "写回原文件路径" in body
 
@@ -538,6 +598,16 @@ class TestCostPrompt:
         assert "列表价" in body
         assert "合同优惠后" in body
         assert "monthly_estimate" in body
+
+    def test_prompt_requires_self_consistent_currency_without_repeating_skill_rules(self):
+        body = COST_PROMPT_MD.read_text(encoding="utf-8")
+
+        assert "币种必须自洽" in body
+        assert "source_currency" in body
+        assert "exchange_rate" in body
+        assert "禁止 USD 原始价与 `currency: CNY` 共存于同一结论" in body
+        assert "符号按 `currency` 取" in body
+        assert "`¥<原价>/月（列表价，合同优惠后约¥<最终价>/月）`" not in body
 
     def test_prompt_receives_only_required_candidate_fields_without_repeating_skill_rules(self):
         body = COST_PROMPT_MD.read_text(encoding="utf-8")

--- a/tests/pipeline/selling/test_pipeline_reviewing.py
+++ b/tests/pipeline/selling/test_pipeline_reviewing.py
@@ -44,7 +44,17 @@ def test_review_enabled_loads_infraguard_repair_step_before_cost() -> None:
                 "deployment_parameters_field": "deployment_parameters",
             },
             "message_key": "hard_constraint_verification_required",
-        }
+        },
+        {
+            "always": True,
+            "require_currency_consistency": {
+                "currency_field": "currency",
+                "source_currency_field": "source_currency",
+                "exchange_rate_field": "exchange_rate",
+                "amount_fields": ["monthly_estimate", "resources[].cost"],
+            },
+            "message_key": "cost_currency_consistency_required",
+        },
     ]
 
     assert review_step.tools is not None


### PR DESCRIPTION
## 问题

跨境产品（如 GA）的 ROS 询价返回 USD 原始价，但 `iac-aliyun-cost` 的 `conclusion_schema` 把 `currency` 硬编码为 `enum: [CNY]`，且没有任何字段承载原始币种和汇率。模型被 schema 逼着在填写 USD 金额的同时声明 `currency: CNY`，导致同一结论内出现两个币种且无汇率说明，用户和下游步骤无法判断真实计费币种。

## 改动

- `currency` 扩展为 `enum: [CNY, USD]`，语义收敛为「`monthly_estimate` / `resources[].cost` 实际使用的币种」
- 新增可选 `source_currency` 与 `exchange_rate`（`from` / `to` / `rate` / `source`）
- 新增 `require_currency_consistency` completion guard：跨币种必须带显式汇率、汇率方向必须与声明的币种对应、`monthly_estimate` 与 `resources[].cost` 必须与 `currency` 同币种。jsonschema 无法表达跨字段相等，故落在代码校验，`complete_step` 阶段直接拒绝矛盾结论
- prompt 与 skill 的金额格式从写死 `¥` 改为按 `currency` 选符号，并给出「按原始币种上报」和「按显式汇率换算」两条合法路径
- 补齐 6 语种 `messages` 目录

## 兼容性

既有 `currency: CNY` 结论保持合法（新字段均为可选），仅新增跨币种场景的强制校验。下游 `confirm_and_select`（含 a2a/rich）、`web/outputs.py`、`ros_deploy_tool.py` 均原样透传 `monthly_estimate` 字符串、不解析币种，无需改动。

## 验证

- `uv run pytest tests -q -n auto`：14349 passed / 4 skipped
- 新增 10 条币种守卫用例 + 5 条 schema / prompt 契约用例
- `uv run ruff check` 与 `uv run ty check src/` 均通过
- 剩余 3 条失败（`test_prerequisites` 的 urllib 错误类型断言、`repl_e2e` sidecar 布局、`test_i18n` msgfmt 对既有 `{s:.0}` 复数占位符的校验）已在未改动的 clean tree 上复现，与本次变更无关
