### PR TITLE
fix(aliyun): validate ROS identifier params before calling the API

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -7012,6 +7012,15 @@ msgid "Provide exactly one of these sources: {}; {} were provided."
 msgstr "Geben Sie genau eine dieser Quellen an: {}; {} wurden bereitgestellt."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+msgid ""
+"Take exactly one source from the page context: TemplateBody/TemplateURL, "
+"TemplateId (not the displayed template name), or TemplateScratchId."
+msgstr ""
+"Verwenden Sie genau eine Quelle aus dem Seitenkontext: "
+"TemplateBody/TemplateURL, TemplateId (nicht der angezeigte Vorlagenname) "
+"oder TemplateScratchId."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
 #, python-brace-format
 msgid "{} provides multiple template sources."
 msgstr "{} bietet mehrere Vorlagenquellen."
@@ -8766,6 +8775,67 @@ msgstr "Eine interne ROS-Validatorkomponente ist fehlgeschlagen."
 #, python-brace-format
 msgid "Component {} raised {}."
 msgstr "Komponente {} erhöhte {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} is missing a required identifier parameter."
+msgstr "{} fehlt ein erforderlicher Identifikator-Parameter."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "Provide exactly one of these identifiers: {fields}; none were provided."
+msgstr ""
+"Geben Sie genau einen dieser Identifikatoren an: {fields}; es wurde "
+"keiner angegeben."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Read one identifier from the page context, using the template page "
+"TemplateId rather than the displayed template name."
+msgstr ""
+"Lesen Sie einen Identifikator aus dem Seitenkontext und verwenden Sie die"
+" TemplateId von der Vorlagenseite anstelle des angezeigten "
+"Vorlagennamens."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} provides multiple mutually exclusive identifier parameters."
+msgstr ""
+"{} gibt mehrere sich gegenseitig ausschließende Identifikator-Parameter "
+"an."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid ""
+"Provide exactly one of these identifiers: {fields}; {provided} were "
+"provided."
+msgstr ""
+"Geben Sie genau einen dieser Identifikatoren an: {fields}; angegeben "
+"wurden {provided}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "Keep only the identifier that matches the target you want to read."
+msgstr "Behalten Sie nur den Identifikator, der zum gewünschten Ziel passt."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "TemplateId is a template display name rather than a ROS identifier."
+msgstr "TemplateId ist ein angezeigter Vorlagenname und kein ROS-Identifikator."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"TemplateId must be the opaque identifier returned by ROS, not the name or"
+" title shown on the page."
+msgstr ""
+"TemplateId muss der von ROS zurückgegebene opake Identifikator sein, "
+"nicht der auf der Seite angezeigte Name oder Titel."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Resolve the real TemplateId first via ros_template ListTemplates filtered"
+" by TemplateName, then retry."
+msgstr ""
+"Ermitteln Sie zuerst die echte TemplateId über ros_template ListTemplates"
+" mit Filter auf TemplateName und versuchen Sie es erneut."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/model.py
 msgid "origin"

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6982,6 +6982,15 @@ msgstr ""
 "proporcionados."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+msgid ""
+"Take exactly one source from the page context: TemplateBody/TemplateURL, "
+"TemplateId (not the displayed template name), or TemplateScratchId."
+msgstr ""
+"Tome exactamente un origen del contexto de la página: "
+"TemplateBody/TemplateURL, TemplateId (no el nombre de plantilla que se "
+"muestra) o TemplateScratchId."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
 #, python-brace-format
 msgid "{} provides multiple template sources."
 msgstr "{} proporciona múltiples fuentes de plantilla."
@@ -8698,6 +8707,66 @@ msgstr "Un componente de validación local ROS falló."
 #, python-brace-format
 msgid "Component {} raised {}."
 msgstr "Componente {} elevado {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} is missing a required identifier parameter."
