### PR TITLE
fix: 本地拦截 alicloud Terraform 资源类型与属性命名错配

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -9109,6 +9109,7 @@ msgid "non-empty String"
 msgstr "nicht leerer String"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
 #, python-brace-format
 msgid "Use {} instead."
 msgstr "Verwenden Sie stattdessen {}."
@@ -9863,6 +9864,31 @@ msgstr "{} benötigt ein Array"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "the condition is invalid"
 msgstr "die Bedingung ist ungültig"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource type {} does not exist in the alicloud provider."
+msgstr "Der Terraform-Ressourcentyp {} existiert im alicloud-Provider nicht."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid ""
+"{file} declares resource {name} with this type; a ROS resource type name "
+"cannot be translated into a Terraform type name literally."
+msgstr ""
+"{file} deklariert die Ressource {name} mit diesem Typ; der Name eines "
+"ROS-Ressourcentyps lässt sich nicht wörtlich in einen Terraform-Typnamen "
+"übersetzen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource {type} has no argument named {argument}."
+msgstr "Die Terraform-Ressource {type} hat kein Argument mit dem Namen {argument}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "{file} sets this argument on resource {name}."
+msgstr "{file} setzt dieses Argument für die Ressource {name}."
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -9037,6 +9037,7 @@ msgid "non-empty String"
 msgstr "String no vacío"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
 #, python-brace-format
 msgid "Use {} instead."
 msgstr "Use {} en su lugar."
@@ -9795,6 +9796,33 @@ msgstr "{} requiere una matriz"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "the condition is invalid"
 msgstr "la condición no es válida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource type {} does not exist in the alicloud provider."
+msgstr "El tipo de recurso de Terraform {} no existe en el proveedor alicloud."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid ""
+"{file} declares resource {name} with this type; a ROS resource type name "
+"cannot be translated into a Terraform type name literally."
+msgstr ""
+"{file} declara el recurso {name} con este tipo; el nombre de un tipo de "
+"recurso de ROS no se puede traducir literalmente a un nombre de tipo de "
+"Terraform."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource {type} has no argument named {argument}."
+msgstr ""
+"El recurso de Terraform {type} no tiene ningún argumento llamado "
+"{argument}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "{file} sets this argument on resource {name}."
+msgstr "{file} establece este argumento en el recurso {name}."
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -9081,6 +9081,7 @@ msgid "non-empty String"
 msgstr "String non vide"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
 #, python-brace-format
 msgid "Use {} instead."
 msgstr "Utilisez {} à la place."
@@ -9841,6 +9842,33 @@ msgstr "{} nécessite un tableau"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "the condition is invalid"
 msgstr "la condition est invalide"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource type {} does not exist in the alicloud provider."
+msgstr ""
+"Le type de ressource Terraform {} n'existe pas dans le fournisseur "
+"alicloud."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid ""
+"{file} declares resource {name} with this type; a ROS resource type name "
+"cannot be translated into a Terraform type name literally."
+msgstr ""
+"{file} déclare la ressource {name} avec ce type ; le nom d'un type de "
+"ressource ROS ne peut pas être traduit littéralement en nom de type "
+"Terraform."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource {type} has no argument named {argument}."
+msgstr "La ressource Terraform {type} n'a aucun argument nommé {argument}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "{file} sets this argument on resource {name}."
+msgstr "{file} définit cet argument sur la ressource {name}."
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -8425,6 +8425,7 @@ msgid "non-empty String"
 msgstr "空でない String"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
 #, python-brace-format
 msgid "Use {} instead."
 msgstr "代わりに {} を使用してください。"
@@ -9067,6 +9068,30 @@ msgstr "{} には配列が必要です"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "the condition is invalid"
 msgstr "条件が無効です"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource type {} does not exist in the alicloud provider."
+msgstr "Terraform リソースタイプ {} は alicloud プロバイダーに存在しません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid ""
+"{file} declares resource {name} with this type; a ROS resource type name "
+"cannot be translated into a Terraform type name literally."
+msgstr ""
+"{file} のリソース {name} がこのタイプを使用しています。ROS のリソースタイプ名をそのまま Terraform "
+"のタイプ名に置き換えることはできません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource {type} has no argument named {argument}."
+msgstr "Terraform リソース {type} には {argument} という引数はありません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "{file} sets this argument on resource {name}."
+msgstr "{file} がリソース {name} にこの引数を設定しています。"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -8953,6 +8953,7 @@ msgid "non-empty String"
 msgstr "String não vazia"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
 #, python-brace-format
 msgid "Use {} instead."
 msgstr "Use {} em vez disso."
@@ -9705,6 +9706,31 @@ msgstr "{} requer uma matriz"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "the condition is invalid"
 msgstr "a condição é inválida"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource type {} does not exist in the alicloud provider."
+msgstr "O tipo de recurso do Terraform {} não existe no provedor alicloud."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid ""
+"{file} declares resource {name} with this type; a ROS resource type name "
+"cannot be translated into a Terraform type name literally."
+msgstr ""
+"{file} declara o recurso {name} com esse tipo; o nome de um tipo de "
+"recurso do ROS não pode ser traduzido literalmente para um nome de tipo "
+"do Terraform."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource {type} has no argument named {argument}."
+msgstr "O recurso do Terraform {type} não tem nenhum argumento chamado {argument}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "{file} sets this argument on resource {name}."
+msgstr "{file} define esse argumento no recurso {name}."
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -8242,6 +8242,7 @@ msgid "non-empty String"
 msgstr "非空 String"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
 #, python-brace-format
 msgid "Use {} instead."
 msgstr "请改用 {}。"
