### PR TITLE
fix(pipeline): make pipeline_failed terminals attributable

### DIFF
--- a/src/iac_code/a2a/pipeline_events.py
+++ b/src/iac_code/a2a/pipeline_events.py
@@ -57,6 +57,7 @@ _TOP_LEVEL_DATA_KEY_ALIASES = {
     "early_exit": "earlyExit",
     "error_details": "errorDetails",
     "error_summary": "errorSummary",
+    "failure_trigger": "failureTrigger",
     "from_step": "fromStep",
     "parent_step_id": "parentStepId",
     "pipeline_type": "pipelineType",

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -2319,14 +2319,19 @@ class IacCodeA2APipelineExecutor:
             permanent=event_type == "pipeline_canceled",
         )
         try:
+            recovery_data: dict[str, Any] = {
+                "sidecarStatus": sidecar_status,
+                "recovered": True,
+            }
+            if event_type == "pipeline_failed":
+                # Replaying a restored terminal must not read as a newly observed
+                # failure, otherwise recovery inflates the failure density.
+                recovery_data["failureTrigger"] = "sidecar_recovery"
             published = await publisher.publish_manual(
                 event_type,
                 "pipeline",
                 status=status,
-                data={
-                    "sidecarStatus": sidecar_status,
-                    "recovered": True,
-                },
+                data=recovery_data,
             )
         except _PipelineBackupBlockedTransitionError:
             await self._reopen_sub_pipeline_permissions_after_terminal_fallback(closing_token)
@@ -2954,6 +2959,7 @@ class IacCodeA2APipelineExecutor:
                     status="failed",
                     data={
                         "source": "executor",
+                        "failureTrigger": "executor_exception",
                         "errorSummary": text,
                         "errorDetails": _public_error_details_for_a2a(failure.details) if failure is not None else {},
                     },

--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -175,6 +175,7 @@ class _PipelineSnapshotReducer:
         self._candidate_restart_keys: set[str] = set()
         self._handoff_history_keys: set[str] = set()
         self._warning_history_keys: set[str] = set()
+        self._failure_history_keys: set[str] = set()
         self._stack_history_keys: set[str] = set()
         self._cleanup_history_keys: set[str] = set()
         self._skip_sequences_through = 0
@@ -227,6 +228,7 @@ class _PipelineSnapshotReducer:
         self._hydrate_candidate_restarts()
         self._hydrate_control_history("handoffHistory", self._handoff_history_keys)
         self._hydrate_control_history("warningHistory", self._warning_history_keys)
+        self._hydrate_control_history("failureHistory", self._failure_history_keys)
         self._hydrate_stack_history()
         self._hydrate_cleanup_history()
 
@@ -522,6 +524,12 @@ class _PipelineSnapshotReducer:
             self._snapshot["status"] = "waiting_input"
 
         terminal_status = _TERMINAL_STATUS_BY_EVENT_TYPE.get(event_type)
+        if event_type == "pipeline_failed":
+            self._append_control_history(
+                "failureHistory",
+                self._failure_history_keys,
+                _failure_history_entry(event),
+            )
         if terminal_status is not None and _is_pending_backup_publication(event):
             self._snapshot["pendingTerminal"] = _terminal_publication(event)
         elif terminal_status is not None:
@@ -1215,6 +1223,28 @@ def _publication_visibility(event: dict[str, Any]) -> str | None:
     return _string_or_none(data.get("visibility"))
 
 
+def _failure_history_entry(event: dict[str, Any]) -> dict[str, Any]:
+    """One auditable row per ``pipeline_failed`` terminal.
+
+    A run can emit several terminals across retries and recovery replays, and
+    counting raw events cannot tell them apart. Recording the trigger and the
+    error id per failure makes the density attributable.
+    """
+    data = _dict_or_empty(event.get("data"))
+    error_details = _dict_or_empty(data.get("errorDetails"))
+    entry = {
+        "eventId": _string_or_none(event.get("eventId")),
+        "sequence": _sequence_value(event),
+        "createdAt": _string_or_none(event.get("createdAt")),
+        "trigger": _string_or_none(data.get("failureTrigger")) or "unclassified",
+        "recovered": data.get("recovered") is True,
+        "errorId": _string_or_none(error_details.get("errorId")),
+        "errorSummary": _string_or_none(data.get("errorSummary")),
+    }
+    _merge_event_coordinates(entry, event)
+    return entry
+
+
 def _warning_history_entry(event: dict[str, Any]) -> dict[str, Any]:
     entry = {
         "eventId": _string_or_none(event.get("eventId")),
@@ -1323,6 +1353,7 @@ def _empty_snapshot() -> dict[str, Any]:
             "candidateRestarts": [],
             "handoffHistory": [],
             "warningHistory": [],
+            "failureHistory": [],
         },
         "seenEventIds": [],
     }