+msgstr "{} carece de un parámetro identificador obligatorio."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "Provide exactly one of these identifiers: {fields}; none were provided."
+msgstr ""
+"Indique exactamente uno de estos identificadores: {fields}; no se indicó "
+"ninguno."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Read one identifier from the page context, using the template page "
+"TemplateId rather than the displayed template name."
+msgstr ""
+"Lea un identificador del contexto de la página y use el TemplateId de la "
+"página de la plantilla en lugar del nombre de plantilla que se muestra."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} provides multiple mutually exclusive identifier parameters."
+msgstr "{} indica varios parámetros identificadores mutuamente excluyentes."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid ""
+"Provide exactly one of these identifiers: {fields}; {provided} were "
+"provided."
+msgstr ""
+"Indique exactamente uno de estos identificadores: {fields}; se indicaron "
+"{provided}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "Keep only the identifier that matches the target you want to read."
+msgstr "Conserve solo el identificador que corresponda al destino que quiere leer."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "TemplateId is a template display name rather than a ROS identifier."
+msgstr ""
+"TemplateId es un nombre de plantilla visible en lugar de un identificador"
+" de ROS."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"TemplateId must be the opaque identifier returned by ROS, not the name or"
+" title shown on the page."
+msgstr ""
+"TemplateId debe ser el identificador opaco que devuelve ROS, no el nombre"
+" ni el título que se muestra en la página."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Resolve the real TemplateId first via ros_template ListTemplates filtered"
+" by TemplateName, then retry."
+msgstr ""
+"Resuelva primero el TemplateId real con ros_template ListTemplates "
+"filtrado por TemplateName y vuelva a intentarlo."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/model.py
 msgid "origin"

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6993,6 +6993,15 @@ msgid "Provide exactly one of these sources: {}; {} were provided."
 msgstr "Fournissez exactement une de ces sources : {}; {} ont été fournies."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+msgid ""
+"Take exactly one source from the page context: TemplateBody/TemplateURL, "
+"TemplateId (not the displayed template name), or TemplateScratchId."
+msgstr ""
+"Prenez exactement une source dans le contexte de la page : "
+"TemplateBody/TemplateURL, TemplateId (et non le nom de modèle affiché) ou"
+" TemplateScratchId."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
 #, python-brace-format
 msgid "{} provides multiple template sources."
 msgstr "{} fournit plusieurs sources de modèles."
@@ -8740,6 +8749,66 @@ msgstr "Un composant interne ROS local-validateur a échoué."
 #, python-brace-format
 msgid "Component {} raised {}."
 msgstr "Composant {} soulevé {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} is missing a required identifier parameter."
+msgstr "{} ne comporte pas de paramètre d'identifiant obligatoire."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "Provide exactly one of these identifiers: {fields}; none were provided."
+msgstr ""
+"Fournissez exactement un de ces identifiants : {fields} ; aucun n'a été "
+"fourni."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Read one identifier from the page context, using the template page "
+"TemplateId rather than the displayed template name."
+msgstr ""
+"Lisez un identifiant depuis le contexte de la page et utilisez le "
+"TemplateId de la page du modèle plutôt que le nom de modèle affiché."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} provides multiple mutually exclusive identifier parameters."
+msgstr "{} fournit plusieurs paramètres d'identifiant mutuellement exclusifs."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid ""
+"Provide exactly one of these identifiers: {fields}; {provided} were "
+"provided."
+msgstr ""
+"Fournissez exactement un de ces identifiants : {fields} ; {provided} ont "
+"été fournis."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "Keep only the identifier that matches the target you want to read."
+msgstr ""
+"Ne conservez que l'identifiant correspondant à la cible que vous voulez "
+"lire."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "TemplateId is a template display name rather than a ROS identifier."
+msgstr "TemplateId est un nom de modèle affiché et non un identifiant ROS."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"TemplateId must be the opaque identifier returned by ROS, not the name or"
+" title shown on the page."
+msgstr ""
+"TemplateId doit être l'identifiant opaque renvoyé par ROS, et non le nom "
+"ou le titre affiché sur la page."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Resolve the real TemplateId first via ros_template ListTemplates filtered"
+" by TemplateName, then retry."
+msgstr ""
+"Résolvez d'abord le véritable TemplateId via ros_template ListTemplates "
+"filtré par TemplateName, puis réessayez."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/model.py
 msgid "origin"

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -6586,6 +6586,15 @@ msgid "Provide exactly one of these sources: {}; {} were provided."
 msgstr "これらのソースの1つを正確に提供:{};{}は提供されました。"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+msgid ""
