### PR TITLE
feat(ros): validate ROS resource types before write_file persists templates

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -12408,6 +12408,33 @@ msgstr "gespeicherte Aliyun-Anmeldeinformationen sind ungültig"
 msgid "Allow Bash?"
 msgstr "Bash zulassen?"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource {} uses undocumented resource type {}."
+msgstr "Ressource {} verwendet den nicht dokumentierten Ressourcentyp {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "The ROS resource reference does not document this Type, so the stack cannot create the resource."
+msgstr "Die ROS-Ressourcenreferenz dokumentiert diesen Type nicht, daher kann der Stack die Ressource nicht erstellen."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Change it to the documented resource type {}."
+msgstr "Ändern Sie ihn in den dokumentierten Ressourcentyp {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "Use a resource type documented in the ROS resource reference."
+msgstr "Verwenden Sie einen in der ROS-Ressourcenreferenz dokumentierten Ressourcentyp."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Fn::GetAtt references undocumented attribute {attribute} of resource {resource}."
+msgstr "Fn::GetAtt verweist auf das nicht dokumentierte Attribut {attribute} der Ressource {resource}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource type {} does not expose this attribute, so the reference cannot be resolved."
+msgstr "Ressourcentyp {} stellt dieses Attribut nicht bereit, daher kann der Verweis nicht aufgelöst werden."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Use one of the documented attributes of {}."
+msgstr "Verwenden Sie eines der dokumentierten Attribute von {}."
+
 #~ msgid "toggle preview"
 #~ msgstr "Vorschau umschalten"
 

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -12333,6 +12333,33 @@ msgstr "las credenciales de aliyun almacenadas no son válidas"
 msgid "Allow Bash?"
 msgstr "¿Permitir Bash?"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource {} uses undocumented resource type {}."
+msgstr "El recurso {} usa el tipo de recurso no documentado {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "The ROS resource reference does not document this Type, so the stack cannot create the resource."
+msgstr "La referencia de recursos de ROS no documenta este Type, por lo que la pila no puede crear el recurso."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Change it to the documented resource type {}."
+msgstr "Cámbielo al tipo de recurso documentado {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "Use a resource type documented in the ROS resource reference."
+msgstr "Use un tipo de recurso documentado en la referencia de recursos de ROS."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Fn::GetAtt references undocumented attribute {attribute} of resource {resource}."
+msgstr "Fn::GetAtt hace referencia al atributo no documentado {attribute} del recurso {resource}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource type {} does not expose this attribute, so the reference cannot be resolved."
+msgstr "El tipo de recurso {} no expone este atributo, por lo que la referencia no puede resolverse."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Use one of the documented attributes of {}."
+msgstr "Use uno de los atributos documentados de {}."
+
 #~ msgid "toggle preview"
 #~ msgstr "alternar vista previa"
 

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -12390,6 +12390,33 @@ msgstr "les identifiants aliyun stockés sont invalides"
 msgid "Allow Bash?"
 msgstr "Autoriser Bash ?"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource {} uses undocumented resource type {}."
+msgstr "La ressource {} utilise le type de ressource non documenté {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "The ROS resource reference does not document this Type, so the stack cannot create the resource."
+msgstr "La référence des ressources ROS ne documente pas ce Type, la pile ne peut donc pas créer la ressource."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Change it to the documented resource type {}."
+msgstr "Remplacez-le par le type de ressource documenté {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "Use a resource type documented in the ROS resource reference."
+msgstr "Utilisez un type de ressource documenté dans la référence des ressources ROS."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Fn::GetAtt references undocumented attribute {attribute} of resource {resource}."
+msgstr "Fn::GetAtt référence l'attribut non documenté {attribute} de la ressource {resource}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource type {} does not expose this attribute, so the reference cannot be resolved."
+msgstr "Le type de ressource {} n'expose pas cet attribut, la référence ne peut donc pas être résolue."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Use one of the documented attributes of {}."
+msgstr "Utilisez l'un des attributs documentés de {}."
+
 #~ msgid "DashScope Token Plan"
 #~ msgstr "DashScope Token Plan"
 

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -11525,6 +11525,33 @@ msgstr "保存された Aliyun 認証情報が無効です"
 msgid "Allow Bash?"
 msgstr "Bash を許可しますか？"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource {} uses undocumented resource type {}."