@@ -8882,6 +8883,28 @@ msgstr "{} 需要一个数组"
 #: src/iac_code/tools/cloud/aliyun/ros_validation/rules/association_property.py
 msgid "the condition is invalid"
 msgstr "条件无效"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource type {} does not exist in the alicloud provider."
+msgstr "Terraform 资源类型 {} 在 alicloud provider 中不存在。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid ""
+"{file} declares resource {name} with this type; a ROS resource type name "
+"cannot be translated into a Terraform type name literally."
+msgstr "{file} 中的资源 {name} 使用了该类型；ROS 资源类型名不能直译为 Terraform 类型名。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "Terraform resource {type} has no argument named {argument}."
+msgstr "Terraform 资源 {type} 没有名为 {argument} 的属性。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+#, python-brace-format
+msgid "{file} sets this argument on resource {name}."
+msgstr "{file} 在资源 {name} 上设置了该属性。"
 
 #: src/iac_code/ui/banner.py
 #, python-brace-format

--- a/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
@@ -87,7 +87,7 @@ auto_trigger:
 3. **必须**阅读 [references/ros-template.md](references/ros-template.md)，了解 ROS 模板最佳实践（RunCommand、嵌套栈、条件部署、常用函数等），未阅读不得生成模板
 4. 生成模板（库存相关属性按「参数化规则」定义为 Parameters，所有 Parameters 必须添加 AssociationProperty）并写入文件
    - 生成的模板默认放在当前工作目录；仅当用户指定其他路径时才写入该路径，不要默认使用 `/tmp` 等工作目录外路径
-   - **Terraform**：生成 `.tf` 等文件后，必须先用 `tf2ros.py` 打包为 ROS Terraform 类型模板（用法见 [references/terraform-template.md](references/terraform-template.md) 的「与 ROS 集成」节），后续步骤校验/部署的都是这份打包后的 `.yml`
+   - **Terraform**：资源类型名与属性名必须符合 [references/terraform-template.md](references/terraform-template.md) 的「资源类型与属性命名规范」，不要把 ROS 类型名/属性名直译成 Terraform 名字。生成 `.tf` 等文件后，必须先用 `tf2ros.py` 打包为 ROS Terraform 类型模板（用法见 [references/terraform-template.md](references/terraform-template.md) 的「与 ROS 集成」节），后续步骤校验/部署的都是这份打包后的 `.yml`
 5. 调用 aliyun_api(product="ros", action="ValidateTemplate", params={"TemplateURL": <模板文件路径>}) 校验
 6. 校验失败 → 分析错误 → 修复 → 重试（最多 5 轮）
 7. 校验通过 → 展示模板 → 询问是否部署（**ROS 与 Terraform 一致**，禁止用 `terraform init/apply` 等本地 CLI 步骤替代部署确认）
@@ -203,6 +203,9 @@ auto_trigger:
 
 ### 校验失败
 分析错误原因 → 查 GetResourceType Schema（如需）→ 修复 → 重试（最多 5 轮）
+
+Terraform 类型模板报 `ROS1130`（资源类型不存在）或 `ROS1131`（资源没有该属性）时，
+按诊断的 `suggestion` 给出的正确名字改名，不要改成另一个凭印象拼出的名字。
 
 ### 部署失败
 分析错误原因：