+"Take exactly one source from the page context: TemplateBody/TemplateURL, "
+"TemplateId (not the displayed template name), or TemplateScratchId."
+msgstr ""
+"ページコンテキストからソースを 1 つだけ指定してください: "
+"TemplateBody/TemplateURL、TemplateId（表示されているテンプレート名ではありません）、または "
+"TemplateScratchId。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
 #, python-brace-format
 msgid "{} provides multiple template sources."
 msgstr "{}は複数のテンプレートソースを提供します。"
@@ -8104,6 +8113,56 @@ msgstr "内部のROSローカルvalidatorコンポーネントは失敗しまし
 #, python-brace-format
 msgid "Component {} raised {}."
 msgstr "コンポーネント{}は{}を上げました。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} is missing a required identifier parameter."
+msgstr "{} に必須の識別子パラメータがありません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "Provide exactly one of these identifiers: {fields}; none were provided."
+msgstr "次の識別子のいずれか 1 つだけを指定してください: {fields}。現在は 1 つも指定されていません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Read one identifier from the page context, using the template page "
+"TemplateId rather than the displayed template name."
+msgstr "ページコンテキストから識別子を 1 つ読み取り、表示されているテンプレート名ではなくテンプレートページの TemplateId を使用してください。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} provides multiple mutually exclusive identifier parameters."
+msgstr "{} に相互排他的な識別子パラメータが複数指定されています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid ""
+"Provide exactly one of these identifiers: {fields}; {provided} were "
+"provided."
+msgstr "次の識別子のいずれか 1 つだけを指定してください: {fields}。現在は {provided} が指定されています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "Keep only the identifier that matches the target you want to read."
+msgstr "読み取りたい対象に一致する識別子だけを残してください。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "TemplateId is a template display name rather than a ROS identifier."
+msgstr "TemplateId が ROS の識別子ではなく、表示用のテンプレート名になっています。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"TemplateId must be the opaque identifier returned by ROS, not the name or"
+" title shown on the page."
+msgstr "TemplateId は ROS が返す不透明な識別子である必要があり、ページに表示される名前やタイトルではありません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Resolve the real TemplateId first via ros_template ListTemplates filtered"
+" by TemplateName, then retry."
+msgstr ""
+"まず ros_template ListTemplates を TemplateName で絞り込んで実際の TemplateId "
+"を解決し、再試行してください。"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/model.py
 msgid "origin"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6925,6 +6925,15 @@ msgid "Provide exactly one of these sources: {}; {} were provided."
 msgstr "Fornecer exatamente uma dessas fontes: {}; {} foram fornecidos."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+msgid ""
+"Take exactly one source from the page context: TemplateBody/TemplateURL, "
+"TemplateId (not the displayed template name), or TemplateScratchId."
+msgstr ""
+"Use exatamente uma origem do contexto da página: "
+"TemplateBody/TemplateURL, TemplateId (não o nome de modelo exibido) ou "
+"TemplateScratchId."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
 #, python-brace-format
 msgid "{} provides multiple template sources."
 msgstr "O {} fornece várias fontes de modelos."
@@ -8614,6 +8623,66 @@ msgstr "Um componente interno de validação local do ROS falhou."
 #, python-brace-format
 msgid "Component {} raised {}."
 msgstr "Componente {} aumentado {}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} is missing a required identifier parameter."