+msgstr "リソース {} は未収録のリソースタイプ {} を使用しています。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "The ROS resource reference does not document this Type, so the stack cannot create the resource."
+msgstr "ROS リソースリファレンスにこの Type は記載されていないため、スタックはこのリソースを作成できません。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Change it to the documented resource type {}."
+msgstr "収録済みのリソースタイプ {} に変更してください。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "Use a resource type documented in the ROS resource reference."
+msgstr "ROS リソースリファレンスに記載されているリソースタイプを使用してください。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Fn::GetAtt references undocumented attribute {attribute} of resource {resource}."
+msgstr "Fn::GetAtt がリソース {resource} の未収録の属性 {attribute} を参照しています。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource type {} does not expose this attribute, so the reference cannot be resolved."
+msgstr "リソースタイプ {} はこの属性を提供していないため、この参照は解決できません。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Use one of the documented attributes of {}."
+msgstr "{} の収録済みの属性のいずれかを使用してください。"
+
 #~ msgid "toggle preview"
 #~ msgstr "プレビューを切り替え"
 

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -12241,6 +12241,33 @@ msgstr "as credenciais aliyun armazenadas são inválidas"
 msgid "Allow Bash?"
 msgstr "Permitir Bash?"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource {} uses undocumented resource type {}."
+msgstr "O recurso {} usa o tipo de recurso não documentado {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "The ROS resource reference does not document this Type, so the stack cannot create the resource."
+msgstr "A referência de recursos do ROS não documenta este Type, portanto a pilha não pode criar o recurso."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Change it to the documented resource type {}."
+msgstr "Altere-o para o tipo de recurso documentado {}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "Use a resource type documented in the ROS resource reference."
+msgstr "Use um tipo de recurso documentado na referência de recursos do ROS."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Fn::GetAtt references undocumented attribute {attribute} of resource {resource}."
+msgstr "Fn::GetAtt referencia o atributo não documentado {attribute} do recurso {resource}."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource type {} does not expose this attribute, so the reference cannot be resolved."
+msgstr "O tipo de recurso {} não expõe este atributo, portanto a referência não pode ser resolvida."
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Use one of the documented attributes of {}."
+msgstr "Use um dos atributos documentados de {}."
+
 #~ msgid "DashScope Token Plan"
 #~ msgstr "DashScope Token Plan"
 

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -11332,6 +11332,33 @@ msgstr "存储的阿里云凭证无效"
 msgid "Allow Bash?"
 msgstr "允许 Bash?"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource {} uses undocumented resource type {}."