@@ -1427,6 +1458,7 @@ def _snapshot_from_existing(existing_snapshot: dict[str, Any] | None) -> dict[st
         "candidateRestarts",
         "handoffHistory",
         "warningHistory",
+        "failureHistory",
     ):
         value = snapshot["control"].get(key)
         snapshot["control"][key] = copy.deepcopy(value) if isinstance(value, list) else []

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -32,7 +32,7 @@ from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_out
 from iac_code.pipeline.engine.interrupt import InterruptController, InterruptVerdict
 from iac_code.pipeline.engine.loader import load_pipeline_dir
 from iac_code.pipeline.engine.observability import PipelineObservability
-from iac_code.pipeline.engine.public_errors import public_error, public_error_from_exception
+from iac_code.pipeline.engine.public_errors import PublicError, public_error, public_error_from_exception
 from iac_code.pipeline.engine.resume_recovery import reconcile_resume_messages, user_message_already_in_resume
 from iac_code.pipeline.engine.session import PipelineIdentity, PipelineSession, RestoreResult
 from iac_code.pipeline.engine.state_machine import StateMachine
@@ -1320,7 +1320,7 @@ class PipelineRunner:
                 type=PipelineEventType.PIPELINE_COMPLETED,
                 step_id=getattr(current_step, "step_id", None),
                 timestamp=time.time(),
-                data={"total_steps": self.state_machine.total_steps, "failed": True},
+                data=self._failed_pipeline_completed_data(failure_trigger="interrupted_failed_sidecar"),
             )
             return
         self.resume_agent_loops()
@@ -1836,6 +1836,30 @@ class PipelineRunner:
                 meta.get("type"),
                 exc_info=True,
             )
+
+    def _failed_pipeline_completed_data(
+        self,
+        *,
+        failure_trigger: str,
+        failure: PublicError | None = None,
+    ) -> dict[str, Any]:
+        """Terminal payload for a failed run, carrying its own attribution.
+
+        ``pipeline_failed`` is projected from this event, so the trigger and the
+        root cause must travel with it instead of only living on the preceding
+        ``step_failed``. Without that, several structurally identical terminals
+        cannot be told apart when auditing failure density.
+        """
+        data: dict[str, Any] = {
+            "total_steps": self.state_machine.total_steps,
+            "failed": True,
+            "failure_trigger": failure_trigger,
+        }
+        if failure is not None:
+            data["error"] = failure.summary
+            data["error_summary"] = failure.summary
+            data["error_details"] = failure.details
+        return data
 
     def _persistence_failure_event(self, exc: PipelineStatePersistenceError) -> PipelineEvent:
         step_id = exc.step_id
@@ -3708,6 +3732,7 @@ class PipelineRunner:
         is_first_step = True
         terminal_pipeline_telemetry_emitted = False
         terminal_backup_completed = False