+msgstr "{} não tem um parâmetro identificador obrigatório."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "Provide exactly one of these identifiers: {fields}; none were provided."
+msgstr ""
+"Forneça exatamente um destes identificadores: {fields}; nenhum foi "
+"fornecido."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Read one identifier from the page context, using the template page "
+"TemplateId rather than the displayed template name."
+msgstr ""
+"Leia um identificador do contexto da página e use o TemplateId da página "
+"do modelo em vez do nome de modelo exibido."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} provides multiple mutually exclusive identifier parameters."
+msgstr "{} fornece vários parâmetros identificadores mutuamente exclusivos."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid ""
+"Provide exactly one of these identifiers: {fields}; {provided} were "
+"provided."
+msgstr ""
+"Forneça exatamente um destes identificadores: {fields}; foram fornecidos "
+"{provided}."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "Keep only the identifier that matches the target you want to read."
+msgstr ""
+"Mantenha apenas o identificador que corresponde ao destino que você quer "
+"ler."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "TemplateId is a template display name rather than a ROS identifier."
+msgstr "TemplateId é um nome de modelo exibido e não um identificador do ROS."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"TemplateId must be the opaque identifier returned by ROS, not the name or"
+" title shown on the page."
+msgstr ""
+"TemplateId deve ser o identificador opaco retornado pelo ROS, e não o "
+"nome ou título exibido na página."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Resolve the real TemplateId first via ros_template ListTemplates filtered"
+" by TemplateName, then retry."
+msgstr ""
+"Resolva primeiro o TemplateId real usando ros_template ListTemplates "
+"filtrado por TemplateName e tente novamente."
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/model.py
 msgid "origin"

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -6425,6 +6425,14 @@ msgid "Provide exactly one of these sources: {}; {} were provided."
 msgstr "必须且只能提供以下来源之一：{}；当前提供了 {} 个。"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+msgid ""
+"Take exactly one source from the page context: TemplateBody/TemplateURL, "
+"TemplateId (not the displayed template name), or TemplateScratchId."
+msgstr ""
+"请从页面上下文中提供且仅提供一个来源：TemplateBody/TemplateURL、TemplateId（不是显示的模板名称）或 "
+"TemplateScratchId。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
 #, python-brace-format
 msgid "{} provides multiple template sources."
 msgstr "{} 同时提供了多个模板来源。"
@@ -7921,6 +7929,54 @@ msgstr "ROS 本地校验器内部组件执行失败。"
 #, python-brace-format
 msgid "Component {} raised {}."
 msgstr "组件 {} 发生 {}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} is missing a required identifier parameter."
+msgstr "{} 缺少必填的标识参数。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "Provide exactly one of these identifiers: {fields}; none were provided."
+msgstr "请在这些标识中提供且仅提供一个：{fields}；当前一个都没有提供。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Read one identifier from the page context, using the template page "
+"TemplateId rather than the displayed template name."
+msgstr "请从页面上下文中读取一个标识，并使用模板页面上的 TemplateId，而不是显示的模板名称。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid "{} provides multiple mutually exclusive identifier parameters."
+msgstr "{} 提供了多个互斥的标识参数。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+#, python-brace-format
+msgid ""
+"Provide exactly one of these identifiers: {fields}; {provided} were "
+"provided."
+msgstr "请在这些标识中提供且仅提供一个：{fields}；当前提供了 {provided}。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "Keep only the identifier that matches the target you want to read."
+msgstr "只保留与你要读取的目标相对应的那个标识。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid "TemplateId is a template display name rather than a ROS identifier."
+msgstr "TemplateId 是模板的显示名称，而不是 ROS 标识。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"TemplateId must be the opaque identifier returned by ROS, not the name or"
+" title shown on the page."
+msgstr "TemplateId 必须是 ROS 返回的不透明标识，而不是页面上显示的名称或标题。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+msgid ""
+"Resolve the real TemplateId first via ros_template ListTemplates filtered"
+" by TemplateName, then retry."
+msgstr "请先通过 ros_template ListTemplates 按 TemplateName 过滤解析出真实的 TemplateId，然后重试。"
 
 #: src/iac_code/tools/cloud/aliyun/ros_validation/model.py
 msgid "origin"

--- a/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
@@ -199,6 +199,20 @@ auto_trigger:
 
 **例外：ROS API 的 Parameters 参数**支持直接传字典格式 `{"参数名": "参数值"}`，工具会自动展开为 `Parameters.<N>.ParameterKey / Parameters.<N>.ParameterValue` 平铺格式。其他 RPC 参数仍需按上述规则手动平铺。
 