--- a/src/iac_code/skills/bundled/iac_aliyun/references/terraform-template.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/terraform-template.md
@@ -51,6 +51,54 @@ data "alicloud_images" "ubuntu" {
 }
 ```
 
+## 资源类型与属性命名规范（重要）
+
+alicloud provider 的资源类型名和属性名**不是** ROS 类型名的机械转写。把 `ALIYUN::VPC::RouteEntry`
+直译成 `alicloud_vpc_route_entry`、把 ROS 的 `NextHopType` 直译成 `next_hop_type` 都会得到不存在的名字，
+模板会在 ValidateTemplate 或部署阶段失败。生成 `.tf` 前必须确认每个类型名和属性名真实存在。
+
+### 高频错配对照
+
+| 错误写法 | 正确写法 | 说明 |
+|----------|----------|------|
+| `alicloud_vpc_route_entry` | `alicloud_route_entry` | VPC 路由条目没有 `vpc_` 前缀 |
+| `next_hop_type` / `next_hop_id` | `nexthop_type` / `nexthop_id` | `alicloud_route_entry` 的下一跳属性没有中间下划线 |
+| `destination_cidr_block` | `destination_cidrblock` | 同一资源的目的网段属性同样是连写 |
+| `alicloud_alb_server_group_attachment` | `alicloud_alb_server_group` 的 `servers` 块 | ALB 后端服务器在 server group 内声明，没有独立 attachment 资源；弹性伸缩场景才用 `alicloud_ess_alb_server_group_attachment` |
+| 直接创建 TR 资源而不开通服务 | 先声明 `data "alicloud_cen_transit_router_service"` | 转发路由器需先开通服务，缺失该 data 源会导致创建失败 |
+
+ALB 后端服务器的正确写法：
+
+```hcl
+resource "alicloud_alb_server_group" "web" {
+  server_group_name = "web"
+  vpc_id            = alicloud_vpc.main.id
+
+  servers {
+    server_id   = alicloud_instance.web.id
+    server_ip   = alicloud_instance.web.private_ip
+    server_type = "Ecs"
+    port        = 80
+  }
+}
+```
+
+转发路由器（TR）先开通服务：
+
+```hcl
+data "alicloud_cen_transit_router_service" "open" {
+  enable = "On"
+}
+```
+
+### 命名不确定时怎么查
+
+- Terraform 资源属性/Schema → `aliyun_api(product="IaCService", action="GetResourceType", style="ROA", method="GET", pathname="/resourceType/<类型>")`
+- 不熟悉的资源类型/属性 → `aliyun_doc_search`（Terraform 传 `category_id=95817`）
+- **写完 `.tf` 后必须先经本地校验**：按「与 ROS 集成」打包成 ROS Terraform 类型模板再 ValidateTemplate。
+  本地校验会在调用云端之前报出 `ROS1130`（资源类型不存在）和 `ROS1131`（资源没有该属性），
+  并在 `suggestion` 中给出正确名字；按提示逐条改名后重跑，不要带着这类错配继续部署。
+
 ## 命名约定
 
 - 资源名：`{env}-{product}-{role}`，如 `prod-ecs-web`

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/rules/terraform_naming.py
@@ -1,0 +1,134 @@
+"""Local naming checks for alicloud resources inside ROS Terraform templates.
+
+ROS Terraform/OpenTofu templates carry their ``.tf`` sources in the top-level
+``Workspace`` section, so resource type and property names can be checked before
+the template reaches the cloud.  Only names that are provably misspellings of a
+documented name are reported; unknown names without a close documented match stay
+silent because the naming catalog is a vendored snapshot.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from iac_code.i18n import _
+from iac_code.tools.cloud.aliyun.ros_validation.facts import FactBuildResult, RulePhase
+from iac_code.tools.cloud.aliyun.ros_validation.model import (
+    Category,
+    Diagnostic,
+    RosPath,
+    Severity,
+    make_diagnostic,
+    mapping_segment,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.template_kind import is_terraform_template
+from iac_code.tools.cloud.aliyun.ros_validation.terraform_naming import (
+    TerraformNamingCatalog,
+    load_terraform_naming_catalog,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.terraform_workspace import ResourceBlock, iter_resource_blocks
+
+PARSED_TEMPLATE = "parsed-template"
+TERRAFORM_NAMING_CATALOG = "terraform-naming-catalog"
+_ALICLOUD_PREFIX = "alicloud_"
+
+
+@dataclass(frozen=True)
+class TerraformNamingCatalogProvider:
+    provider_id: str = "builtin.terraform-naming-catalog"
+    phase: RulePhase = RulePhase.STRUCTURE
+    requires: frozenset[str] = frozenset()
+    optional_requires: frozenset[str] = frozenset()
+    provides: frozenset[str] = frozenset({TERRAFORM_NAMING_CATALOG})
+
+    def build(self, context: Any) -> FactBuildResult:
+        del context
+        return FactBuildResult(provided={TERRAFORM_NAMING_CATALOG: load_terraform_naming_catalog()})
+
+
+@dataclass(frozen=True)
+class TerraformNamingRule:
+    rule_id: str = "builtin.terraform-naming"
+    phase: RulePhase = RulePhase.RESOURCES
+    requires: frozenset[str] = frozenset({PARSED_TEMPLATE, TERRAFORM_NAMING_CATALOG})
+    optional_requires: frozenset[str] = frozenset()
+
+    def check(self, context: Any) -> tuple[Diagnostic, ...]:
+        parsed = context.fact_store.get_required(PARSED_TEMPLATE)
+        catalog = context.fact_store.get_required(TERRAFORM_NAMING_CATALOG)
+        if not isinstance(parsed.data, Mapping) or not is_terraform_template(parsed.data):
+            return ()
+        workspace = parsed.data.get("Workspace")
+        if not isinstance(workspace, Mapping):
+            return ()
+        diagnostics: list[Diagnostic] = []
+        for filename, content in workspace.items():
+            if not isinstance(filename, str) or not filename.endswith(".tf") or not isinstance(content, str):
+                continue
+            path = (mapping_segment("Workspace"), mapping_segment(filename))
+            for block in iter_resource_blocks(content):
+                diagnostics.extend(_check_block(block, filename, path, parsed.source_map, catalog))
+        return tuple(diagnostics)
+
+
+def _check_block(
+    block: ResourceBlock,
+    filename: str,
+    path: RosPath,
+    source_map: Any,
+    catalog: TerraformNamingCatalog,
+) -> list[Diagnostic]:
+    if not block.resource_type.startswith(_ALICLOUD_PREFIX):
+        return []
+    if correction := catalog.resource_type_correction(block.resource_type):
+        return [
+            make_diagnostic(
+                code="ROS1130",
+                severity=Severity.ERROR,
+                category=Category.COMPATIBILITY,
+                summary=_("Terraform resource type {} does not exist in the alicloud provider.").format(
+                    block.resource_type
+                ),
+                detail=_(
+                    "{file} declares resource {name} with this type; a ROS resource type name cannot be "
+                    "translated into a Terraform type name literally."
+                ).format(file=filename, name=block.resource_name),
+                path=path,
+                source_map=source_map,
+                subject=block.resource_type,
+                stable_args=("resource-type", filename, block.resource_type, correction),
+                expected=correction,
+                actual=block.resource_type,
+                suggestion=_("Use {} instead.").format(correction),
+            )
+        ]
+    if not catalog.knows_resource_type(block.resource_type):
+        return []
+    diagnostics: list[Diagnostic] = []
+    for argument in block.arguments:
+        correction = catalog.argument_correction(block.resource_type, argument)
+        if correction is None:
+            continue
+        diagnostics.append(
+            make_diagnostic(
+                code="ROS1131",
+                severity=Severity.ERROR,
+                category=Category.COMPATIBILITY,
+                summary=_("Terraform resource {type} has no argument named {argument}.").format(
+                    type=block.resource_type, argument=argument
+                ),
+                detail=_("{file} sets this argument on resource {name}.").format(
+                    file=filename, name=block.resource_name
+                ),
+                path=path,
+                source_map=source_map,
+                subject="{}.{}".format(block.resource_type, argument),
+                stable_args=("resource-argument", filename, block.resource_type, argument, correction),
+                expected=correction,
+                actual=argument,
+                suggestion=_("Use {} instead.").format(correction),
+            )
+        )
+    return diagnostics

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/terraform_naming.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/terraform_naming.py
@@ -1,0 +1,219 @@
+"""Terraform (alicloud provider) resource type and property naming catalog.
+
+The catalog is built from the vendored ROS/Terraform resource metadata in
+``iac_code.pipeline.engine.architecture_metas``, which maps every documented ROS
+resource type to its Terraform counterpart and every ROS property to its
+Terraform property name.  Only the JSON payload is read here so the ROS tool
+layer keeps no import dependency on the pipeline package.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib.resources import files
+from types import MappingProxyType
+from typing import Any, Mapping
+
+# Block-level arguments that Terraform itself defines for every resource, so they
+# never appear in the provider schema derived from the vendored metadata.
+META_ARGUMENTS = frozenset({"count", "depends_on", "for_each", "lifecycle", "provider", "provisioner"})
+
+_TOKEN_SEPARATOR = re.compile(r"[_-]+")
+
+
+def _normalize(name: str) -> str:
+    """Drop word separators so ``next_hop_type`` and ``nexthop_type`` collide."""
+
+    return _TOKEN_SEPARATOR.sub("", name).lower()
+
+
+def _tokens(name: str) -> tuple[str, ...]:
+    return tuple(part for part in _TOKEN_SEPARATOR.split(name.lower()) if part)
+
+
+def _edit_distance_within_one(left: str, right: str) -> bool:
+    if abs(len(left) - len(right)) > 1:
+        return False
+    if left == right:
+        return True
+    if len(left) > len(right):
+        left, right = right, left
+    # ``left`` is now the shorter (or equal length) string.
+    for index, (short, long) in enumerate(zip(left, right)):
+        if short == long:
+            continue
+        if len(left) == len(right):
+            return left[index + 1 :] == right[index + 1 :]
+        return left[index:] == right[index + 1 :]
+    return True
+
+
+def _token_multiset_off_by_one(left: tuple[str, ...], right: tuple[str, ...]) -> bool:
+    """Detect a single extra or missing token, as in ``alicloud_vpc_route_entry``."""
+
+    if abs(len(left) - len(right)) != 1:
+        return False
+    if len(left) > len(right):
+        left, right = right, left
+    remaining = list(right)
+    for token in left:
+        if token not in remaining:
+            return False
+        remaining.remove(token)
+    return len(remaining) == 1
+
+
+def _closest(name: str, candidates: set[str]) -> str | None:
+    """Return the single closest correction for ``name``.
+
+    A candidate whose tokens are all present in ``name`` wins, because a spurious
+    extra token (``alicloud_vpc_route_entry`` for ``alicloud_route_entry``) is a
+    more likely mistake than substituting a token for a different real product.
+    """
+
+    if not candidates:
+        return None
+    normalized = _normalize(name)
+    tokens = set(_tokens(name))
+    return min(
+        candidates,
+        key=lambda candidate: (
+            _normalize(candidate) != normalized,
+            not set(_tokens(candidate)) <= tokens,
+            abs(len(candidate) - len(name)),
+            candidate,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class TerraformResourceSpec:
+    resource_type: str
+    ros_resource_type: str | None
+    properties: frozenset[str]
+    attributes: frozenset[str]
+
+
+class TerraformNamingCatalog:
+    """Known alicloud resource types with the property names they accept."""
+
+    def __init__(self, specs: Mapping[str, TerraformResourceSpec]) -> None:
+        self._specs = MappingProxyType(dict(specs))
+        normalized: dict[str, list[str]] = {}
+        for resource_type in self._specs:
+            normalized.setdefault(_normalize(resource_type), []).append(resource_type)
+        self._normalized_types = MappingProxyType({key: tuple(sorted(value)) for key, value in normalized.items()})
+
+    def __len__(self) -> int:
+        return len(self._specs)
+
+    @property
+    def resource_types(self) -> frozenset[str]:
+        return frozenset(self._specs)
+
+    def get(self, resource_type: str) -> TerraformResourceSpec | None:
+        return self._specs.get(resource_type)
+
+    def knows_resource_type(self, resource_type: str) -> bool:
+        return resource_type in self._specs
+
+    def resource_type_correction(self, resource_type: str) -> str | None:
+        """Return the documented type name ``resource_type`` was likely meant to be.
+
+        The catalog is a vendored snapshot, so a missing type is not proof of an
+        error.  Only a near-identical documented name is reported, which keeps
+        genuinely new provider resources from being rejected locally.
+        """
+
+        if self.knows_resource_type(resource_type):
+            return None
+        exact = self._normalized_types.get(_normalize(resource_type), ())
+        if exact:
+            return _closest(resource_type, set(exact))
+        tokens = _tokens(resource_type)
+        normalized = _normalize(resource_type)
+        return _closest(
+            resource_type,
+            {
+                candidate
+                for candidate in self._specs
+                if _token_multiset_off_by_one(tokens, _tokens(candidate))
+                or _edit_distance_within_one(normalized, _normalize(candidate))
+            },
+        )
+
+    def argument_correction(self, resource_type: str, argument: str) -> str | None:
+        """Return the documented argument name ``argument`` was likely meant to be."""
+
+        spec = self._specs.get(resource_type)
+        if spec is None or argument in spec.properties or argument in META_ARGUMENTS:
+            return None
+        normalized = _normalize(argument)
+        tokens = _tokens(argument)
+        return _closest(
+            argument,
+            {
+                candidate
+                for candidate in spec.properties
+                if _normalize(candidate) == normalized
+                or _token_multiset_off_by_one(tokens, _tokens(candidate))
+                or _edit_distance_within_one(normalized, _normalize(candidate))
+            },
+        )
+
+
+def _terraform_names(entries: Any) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(entries, list):
+        return names
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        name = entry.get("Terraform")
+        if isinstance(name, str) and name:
+            names.add(name)
+        names |= _terraform_names(entry.get("Properties"))
+    return names
+
+
+def build_catalog(config: Any) -> TerraformNamingCatalog:
+    specs: dict[str, TerraformResourceSpec] = {}
+    if not isinstance(config, list):
+        return TerraformNamingCatalog({})
+    for item in config:
+        if not isinstance(item, Mapping):
+            continue
+        resource_type_names = item.get("ResourceType")
+        if not isinstance(resource_type_names, Mapping):
+            continue
+        resource_type = resource_type_names.get("Terraform")
+        if not isinstance(resource_type, str) or not resource_type:
+            continue
+        ros_resource_type = resource_type_names.get("ROS")
+        properties = _terraform_names(item.get("Properties"))
+        attributes = _terraform_names(item.get("Attributes"))
+        existing = specs.get(resource_type)
+        if existing is not None:
+            properties |= existing.properties
+            attributes |= existing.attributes
+            ros_resource_type = existing.ros_resource_type or ros_resource_type
+        specs[resource_type] = TerraformResourceSpec(
+            resource_type=resource_type,
+            ros_resource_type=ros_resource_type if isinstance(ros_resource_type, str) else None,
+            properties=frozenset(properties),
+            attributes=frozenset(attributes),
+        )
+    return TerraformNamingCatalog(specs)
+
+
+@lru_cache(maxsize=1)
+def load_terraform_naming_catalog() -> TerraformNamingCatalog:
+    # Addressed through the top-level package so importing the catalog does not
+    # pull in the pipeline engine module tree.
+    data_path = files("iac_code").joinpath("pipeline/engine/architecture_metas/config.json")
+    if not data_path.is_file():
+        return TerraformNamingCatalog({})
+    return build_catalog(json.loads(data_path.read_text(encoding="utf-8")))

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/terraform_workspace.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/terraform_workspace.py
@@ -1,0 +1,106 @@
+"""Minimal HCL scanner for ``resource`` blocks inside a ROS Workspace.
+
+Only what naming checks need is extracted: the resource type, the resource name
+and the top-level argument names of each block.  Nested blocks, expressions and
+values are skipped, and a block whose braces do not balance is dropped rather
+than guessed at.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterator
+
+_RESOURCE_HEADER = re.compile(r'(?m)^[ \t]*resource[ \t]+"([^"\r\n]+)"[ \t]+"([^"\r\n]+)"[ \t]*\{')
+_ARGUMENT = re.compile(r"^[ \t]*([A-Za-z_][A-Za-z0-9_-]*)[ \t]*=")
+_HEREDOC_HEADER = re.compile(r"<<[-~]?([A-Za-z_][A-Za-z0-9_]*)")
+
+
+@dataclass(frozen=True)
+class ResourceBlock:
+    resource_type: str
+    resource_name: str
+    arguments: tuple[str, ...]
+
+
+def _blank(text: str) -> str:
+    return "".join("\n" if character == "\n" else " " for character in text)
+
+
+def _scrub(content: str) -> str:
+    """Blank comments, quoted strings and heredocs, keeping every offset stable.
+
+    Offsets stay aligned with the original text so resource headers can be matched
+    on the source while brace balancing and argument scanning use the scrubbed
+    copy, where braces inside strings or comments can no longer mislead.
+    """
+
+    result: list[str] = []
+    index = 0
+    length = len(content)
+    while index < length:
+        character = content[index]
+        if character == "#" or content.startswith("//", index):
+            end = content.find("\n", index)
+            end = length if end == -1 else end
+        elif content.startswith("/*", index):
+            end = content.find("*/", index + 2)
+            end = length if end == -1 else end + 2
+        elif heredoc := _HEREDOC_HEADER.match(content, index):
+            terminator = re.compile(r"(?m)^[ \t]*{}[ \t]*$".format(re.escape(heredoc.group(1))))
+            match = terminator.search(content, heredoc.end())
+            end = length if match is None else match.end()
+        elif character == '"':
+            end = index + 1
+            while end < length and content[end] not in {'"', "\n"}:
+                end += 2 if content[end] == "\\" else 1
+            end = min(end + 1, length)
+        else:
+            result.append(character)
+            index += 1
+            continue
+        result.append(_blank(content[index:end]))
+        index = end
+    return "".join(result)
+
+
+def _block_body(scrubbed: str, open_brace: int) -> str | None:
+    depth = 0
+    for index in range(open_brace, len(scrubbed)):
+        character = scrubbed[index]
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return scrubbed[open_brace + 1 : index]
+    return None
+
+
+def _top_level_arguments(body: str) -> tuple[str, ...]:
+    arguments: list[str] = []
+    depth = 0
+    for line in body.splitlines():
+        if depth == 0 and (match := _ARGUMENT.match(line)):
+            if match.group(1) not in arguments:
+                arguments.append(match.group(1))
+        opened = line.count("{") + line.count("[") + line.count("(")
+        closed = line.count("}") + line.count("]") + line.count(")")
+        depth = max(depth + opened - closed, 0)
+    return tuple(arguments)
+
+
+def iter_resource_blocks(content: str) -> Iterator[ResourceBlock]:
+    scrubbed = _scrub(content)
+    for header in _RESOURCE_HEADER.finditer(content):
+        if scrubbed[header.end() - 1] != "{":
+            continue
+        body = _block_body(scrubbed, header.end() - 1)
+        if body is None:
+            continue
+        yield ResourceBlock(
+            resource_type=header.group(1),
+            resource_name=header.group(2),
+            arguments=_top_level_arguments(body),
+        )

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/validator.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/validator.py
@@ -34,6 +34,10 @@ from iac_code.tools.cloud.aliyun.ros_validation.rules.association_property impor
     AssociationPropertySpecsProvider,
 )
 from iac_code.tools.cloud.aliyun.ros_validation.rules.registry import create_validation_registry
+from iac_code.tools.cloud.aliyun.ros_validation.rules.terraform_naming import (
+    TerraformNamingCatalogProvider,
+    TerraformNamingRule,
+)
 from iac_code.tools.cloud.aliyun.ros_validation.symbols import collect_symbols
 
 PARSED_TEMPLATE = "parsed-template"
@@ -245,12 +249,19 @@ _VALIDATION_REGISTRY = create_validation_registry(
     providers=(
         _ParserProvider(),
         AssociationPropertySpecsProvider(),
+        TerraformNamingCatalogProvider(),
         _SymbolsProvider(),
         _AnalyzerProvider(),
         _LocalsPrecompileProvider(),
         _CountPrecompileProvider(),
     ),
-    rules=(AssociationPropertyRule(), _StructureRule(), _ConditionRule(), _ResourceRule()),
+    rules=(
+        AssociationPropertyRule(),
+        TerraformNamingRule(),
+        _StructureRule(),
+        _ConditionRule(),
+        _ResourceRule(),
+    ),
 )
 
 

--- a/tests/tools/cloud/aliyun/test_ros_terraform_naming.py
+++ b/tests/tools/cloud/aliyun/test_ros_terraform_naming.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import textwrap
+
+from iac_code.tools.cloud.aliyun.ros_validation.model import (
+    MaterializedTemplateSource,
+    RequestValidationContext,
+    Severity,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.terraform_naming import (
+    build_catalog,
+    load_terraform_naming_catalog,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.terraform_workspace import iter_resource_blocks
+from iac_code.tools.cloud.aliyun.ros_validation.validator import validate_ros_template
+
+
+def validate_workspace(files: dict[str, str], *, transform: str = "Aliyun::OpenTofu-v1.8"):
+    workspace = "\n".join(
+        "  {}: |\n{}".format(name, textwrap.indent(textwrap.dedent(content).strip("\n"), " " * 4))
+        for name, content in files.items()
+    )
+    body = "ROSTemplateFormatVersion: 2015-09-01\nTransform: {}\nWorkspace:\n{}\n".format(transform, workspace)
+    return validate_ros_template(
+        MaterializedTemplateSource(body),
+        RequestValidationContext(action="ValidateTemplate"),
+    )
+
+
+def naming_diagnostics(report):
+    return [item for item in report.diagnostics if item.code in {"ROS1130", "ROS1131"}]
+
+
+def test_catalog_covers_documented_alicloud_types() -> None:
+    catalog = load_terraform_naming_catalog()
+
+    assert catalog.knows_resource_type("alicloud_route_entry")
+    assert catalog.knows_resource_type("alicloud_alb_server_group")
+    assert not catalog.knows_resource_type("alicloud_vpc_route_entry")
+
+
+def test_catalog_never_flags_a_documented_name() -> None:
+    catalog = load_terraform_naming_catalog()
+
+    for resource_type in catalog.resource_types:
+        assert catalog.resource_type_correction(resource_type) is None
+        spec = catalog.get(resource_type)
+        assert spec is not None
+        for argument in spec.properties:
+            assert catalog.argument_correction(resource_type, argument) is None
+
+
+def test_catalog_corrects_an_extra_type_token() -> None:
+    catalog = load_terraform_naming_catalog()
+
+    assert catalog.resource_type_correction("alicloud_vpc_route_entry") == "alicloud_route_entry"
+    assert catalog.resource_type_correction("alicloud_alb_server_group_attachment") == "alicloud_alb_server_group"
+
+
+def test_catalog_corrects_separator_and_spelling_mistakes() -> None:
+    catalog = load_terraform_naming_catalog()
+
+    assert catalog.argument_correction("alicloud_route_entry", "next_hop_type") == "nexthop_type"
+    assert catalog.argument_correction("alicloud_route_entry", "next_hop_id") == "nexthop_id"
+    assert catalog.argument_correction("alicloud_route_entry", "destination_cidr_block") == "destination_cidrblock"
+
+
+def test_catalog_stays_silent_for_meta_arguments_and_unknown_names() -> None:
+    catalog = load_terraform_naming_catalog()
+
+    for meta in ("count", "depends_on", "for_each", "lifecycle", "provider"):
+        assert catalog.argument_correction("alicloud_route_entry", meta) is None
+    # A vendored snapshot cannot prove that an unfamiliar name is wrong.
+    assert catalog.resource_type_correction("alicloud_some_unreleased_product_thing") is None
+    assert catalog.argument_correction("alicloud_route_entry", "some_unreleased_argument") is None
+
+
+def test_catalog_merges_duplicate_terraform_types() -> None:
+    catalog = build_catalog(
+        [
+            {
+                "ResourceType": {"ROS": "ALIYUN::ECS::Route", "Terraform": "alicloud_route_entry"},
+                "Properties": [{"ROS": "NextHopId", "Terraform": "nexthop_id"}],
+            },
+            {
+                "ResourceType": {"ROS": None, "Terraform": "alicloud_route_entry"},
+                "Properties": [{"ROS": "RouteTableId", "Terraform": "route_table_id"}],
+            },
+        ]
+    )
+
+    spec = catalog.get("alicloud_route_entry")
+    assert spec is not None
+    assert spec.properties == {"nexthop_id", "route_table_id"}
+    assert spec.ros_resource_type == "ALIYUN::ECS::Route"
+
+
+def test_reports_misnamed_resource_type_with_the_documented_name() -> None:
+    report = validate_workspace(
+        {
+            "main.tf": """
+            resource "alicloud_vpc_route_entry" "default" {
+              route_table_id        = alicloud_vpc.main.route_table_id
+              destination_cidrblock = "0.0.0.0/0"
+            }
+            """
+        }
+    )
+
+    diagnostics = naming_diagnostics(report)
+    assert [item.code for item in diagnostics] == ["ROS1130"]
+    assert diagnostics[0].severity == Severity.ERROR
+    assert diagnostics[0].expected == "alicloud_route_entry"
+    assert diagnostics[0].actual == "alicloud_vpc_route_entry"
+    assert "alicloud_route_entry" in diagnostics[0].suggestion
+
+
+def test_reports_misnamed_arguments_of_a_documented_resource() -> None:
+    report = validate_workspace(
+        {
+            "main.tf": """
+            resource "alicloud_route_entry" "default" {
+              route_table_id        = alicloud_vpc.main.route_table_id
+              destination_cidrblock = "0.0.0.0/0"
+              next_hop_type         = "NatGateway"
+              next_hop_id           = alicloud_nat_gateway.main.id
+            }
+            """
+        }
+    )
+
+    diagnostics = naming_diagnostics(report)
+    assert [item.code for item in diagnostics] == ["ROS1131", "ROS1131"]
+    assert [item.actual for item in diagnostics] == ["next_hop_type", "next_hop_id"]
+    assert [item.expected for item in diagnostics] == ["nexthop_type", "nexthop_id"]
+
+
+def test_accepts_a_correctly_named_terraform_workspace() -> None:
+    report = validate_workspace(
+        {
+            "main.tf": """
+            data "alicloud_zones" "available" {
+              available_resource_creation = "VSwitch"
+            }
+
+            data "alicloud_cen_transit_router_service" "open" {
+              enable = "On"
+            }
+
+            resource "alicloud_vpc" "main" {
+              vpc_name   = "ha-vpc"
+              cidr_block = "10.0.0.0/16"
+              tags = {
+                next_hop_type = "a nested block is not an argument"
+              }
+            }
+
+            resource "alicloud_route_entry" "default" {
+              route_table_id        = alicloud_vpc.main.route_table_id
+              destination_cidrblock = "0.0.0.0/0"
+              nexthop_type          = "NatGateway"
+              nexthop_id            = alicloud_nat_gateway.main.id
+              depends_on            = [alicloud_vpc.main]
+            }
+
+            resource "alicloud_alb_server_group" "web" {
+              server_group_name = "web"
+              vpc_id            = alicloud_vpc.main.id
+              servers {
+                server_id   = alicloud_instance.web.id
+                server_type = "Ecs"
+                port        = 80
+              }
+            }
+            """
+        }
+    )
+
+    assert naming_diagnostics(report) == []
+
+
+def test_ignores_comments_heredocs_and_non_alicloud_providers() -> None:
+    report = validate_workspace(
+        {
+            "main.tf": """
+            # resource "alicloud_vpc_route_entry" "commented" {}
+            /* resource "alicloud_vpc_route_entry" "block_commented" {} */
+
+            resource "random_password" "db" {
+              length      = 16
+              unknown_arg = true
+            }
+
+            resource "alicloud_instance" "web" {
+              instance_type = var.instance_type
+              user_data     = <<-EOT
+                #!/bin/bash
+                next_hop_type = "not terraform source"
+              EOT
+            }
+            """
+        }
+    )
+
+    assert naming_diagnostics(report) == []
+
+
+def test_ignores_non_terraform_and_non_tf_workspace_entries() -> None:
+    ros_native = validate_ros_template(
+        MaterializedTemplateSource(
+            "ROSTemplateFormatVersion: 2015-09-01\n"
+            "Workspace:\n"
+            "  main.tf: |\n"
+            '    resource "alicloud_vpc_route_entry" "default" {}\n'
+        ),
+        RequestValidationContext(action="ValidateTemplate"),
+    )
+    assert naming_diagnostics(ros_native) == []
+
+    non_tf = validate_workspace(
+        {"README.md": 'resource "alicloud_vpc_route_entry" "default" {\n  next_hop_type = "NatGateway"\n}'}
+    )
+    assert naming_diagnostics(non_tf) == []
+
+
+def test_resource_block_scanner_extracts_top_level_arguments_only() -> None:
+    blocks = list(
+        iter_resource_blocks(
+            textwrap.dedent(
+                """
+                resource "alicloud_alb_server_group" "web" {
+                  server_group_name = "web"
+                  health_check_config {
+                    health_check_enabled = false
+                  }
+                  servers {
+                    port = 80
+                  }
+                  tags = {
+                    nested = "value"
+                  }
+                }
+                """
+            )
+        )
+    )
+
+    assert len(blocks) == 1
+    assert blocks[0].resource_type == "alicloud_alb_server_group"
+    assert blocks[0].resource_name == "web"
+    assert blocks[0].arguments == ("server_group_name", "tags")
+
+
+def test_resource_block_scanner_skips_unbalanced_blocks() -> None:
+    assert list(iter_resource_blocks('resource "alicloud_vpc" "main" {\n  vpc_name = "x"\n')) == []


### PR DESCRIPTION
Terraform 模板资源类型/属性命名错配在本地无法被发现，只能等 ValidateTemplate 或部署失败才暴露。

## 根因
`iac_aliyun` skill 的 `references/terraform-template.md` 没有 alicloud provider 的资源类型与属性命名规范，模型只能按 ROS 类型名（`ALIYUN::VPC::RouteEntry`、`NextHopType`）反推 Terraform 名字；生成 `.tf` 后也没有任何本地校验，错配一路带到云端。

## 改动
**校验层**：新增 Terraform 命名本地校验，接入现有 `ros_validation` FactProvider/ValidationRule 框架。
- `terraform_naming.py` — 从已 vendored 的 `pipeline/engine/architecture_metas/config.json`（824 个 `ResourceType.Terraform` 与逐属性 `Properties[].Terraform`）构建命名目录；只读 JSON，不 import pipeline 代码。
- `terraform_workspace.py` — 极简 HCL 扫描器，抽取 `resource "<type>" "<name>"` 的类型名与顶层属性名；注释、字符串、heredoc 先按偏移对齐置空，大括号不配对的块直接丢弃而非猜测。
- `rules/terraform_naming.py` — 仅对 `Transform: Aliyun::Terraform-*`/`Aliyun::OpenTofu-*` 的 `Workspace` 内 `.tf` 生效，报 `ROS1130`（资源类型不存在）/`ROS1131`（资源无该属性），`suggestion` 直接给出正确名字。

**避免误报**：目录是快照，"查不到"不等于"写错了"。只有能证明是拼错才报 ERROR——分隔符归一化后相同（`next_hop_type`→`nexthop_type`）、token 只多/少一个（`alicloud_vpc_route_entry`→`alicloud_route_entry`）、或编辑距离 ≤1。找不到相近正确名一律放行；`count`/`depends_on`/`lifecycle` 等 meta-argument 与 `data` 块不参与判定。已全量自检：824 个已知类型和其全部已知属性零误报。

**提示词层**：`references/terraform-template.md` 新增「资源类型与属性命名规范」（含高频错配对照表、ALB `servers` 块写法、TR `alicloud_cen_transit_router_service` data 源），`SKILL.md` 生成流程与校验失败处理同步引用。selling pipeline 的同名 reference 是 symlink，自动一致。

## 4 项缺陷验证
| 缺陷 | 结果 |
|------|------|
| `alicloud_vpc_route_entry` | ROS1130 → 建议 `alicloud_route_entry` |
| `alicloud_alb_server_group_attachment` | ROS1130 → 建议 `alicloud_alb_server_group` |
| `next_hop_type` / `next_hop_id` | ROS1131 → 建议 `nexthop_type` / `nexthop_id` |
| 缺少 TR 服务开通 data 源 | 提示词规范补齐（无法由命名校验判定缺失） |

## 验证
- 新增 `tests/tools/cloud/aliyun/test_ros_terraform_naming.py` 13 项全部通过
- `tests/tools` + `tests/skills` + `tests/pipeline` 4942 passed / 2 skipped
- `ruff check` 与 `ty check src/` 全部通过；`make translate` 已补齐 zh/es/fr/de/ja/pt 六语翻译
- 唯一失败 `test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` 为改动前既有失败，已在 baseline commit `88ed89c` 的独立 worktree 复现（沙箱代理让 urllib 抛 HTTPError 而非 InvalidURL），与本改动无关