+        terminal_failure: PublicError | None = None
         step_result: StepResult | None = None
         restored_step_user_input = self._consume_restored_current_step_user_input() if user_input is None else None
         restored_resume_messages, restored_precompleted_tools = (
@@ -3854,6 +3879,7 @@ class PipelineRunner:
                         yield blocked_event
                         return
                     terminal_backup_completed = True
+                    terminal_failure = failure
                     self._observability.step_failed(
                         step_id=step.step_id,
                         duration_ms=self._observability.duration_ms(step_started_at),
@@ -4066,6 +4092,7 @@ class PipelineRunner:
                     yield blocked_event
                     return
                 terminal_backup_completed = True
+                terminal_failure = failure
                 self._observability.step_failed(
                     step_id=step.step_id,
                     duration_ms=self._observability.duration_ms(step_started_at),
@@ -4250,7 +4277,10 @@ class PipelineRunner:
                         type=PipelineEventType.PIPELINE_COMPLETED,
                         step_id=step.step_id,
                         timestamp=time.time(),
-                        data={"total_steps": self.state_machine.total_steps, "failed": True},
+                        data=self._failed_pipeline_completed_data(
+                            failure_trigger="invalid_rollback_target",
+                            failure=failure,
+                        ),
                     )
                     return
                 self._mark_attempt_status(current_attempt_id, "rolled_back")
@@ -4443,7 +4473,10 @@ class PipelineRunner:
                 type=PipelineEventType.PIPELINE_COMPLETED,
                 step_id=step.step_id,
                 timestamp=time.time(),
-                data={"total_steps": self.state_machine.total_steps, "failed": True},
+                data=self._failed_pipeline_completed_data(
+                    failure_trigger="step_failed",
+                    failure=terminal_failure,
+                ),
             )
 
     def clear_sidecar(self) -> None:

--- a/tests/a2a/test_pipeline_events.py
+++ b/tests/a2a/test_pipeline_events.py
@@ -2630,3 +2630,65 @@ def test_sanitize_tool_input_passthrough_keeps_template_and_conclusion() -> None
     assert result == tool_input
     assert "[REDACTED]" not in json.dumps(result)
     assert "***" not in json.dumps(result)
+
+
+def test_failed_terminal_projects_failure_trigger_and_root_cause() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    [envelope] = translator.translate(
+        PipelineEvent(
+            type=PipelineEventType.PIPELINE_COMPLETED,
+            step_id="confirm_and_select",
+            timestamp=time.time(),
+            data={
+                "total_steps": 4,
+                "failed": True,
+                "failure_trigger": "step_failed",
+                "error": "generate_template exploded",
+                "error_summary": "generate_template exploded",
+                "error_details": {"type": "StepFailed", "error_id": "abc123abc123"},
+            },
+        )
+    )
+
+    assert envelope["eventType"] == "pipeline_failed"
+    assert envelope["status"] == "failed"
+    assert envelope["data"]["failureTrigger"] == "step_failed"
+    assert envelope["data"]["errorSummary"] == "generate_template exploded"
+    assert envelope["data"]["errorDetails"]["errorId"] == "abc123abc123"
+
+
+@pytest.mark.parametrize(
+    "failure_trigger",
+    ["step_failed", "invalid_rollback_target", "interrupted_failed_sidecar"],
+)
+def test_every_engine_failure_trigger_reaches_the_a2a_event(failure_trigger: str) -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    [envelope] = translator.translate(
+        PipelineEvent(
+            type=PipelineEventType.PIPELINE_COMPLETED,
+            step_id="confirm_and_select",
+            timestamp=time.time(),
+            data={"total_steps": 4, "failed": True, "failure_trigger": failure_trigger},
+        )
+    )
+
+    assert envelope["eventType"] == "pipeline_failed"
+    assert envelope["data"]["failureTrigger"] == failure_trigger
+
+
+def test_successful_terminal_carries_no_failure_trigger() -> None:
+    translator = PipelineEventTranslator(_ctx())
+
+    [envelope] = translator.translate(
+        PipelineEvent(
+            type=PipelineEventType.PIPELINE_COMPLETED,
+            step_id=None,
+            timestamp=time.time(),
+            data={"total_steps": 4},
+        )
+    )
+
+    assert envelope["eventType"] == "pipeline_completed"
+    assert "failureTrigger" not in envelope["data"]

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -1480,3 +1480,82 @@ def test_store_returns_none_for_invalid_utf8_snapshot(tmp_path) -> None:
 def test_snapshot_schema_version_is_exported() -> None:
     assert SNAPSHOT_SCHEMA_VERSION == "1.1"
     assert "SNAPSHOT_SCHEMA_VERSION" in pipeline_snapshot.__all__
+
+
+def test_failure_history_records_each_failure_trigger() -> None:
+    started = _base("evt-start", 1, "pipeline_started")
+    step_failure = _base("evt-fail-1", 2, "pipeline_failed", status="failed")
+    step_failure["data"] = {
+        "totalSteps": 5,
+        "failed": True,
+        "failureTrigger": "step_failed",
+        "errorSummary": "generate_template exploded",
+        "errorDetails": {"type": "StepFailed", "errorId": "abc123abc123"},
+    }
+    executor_failure = _base("evt-fail-2", 3, "pipeline_failed", status="failed")
+    executor_failure["data"] = {
+        "source": "executor",
+        "failureTrigger": "executor_exception",
+        "errorSummary": "RuntimeError: boom",
+        "errorDetails": {"type": "RuntimeError", "errorId": "def456def456"},
+    }
+
+    snapshot = reduce_pipeline_events([started, step_failure, executor_failure])
+
+    assert snapshot["status"] == "failed"
+    assert [entry["trigger"] for entry in snapshot["control"]["failureHistory"]] == [
+        "step_failed",
+        "executor_exception",
+    ]
+    assert [entry["errorId"] for entry in snapshot["control"]["failureHistory"]] == [
+        "abc123abc123",
+        "def456def456",
+    ]
+    assert snapshot["control"]["failureHistory"][0]["errorSummary"] == "generate_template exploded"
+    assert all(entry["recovered"] is False for entry in snapshot["control"]["failureHistory"])
+
+
+def test_failure_history_marks_sidecar_recovery_replay() -> None:
+    recovery = _base("evt-recovered", 1, "pipeline_failed", status="failed")
+    recovery["data"] = {
+        "sidecarStatus": "failed",
+        "recovered": True,
+        "failureTrigger": "sidecar_recovery",
+    }
+
+    snapshot = reduce_pipeline_events([recovery])
+
+    assert snapshot["control"]["failureHistory"] == [
+        {
+            "eventId": "evt-recovered",
+            "sequence": 1,
+            "createdAt": "2026-06-08T10:00:00Z",
+            "trigger": "sidecar_recovery",
+            "recovered": True,
+            "errorId": None,
+            "errorSummary": None,
+        }
+    ]
+
+
+def test_failure_history_defaults_trigger_and_dedups_replayed_events() -> None:
+    failure = _base("evt-fail", 1, "pipeline_failed", status="failed")
+    failure["data"] = {"totalSteps": 5, "failed": True}
+
+    snapshot = reduce_pipeline_events([failure])
+    assert [entry["trigger"] for entry in snapshot["control"]["failureHistory"]] == ["unclassified"]
+
+    replayed = reduce_pipeline_events([failure], existing_snapshot=snapshot)
+    assert [entry["trigger"] for entry in replayed["control"]["failureHistory"]] == ["unclassified"]
+
+
+def test_failure_history_migrates_snapshot_without_the_key() -> None:
+    legacy = reduce_pipeline_events([_base("evt-start", 1, "pipeline_started")])
+    del legacy["control"]["failureHistory"]
+
+    failure = _base("evt-fail", 2, "pipeline_failed", status="failed")
+    failure["data"] = {"failureTrigger": "invalid_rollback_target"}
+
+    snapshot = reduce_pipeline_events([failure], existing_snapshot=legacy)
+
+    assert [entry["trigger"] for entry in snapshot["control"]["failureHistory"]] == ["invalid_rollback_target"]

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -4366,6 +4366,9 @@ class TestInvalidRollbackTarget:
         assert "empty" in failed[0].data["error"]
         assert len(completed) == 1
         assert completed[0].data.get("failed") is True
+        assert completed[0].data.get("failure_trigger") == "step_failed"
+        assert completed[0].data.get("error_summary") == failed[0].data["error_summary"]
+        assert completed[0].data.get("error_details") == failed[0].data["error_details"]
         runner._observability.step_failed.assert_called_once()
 
     @pytest.mark.asyncio
@@ -4446,6 +4449,9 @@ class TestInvalidRollbackTarget:
         ]
         assert len(completed) == 1, f"Expected one PIPELINE_COMPLETED, got: {events}"
         assert completed[0].data.get("failed") is True