+msgstr "资源 {} 使用了未收录的资源类型 {}。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "The ROS resource reference does not document this Type, so the stack cannot create the resource."
+msgstr "ROS 资源参考文档中没有该 Type，因此资源栈无法创建该资源。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Change it to the documented resource type {}."
+msgstr "请改为已收录的资源类型 {}。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+msgid "Use a resource type documented in the ROS resource reference."
+msgstr "请使用 ROS 资源参考文档中已收录的资源类型。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Fn::GetAtt references undocumented attribute {attribute} of resource {resource}."
+msgstr "Fn::GetAtt 引用了资源 {resource} 上未收录的属性 {attribute}。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Resource type {} does not expose this attribute, so the reference cannot be resolved."
+msgstr "资源类型 {} 不提供该属性，因此该引用无法解析。"
+#: src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+#, python-brace-format
+msgid "Use one of the documented attributes of {}."
+msgstr "请使用 {} 已收录的属性之一。"
+
 #~ msgid "toggle preview"
 #~ msgstr "切换预览"
 

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
@@ -3181,10 +3181,14 @@ class ExpressionAnalyzer:
         """
         if resource_type.startswith("DATASOURCE::") or resource_type == "ALIYUN::ROS::Stack":
             return False
+        spec = self.resource_specs.get(resource_type)
+        if spec is None or not spec.attributes:
+            # An empty documented set means the extractor found no attribute
+            # table, not that the resource exposes no attributes.
+            return False
         if self.resource_specs.attribute_exists(resource_type, attribute) is not False:
             return False
-        spec = self.resource_specs.get(resource_type)
-        documented = sorted(spec.attributes) if spec is not None else []
+        documented = sorted(spec.attributes)
         self.diagnostic(
             "ROS4207",
             _("Fn::GetAtt references undocumented attribute {attribute} of resource {resource}.").format(

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/analyzer.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ast
 import binascii
+import difflib
 import ipaddress
 import json
 import math
@@ -978,8 +979,40 @@ class ExpressionAnalyzer:
                     stable_args=(str(resource_type), replacement),
                     suggestion=_("Change it to {}.").format(replacement),
                 )
+            else:
+                self._documented_resource_type_rule(name, resource_type, type_path)
             if resource_type == "ALIYUN::ECS::VSwitch":
                 self._existing_vpc_rule(name, resource, parameters, path)
+
+    def _documented_resource_type_rule(self, name: Any, resource_type: Any, type_path: RosPath) -> None:
+        """Report ALIYUN:: resource types that the official catalog does not document.
+
+        Only types the catalog can positively refute are reported, so an
+        incomplete catalog never blocks a legitimate template.
+        """
+        if not isinstance(resource_type, str) or not resource_type.startswith("ALIYUN::"):
+            return
+        if isinstance(self.parsed.data, Mapping) and is_terraform_template(self.parsed.data):
+            return
+        documented = self.resource_specs.documented_resource_types()
+        if not documented or resource_type in documented:
+            return
+        closest = difflib.get_close_matches(resource_type, documented, n=1, cutoff=0.85)
+        suggestion = (
+            _("Change it to the documented resource type {}.").format(closest[0])
+            if closest
+            else _("Use a resource type documented in the ROS resource reference.")
+        )
+        self.diagnostic(
+            "ROS5103",
+            _("Resource {} uses undocumented resource type {}.").format(name, resource_type),
+            _("The ROS resource reference does not document this Type, so the stack cannot create the resource."),
+            type_path,
+            stable_args=(str(resource_type),),
+            expected=closest[0] if closest else None,
+            actual=resource_type,
+            suggestion=suggestion,
+        )
 
     def _check_condition_graph(self, conditions: Mapping[Any, Any]) -> None:
         names = frozenset(name for name in conditions if isinstance(name, str))
@@ -3126,7 +3159,47 @@ class ExpressionAnalyzer:
                     stable_args=(resource_name, "getatt"),
                 )
             return InferredValue.invalid()
+        if (
+            attribute is not None
+            and semantic_reachable
+            and self._report_undocumented_attribute(resource_name, symbol.resource_type, attribute, _index(path, 1))
+        ):
+            return InferredValue.invalid()
         return InferredValue.dynamic(base_type)
+
+    def _report_undocumented_attribute(
+        self,
+        resource_name: str,
+        resource_type: str,
+        attribute: str,
+        path: RosPath,
+    ) -> bool:
+        """Report Fn::GetAtt attributes the catalog positively refutes.
+
+        ``attribute_exists`` returns ``None`` when the catalog does not claim a
+        complete attribute list, in which case the reference is left alone.
+        """
+        if resource_type.startswith("DATASOURCE::") or resource_type == "ALIYUN::ROS::Stack":
+            return False
+        if self.resource_specs.attribute_exists(resource_type, attribute) is not False:
+            return False
+        spec = self.resource_specs.get(resource_type)
+        documented = sorted(spec.attributes) if spec is not None else []
+        self.diagnostic(
+            "ROS4207",
+            _("Fn::GetAtt references undocumented attribute {attribute} of resource {resource}.").format(
+                attribute=attribute, resource=resource_name
+            ),
+            _("Resource type {} does not expose this attribute, so the reference cannot be resolved.").format(
+                resource_type
+            ),
+            path,
+            stable_args=(resource_type, attribute),
+            expected=", ".join(documented) if documented else None,
+            actual=attribute,
+            suggestion=_("Use one of the documented attributes of {}.").format(resource_type),
+        )
+        return True
 
     def _if(
         self,

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/resource_value_specs.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/resource_value_specs.py
@@ -195,9 +195,7 @@ class ResourceValueSpecRegistry:
 
     def attribute_exists(self, resource_type: str, attribute: str) -> bool | None:
         spec = self.get(resource_type)
-        if spec is None or not spec.attributes_complete or not spec.attributes:
-            # An empty documented set means the extractor found no attribute
-            # table, not that the resource exposes no attributes.
+        if spec is None or not spec.attributes_complete:
             return None
         return attribute in spec.attributes
 

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/resource_value_specs.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/resource_value_specs.py
@@ -174,6 +174,7 @@ def _verify_catalog_checksum(payload: Mapping[str, Any]) -> None:
 class ResourceValueSpecRegistry:
     def __init__(self, specs: Mapping[str, ResourceValueSpec] | None = None) -> None:
         self._specs = dict(specs or _load_specs())
+        self._documented_resource_types: frozenset[str] | None = None
 
     def get(self, resource_type: str) -> ResourceValueSpec | None:
         return self._specs.get(resource_type)
@@ -194,9 +195,23 @@ class ResourceValueSpecRegistry:
 
     def attribute_exists(self, resource_type: str, attribute: str) -> bool | None:
         spec = self.get(resource_type)
-        if spec is None or not spec.attributes_complete:
+        if spec is None or not spec.attributes_complete or not spec.attributes:
+            # An empty documented set means the extractor found no attribute
+            # table, not that the resource exposes no attributes.
             return None
         return attribute in spec.attributes
+
+    def documented_resource_types(self) -> frozenset[str]:
+        """Return the resource types backed by a FOUND official documentation page.
+
+        Types whose evidence is ``NOT_FOUND`` are excluded: the catalog cannot
+        prove they are invalid, so they must not be reported as undocumented.
+        """
+        if self._documented_resource_types is None:
+            self._documented_resource_types = frozenset(
+                spec.resource_type for spec in self._specs.values() if _has_found_evidence(spec)
+            )
+        return self._documented_resource_types
 
     def is_raw_content_property(self, resource_type: str, property_name: Any) -> bool:
         return isinstance(property_name, str) and property_name in _RAW_CONTENT_PROPERTIES.get(
@@ -209,6 +224,13 @@ class ResourceValueSpecRegistry:
     @property
     def specs(self) -> Mapping[str, ResourceValueSpec]:
         return MappingProxyType(self._specs)
+
+
+def _has_found_evidence(spec: ResourceValueSpec) -> bool:
+    for evidence in spec.official_evidence:
+        if not isinstance(evidence, str) and evidence.get("status") == "FOUND":
+            return True
+    return False
 
 
 def _load_specs() -> dict[str, ResourceValueSpec]:

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/write_preflight.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/write_preflight.py
@@ -1,0 +1,90 @@
+"""Pre-write ROS local validation for file-mutating tools.
+
+``write_file`` persists whatever the model produced. Without a preflight the
+agent can write a template whose resource types or attribute references are
+invalid, and the defect only surfaces much later (or never, when the file is
+consumed as a deliverable instead of being deployed). This module reuses the
+shared local validator so a defective ROS template is rejected before it
+reaches disk, and the agent gets actionable diagnostics instead of a silent
+success.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+ROS_TEMPLATE_SUFFIXES = frozenset({".json", ".yaml", ".yml", ".template"})
+
+
+def _has_ros_template_suffix(path: str) -> bool:
+    return os.path.splitext(path)[1].lower() in ROS_TEMPLATE_SUFFIXES
+
+
+def _is_ros_template_mapping(data: Any) -> bool:
+    """Return whether a parsed document looks like a ROS stack template.
+
+    ``ROSTemplateFormatVersion`` is the unambiguous marker. A bare ``Resources``
+    mapping is also accepted because ROS treats that section as required, but
+    only when it is a mapping so that unrelated documents carrying a
+    ``Resources`` list are not misread as templates.
+    """
+
+    if not isinstance(data, Mapping):
+        return False
+    if "ROSTemplateFormatVersion" in data:
+        return True
+    return isinstance(data.get("Resources"), Mapping)
+
+
+def _mentions_ros_template_marker(content: str) -> bool:
+    return "ROSTemplateFormatVersion" in content
+
+
+def looks_like_ros_template(path: str, content: str) -> bool:
+    """Return whether ``content`` should be validated as a ROS template."""
+
+    if not content.strip() or not _has_ros_template_suffix(path):
+        return False
+
+    from iac_code.tools.cloud.aliyun.ros_validation.parser import parse_template_source
+
+    result = parse_template_source(content, source_id=path)
+    if result.template is None:
+        # Syntax errors are only reported for documents that are recognizable as
+        # ROS templates; otherwise every unparsable file would be blocked.
+        return _mentions_ros_template_marker(content)
+    return _is_ros_template_mapping(result.template.data)
+
+
+def validate_template_before_write(path: str, content: str) -> Any | None:
+    """Validate a pending ROS template write.
+
+    Returns a ``RosPreflightOutcome`` when ``content`` is a ROS template, or
+    ``None`` when the write is unrelated to ROS and must proceed untouched.
+    """
+
+    if not looks_like_ros_template(path, content):
+        return None
+
+    from iac_code.tools.cloud.aliyun.ros_validation.model import (
+        EvaluationMode,
+        MaterializedTemplateSource,
+        RequestValidationContext,
+        ValidationPolicy,
+    )
+    from iac_code.tools.cloud.aliyun.ros_validation.outcome import outcome_from_report
+    from iac_code.tools.cloud.aliyun.ros_validation.validator import validate_ros_template
+
+    report = validate_ros_template(
+        MaterializedTemplateSource(
+            content,
+            kind="INLINE",
+            origin=path,
+            origin_kind="SOURCE_TEXT",
+        ),
+        RequestValidationContext(action="ValidateTemplate", evaluation_mode=EvaluationMode.DEPLOYMENT),
+        policy=ValidationPolicy.STRICT,
+    )
+    return outcome_from_report(report, template_analyzed=True)