+### 调用前先从页面上下文取齐必填标识参数
+
+**不要靠错误码驱动重试。** 调用前先确认必填参数已齐备：
+
+- `GetTemplate` 必须且只能传 `TemplateId / StackId / ChangeSetId / StackGroupName` 中的**一个**。一个都不传会返回 `MissingParameter`。
+- `GetTemplateEstimateCost` 必须且只能传 `TemplateBody / TemplateURL / TemplateId / TemplateScratchId` 中的**一个**。一个都不传会触发 ROS 本地校验 `ROS1201 no source location`。
+- 优先从当前 ROS 页面上下文提取这些标识：模板详情页取 `TemplateId`，资源栈详情页取 `StackId`，变更集详情页取 `ChangeSetId`，资源栈组页取 `StackGroupName`。
+
+### TemplateId 不是模板展示名称
+
+`TemplateId` 是 ROS 返回的不透明标识（如 `5ecd1e10-b0e9-4389-a565-e4c48b1c1234`），**不是**页面上显示的模板名称或标题。把名称/标题当作 `TemplateId` 传入会返回 `InvalidParameter`。
+
+只有模板名称时，先用 `ros_template` 的 `ListTemplates`（可按 `TemplateName` 过滤）解析出真实 `TemplateId`，再发起调用。
+
 ## 错误处理
 
 ### 校验失败

