### PR TITLE
feat(pipeline): checkpoint candidate lookups and expose handoff progress

### DIFF
--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -58,7 +58,11 @@ from iac_code.pipeline import create_pipeline, discover_pipelines
 from iac_code.pipeline.config import get_pipeline_name, is_selling_review_step_enabled
 from iac_code.pipeline.engine.cleanup import CleanupLedger
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
-from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_outcome_from_completed_event
+from iac_code.pipeline.engine.handoff import (
+    build_handoff_summary,
+    candidate_progress_from_execution,
+    terminal_outcome_from_completed_event,
+)
 from iac_code.pipeline.engine.loader import _resolve_feature_flags, load_pipeline_dir
 from iac_code.pipeline.engine.prerequisites import inspect_prerequisites
 from iac_code.pipeline.engine.public_errors import public_error
@@ -3912,6 +3916,11 @@ def _waiting_input_cancel_handoff_event(
         outcome="canceled",
         context_snapshot=context_snapshot,
         include_fields=include_fields,
+        candidate_progress=_candidate_progress_from_sidecar(
+            cwd=cwd,
+            session_id=session_id,
+            loaded_pipeline=loaded_pipeline,
+        ),
     )
     data: dict[str, Any] = {
         "action": "switch_to_normal",
@@ -3954,6 +3963,28 @@ def _flat_pipeline_context_from_sidecar(*, cwd: str, session_id: str) -> dict[st
     if not isinstance(context_snapshot, dict):
         return {}
     return _flatten_pipeline_context_snapshot(context_snapshot)
+
+
+def _candidate_progress_from_sidecar(*, cwd: str, session_id: str, loaded_pipeline: Any) -> list[dict[str, Any]]:
+    """Candidate sub-step progress for a cancel handoff, read from the pipeline sidecar.
+
+    Cancelling during ``evaluate_candidates`` leaves the per-candidate progress only
+    in sidecar metadata, so the flat context snapshot alone cannot tell normal chat
+    which candidate sub-steps already finished.
+    """
+    try:
+        session = PipelineSession(SessionStorage().session_dir(cwd, session_id) / "pipeline")
+        execution = session.load_execution_metadata()
+    except Exception:
+        logger.warning("Failed to load candidate progress for A2A cancel handoff", exc_info=True)
+        return []
+    if not isinstance(execution, dict):
+        return []
+    sub_pipeline_name = execution.get("sub_pipeline_name")
+    sub_pipelines = getattr(loaded_pipeline, "sub_pipelines", {})
+    sub_spec = sub_pipelines.get(sub_pipeline_name) if isinstance(sub_pipelines, dict) else None
+    sub_step_ids = [str(step.step_id) for step in getattr(sub_spec, "steps", [])] if sub_spec is not None else []
+    return candidate_progress_from_execution(execution, sub_step_ids)
 
 
 def _flat_pipeline_context_from_a2a_snapshot(snapshot: dict[str, Any] | None, loaded_pipeline: Any) -> dict[str, Any]:

--- a/src/iac_code/pipeline/engine/candidate_tool_cache.py
+++ b/src/iac_code/pipeline/engine/candidate_tool_cache.py
@@ -1,0 +1,155 @@
+"""Idempotent read-only tool result cache for candidate sub-pipelines.
+
+Candidate sub-pipelines (``evaluate_candidates``) spend most of their time on
+read-only lookups such as ROS resource type schemas (``aliyun_api``) and
+reference files (``read_file``). Sidecar checkpoints are only written at
+sub-step boundaries, so an interrupt in the middle of a sub-step used to
+discard every lookup done so far and force the resumed run to repeat them.
+
+This module keys successful read-only tool results by
+``(candidate_index, sub_step_id, tool_name, normalized_input)`` so a resumed run
+can replay them as ``precompleted_tools`` instead of calling the tool again.
+Only read-only tools are cached — anything with side effects must re-run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+CACHEABLE_TOOL_NAMES = frozenset(
+    {
+        "aliyun_api",
+        "aliyun_api_doc",
+        "aliyun_doc_search",
+        "read_file",
+        "grep",
+        "glob",
+        "list_files",
+        "ros_get_template_parameter_constraints",
+        "ros_estimate_template_cost",
+        "ros_preview_template",
+    }
+)
+
+
+def _canonical_input(tool_input: Any) -> Any:
+    if isinstance(tool_input, dict):
+        return {str(key): _canonical_input(tool_input[key]) for key in sorted(tool_input, key=str)}
+    if isinstance(tool_input, list):
+        return [_canonical_input(item) for item in tool_input]
+    return tool_input
+
+
+def input_fingerprint(tool_input: dict[str, Any] | None) -> str:
+    """Return a stable digest for a tool invocation's parameters."""
+    canonical = json.dumps(_canonical_input(tool_input or {}), ensure_ascii=False, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def is_cacheable_tool(tool_name: str, tool_input: dict[str, Any] | None = None) -> bool:
+    """Whether a tool result may be replayed on resume without re-calling it."""
+    if tool_name not in CACHEABLE_TOOL_NAMES:
+        return False
+    if tool_name == "aliyun_api":
+        # Only read-only Aliyun actions are safe to replay; writes must re-run.
+        return _is_read_only_aliyun_action(tool_input)
+    return True
+
+
+def _is_read_only_aliyun_action(tool_input: dict[str, Any] | None) -> bool:
+    action = (tool_input or {}).get("action")
+    if not isinstance(action, str) or not action:
+        return False
+    return action.startswith(("Describe", "Get", "List", "Query", "Check", "Preview", "Validate"))
+
+
+class CandidateToolResultCache:
+    """Per-candidate cache of replayable read-only tool results."""
+
+    def __init__(self, entries: dict[str, dict[str, Any]] | None = None) -> None:
+        self._entries: dict[str, dict[str, Any]] = dict(entries or {})
+
+    @staticmethod
+    def _entry_key(candidate_index: int, sub_step_id: str, tool_name: str, fingerprint: str) -> str:
+        return f"{candidate_index}|{sub_step_id}|{tool_name}|{fingerprint}"
+
+    def record(
+        self,
+        *,
+        candidate_index: int,
+        sub_step_id: str,
+        tool_name: str,
+        tool_input: dict[str, Any] | None,
+        result: Any,
+    ) -> bool:
+        """Cache one successful read-only tool result. Returns whether it was stored."""
+        if not is_cacheable_tool(tool_name, tool_input):
+            return False
+        if not isinstance(result, dict):
+            return False
+        fingerprint = input_fingerprint(tool_input)
+        key = self._entry_key(candidate_index, sub_step_id, tool_name, fingerprint)
+        self._entries[key] = {
+            "candidate_index": candidate_index,
+            "sub_step_id": sub_step_id,
+            "tool_name": tool_name,
+            "fingerprint": fingerprint,
+            "result": result,
+        }
+        return True
+
+    def precompleted_tools_for(self, candidate_index: int, sub_step_id: str) -> dict[str, dict[str, Any]]:
+        """Return cached results for one candidate sub-step, keyed by tool name.
+
+        ``StepExecutor`` consumes this as ``precompleted_tools`` so completion
+        guards accept the already-known results and the agent does not need to
+        repeat the lookups.
+        """
+        precompleted: dict[str, dict[str, Any]] = {}
+        for entry in self._entries.values():
+            if entry.get("candidate_index") != candidate_index or entry.get("sub_step_id") != sub_step_id:
+                continue
+            tool_name = entry.get("tool_name")
+            result = entry.get("result")
+            if isinstance(tool_name, str) and isinstance(result, dict):
+                precompleted[tool_name] = result
+        return precompleted
+
+    def cached_result_count(self, candidate_index: int | None = None) -> int:
+        if candidate_index is None:
+            return len(self._entries)
+        return sum(1 for entry in self._entries.values() if entry.get("candidate_index") == candidate_index)
+
+    def to_snapshot(self) -> dict[str, dict[str, Any]]:
+        return {key: dict(entry) for key, entry in self._entries.items()}
+
+    @classmethod
+    def from_snapshot(cls, snapshot: Any) -> CandidateToolResultCache:
+        if not isinstance(snapshot, dict):
+            return cls()
+        entries: dict[str, dict[str, Any]] = {}
+        for key, entry in snapshot.items():
+            if not isinstance(key, str) or not isinstance(entry, dict):
+                continue
+            tool_name = entry.get("tool_name")
+            result = entry.get("result")
+            candidate_index = entry.get("candidate_index")
+            sub_step_id = entry.get("sub_step_id")
+            if (
+                not isinstance(tool_name, str)
+                or not isinstance(result, dict)
+                or not isinstance(sub_step_id, str)
+                or not isinstance(candidate_index, int)
+                or isinstance(candidate_index, bool)
+            ):
+                continue
+            entries[key] = {
+                "candidate_index": candidate_index,
+                "sub_step_id": sub_step_id,
+                "tool_name": tool_name,
+                "fingerprint": str(entry.get("fingerprint") or ""),
+                "result": result,
+            }
+        return cls(entries)

--- a/src/iac_code/pipeline/engine/handoff.py
+++ b/src/iac_code/pipeline/engine/handoff.py
@@ -24,6 +24,7 @@ def build_handoff_summary(
     outcome: TerminalOutcome,
     context_snapshot: dict,
     include_fields: list[str],
+    candidate_progress: list[dict] | None = None,
 ) -> str:
     """Build deterministic text for continuing in normal chat after a pipeline."""
     included = {
@@ -43,6 +44,18 @@ def build_handoff_summary(
     if missing:
         lines.extend(["", "Missing context fields:"])
         lines.extend(f"- {field_name}" for field_name in missing)
+    if candidate_progress:
+        lines.extend(
+            [
+                "",
+                "Candidate sub-step progress:",
+                json.dumps(candidate_progress, ensure_ascii=False, indent=2),
+                (
+                    "Sub-steps listed under completed_sub_steps already produced their conclusions; "
+                    "reuse them instead of re-evaluating the candidate from scratch."
+                ),
+            ]
+        )
     lines.extend(
         [
             "",
@@ -58,3 +71,50 @@ def build_handoff_summary(
         ]
     )
     return "\n".join(lines)
+
+
+def candidate_progress_from_execution(
+    execution: dict | None,
+    sub_step_ids: list[str],
+) -> list[dict]:
+    """Derive machine-readable candidate sub-step progress from sidecar execution state.
+
+    Interrupting ``evaluate_candidates`` leaves per-candidate progress in the
+    sidecar's ``execution.candidates`` map, which the pipeline context alone does
+    not expose. Surfacing it in the handoff lets normal chat resume from the
+    already-completed sub-steps instead of re-evaluating every candidate.
+    """
+    if not isinstance(execution, dict) or execution.get("kind") != "parallel_sub_pipeline":
+        return []
+    candidates = execution.get("candidates")
+    if not isinstance(candidates, dict):
+        return []
+
+    progress: list[dict] = []
+    for raw_index, state in candidates.items():
+        try:
+            candidate_index = int(raw_index)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(state, dict):
+            continue
+        step_conclusions = state.get("step_conclusions")
+        if not isinstance(step_conclusions, dict):
+            step_conclusions = {}
+        completed = [step_id for step_id in sub_step_ids if step_id in step_conclusions]
+        pending = [step_id for step_id in sub_step_ids if step_id not in completed]
+        candidate = state.get("candidate") if isinstance(state.get("candidate"), dict) else {}
+        cached = state.get("tool_result_cache")
+        progress.append(
+            {
+                "candidate_index": candidate_index,
+                "candidate_name": candidate.get("name", ""),
+                "status": state.get("status", "unknown"),
+                "current_sub_step": state.get("current_sub_step", ""),
+                "completed_sub_steps": completed,
+                "pending_sub_steps": pending,
+                "cached_tool_results": len(cached) if isinstance(cached, dict) else 0,
+            }
+        )
+    progress.sort(key=lambda item: item["candidate_index"])
+    return progress

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock
 
 from iac_code.agent.message import ContentBlock, Message, ToolResultBlock
 from iac_code.i18n import _
+from iac_code.pipeline.engine.candidate_tool_cache import CandidateToolResultCache
 from iac_code.pipeline.engine.cleanup import (
     CleanupLedger,
     CleanupLedgerWriteStatus,
@@ -28,7 +29,11 @@ from iac_code.pipeline.engine.cleanup import (
 from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.display_replay import DISPLAY_TRANSCRIPT_FILENAME
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType, backup_blocked_event
-from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_outcome_from_completed_event
+from iac_code.pipeline.engine.handoff import (
+    build_handoff_summary,
+    candidate_progress_from_execution,
+    terminal_outcome_from_completed_event,
+)
 from iac_code.pipeline.engine.interrupt import InterruptController, InterruptVerdict
 from iac_code.pipeline.engine.loader import load_pipeline_dir
 from iac_code.pipeline.engine.observability import PipelineObservability
@@ -1002,7 +1007,18 @@ class PipelineRunner:
             outcome=outcome,
             context_snapshot=self.context.snapshot(),
             include_fields=include_fields,
+            candidate_progress=self._candidate_progress_for_handoff(),
         )
+
+    def _candidate_progress_for_handoff(self) -> list[dict[str, Any]]:
+        """Candidate sub-step progress for the current parallel step, if any."""
+        execution = self._execution if isinstance(self._execution, dict) else None
+        if not execution:
+            return []
+        sub_pipeline_name = execution.get("sub_pipeline_name")
+        sub_spec = self._loaded.sub_pipelines.get(sub_pipeline_name) if isinstance(sub_pipeline_name, str) else None
+        sub_step_ids = [step.step_id for step in sub_spec.steps] if sub_spec is not None else []
+        return candidate_progress_from_execution(execution, sub_step_ids)
 
     def mark_normal_handoff(self, status: str, failed_reason: str | None = None) -> None:
         """Record terminal pipeline-to-normal handoff metadata without deleting the sidecar."""
@@ -4554,6 +4570,9 @@ class PipelineRunner:
             step_conclusions = payload.get("step_conclusions")
             if step_conclusions is not None:
                 entry["step_conclusions"] = step_conclusions
+            tool_result_cache = payload.get("tool_result_cache")
+            if isinstance(tool_result_cache, dict):
+                entry["tool_result_cache"] = tool_result_cache
             active_state = self._active_candidates.get(i)
             pending_ask_resume = (
                 active_state.get(_PENDING_ASK_USER_QUESTION_RESUME_KEY) if isinstance(active_state, dict) else None
@@ -4576,6 +4595,7 @@ class PipelineRunner:
                 "transcript_id": state.get("transcript_id"),
                 "conclusions": conclusions,
                 "step_conclusions": state.get("step_conclusions", {}),
+                "tool_result_cache": state.get("tool_result_cache", {}),
             }
             self._execution.setdefault("candidates", {})[str(i)] = entry
             await self._save_running(step.step_id, reason="parallel candidate completed")
@@ -4596,6 +4616,7 @@ class PipelineRunner:
                 "transcript_id": state.get("transcript_id"),
                 "conclusions": state.get("conclusions", {}),
                 "step_conclusions": state.get("step_conclusions", {}),
+                "tool_result_cache": state.get("tool_result_cache", {}),
             }
             if state.get("error") is not None:
                 entry["error"] = state["error"]
@@ -4658,6 +4679,7 @@ class PipelineRunner:
                 "context": (resume_state or {}).get("context"),
                 "active_attempt_id": (resume_state or {}).get("active_attempt_id"),
                 "transcript_id": (resume_state or {}).get("transcript_id"),
+                "tool_result_cache": (resume_state or {}).get("tool_result_cache", {}),
             }
             pending_ask_resume = (resume_state or {}).get(_PENDING_ASK_USER_QUESTION_RESUME_KEY)
             if pending_ask_resume is not None:
@@ -4696,6 +4718,10 @@ class PipelineRunner:
                     state["transcript_id"] = None
                 state["conclusions"] = payload.get("conclusions", state.get("conclusions", {}))
                 state["step_conclusions"] = payload.get("step_conclusions", state.get("step_conclusions", {}))
+                state["tool_result_cache"] = payload.get(
+                    "tool_result_cache",
+                    state.get("tool_result_cache", {}),
+                )
                 await save_candidate_execution_state(
                     i,
                     payload,
@@ -4747,6 +4773,10 @@ class PipelineRunner:
                         recovery_kwargs["precompleted_tools"] = candidate_precompleted_tools
                     if "resume_messages" in parameters or has_var_keyword:
                         recovery_kwargs["resume_messages"] = candidate_resume_messages
+                    if "tool_result_cache" in parameters or has_var_keyword:
+                        recovery_kwargs["tool_result_cache"] = CandidateToolResultCache.from_snapshot(
+                            state.get("tool_result_cache"),
+                        )
                     event_stream = execute_streaming(**stream_kwargs, **recovery_kwargs)
                 else:
                     event_stream = execute_streaming(**stream_kwargs)

--- a/src/iac_code/pipeline/engine/session.py
+++ b/src/iac_code/pipeline/engine/session.py
@@ -559,6 +559,10 @@ class PipelineSession:
         attempts = self._load_existing_meta().get("attempts")
         return attempts if isinstance(attempts, dict) else None
 
+    def load_execution_metadata(self) -> dict[str, Any] | None:
+        execution = self._load_existing_meta().get("execution")
+        return execution if isinstance(execution, dict) else None
+
     def peek_prerequisites_sync(self) -> dict[str, Any]:
         prerequisites = self._load_existing_meta().get("prerequisites")
         if not isinstance(prerequisites, dict):

--- a/src/iac_code/pipeline/engine/sub_pipeline_executor.py
+++ b/src/iac_code/pipeline/engine/sub_pipeline_executor.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from iac_code.agent.message import ContentBlock, Message
 from iac_code.i18n import _
+from iac_code.pipeline.engine.candidate_tool_cache import CandidateToolResultCache
 from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.pipeline.engine.observability import PipelineObservability
@@ -24,7 +25,7 @@ from iac_code.pipeline.engine.step_executor import StepExecutor
 from iac_code.pipeline.engine.step_spec import LoadedPipeline, SubPipelineSpec
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.services.session_backup import SessionBackupBlocked
-from iac_code.types.stream_events import SubPipelineStreamEvent
+from iac_code.types.stream_events import SubPipelineStreamEvent, ToolResultEvent, ToolUseEndEvent
 from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
@@ -385,9 +386,14 @@ class SubPipelineExecutor:
         sub_step_attempt_allocator: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
         sub_step_state_callback: Callable[[dict[str, Any]], Any] | None = None,
         precompleted_tools: dict[str, dict[str, Any]] | None = None,
+        tool_result_cache: CandidateToolResultCache | None = None,
     ) -> AsyncGenerator[PipelineEvent | SubPipelineStreamEvent, None]:
         """Execute sub-pipeline yielding all events in real-time for UI rendering."""
         self._observability.session_id = session_id
+        if tool_result_cache is None:
+            tool_result_cache = CandidateToolResultCache.from_snapshot(
+                (resume_state or {}).get("tool_result_cache"),
+            )
         sub_pipeline_id = (
             str(resume_state["sub_pipeline_id"])
             if resume_state and resume_state.get("sub_pipeline_id")
@@ -487,6 +493,7 @@ class SubPipelineExecutor:
         sub_step_started_at: float | None = None
         current_sub_step_id: str | None = None
         attempt_info: dict[str, Any] | None = None
+        pending_tool_inputs: dict[str, tuple[str, dict[str, Any]]] = {}
 
         async def publish_sub_step_state(
             *,
@@ -514,6 +521,7 @@ class SubPipelineExecutor:
                 "transcript_id": attempt_info.get("transcript_id"),
                 "conclusions": dict(conclusions),
                 "step_conclusions": dict(step_conclusions),
+                "tool_result_cache": tool_result_cache.to_snapshot(),
             }
             result = sub_step_state_callback(payload)
             if asyncio.iscoroutine(result):
@@ -637,7 +645,14 @@ class SubPipelineExecutor:
                         )
 
                         step_msg = user_message if is_first_step else None
-                        step_precompleted_tools = precompleted_tools if is_first_step else None
+                        step_precompleted_tools: dict[str, dict[str, Any]] = (
+                            dict(precompleted_tools) if is_first_step and precompleted_tools else {}
+                        )
+                        # Replay read-only lookups already completed for this candidate sub-step so a
+                        # run resumed mid-sub-step does not repeat the same schema/pricing queries.
+                        cached_precompleted = tool_result_cache.precompleted_tools_for(candidate_index, step.step_id)
+                        for cached_tool_name, cached_result in cached_precompleted.items():
+                            step_precompleted_tools.setdefault(cached_tool_name, cached_result)
                         attempt_resume_messages = attempt_info.get("resume_messages")
                         if not isinstance(attempt_resume_messages, list):
                             attempt_resume_messages = []
@@ -660,7 +675,7 @@ class SubPipelineExecutor:
                                 "attempt_id": attempt_info.get("attempt_id"),
                                 "transcript_id": attempt_info.get("transcript_id"),
                                 "resume_messages": step_resume_messages,
-                                "precompleted_tools": step_precompleted_tools,
+                                "precompleted_tools": step_precompleted_tools or None,
                                 "rollback_targets": state_machine.completed_non_future_rollback_targets(),
                                 "rollback_count": state_machine.rollback_count,
                                 "max_rollbacks": state_machine.max_rollbacks,
@@ -687,6 +702,13 @@ class SubPipelineExecutor:
                                     # Forward pipeline-level events from the step executor directly
                                     yield event
                                 else:
+                                    self._record_cacheable_tool_event(
+                                        tool_result_cache,
+                                        event,
+                                        pending_tool_inputs,
+                                        candidate_index=candidate_index,
+                                        sub_step_id=step.step_id,
+                                    )
                                     yield SubPipelineStreamEvent(
                                         sub_pipeline_id=sub_pipeline_id,
                                         candidate_index=candidate_index,
@@ -988,6 +1010,32 @@ class SubPipelineExecutor:
                     "step_conclusions": step_conclusions,
                 },
             ),
+        )
+
+    @staticmethod
+    def _record_cacheable_tool_event(
+        tool_result_cache: CandidateToolResultCache,
+        event: Any,
+        pending_tool_inputs: dict[str, tuple[str, dict[str, Any]]],
+        *,
+        candidate_index: int,
+        sub_step_id: str,
+    ) -> None:
+        """Track tool inputs and cache successful read-only results for resume replay."""
+        if isinstance(event, ToolUseEndEvent):
+            tool_input = event.input if isinstance(event.input, dict) else {}
+            pending_tool_inputs[event.tool_use_id] = (event.name, tool_input)
+            return
+        if not isinstance(event, ToolResultEvent) or event.is_error:
+            return
+        pending = pending_tool_inputs.pop(event.tool_use_id, None)
+        tool_name, tool_input = pending if pending is not None else (event.tool_name, {})
+        tool_result_cache.record(
+            candidate_index=candidate_index,
+            sub_step_id=sub_step_id,
+            tool_name=tool_name,
+            tool_input=tool_input,
+            result={"result": event.result, "metadata": event.metadata},
         )
 
     def _build_sub_context(

--- a/tests/pipeline/engine/test_candidate_tool_cache.py
+++ b/tests/pipeline/engine/test_candidate_tool_cache.py
@@ -1,0 +1,133 @@
+"""Tests for the candidate sub-pipeline read-only tool result cache."""
+
+from iac_code.pipeline.engine.candidate_tool_cache import (
+    CandidateToolResultCache,
+    input_fingerprint,
+    is_cacheable_tool,
+)
+
+
+def test_input_fingerprint_is_stable_across_key_order():
+    assert input_fingerprint({"product": "ROS", "action": "GetResourceType"}) == input_fingerprint(
+        {"action": "GetResourceType", "product": "ROS"}
+    )
+
+
+def test_input_fingerprint_differs_for_different_parameters():
+    assert input_fingerprint({"action": "GetResourceType", "type": "NAS"}) != input_fingerprint(
+        {"action": "GetResourceType", "type": "InstanceGroup"}
+    )
+
+
+def test_read_only_aliyun_actions_are_cacheable():
+    assert is_cacheable_tool("aliyun_api", {"action": "GetResourceType"}) is True
+    assert is_cacheable_tool("aliyun_api", {"action": "DescribeRegions"}) is True
+    assert is_cacheable_tool("read_file", {"path": "reference.md"}) is True
+
+
+def test_mutating_tools_are_not_cacheable():
+    assert is_cacheable_tool("aliyun_api", {"action": "CreateStack"}) is False
+    assert is_cacheable_tool("aliyun_api", {}) is False
+    assert is_cacheable_tool("ros_deploy", {"action": "create"}) is False
+    assert is_cacheable_tool("write_file", {"path": "template.yaml"}) is False
+
+
+def test_record_and_replay_scoped_to_candidate_and_sub_step():
+    cache = CandidateToolResultCache()
+
+    assert (
+        cache.record(
+            candidate_index=0,
+            sub_step_id="template_generating",
+            tool_name="aliyun_api",
+            tool_input={"action": "GetResourceType", "type": "ALIYUN::NAS::FileSystem"},
+            result={"result": "nas-schema"},
+        )
+        is True
+    )
+
+    assert cache.precompleted_tools_for(0, "template_generating") == {"aliyun_api": {"result": "nas-schema"}}
+    assert cache.precompleted_tools_for(1, "template_generating") == {}
+    assert cache.precompleted_tools_for(0, "cost_estimating") == {}
+
+
+def test_record_rejects_non_cacheable_tool_and_non_dict_result():
+    cache = CandidateToolResultCache()
+
+    assert (
+        cache.record(
+            candidate_index=0,
+            sub_step_id="template_generating",
+            tool_name="write_file",
+            tool_input={"path": "template.yaml"},
+            result={"file_path": "template.yaml"},
+        )
+        is False
+    )
+    assert (
+        cache.record(
+            candidate_index=0,
+            sub_step_id="template_generating",
+            tool_name="read_file",
+            tool_input={"path": "reference.md"},
+            result="plain text",
+        )
+        is False
+    )
+    assert cache.cached_result_count() == 0
+
+
+def test_distinct_parameters_are_cached_separately():
+    cache = CandidateToolResultCache()
+    for resource_type in ("ALIYUN::NAS::FileSystem", "ALIYUN::ECS::InstanceGroup"):
+        cache.record(
+            candidate_index=0,
+            sub_step_id="template_generating",
+            tool_name="aliyun_api",
+            tool_input={"action": "GetResourceType", "type": resource_type},
+            result={"result": resource_type},
+        )
+
+    assert cache.cached_result_count(candidate_index=0) == 2
+
+
+def test_snapshot_round_trip_preserves_replayable_entries():
+    cache = CandidateToolResultCache()
+    cache.record(
+        candidate_index=1,
+        sub_step_id="cost_estimating",
+        tool_name="ros_estimate_template_cost",
+        tool_input={"template_url": "oss://template.yaml"},
+        result={"result": "120 CNY"},
+    )
+
+    restored = CandidateToolResultCache.from_snapshot(cache.to_snapshot())
+
+    assert restored.precompleted_tools_for(1, "cost_estimating") == {
+        "ros_estimate_template_cost": {"result": "120 CNY"}
+    }
+
+
+def test_from_snapshot_ignores_malformed_entries():
+    restored = CandidateToolResultCache.from_snapshot(
+        {
+            "bad-no-tool": {"candidate_index": 0, "sub_step_id": "s", "result": {}},
+            "bad-index": {"candidate_index": "0", "sub_step_id": "s", "tool_name": "read_file", "result": {}},
+            "bad-result": {"candidate_index": 0, "sub_step_id": "s", "tool_name": "read_file", "result": "x"},
+            "ok": {
+                "candidate_index": 0,
+                "sub_step_id": "s",
+                "tool_name": "read_file",
+                "fingerprint": "abc",
+                "result": {"result": "content"},
+            },
+        }
+    )
+
+    assert restored.cached_result_count() == 1
+    assert restored.precompleted_tools_for(0, "s") == {"read_file": {"result": "content"}}
+
+
+def test_from_snapshot_tolerates_non_dict_input():
+    assert CandidateToolResultCache.from_snapshot(None).cached_result_count() == 0
+    assert CandidateToolResultCache.from_snapshot("nope").cached_result_count() == 0

--- a/tests/pipeline/engine/test_pipeline_handoff.py
+++ b/tests/pipeline/engine/test_pipeline_handoff.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 
 import yaml
 
-from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_outcome_from_completed_event
+from iac_code.pipeline.engine.handoff import (
+    build_handoff_summary,
+    candidate_progress_from_execution,
+    terminal_outcome_from_completed_event,
+)
 from iac_code.pipeline.engine.pipeline_runner import PipelineRunner
 
 
@@ -181,3 +185,115 @@ def test_runner_build_normal_handoff_summary_uses_configured_context_values(tmp_
     assert "Outcome: completed" in summary
     assert '"summary": "deploy nginx"' in summary
     assert "Missing context fields:\n- architecture" in summary
+
+
+def _evaluate_candidates_execution() -> dict:
+    return {
+        "kind": "parallel_sub_pipeline",
+        "step_id": "evaluate_candidates",
+        "sub_pipeline_name": "evaluate_candidate",
+        "candidates": {
+            "1": {
+                "status": "running",
+                "candidate": {"name": "低成本单机"},
+                "current_sub_step": "template_generating",
+                "step_conclusions": {},
+                "tool_result_cache": {"k1": {}, "k2": {}, "k3": {}},
+            },
+            "0": {
+                "status": "running",
+                "candidate": {"name": "高可用多可用区"},
+                "current_sub_step": "cost_estimating",
+                "step_conclusions": {"template_generating": {"file_path": "ha.yaml"}},
+                "tool_result_cache": {"k1": {}},
+            },
+        },
+    }
+
+
+def test_candidate_progress_from_execution_lists_completed_and_pending_sub_steps():
+    progress = candidate_progress_from_execution(
+        _evaluate_candidates_execution(),
+        ["template_generating", "cost_estimating"],
+    )
+
+    assert progress == [
+        {
+            "candidate_index": 0,
+            "candidate_name": "高可用多可用区",
+            "status": "running",
+            "current_sub_step": "cost_estimating",
+            "completed_sub_steps": ["template_generating"],
+            "pending_sub_steps": ["cost_estimating"],
+            "cached_tool_results": 1,
+        },
+        {
+            "candidate_index": 1,
+            "candidate_name": "低成本单机",
+            "status": "running",
+            "current_sub_step": "template_generating",
+            "completed_sub_steps": [],
+            "pending_sub_steps": ["template_generating", "cost_estimating"],
+            "cached_tool_results": 3,
+        },
+    ]
+
+
+def test_candidate_progress_from_execution_ignores_unrelated_execution_state():
+    assert candidate_progress_from_execution(None, ["template_generating"]) == []
+    assert candidate_progress_from_execution({}, ["template_generating"]) == []
+    assert candidate_progress_from_execution({"kind": "step", "candidates": {}}, ["template_generating"]) == []
+    assert (
+        candidate_progress_from_execution(
+            {"kind": "parallel_sub_pipeline", "candidates": "nope"},
+            ["template_generating"],
+        )
+        == []
+    )
+
+
+def test_build_handoff_summary_includes_machine_readable_candidate_progress():
+    progress = candidate_progress_from_execution(
+        _evaluate_candidates_execution(),
+        ["template_generating", "cost_estimating"],
+    )
+
+    summary = build_handoff_summary(
+        pipeline_name="selling",
+        outcome="canceled",
+        context_snapshot={"intent": {"summary": "部署 NAS"}},
+        include_fields=["intent", "evaluated_candidates"],
+        candidate_progress=progress,
+    )
+
+    assert "Candidate sub-step progress:" in summary
+    assert '"candidate_index": 0' in summary
+    assert '"completed_sub_steps": [' in summary
+    assert '"pending_sub_steps": [' in summary
+    assert '"cached_tool_results": 3' in summary
+    assert "reuse them instead of re-evaluating the candidate from scratch" in summary
+    # Existing handoff structure is preserved.
+    assert "Missing context fields:\n- evaluated_candidates" in summary
+
+
+def test_build_handoff_summary_omits_progress_section_without_candidates():
+    summary = build_handoff_summary(
+        pipeline_name="selling",
+        outcome="completed",
+        context_snapshot={},
+        include_fields=[],
+    )
+
+    assert "Candidate sub-step progress:" not in summary
+
+
+def test_runner_build_normal_handoff_summary_includes_candidate_progress(tmp_path):
+    runner = _make_runner(tmp_path, _switch_policy("canceled", include=["intent"]))
+    runner.context.set_conclusion("intent", {"summary": "部署 NAS"})
+    runner._execution = _evaluate_candidates_execution()
+
+    summary = runner.build_normal_handoff_summary({"canceled": True})
+
+    assert "Outcome: canceled" in summary
+    assert "Candidate sub-step progress:" in summary
+    assert '"candidate_name": "高可用多可用区"' in summary

--- a/tests/pipeline/engine/test_sub_pipeline_executor.py
+++ b/tests/pipeline/engine/test_sub_pipeline_executor.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from iac_code.agent.message import ImageBlock, Message, ToolResultBlock, ToolUseBlock
+from iac_code.pipeline.engine.candidate_tool_cache import CandidateToolResultCache
 from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.pipeline.engine.state_machine import StateMachine
@@ -1761,3 +1762,183 @@ class TestFailedCandidateErrorPropagated:
             conclusions={},
         )
         assert result.error_details is None
+
+
+class TestCandidateToolResultCacheIntegration:
+    """Mid-sub-step interrupts must not force repeated read-only lookups on resume."""
+
+    @staticmethod
+    def _pipeline() -> LoadedPipeline:
+        return LoadedPipeline(
+            name="test",
+            steps=[],
+            context_dependencies={"intent": []},
+            max_rollbacks=3,
+            skills={"iac_aliyun": "# IaC Skill"},
+        )
+
+    @staticmethod
+    def _parent_context() -> PipelineContext:
+        parent_ctx = PipelineContext({"intent": []})
+        parent_ctx.set_conclusion("intent", {"type": "test"})
+        return parent_ctx
+
+    @staticmethod
+    def _executor(tmp_path, monkeypatch, step_executor) -> SubPipelineExecutor:
+        (tmp_path / "prompts").mkdir(exist_ok=True)
+        (tmp_path / "prompts" / "template.md").write_text("Generate template", encoding="utf-8")
+        executor = SubPipelineExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=TestCandidateToolResultCacheIntegration._pipeline(),
+            pipeline_dir=tmp_path,
+            cwd=str(tmp_path),
+        )
+        monkeypatch.setattr(executor, "_make_step_executor", lambda: step_executor)
+        return executor
+
+    @pytest.mark.asyncio
+    async def test_successful_read_only_lookups_are_persisted_for_resume(self, tmp_path, monkeypatch):
+        class LookupStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                yield ToolUseEndEvent(
+                    tool_use_id="t1",
+                    name="aliyun_api",
+                    input={"action": "GetResourceType", "type": "ALIYUN::NAS::FileSystem"},
+                )
+                yield ToolResultEvent(tool_use_id="t1", tool_name="aliyun_api", result="nas-schema")
+                yield ToolUseEndEvent(tool_use_id="t2", name="read_file", input={"path": "reference.md"})
+                yield ToolResultEvent(tool_use_id="t2", tool_name="read_file", result="reference body")
+                # Writes must never be replayed from cache.
+                yield ToolUseEndEvent(tool_use_id="t3", name="write_file", input={"path": "template.yaml"})
+                yield ToolResultEvent(tool_use_id="t3", tool_name="write_file", result="written")
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        published: list[dict] = []
+        executor = self._executor(tmp_path, monkeypatch, LookupStepExecutor())
+
+        async for _event in executor.execute_streaming(
+            sub_spec=_make_single_step_sub_spec(),
+            candidate={"name": "Plan A"},
+            candidate_index=0,
+            parent_context=self._parent_context(),
+            session_id="test_session",
+            sub_step_state_callback=lambda payload: published.append(payload),
+        ):
+            pass
+
+        assert published, "sub-step state must be published for checkpointing"
+        cache_snapshot = published[-1]["tool_result_cache"]
+        cached_tools = sorted(entry["tool_name"] for entry in cache_snapshot.values())
+        assert cached_tools == ["aliyun_api", "read_file"]
+        assert all(entry["sub_step_id"] == "template_generating" for entry in cache_snapshot.values())
+        assert all(entry["candidate_index"] == 0 for entry in cache_snapshot.values())
+
+    @pytest.mark.asyncio
+    async def test_failed_lookups_are_not_cached(self, tmp_path, monkeypatch):
+        class FailingLookupStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                yield ToolUseEndEvent(tool_use_id="t1", name="aliyun_api", input={"action": "GetResourceType"})
+                yield ToolResultEvent(
+                    tool_use_id="t1",
+                    tool_name="aliyun_api",
+                    result="throttled",
+                    is_error=True,
+                )
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        published: list[dict] = []
+        executor = self._executor(tmp_path, monkeypatch, FailingLookupStepExecutor())
+
+        async for _event in executor.execute_streaming(
+            sub_spec=_make_single_step_sub_spec(),
+            candidate={"name": "Plan A"},
+            candidate_index=0,
+            parent_context=self._parent_context(),
+            session_id="test_session",
+            sub_step_state_callback=lambda payload: published.append(payload),
+        ):
+            pass
+
+        assert published[-1]["tool_result_cache"] == {}
+
+    @pytest.mark.asyncio
+    async def test_resume_replays_cached_lookups_as_precompleted_tools(self, tmp_path, monkeypatch):
+        cache = CandidateToolResultCache()
+        cache.record(
+            candidate_index=0,
+            sub_step_id="template_generating",
+            tool_name="aliyun_api",
+            tool_input={"action": "GetResourceType", "type": "ALIYUN::NAS::FileSystem"},
+            result={"result": "nas-schema"},
+        )
+        cache.record(
+            candidate_index=0,
+            sub_step_id="template_generating",
+            tool_name="read_file",
+            tool_input={"path": "reference.md"},
+            result={"result": "reference body"},
+        )
+        # Another candidate's cache must not leak into this candidate's replay.
+        cache.record(
+            candidate_index=1,
+            sub_step_id="template_generating",
+            tool_name="aliyun_api",
+            tool_input={"action": "DescribeRegions"},
+            result={"result": "regions"},
+        )
+
+        observed_kwargs: list[dict] = []
+
+        class RecordingStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                observed_kwargs.append(kwargs)
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        executor = self._executor(tmp_path, monkeypatch, RecordingStepExecutor())
+
+        async for _event in executor.execute_streaming(
+            sub_spec=_make_single_step_sub_spec(),
+            candidate={"name": "Plan A"},
+            candidate_index=0,
+            parent_context=self._parent_context(),
+            session_id="test_session",
+            resume_state={"tool_result_cache": cache.to_snapshot()},
+        ):
+            pass
+
+        precompleted = observed_kwargs[0]["precompleted_tools"]
+        assert precompleted == {
+            "aliyun_api": {"result": "nas-schema"},
+            "read_file": {"result": "reference body"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_fresh_run_without_cache_passes_no_precompleted_tools(self, tmp_path, monkeypatch):
+        observed_kwargs: list[dict] = []
+
+        class RecordingStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                observed_kwargs.append(kwargs)
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        executor = self._executor(tmp_path, monkeypatch, RecordingStepExecutor())
+
+        async for _event in executor.execute_streaming(
+            sub_spec=_make_single_step_sub_spec(),
+            candidate={"name": "Plan A"},
+            candidate_index=0,
+            parent_context=self._parent_context(),
+            session_id="test_session",
+        ):
+            pass
+
+        assert observed_kwargs[0]["precompleted_tools"] is None


### PR DESCRIPTION
## 背景

针对 Session `9dc515b2084a4da49a24ede6a624372b`：取消发生在 `evaluate_candidates` 的候选子流程正在查询 ROS 资源类型 schema 期间，续跑需要重做 36 次 `candidate_step` 工具调用（含 10 次 `aliyun_api`、19 次 `read_file`）。

## 根因

1. **候选子流程 checkpoint 粒度只到 sub-step 边界**：`record_sub_step_state` 只在子步骤 `running/completed/failed` 时写 sidecar；子步骤*执行中途*的 `aliyun_api` / `read_file` 结果只存在于 AgentLoop transcript，仅供 completion guard 使用，不构成可跳过重复调用的幂等缓存。
2. **`switch_to_normal` handoff 只序列化 `PipelineContext`**：取消发生在 `evaluated_candidates` 写入之前时，`_flat_pipeline_context_from_sidecar` 不读 `meta.yaml.execution.candidates`，handoff 因此既没有"已完成"也没有"未完成"的候选子步骤清单。

## 改动

- 新增 `CandidateToolResultCache`，按 `(候选, 子步骤, 工具, 规范化入参 sha256)` 缓存**只读**工具结果；`aliyun_api` 仅 `Describe/Get/List/Query/Check/Preview/Validate` 开头的 action 可缓存，`ros_deploy` / `write_file` / `edit_file` 等副作用工具一律不缓存。
- 缓存随候选执行状态持久化到 sidecar，续跑时命中项作为 `precompleted_tools` 注入 `StepExecutor`，让 completion guard 直接认这些结果，Agent 不再重复发起同一 schema/询价查询。
- 新增纯函数 `candidate_progress_from_execution`，从 sidecar `execution.candidates` 推导逐候选 `completed_sub_steps` / `pending_sub_steps` / `current_sub_step` / `cached_tool_results`，并加入 `build_handoff_summary` 的机读段；runner 与 A2A 取消两条 handoff 路径都已接入。

## 验收

构造"候选查询 schema 期间取消后续接"用例：
- `test_resume_replays_cached_lookups_as_precompleted_tools` 断言续接把已完成的 `aliyun_api` / `read_file` 作为 `precompleted_tools` 注入，不重复调用，且不跨候选泄漏缓存。
- `test_build_handoff_summary_includes_machine_readable_candidate_progress` 断言 handoff 含可机读候选子步骤进度清单。

## 测试

- `pytest tests`：14340 passed / 5 skipped。14 个失败全部为 clean tree 上已存在的 i18n `.pot`/`.mo` 构建产物缺失与 `repl_e2e` sidecar 用例，与本次改动无关（已在干净树复现）。
- 新增 19 个用例（`test_candidate_tool_cache.py` 10、`test_pipeline_handoff.py` 5、`test_sub_pipeline_executor.py` 4）。
- `ruff check src/ tests/` 与 `ty check src/` 均通过。

## 兼容性

handoff 的候选进度是附加段，`Included context:` 既有结构不变；无候选进度时不输出该段，现有 handoff 断言与 Web/A2A 消费方不受影响。