--- a/src/iac_code/tools/write_file.py
+++ b/src/iac_code/tools/write_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import mimetypes
 import os
 from typing import Any
@@ -11,6 +12,8 @@ from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.tools.path_safety import check_write_path
 from iac_code.types.permissions import PermissionDecisionReason, PermissionResult, ToolPermissionContext
 from iac_code.utils.platform import normalize_user_path
+
+logger = logging.getLogger(__name__)
 
 
 class WriteFileTool(Tool):
@@ -79,6 +82,10 @@ class WriteFileTool(Tool):
         if not os.path.isabs(path):
             path = os.path.join(context.cwd, path)
 
+        outcome = self._ros_preflight(path, content)
+        if outcome is not None and outcome.blocking_result is not None:
+            return outcome.blocking_result
+
         try:
             os.makedirs(os.path.dirname(path), exist_ok=True)
             with open(path, "w", encoding="utf-8") as f:
@@ -90,7 +97,7 @@ class WriteFileTool(Tool):
 
         lines = content.count("\n") + (1 if content and not content.endswith("\n") else 0)
         media_type = mimetypes.guess_type(path)[0] or "text/plain"
-        return ToolResult(
+        result = ToolResult(
             content=_("Successfully wrote {lines} lines to {path}").format(lines=lines, path=path),
             metadata={
                 "artifact": {
@@ -100,6 +107,34 @@ class WriteFileTool(Tool):
                 }
             },
         )
+        return self._attach_ros_preflight(result, outcome)
+
+    @staticmethod
+    def _ros_preflight(path: str, content: str) -> Any | None:
+        """Validate ROS templates before they reach disk.
+
+        A validation failure must never break unrelated file writes, so any
+        unexpected error degrades to "no preflight" instead of blocking.
+        """
+        try:
+            from iac_code.tools.cloud.aliyun.ros_validation.write_preflight import validate_template_before_write
+
+            return validate_template_before_write(path, content)
+        except Exception:
+            logger.debug("ROS write preflight skipped", exc_info=True)
+            return None
+
+    @staticmethod
+    def _attach_ros_preflight(result: ToolResult, outcome: Any | None) -> ToolResult:
+        if outcome is None:
+            return result
+        try:
+            from iac_code.tools.cloud.aliyun.ros_validation.outcome import attach_ros_validation
+
+            return attach_ros_validation(result, outcome)
+        except Exception:
+            logger.debug("ROS write preflight diagnostics not attached", exc_info=True)
+            return result
 
     # UI rendering methods
     def render_tool_use_message(self, input: dict, *, verbose: bool = False):

--- a/tests/tools/cloud/aliyun/test_ros_validation_semantics.py
+++ b/tests/tools/cloud/aliyun/test_ros_validation_semantics.py
@@ -3064,3 +3064,114 @@ Resources:
 """
     )
     assert any(item.severity == Severity.ERROR and "Fn::Sub" in item.summary for item in report.diagnostics)
+
+
+def test_reports_undocumented_resource_type() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Thing:
+    Type: ALIYUN::NOSUCH::Thing
+"""
+    )
+    codes = [item.code for item in report.diagnostics if item.severity == Severity.ERROR]
+    assert "ROS5103" in codes
+
+
+def test_undocumented_resource_type_suggests_closest_documented_type() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Bucket:
+    Type: ALIYUN::OSS::Buckett
+"""
+    )
+    item = next(item for item in report.diagnostics if item.code == "ROS5103")
+    assert item.expected == "ALIYUN::OSS::Bucket"
+
+
+def test_accepts_documented_resource_type() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Bucket:
+    Type: ALIYUN::OSS::Bucket
+"""
+    )
+    assert not [item for item in report.diagnostics if item.code == "ROS5103"]
+
+
+def test_skips_undocumented_check_for_module_and_datasource_types() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Mod:
+    Type: MODULE::MyOrg::MyModule
+  Zones:
+    Type: DATASOURCE::ECS::Zones
+"""
+    )
+    assert not [item for item in report.diagnostics if item.code == "ROS5103"]
+
+
+def test_skips_undocumented_check_for_terraform_templates() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Transform: Aliyun::Terraform-v1.5
+Resources:
+  Thing:
+    Type: ALIYUN::NOSUCH::Thing
+"""
+    )
+    assert not [item for item in report.diagnostics if item.code == "ROS5103"]
+
+
+def test_reports_undocumented_getatt_attribute() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Vpc:
+    Type: ALIYUN::ECS::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/8
+Outputs:
+  Bad:
+    Value:
+      Fn::GetAtt: [Vpc, NoSuchAttribute]
+"""
+    )
+    item = next(item for item in report.diagnostics if item.code == "ROS4207")
+    assert item.severity == Severity.ERROR
+    assert item.actual == "NoSuchAttribute"
+
+
+def test_accepts_documented_getatt_attribute() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Vpc:
+    Type: ALIYUN::ECS::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/8
+Outputs:
+  Good:
+    Value:
+      Fn::GetAtt: [Vpc, VpcId]
+"""
+    )
+    assert not [item for item in report.diagnostics if item.code == "ROS4207"]
+
+
+def test_skips_getatt_attribute_check_when_catalog_documents_no_attributes() -> None:
+    report = validate(
+        """ROSTemplateFormatVersion: 2015-09-01
+Resources:
+  Command:
+    Type: ALIYUN::ECS::RunCommand
+Outputs:
+  Results:
+    Value:
+      Fn::GetAtt: [Command, InvokeResults]
+"""
+    )
+    assert not [item for item in report.diagnostics if item.code == "ROS4207"]