+        assert completed[0].data.get("failure_trigger") == "invalid_rollback_target"
+        assert completed[0].data.get("error_summary") == error_msg
+        assert completed[0].data.get("error_details", {}).get("error_id")
 
         # Order: STEP_FAILED comes before PIPELINE_COMPLETED
         step_failed_idx = events.index(failed[0])


### PR DESCRIPTION
## Problem

A pipeline run could record `pipeline_failed=6` while still ending in `confirm_and_select(waiting_input)`, with no way to tell the six failures apart.

Four engine paths plus the executor exception path all emitted structurally identical terminals, and the sidecar recovery path republished a *restored* terminal that counted as a brand new failure. Retries and recovery replays therefore inflated the failure density and masked the root cause: `pipeline_failed` carried no attribution of its own, so the reason only existed on the preceding `step_failed`.

## Change

- Failed terminals now carry `failure_trigger`: `step_failed`, `invalid_rollback_target`, `interrupted_failed_sidecar`, `executor_exception`, `sidecar_recovery`.
- The step-failure paths also attach `error_summary` / `error_details` (incl. `error_id`), so a `pipeline_failed` event is attributable standalone.
- Recovery replays are tagged `sidecar_recovery` so restoring a terminal no longer reads as a newly observed failure.
- The A2A snapshot reducer sequences failures into `control.failureHistory` (deduped by `eventId`), making "which failures and why" checkable straight from `a2a-snapshot.json`.

## Compatibility

All added fields are optional; no event type, state-machine semantics or recovery flow changed. Downstream consumers read via `.get()` and are unaffected.

## Verification

- `pytest tests/` — 14330 passed, 5 skipped. The 15 failures reproduce identically on the base commit (`88ed89c`) and are sandbox-only (generated `messages.pot` absent, no outbound network). Zero regressions.
- `ruff check src/ tests/` and `ty check src/` pass.
- Added: 4 snapshot cases, 5 event-translation cases, and strengthened 2 engine terminal assertions.