--- a/src/iac_code/tools/cloud/aliyun/hooks/ros_identifiers.py
+++ b/src/iac_code/tools/cloud/aliyun/hooks/ros_identifiers.py
@@ -1,0 +1,36 @@
+"""Pre-call hook for ROS actions selected by mutually exclusive identifiers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from iac_code.tools.base import ToolContext
+from iac_code.tools.cloud.aliyun.api_hooks import before_call
+from iac_code.tools.cloud.aliyun.ros_validation.identifier_policy import (
+    IDENTIFIER_SOURCE_ACTIONS,
+    validate_identifier_request,
+    validate_template_id_shape,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.model import ValidationReport
+from iac_code.tools.cloud.aliyun.ros_validation.outcome import (
+    RosPreflightOutcome,
+    outcome_from_report,
+)
+
+
+@before_call("ros", list(IDENTIFIER_SOURCE_ACTIONS))
+def check_identifiers(
+    product: str,
+    action: str,
+    params: dict[str, Any],
+    *,
+    context: ToolContext | None = None,
+) -> RosPreflightOutcome | None:
+    del product, context
+    diagnostics = [
+        *validate_identifier_request(action, params),
+        *validate_template_id_shape(action, params),
+    ]
+    if not diagnostics:
+        return None
+    return outcome_from_report(ValidationReport.build(diagnostics, analysis_incomplete=False))

--- a/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
+++ b/src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
@@ -16,6 +16,7 @@ from iac_code.tools.cloud.aliyun.ros_validation.action_policy import (
     TEMPLATE_BODY_ACTIONS,
     validate_action_request,
 )
+from iac_code.tools.cloud.aliyun.ros_validation.identifier_policy import validate_template_id_shape
 from iac_code.tools.cloud.aliyun.ros_validation.model import (
     Category,
     MaterializedTemplateSource,
@@ -149,6 +150,7 @@ def check_template(
     if action_policy is None:
         return None
     diagnostics = list(request_diagnostics)
+    diagnostics.extend(validate_template_id_shape(action, params))
     analysis_incomplete = False
     if active_body:
         template_body = params.get("TemplateBody")

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/action_policy.py
@@ -114,13 +114,14 @@ def _present(params: Mapping[str, Any], field: str) -> bool:
     return value is not None and value != "" and value != []
 
 
-def _request_error(action: str, summary: str, detail: str, *stable: str) -> Diagnostic:
+def _request_error(action: str, summary: str, detail: str, *stable: str, suggestion: str | None = None) -> Diagnostic:
     return make_diagnostic(
         code="ROS1201",
         severity=Severity.ERROR,
         category=Category.COMPATIBILITY,
         summary=summary,
         detail=detail,
+        suggestion=suggestion,
         stable_args=(action, *stable),
         subject="template-source",
     )
@@ -510,6 +511,10 @@ def validate_action_request(
                     ", ".join(sorted(policy.allowed_fields)), len(sources)
                 ),
                 str(len(sources)),
+                suggestion=_(
+                    "Take exactly one source from the page context: TemplateBody/TemplateURL, TemplateId (not the "
+                    "displayed template name), or TemplateScratchId."
+                ),
             )
         )
     elif policy.cardinality == Cardinality.ZERO_OR_ONE and len(sources) > 1:

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/identifier_policy.py
@@ -1,0 +1,123 @@
+"""Identifier-source policies for ROS actions that carry no TemplateBody field.
+
+The locked ``ros_template_body_action_policies.json`` registry only covers actions
+whose SDK request declares ``template_body``. Read-only actions such as
+``GetTemplate`` select their target through mutually exclusive identifier
+parameters instead, so they are absent from that registry and previously reached
+the ROS API without any local pre-call validation. This module adds an
+independent policy layer for those actions and keeps the locked TemplateBody
+registry, including its ``request_fields_sha256`` evidence, untouched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from iac_code.i18n import _
+from iac_code.tools.cloud.aliyun.ros_validation.model import (
+    Category,
+    Diagnostic,
+    Severity,
+    make_diagnostic,
+)
+
+
+@dataclass(frozen=True)
+class IdentifierPolicy:
+    """Exactly-one identifier contract for one ROS action."""
+
+    action: str
+    identifier_fields: frozenset[str]
+
+
+IDENTIFIER_POLICIES: Mapping[str, IdentifierPolicy] = MappingProxyType(
+    {
+        "GetTemplate": IdentifierPolicy(
+            action="GetTemplate",
+            identifier_fields=frozenset({"ChangeSetId", "StackGroupName", "StackId", "TemplateId"}),
+        ),
+    }
+)
+
+IDENTIFIER_SOURCE_ACTIONS = tuple(IDENTIFIER_POLICIES)
+
+
+def _present(params: Mapping[str, Any], field: str) -> bool:
+    value = params.get(field)
+    return value is not None and value != "" and value != []
+
+
+def _identifier_error(action: str, summary: str, detail: str, suggestion: str, *stable: str) -> Diagnostic:
+    return make_diagnostic(
+        code="ROS1201",
+        severity=Severity.ERROR,
+        category=Category.COMPATIBILITY,
+        summary=summary,
+        detail=detail,
+        suggestion=suggestion,
+        stable_args=(action, *stable),
+        subject="identifier-source",
+    )
+
+
+def validate_identifier_request(action: str, params: Mapping[str, Any]) -> list[Diagnostic]:
+    """Return ROS1201 diagnostics when identifier-source cardinality is violated."""
+
+    policy = IDENTIFIER_POLICIES.get(action)
+    if policy is None:
+        return []
+    present = sorted(field for field in policy.identifier_fields if _present(params, field))
+    if len(present) == 1:
+        return []
+    fields = ", ".join(sorted(policy.identifier_fields))
+    if not present:
+        return [
+            _identifier_error(
+                action,
+                _("{} is missing a required identifier parameter.").format(action),
+                _("Provide exactly one of these identifiers: {fields}; none were provided.").format(fields=fields),
+                _(
+                    "Read one identifier from the page context, using the template page TemplateId rather than "
+                    "the displayed template name."
+                ),
+                "missing-identifier",
+            )
+        ]
+    return [
+        _identifier_error(
+            action,
+            _("{} provides multiple mutually exclusive identifier parameters.").format(action),
+            _("Provide exactly one of these identifiers: {fields}; {provided} were provided.").format(
+                fields=fields, provided=", ".join(present)
+            ),
+            _("Keep only the identifier that matches the target you want to read."),
+            "conflicting-identifier",
+            str(len(present)),
+        )
+    ]
+
+
+def validate_template_id_shape(action: str, params: Mapping[str, Any]) -> list[Diagnostic]:
+    """Distinguish a real ROS TemplateId from a template display name or title."""
+
+    value = params.get("TemplateId")
+    if not isinstance(value, str) or not value:
+        return []
+    # ROS identifiers are opaque ASCII tokens. Whitespace or non-ASCII characters
+    # mean the caller passed a template display name or title instead.
+    if not any(character.isspace() for character in value) and value.isascii():
+        return []
+    return [
+        _identifier_error(
+            action,
+            _("TemplateId is a template display name rather than a ROS identifier."),
+            _("TemplateId must be the opaque identifier returned by ROS, not the name or title shown on the page."),
+            _(
+                "Resolve the real TemplateId first via ros_template ListTemplates filtered by TemplateName, "
+                "then retry."
+            ),
+            "template-id-is-display-name",
+        )
+    ]