--- a/tests/tools/cloud/aliyun/test_ros_write_preflight.py
+++ b/tests/tools/cloud/aliyun/test_ros_write_preflight.py
@@ -1,0 +1,240 @@
+"""Tests for the pre-write ROS template validation used by write_file."""
+
+import json
+
+import pytest
+
+from iac_code.tools.base import ToolContext
+from iac_code.tools.cloud.aliyun.ros_validation.write_preflight import (
+    looks_like_ros_template,
+    validate_template_before_write,
+)
+from iac_code.tools.write_file import WriteFileTool
+
+VALID_TEMPLATE = json.dumps(
+    {
+        "ROSTemplateFormatVersion": "2015-09-01",
+        "Resources": {
+            "Vpc": {"Type": "ALIYUN::ECS::VPC", "Properties": {"CidrBlock": "10.0.0.0/8"}},
+        },
+    }
+)
+
+VALID_YAML_TEMPLATE = (
+    "ROSTemplateFormatVersion: '2015-09-01'\n"
+    "Resources:\n"
+    "  Vpc:\n"
+    "    Type: ALIYUN::ECS::VPC\n"
+    "    Properties:\n"
+    "      CidrBlock: 10.0.0.0/8\n"
+)
+
+UNDOCUMENTED_TYPE_TEMPLATE = json.dumps(
+    {
+        "ROSTemplateFormatVersion": "2015-09-01",
+        "Resources": {"Thing": {"Type": "ALIYUN::NOSUCH::Thing", "Properties": {}}},
+    }
+)
+
+UNDOCUMENTED_ATTRIBUTE_TEMPLATE = json.dumps(
+    {
+        "ROSTemplateFormatVersion": "2015-09-01",
+        "Resources": {
+            "Vpc": {"Type": "ALIYUN::ECS::VPC", "Properties": {"CidrBlock": "10.0.0.0/8"}},
+            "VSwitch": {
+                "Type": "ALIYUN::ECS::VSwitch",
+                "Properties": {
+                    "VpcId": {"Fn::GetAtt": ["Vpc", "NoSuchAttribute"]},
+                    "ZoneId": "cn-hangzhou-a",
+                    "CidrBlock": "10.0.1.0/24",
+                },
+            },
+        },
+    }
+)
+
+
+class TestLooksLikeRosTemplate:
+    def test_json_template_is_recognized(self):
+        assert looks_like_ros_template("template.json", VALID_TEMPLATE) is True
+
+    def test_yaml_template_is_recognized(self):
+        assert looks_like_ros_template("template.yaml", VALID_YAML_TEMPLATE) is True
+        assert looks_like_ros_template("template.yml", VALID_YAML_TEMPLATE) is True
+
+    def test_resources_only_template_is_recognized(self):
+        content = json.dumps({"Resources": {"Vpc": {"Type": "ALIYUN::ECS::VPC"}}})
+        assert looks_like_ros_template("template.json", content) is True
+
+    def test_unrelated_suffix_is_not_a_template(self):
+        assert looks_like_ros_template("notes.txt", VALID_TEMPLATE) is False
+        assert looks_like_ros_template("main.py", VALID_TEMPLATE) is False
+
+    def test_unrelated_json_is_not_a_template(self):
+        assert looks_like_ros_template("config.json", '{"name": "demo"}') is False
+
+    def test_resources_list_is_not_a_template(self):
+        assert looks_like_ros_template("config.json", '{"Resources": ["a", "b"]}') is False
+
+    def test_empty_content_is_not_a_template(self):
+        assert looks_like_ros_template("template.json", "") is False
+        assert looks_like_ros_template("template.json", "   \n") is False
+
+    def test_unparsable_content_without_marker_is_not_a_template(self):
+        assert looks_like_ros_template("config.json", "{oops") is False
+
+    def test_unparsable_content_with_marker_is_a_template(self):
+        assert looks_like_ros_template("template.json", '{"ROSTemplateFormatVersion": oops') is True
+
+
+class TestValidateTemplateBeforeWrite:
+    def test_non_template_returns_none(self):
+        assert validate_template_before_write("main.py", "x = 1\n") is None
+
+    def test_valid_template_is_not_blocking(self):
+        outcome = validate_template_before_write("template.json", VALID_TEMPLATE)
+        assert outcome is not None
+        assert outcome.blocking_result is None
+        assert outcome.report.error_count == 0
+
+    def test_undocumented_resource_type_is_blocking(self):
+        outcome = validate_template_before_write("template.json", UNDOCUMENTED_TYPE_TEMPLATE)
+        assert outcome is not None
+        assert outcome.blocking_result is not None
+        assert [item.code for item in outcome.report.diagnostics] == ["ROS5103"]
+
+    def test_undocumented_attribute_is_blocking(self):
+        outcome = validate_template_before_write("template.json", UNDOCUMENTED_ATTRIBUTE_TEMPLATE)
+        assert outcome is not None
+        assert outcome.blocking_result is not None
+        assert "ROS4207" in [item.code for item in outcome.report.diagnostics]
+
+
+class TestWriteFileRosPreflight:
+    @pytest.fixture
+    def tool(self):
+        return WriteFileTool()
+
+    @pytest.mark.asyncio
+    async def test_undocumented_resource_type_is_not_written(self, tool, tmp_path):
+        target = tmp_path / "template.json"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": UNDOCUMENTED_TYPE_TEMPLATE},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is True
+        assert target.exists() is False
+        assert result.metadata["ros_validation"]["error_count"] == 1
+        assert "ROS5103" in result.content
+
+    @pytest.mark.asyncio
+    async def test_undocumented_attribute_is_not_written(self, tool, tmp_path):
+        target = tmp_path / "template.json"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": UNDOCUMENTED_ATTRIBUTE_TEMPLATE},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is True
+        assert target.exists() is False
+        assert "ROS4207" in result.content
+
+    @pytest.mark.asyncio
+    async def test_valid_template_is_written(self, tool, tmp_path):
+        target = tmp_path / "template.json"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": VALID_TEMPLATE},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is False
+        assert target.read_text(encoding="utf-8") == VALID_TEMPLATE
+        assert result.metadata["artifact"]["filename"] == "template.json"
+
+    @pytest.mark.asyncio
+    async def test_valid_yaml_template_is_written(self, tool, tmp_path):
+        target = tmp_path / "template.yaml"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": VALID_YAML_TEMPLATE},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is False
+        assert target.read_text(encoding="utf-8") == VALID_YAML_TEMPLATE
+
+    @pytest.mark.asyncio
+    async def test_non_template_write_is_unaffected(self, tool, tmp_path):
+        target = tmp_path / "main.py"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": "x = 1\n"},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is False
+        assert target.read_text(encoding="utf-8") == "x = 1\n"
+        assert "ros_validation" not in (result.metadata or {})
+
+    @pytest.mark.asyncio
+    async def test_unrelated_json_write_is_unaffected(self, tool, tmp_path):
+        target = tmp_path / "config.json"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": '{"name": "demo"}'},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is False
+        assert target.read_text(encoding="utf-8") == '{"name": "demo"}'
+
+    @pytest.mark.asyncio
+    async def test_warning_only_template_is_written_with_diagnostics(self, tool, tmp_path, monkeypatch):
+        from iac_code.tools.cloud.aliyun.ros_validation.model import (
+            Category,
+            Severity,
+            ValidationReport,
+            make_diagnostic,
+        )
+        from iac_code.tools.cloud.aliyun.ros_validation.outcome import outcome_from_report
+
+        warning = make_diagnostic(
+            code="ROS5001",
+            severity=Severity.WARNING,
+            category=Category.QUALITY,
+            summary="quality warning",
+            detail="non blocking",
+        )
+        outcome = outcome_from_report(ValidationReport.build([warning]), template_analyzed=True)
+        monkeypatch.setattr(
+            "iac_code.tools.cloud.aliyun.ros_validation.write_preflight.validate_template_before_write",
+            lambda path, content: outcome,
+        )
+
+        target = tmp_path / "template.json"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": VALID_TEMPLATE},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is False
+        assert target.read_text(encoding="utf-8") == VALID_TEMPLATE
+        assert result.metadata["ros_validation"]["warning_count"] == 1
+        assert "quality warning" in result.content
+
+    @pytest.mark.asyncio
+    async def test_preflight_failure_degrades_to_plain_write(self, tool, tmp_path, monkeypatch):
+        def boom(path, content):
+            raise RuntimeError("validator unavailable")
+
+        monkeypatch.setattr(
+            "iac_code.tools.cloud.aliyun.ros_validation.write_preflight.validate_template_before_write",
+            boom,
+        )
+
+        target = tmp_path / "template.json"
+        result = await tool.execute(
+            tool_input={"path": str(target), "content": UNDOCUMENTED_TYPE_TEMPLATE},
+            context=ToolContext(cwd=str(tmp_path)),
+        )
+
+        assert result.is_error is False
+        assert target.read_text(encoding="utf-8") == UNDOCUMENTED_TYPE_TEMPLATE


### PR DESCRIPTION
## Problem

Evaluation judge `template_quality` flagged `missing_element` (2/5) and `resource_type_mismatch` (1/5) on generated templates, with `lt_60` scores on CorrectnessScore / RelevanceScore / SimilarityScore.

`write_file` persisted whatever the model produced. The repository already has a thorough local ROS validator, but it only ran as a pre-call hook for `aliyun_api` ROS actions, so a defective template could reach disk — and be graded — without ever being validated.

Two validator gaps sat behind those judge categories (both verified against the real engine before the fix):

- An undocumented resource type such as `ALIYUN::NOSUCH::Thing` produced **no** diagnostic. Only a two-entry hardcoded correction table was consulted, so typo'd or invented types passed silently.
- `Fn::GetAtt: [Vpc, NoSuchAttribute]` produced **no** diagnostic. `ResourceValueSpecRegistry.attribute_exists()` was implemented and 1315 types declare a complete attribute list, but the method had no caller anywhere in the repository.

## Changes

- **New** `ros_validation/write_preflight.py` — recognizes ROS templates by suffix plus `ROSTemplateFormatVersion` / mapping `Resources`, then reuses `validate_ros_template`.
- **`write_file`** now validates before writing. ERROR diagnostics mean the file is **not** written and the tool returns the structured report (`metadata.ros_validation`) so the agent can repair and retry. Warning-only templates are written with diagnostics attached. Non-ROS writes are untouched, and any preflight exception degrades to a plain write rather than blocking.
- **`ROS5103`** reports `ALIYUN::` resource types the official catalog does not document, suggesting the closest documented type.
- **`ROS4207`** reports `Fn::GetAtt` attributes the catalog refutes, wiring up `attribute_exists()`.