--- a/tests/tools/cloud/aliyun/test_ros_identifier_policy.py
+++ b/tests/tools/cloud/aliyun/test_ros_identifier_policy.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from iac_code.tools.cloud.aliyun.hooks.ros_identifiers import check_identifiers
+from iac_code.tools.cloud.aliyun.ros_validation.action_policy import validate_action_request
+from iac_code.tools.cloud.aliyun.ros_validation.identifier_policy import (
+    IDENTIFIER_POLICIES,
+    validate_identifier_request,
+    validate_template_id_shape,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.model import Severity
+
+
+def test_get_template_is_covered_by_the_identifier_policy_layer() -> None:
+    policy = IDENTIFIER_POLICIES["GetTemplate"]
+    assert policy.identifier_fields == frozenset({"ChangeSetId", "StackGroupName", "StackId", "TemplateId"})
+
+
+def test_get_template_without_any_identifier_is_blocked_locally() -> None:
+    diagnostics = validate_identifier_request("GetTemplate", {})
+    assert [item.code for item in diagnostics] == ["ROS1201"]
+    diagnostic = diagnostics[0]
+    assert diagnostic.severity == Severity.ERROR
+    assert "TemplateId" in diagnostic.detail
+    assert "StackId" in diagnostic.detail
+    assert diagnostic.suggestion is not None
+    assert "page context" in diagnostic.suggestion
+    assert "displayed template name" in diagnostic.suggestion
+
+
+def test_get_template_with_exactly_one_identifier_passes() -> None:
+    assert validate_identifier_request("GetTemplate", {"StackId": "stack-1"}) == []
+
+
+def test_get_template_with_conflicting_identifiers_is_blocked_locally() -> None:
+    diagnostics = validate_identifier_request(
+        "GetTemplate",
+        {"StackId": "stack-1", "TemplateId": "5ecd1e10-b0e9-4389-a565-e4c48b1c1234"},
+    )
+    assert [item.code for item in diagnostics] == ["ROS1201"]
+    assert diagnostics[0].severity == Severity.ERROR
+
+
+def test_template_display_name_used_as_template_id_is_blocked_locally() -> None:
+    diagnostics = validate_template_id_shape("GetTemplate", {"TemplateId": "My Web Stack"})
+    assert [item.code for item in diagnostics] == ["ROS1201"]
+    diagnostic = diagnostics[0]
+    assert diagnostic.severity == Severity.ERROR
+    assert diagnostic.suggestion is not None
+    assert "ListTemplates" in diagnostic.suggestion
+
+    non_ascii = validate_template_id_shape("GetTemplate", {"TemplateId": "网站模板"})
+    assert [item.severity for item in non_ascii] == [Severity.ERROR]
+
+
+def test_opaque_template_id_values_are_accepted() -> None:
+    assert validate_template_id_shape("GetTemplate", {"TemplateId": "5ecd1e10-b0e9-4389-a565-e4c48b1c1234"}) == []
+    assert validate_template_id_shape("GetTemplate", {"TemplateId": "template-id"}) == []
+
+
+def test_identifier_hook_blocks_get_template_and_stays_silent_when_valid() -> None:
+    outcome = check_identifiers("ros", "GetTemplate", {})
+    assert outcome is not None
+    assert outcome.blocking_result is not None
+    assert outcome.blocking_result.is_error
+
+    assert check_identifiers("ros", "GetTemplate", {"StackId": "stack-1"}) is None
+
+
+def test_get_template_estimate_cost_without_source_reports_actionable_suggestion() -> None:
+    _, diagnostics, _active = validate_action_request("GetTemplateEstimateCost", {})
+    errors = [item for item in diagnostics if item.severity == Severity.ERROR]
+    assert [item.code for item in errors] == ["ROS1201"]
+    suggestion = errors[0].suggestion
+    assert suggestion is not None
+    assert "TemplateURL" in suggestion
+    assert "TemplateScratchId" in suggestion
+    assert "displayed template name" in suggestion
+
+
+def test_template_body_actions_also_reject_a_display_name_template_id() -> None:
+    from iac_code.tools.cloud.aliyun.hooks.ros_validate import check_template
+
+    outcome = check_template("ros", "GetTemplateEstimateCost", {"TemplateId": "My Web Stack"})
+    assert outcome is not None
+    assert outcome.blocking_result is not None
+    assert any(
+        item["code"] == "ROS1201" and "display name" in item["summary"]
+        for item in outcome.report.to_dict()["diagnostics"]
+    )


### PR DESCRIPTION
## 问题

`aliyun_api` 调用 ROS `GetTemplate` 时，本地没有任何前置校验：

- 缺失标识参数时，只能由服务端返回 HTTP 400 `MissingParameter`
- 把模板展示名称当作 `TemplateId` 传入时，只能由服务端返回 HTTP 400 `InvalidParameter`

两者都只能靠对着 API 反复重试来恢复，每次错误浪费一轮工具调用。

## 根因

`ACTION_POLICIES` 由 `data/ros_template_body_action_policies.json` 装载，而该 fixture 的生成口径被 `test_ros_validation_registry.py` 锁定为「SDK Request 声明 `template_body` 字段」：

```python
if "template_body" not in request_fields:
    continue
```

`GetTemplateRequest` 的字段是 `change_set_id / stack_group_name / stack_id / template_id / template_stage / template_version / include_permission / include_tags / region_id`，**不含 `template_body`**，因此 `GetTemplate` 被整体排除在这 18 个 action 之外。`hooks/ros_validate.py` 只对 `TEMPLATE_BODY_ACTIONS` 注册 `@before_call`，`GetTemplate` 于是零校验直达 ROS API。

同时 `tools/cloud/aliyun/*.py` 中对 `TemplateId` 没有任何取值判别，`api_contract.py` 仅按 OpenMeta schema 校验类型，展示名称在本地完全合法。

## 改动

新增**独立的**标识来源策略层，而不是扩大既有注册表口径，因此被锁定的 TemplateBody fixture 及其 `request_fields_sha256` 证据哈希保持不变：

- `ros_validation/identifier_policy.py`：`GetTemplate` 必须且只能提供 `TemplateId / StackId / ChangeSetId / StackGroupName` 之一，缺失或冲突时本地返回 `ROS1201`，并提示从页面上下文读取
- `hooks/ros_identifiers.py`：经 `api_hooks` 自动发现机制注册，走既有 `RosPreflightOutcome` 阻塞链路
- `TemplateId` 展示名称判别：仅当取值含空白或非 ASCII 字符（**不可能**是 ROS 标识）时报错，并提示先用 `ros_template ListTemplates` 按 `TemplateName` 解析真实 `TemplateId`；该判别同时复用到 `hooks/ros_validate.py`，使 `GetTemplateEstimateCost` 等路径一并受益
- `action_policy.py`：为既有 `EXACTLY_ONE` 模板来源错误补充可执行 `suggestion`，让 `GetTemplateEstimateCost` 的 `ROS1201` 说明各来源从哪里取，而非只陈述基数规则
- `skills/bundled/iac_aliyun/SKILL.md`：新增调用前必填标识参数约定，并显式写明 `TemplateId` ≠ 模板展示名称
- 补齐 `zh/es/fr/de/ja/pt` 六个 locale 的翻译

## 验证

- 新增 `tests/tools/cloud/aliyun/test_ros_identifier_policy.py`（9 条）全部通过，不触网、不依赖真实云账号
- `tests/tools/cloud/aliyun/` 2309 条全部通过
- `make lint`（ruff + ty）全部通过
- `make test`：14343 passed / 3 failed / 4 skipped。3 条失败已在父提交 `88ed89c` 上逐条复现，属环境预置缺陷、与本次改动无关（`zh` 既有 `{n} day{s} ago` 的 `{s:.0}` 复数写法触发 msgfmt 检查，以及两条 pipeline 用例）。i18n 相关失败由 13 条降至 1 条，无新增。

## 修复效果

复现证据 Session `513d98fe6231473ab168fa37a2fa3552` 与 `0e2fdd13f1e44efaa10946f3e4e6d9a9` 中的三类入参缺陷，现在都在**发起 API 调用之前**被本地拦截，并给出可执行的修复指引。