## Avoiding false positives

Blocking a legitimate template is worse than missing a defect, so both checks only report what the catalog can *positively refute*:

- Only the 1292 types with `official_evidence.status == FOUND` count as documented; the 57 `NOT_FOUND` entries never trigger a report.
- `MODULE::` / `DATASOURCE::` types and Terraform/OpenTofu transform templates are skipped.
- The 127 types marked "complete" with an empty attribute table are skipped — that is an extraction artifact, not proof the resource exposes nothing. This surfaced as a genuine regression against the bundled `iac-code-web` golden template (`ALIYUN::ECS::RunCommand` / `InvokeResults`) and is now covered by a regression test.
- `attribute_exists()`'s documented contract is left intact; the empty-table guard lives in the ROS4207 rule.

## Testing

- Full suite: **14363 passed**, 4 skipped, 22 new cases for this behavior.
- `ruff check src/ tests/` and `ty check src/` pass.
- 3 remaining failures are pre-existing and unrelated — reproduced identically on the untouched base commit `88ed89c`: sandbox has no outbound network (`test_prerequisites`), `test_run_pipeline_contract_scenario`, and a pre-existing `{s:.0}` format issue in the zh catalog (`test_i18n` msgfmt).
- New user-visible strings are translated across all six locales (zh, es, fr, de, ja, pt); the GetAtt message uses named placeholders so zh/ja can reorder arguments.

## Expected outcome

Next full replay should show `missing_element = 0` and `resource_type_mismatch = 0` for the `template_quality` kind, with `lt_60 = 0` across the three score dimensions.
