### PR TITLE
fix(pipeline): enforce resource type consistency in template generation

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1731,9 +1731,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             raise ValueError("Invalid A2A workspace metadata.")
         logical_cwd = os.path.normpath(cwd)
         resolved_cwd = resolve_workspace_path(Path(logical_cwd))
-        if not trust_request_cwd() and not any(
-            _is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()
-        ):
+        if not trust_request_cwd() and not any(_is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()):
             raise ValueError("Invalid A2A workspace metadata.")
         if resolved_cwd.exists():
             if not resolved_cwd.is_dir():

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -178,35 +178,29 @@ def permission_display_fields(request: PermissionRequestEvent, *, language: str 
             command = safe_input.get("command") or safe_input.get("cmd")
         if isinstance(command, str) and command.strip():
             command_fallback = translate_message("shell command", language=language)
-            target = translate_message(
-                "the current local workspace; command: {command}", language=language
-            ).format(command=_display_text(command, fallback=command_fallback, maximum=240))
+            target = translate_message("the current local workspace; command: {command}", language=language).format(
+                command=_display_text(command, fallback=command_fallback, maximum=240)
+            )
         else:
             target = translate_message("the current local workspace", language=language)
         effect = "read" if is_read_only else ("local_execution" if read_only_known else "unknown")
     elif tool_name in {"write_file", "edit_file"}:
         title = translate_message("Change a workspace file", language=language)
-        purpose = translate_message(
-            "Write a file needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Write a file needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "a file in the current workspace", language=language
         )
         effect = "file_change"
     elif tool_name in {"read_file", "glob", "grep"} or is_read_only:
         title = translate_message("Read workspace data with {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Read local data needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Read local data needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current local workspace", language=language
         )
         effect = "read"
     else:
         title = translate_message("Run {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Run this operation for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Run this operation for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current task workspace or cloud account", language=language
         )
@@ -319,9 +313,7 @@ def _cloud_operation_title(product: str, action: str, *, is_read_only: bool, lan
     if action == "CreateStack":
         return translate_message("Create {product} stack", language=language).format(product=product_label)
     if action == "ContinueCreateStack":
-        return translate_message("Continue creating {product} stack", language=language).format(
-            product=product_label
-        )
+        return translate_message("Continue creating {product} stack", language=language).format(product=product_label)
     if action == "UpdateStack":
         return translate_message("Update {product} stack", language=language).format(product=product_label)
     if action == "DeleteStack":
@@ -344,9 +336,7 @@ def _safe_input_target(value: Any, *, language: str) -> str:
     for key in ("file_path", "filePath", "path", "region_id", "regionId", "resource_id", "resourceId"):
         candidate = value.get(key)
         if isinstance(candidate, str) and candidate.strip():
-            return _display_text(
-                candidate, fallback=translate_message("the current task scope", language=language)
-            )
+            return _display_text(candidate, fallback=translate_message("the current task scope", language=language))
     return ""
 
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -1235,11 +1235,7 @@ class IacCodeA2APipelineExecutor:
             def permission_context_getter() -> Any:
                 return getattr(agent_loop, "_permission_context", None)
 
-        surface = (
-            A2A_RICH_CANDIDATE_SURFACE
-            if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION
-            else "a2a"
-        )
+        surface = A2A_RICH_CANDIDATE_SURFACE if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION else "a2a"
         return create_pipeline(
             pipeline_name,
             provider_manager=runtime.provider_manager,

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -864,9 +864,7 @@ class A2ATaskStore(TaskStore):
                 any(record.active_task is not None and not record.active_task.done() for record in self._tasks.values())
                 or any(not task.done() for task in self._context_runtime_tasks.values())
                 or any(
-                    not task.done()
-                    for starts in self._context_execution_starts.values()
-                    for task in starts.values()
+                    not task.done() for starts in self._context_execution_starts.values() for task in starts.values()
                 )
                 or any(self._context_reconciliation_waiters.values())
                 or any(lock.locked() for lock in self._reconciliation_locks.values())

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4088,6 +4088,24 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Generated resource types must match the candidate resource_intents; fix "
+"the template resource types and validate it again before completing the "
+"step."
+msgstr ""
+"Die generierten Ressourcentypen müssen den resource_intents des "
+"Kandidaten entsprechen; korrigieren Sie die Ressourcentypen der Vorlage "
+"und validieren Sie sie erneut, bevor Sie den Schritt abschließen."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr ""
+"template_generating muss die generierte Vorlage mit ros_validate_template"
+" für denselben file_path validieren."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4195,13 +4213,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "Eine Abschlussbedingung ist falsch konfiguriert."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Validierungsproblem: {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "Eine Abschlussbedingung ist falsch konfiguriert."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4065,6 +4065,24 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Generated resource types must match the candidate resource_intents; fix "
+"the template resource types and validate it again before completing the "
+"step."
+msgstr ""
+"Los tipos de recurso generados deben coincidir con resource_intents del "
+"candidato; corrige los tipos de recurso de la plantilla y vuelve a "
+"validarla antes de completar el paso."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr ""
+"template_generating debe validar la plantilla generada con "
+"ros_validate_template para el mismo file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4169,13 +4187,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "La guarda de finalización está mal configurada."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Problema de validación: {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "La guarda de finalización está mal configurada."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4074,6 +4074,24 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Generated resource types must match the candidate resource_intents; fix "
+"the template resource types and validate it again before completing the "
+"step."
+msgstr ""
+"Les types de ressources générés doivent correspondre aux resource_intents"
+" du candidat ; corrigez les types de ressources du modèle et validez-le à"
+" nouveau avant de terminer l'étape."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr ""
+"template_generating doit valider le modèle généré avec "
+"ros_validate_template pour le même file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4176,13 +4194,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "Une garde de finalisation est mal configurée."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Problème de validation : {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "Une garde de finalisation est mal configurée."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3876,6 +3876,23 @@ msgstr "ユーザーが明示した各ハード制約は、パラメーターと
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Generated resource types must match the candidate resource_intents; fix "
+"the template resource types and validate it again before completing the "
+"step."
+msgstr ""
+"生成されたリソースタイプは候補の resource_intents "
+"と一致していなければなりません。テンプレートのリソースタイプを修正し、再度検証してからステップを完了してください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr ""
+"template_generating は生成したテンプレートを同じ file_path で ros_validate_template "
+"により検証する必要があります。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -3968,13 +3985,13 @@ msgid ""
 msgstr "{message} complete_step.conclusion には次のいずれかのフィールドが必要です: {fields}。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "完了ガードの設定に誤りがあります。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} 検証上の問題: {code} ({detail})。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "完了ガードの設定に誤りがあります。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4046,6 +4046,24 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Generated resource types must match the candidate resource_intents; fix "
+"the template resource types and validate it again before completing the "
+"step."
+msgstr ""
+"Os tipos de recurso gerados devem corresponder aos resource_intents do "
+"candidato; corrija os tipos de recurso do modelo e valide-o novamente "
+"antes de concluir a etapa."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr ""
+"template_generating deve validar o modelo gerado com "
+"ros_validate_template para o mesmo file_path."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""
@@ -4145,13 +4163,13 @@ msgstr ""
 "{fields}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "Uma proteção de conclusão está configurada incorretamente."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} Problema de validação: {code} ({detail})."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "Uma proteção de conclusão está configurada incorretamente."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3840,6 +3840,19 @@ msgstr "每个用户明确提出的硬约束都必须由一条状态为满足的
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Generated resource types must match the candidate resource_intents; fix "
+"the template resource types and validate it again before completing the "
+"step."
+msgstr "生成的资源类型必须与候选方案的 resource_intents 一致；请先修正模板资源类型并重新校验，然后再完成该步骤。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"template_generating must validate the generated template with "
+"ros_validate_template for the same file_path."
+msgstr "template_generating 必须使用 ros_validate_template 校验生成的模板，且 file_path 必须一致。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr "调用此工具提交结论以完成当前步骤。如需回滚到较早步骤，请设置 rollback_request。"
@@ -3930,13 +3943,13 @@ msgid ""
 msgstr "{message} complete_step.conclusion 必须包含以下字段之一: {fields}。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
-msgid "A completion guard is misconfigured."
-msgstr "完成守卫配置错误。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
 msgid "{message} Validation issue: {code} ({detail})."
 msgstr "{message} 校验问题：{code}（{detail}）。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "A completion guard is misconfigured."
+msgstr "完成守卫配置错误。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "A conclusion content hash is required before completing the current step."

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -14,6 +14,10 @@ import jsonschema
 from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
 from iac_code.pipeline.engine.hard_constraints import collect_hard_constraints, validate_hard_constraint_checks
+from iac_code.pipeline.engine.resource_type_consistency import (
+    format_resource_type_issues,
+    validate_template_resource_types,
+)
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.utils.public_errors import sanitize_strict_text
@@ -60,6 +64,13 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
     ),
+    "template_resource_type_consistency_required": (
+        "Generated resource types must match the candidate resource_intents; fix the template resource types "
+        "and validate it again before completing the step."
+    ),
+    "template_generating_validate_template_required": (
+        "template_generating must validate the generated template with ros_validate_template for the same file_path."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -99,6 +110,14 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
         _(
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
+        ),
+        _(
+            "Generated resource types must match the candidate resource_intents; fix the template resource types "
+            "and validate it again before completing the step."
+        ),
+        _(
+            "template_generating must validate the generated template with ros_validate_template "
+            "for the same file_path."
         ),
     )
 
@@ -324,6 +343,7 @@ class CompleteStepTool(Tool):
             required_tool_result = guard.get("require_tool_result")
             required_conclusion_sha256 = guard.get("require_conclusion_sha256")
             required_constraint_coverage = guard.get("require_context_constraint_coverage")
+            required_resource_type_consistency = guard.get("require_template_resource_type_consistency")
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
@@ -383,7 +403,43 @@ class CompleteStepTool(Tool):
                 )
                 if validation_error is not None:
                     return validation_error
+            if isinstance(required_resource_type_consistency, dict):
+                validation_error = self._validate_template_resource_type_consistency(
+                    required_resource_type_consistency,
+                    conclusion,
+                    self._completion_guard_message(guard, None),
+                )
+                if validation_error is not None:
+                    return validation_error
         return None
+
+    def _validate_template_resource_type_consistency(
+        self,
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        message: str | None,
+    ) -> str | None:
+        template = self._resolve_dotted(conclusion, str(requirement.get("template_field") or "template"))
+        context_snapshot = self._completion_guard_state.get("context_snapshot")
+        if not isinstance(context_snapshot, dict):
+            context_snapshot = {}
+        intents = self._resolve_dotted(
+            context_snapshot,
+            str(requirement.get("resource_intents_field") or "candidate.resource_intents"),
+        )
+        issues = validate_template_resource_types(template, intents)
+        if not issues:
+            return None
+        base_message = message or _(
+            "Generated resource types must match the candidate resource_intents; fix the template resource types "
+            "and validate it again before completing the step."
+        )
+        code = issues[0].code if len(issues) == 1 else "multiple_resource_type_issues"
+        return _("{message} Validation issue: {code} ({detail}).").format(
+            message=base_message,
+            code=code,
+            detail=format_resource_type_issues(issues),
+        )
 
     def _validate_context_constraint_coverage(
         self,

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -343,9 +343,7 @@ def _parse_surface_overrides(raw: object, step_id: str) -> dict[str, StepSurface
 
         conclusion_schema = override.get("conclusion_schema")
         if conclusion_schema is not None and not isinstance(conclusion_schema, dict):
-            raise ValueError(
-                f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping"
-            )
+            raise ValueError(f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping")
 
         overrides[surface] = StepSurfaceOverride(
             prompt_file=prompt,

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -43,6 +43,7 @@ _SUPPORTED_COMPLETION_GUARD_KEYS = {
     "message_key",
     "require_conclusion_sha256",
     "require_context_constraint_coverage",
+    "require_template_resource_type_consistency",
     "require_tool",
     "require_tool_result",
     "required_conclusion_any_of",

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -93,6 +93,8 @@ _REAL_RESTORE_FAILURE_REASONS = {
 
 def _is_a2a_surface(surface: str) -> bool:
     return surface == "a2a" or surface.startswith("a2a_")
+
+
 _SIDECAR_ROOT_DIRS = {"a2a", "image-cache", "pipeline", "tool-results"}
 _SIDECAR_ROOT_FILES = {
     ".backup-state.json",

--- a/src/iac_code/pipeline/engine/resource_type_consistency.py
+++ b/src/iac_code/pipeline/engine/resource_type_consistency.py
@@ -1,0 +1,274 @@
+"""Deterministic resource type consistency checks for generated ROS templates.
+
+The template generation step previously relied on prompt wording alone to keep
+generated resource types aligned with the candidate's ``resource_intents``.
+This module turns that contract into an offline, code-level check so a template
+whose resource types contradict the candidate cannot complete the step.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from iac_code.pipeline.engine.architecture_meta import ArchitectureMetaRepository
+from iac_code.tools.cloud.aliyun.ros_yaml import ros_yaml_load
+
+_CREATE_ACTIONS = frozenset({"create"})
+_EXISTING_ACTIONS = frozenset({"use_existing", "reference"})
+_FORBID_ACTIONS = frozenset({"forbid"})
+
+
+@dataclass(frozen=True)
+class ResourceTypeIssue:
+    """One resource type inconsistency found in a generated template."""
+
+    code: str
+    resource_name: str = ""
+    resource_type: str = ""
+    product: str = ""
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {key: value for key, value in asdict(self).items() if value}
+
+
+@lru_cache(maxsize=1)
+def known_resource_types() -> frozenset[str]:
+    """Return the offline authoritative ROS resource type catalog.
+
+    The catalog merges the official resource index used by the local ROS
+    validator with the vendored architecture metadata, so a hallucinated type
+    such as ``ALIYUN::VPC::VPC`` (the real type is ``ALIYUN::ECS::VPC``) is
+    recognized as unknown without any network or cloud account access.
+    """
+
+    types: set[str] = set()
+    index_path = files("iac_code.tools.cloud.aliyun.ros_validation").joinpath("data/ros_official_resource_index.json")
+    raw_index = json.loads(index_path.read_text(encoding="utf-8"))
+    resources = raw_index.get("resources")
+    if isinstance(resources, dict):
+        types.update(key for key in resources if isinstance(key, str) and key)
+
+    config_path = Path(__file__).with_name("architecture_metas") / "config.json"
+    raw_config = json.loads(config_path.read_text(encoding="utf-8"))
+    if isinstance(raw_config, list):
+        for item in raw_config:
+            if not isinstance(item, dict):
+                continue
+            resource_type = (item.get("ResourceType") or {}).get("ROS")
+            if isinstance(resource_type, str) and resource_type.startswith("ALIYUN::"):
+                types.add(resource_type)
+    return frozenset(types)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().casefold()
+
+
+def _product_aliases(resource_type: str, repository: ArchitectureMetaRepository) -> frozenset[str]:
+    """Return every accepted spelling of the product owning ``resource_type``.
+
+    ``resource_intents[].product`` is model-authored free text, so the same
+    product legitimately appears as a ROS namespace segment (``ECS``), a
+    product code (``vpc``), a product display name, or the full resource type.
+    Matching on all of them keeps the check strict about real mismatches
+    without failing a template over spelling differences.
+    """
+
+    aliases: set[str] = {_normalize(resource_type)}
+    segments = resource_type.split("::")
+    if len(segments) >= 2:
+        aliases.add(_normalize(segments[1]))
+    if len(segments) >= 3:
+        aliases.add(_normalize(segments[-1]))
+        aliases.add(_normalize(f"{segments[1]}::{segments[-1]}"))
+
+    meta = repository.get_resource(resource_type)
+    if meta is not None:
+        for value in (meta.product_code, meta.name_en, meta.name_zh):
+            if value:
+                aliases.add(_normalize(value))
+        if meta.product_code:
+            product = repository.get_product(meta.product_code)
+            if product is not None:
+                for value in (product.ros_code, product.name_en, product.name_zh):
+                    if value:
+                        aliases.add(_normalize(value))
+    aliases.discard("")
+    return frozenset(aliases)
+
+
+def _parse_template_resources(template: Any) -> tuple[dict[str, str], ResourceTypeIssue | None]:
+    """Extract ``{logical_name: resource_type}`` from a generated template."""
+
+    if not isinstance(template, str) or not template.strip():
+        return {}, ResourceTypeIssue("invalid_template_structure", detail="template must be a non-empty string")
+    try:
+        document = ros_yaml_load(template)
+    except yaml.YAMLError as error:
+        return {}, ResourceTypeIssue("invalid_template_structure", detail=type(error).__name__)
+    if not isinstance(document, dict):
+        return {}, ResourceTypeIssue("invalid_template_structure", detail="template root must be a mapping")
+
+    raw_resources = document.get("Resources")
+    if raw_resources is None:
+        return {}, ResourceTypeIssue("invalid_template_structure", detail="template must define Resources")
+    if not isinstance(raw_resources, dict):
+        return {}, ResourceTypeIssue("invalid_template_structure", detail="Resources must be a mapping")
+
+    resources: dict[str, str] = {}
+    for name, body in raw_resources.items():
+        if not isinstance(name, str) or not name:
+            return {}, ResourceTypeIssue("invalid_template_structure", detail="resource names must be strings")
+        if not isinstance(body, dict):
+            return {}, ResourceTypeIssue("invalid_template_structure", resource_name=name, detail="must be a mapping")
+        resource_type = body.get("Type")
+        if not isinstance(resource_type, str) or not resource_type:
+            return {}, ResourceTypeIssue("invalid_template_structure", resource_name=name, detail="missing Type")
+        resources[name] = resource_type
+    return resources, None
+
+
+def _collect_intents(resource_intents: Any) -> tuple[dict[str, set[str]], list[ResourceTypeIssue]]:
+    """Group declared products by action, keeping the original spelling."""
+
+    issues: list[ResourceTypeIssue] = []
+    by_action: dict[str, set[str]] = {}
+    if not isinstance(resource_intents, list):
+        return by_action, issues
+    for intent in resource_intents:
+        if not isinstance(intent, dict):
+            issues.append(ResourceTypeIssue("invalid_resource_intent", detail="resource intent must be a mapping"))
+            continue
+        product = intent.get("product")
+        action = intent.get("action")
+        if not isinstance(product, str) or not product:
+            issues.append(ResourceTypeIssue("invalid_resource_intent", detail="missing product"))
+            continue
+        if not isinstance(action, str) or not action:
+            issues.append(ResourceTypeIssue("invalid_resource_intent", product=product, detail="missing action"))
+            continue
+        by_action.setdefault(_normalize(action), set()).add(product)
+    return by_action, issues
+
+
+def validate_template_resource_types(
+    template: Any,
+    resource_intents: Any,
+    *,
+    repository: ArchitectureMetaRepository | None = None,
+    resource_type_catalog: frozenset[str] | None = None,
+) -> list[ResourceTypeIssue]:
+    """Validate generated resource types against the candidate resource intents.
+
+    Templates without ``resource_intents`` are only checked for resource types
+    that actually exist, so candidates that never declared lifecycle semantics
+    keep their previous behavior.
+    """
+
+    repository = repository or ArchitectureMetaRepository.load_default()
+    catalog = resource_type_catalog if resource_type_catalog is not None else known_resource_types()
+
+    resources, parse_issue = _parse_template_resources(template)
+    if parse_issue is not None:
+        return [parse_issue]
+
+    intents_by_action, issues = _collect_intents(resource_intents)
+
+    aliases_by_resource: dict[str, frozenset[str]] = {}
+    for name, resource_type in resources.items():
+        if resource_type not in catalog:
+            issues.append(
+                ResourceTypeIssue(
+                    "unknown_resource_type",
+                    resource_name=name,
+                    resource_type=resource_type,
+                    detail="not a known ROS resource type",
+                )
+            )
+            continue
+        aliases_by_resource[name] = _product_aliases(resource_type, repository)
+
+    declared: set[str] = set()
+    for products in intents_by_action.values():
+        declared.update(products)
+    if not declared:
+        return issues
+
+    def matches(product: str) -> list[str]:
+        normalized = _normalize(product)
+        return [name for name, aliases in aliases_by_resource.items() if normalized in aliases]
+
+    for action, products in intents_by_action.items():
+        for product in sorted(products):
+            matched = matches(product)
+            if action in _CREATE_ACTIONS and not matched:
+                issues.append(
+                    ResourceTypeIssue(
+                        "missing_required_resource",
+                        product=product,
+                        detail="resource_intents requires creating this product",
+                    )
+                )
+            elif action in _FORBID_ACTIONS:
+                for name in matched:
+                    issues.append(
+                        ResourceTypeIssue(
+                            "forbidden_resource_created",
+                            resource_name=name,
+                            resource_type=resources[name],
+                            product=product,
+                            detail="resource_intents forbids this product",
+                        )
+                    )
+            elif action in _EXISTING_ACTIONS:
+                for name in matched:
+                    issues.append(
+                        ResourceTypeIssue(
+                            "use_existing_resource_created",
+                            resource_name=name,
+                            resource_type=resources[name],
+                            product=product,
+                            detail="must be referenced through a Parameter instead of created",
+                        )
+                    )
+
+    forbidden_aliases: set[str] = set()
+    for action, products in intents_by_action.items():
+        if action in _FORBID_ACTIONS:
+            forbidden_aliases.update(_normalize(product) for product in products)
+
+    declared_aliases = {_normalize(product) for product in declared}
+    for name, aliases in aliases_by_resource.items():
+        if aliases & declared_aliases:
+            continue
+        if aliases & forbidden_aliases:
+            continue
+        issues.append(
+            ResourceTypeIssue(
+                "extra_resource_product",
+                resource_name=name,
+                resource_type=resources[name],
+                detail="product is not declared in resource_intents",
+            )
+        )
+    return issues
+
+
+def format_resource_type_issues(issues: list[ResourceTypeIssue]) -> str:
+    """Render issues as a compact, model-actionable summary."""
+
+    summaries: list[str] = []
+    for issue in issues:
+        specifics = ", ".join(
+            value for value in (issue.resource_name, issue.resource_type, issue.product, issue.detail) if value
+        )
+        summaries.append(f"{issue.code}[{specifics}]" if specifics else issue.code)
+    return "; ".join(summaries)

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -149,6 +149,22 @@ sub_pipelines:
         skill: iac-aliyun-template-generating
         prompt: prompts/template_generating.md
         context_fields: [candidate]
+        completion_guards:
+          - always: true
+            require_template_resource_type_consistency:
+              template_field: template
+              resource_intents_field: candidate.resource_intents
+            message_key: template_resource_type_consistency_required
+          - always: true
+            require_tool_result:
+              tool: ros_validate_template
+              match_conclusion_field: file_path
+              match_result_field: input.template_url
+              disallow_tool_results_after_match:
+                - tools: [write_file, edit_file]
+                  match_conclusion_field: file_path
+                  match_result_field: result.file_path
+            message_key: template_generating_validate_template_required
         tools:
           include: []
           exclude:

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-template-generating/SKILL.md
@@ -63,6 +63,21 @@ conclusion_schema:
 
 示例：`resource_intents: [{"product": "SecurityGroup", "action": "create"}, {"product": "VPC", "action": "use_existing"}]` 时，只生成 `ALIYUN::ECS::SecurityGroup`，不要生成 `ALIYUN::ECS::VPC` 或 `ALIYUN::ECS::VSwitch`。
 
+## 资源类型自检
+
+写入文件后、调用 `complete_step` 前**必须**逐条自检模板 `Resources` 的资源类型：
+
+- 每个资源的 `Type` 是真实存在的 ROS 资源类型；不确定就用
+  `aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<类型>"})` 确认。
+  常见错误是把产品名直接拼成命名空间，例如 VPC 的真实类型是 `ALIYUN::ECS::VPC`，不存在 `ALIYUN::VPC::VPC`。
+- `resource_intents` 中 `action=create` 的每个 product 都有对应资源。
+- `action=use_existing` / `reference` 的 product 没有被建成新建资源，而是通过 Parameter 引用。
+- `action=forbid` 的 product 没有出现在 `Resources` 中。
+- 没有 `resource_intents` 未声明的多余 product。
+
+自检不通过就先修模板再重新校验，不要提交一个资源类型与候选方案不一致的结论。
+`complete_step` 会在代码层复核这些条件，冲突时结论会被驳回。
+
 ## 用户硬约束
 
 候选架构的 `hard_constraints` 必须原样贯穿模板生成：

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -298,9 +298,7 @@ class AliyunCredentials:
 
             owns_client = oauth_client is None
             client = (
-                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type))
-                if oauth_client is None
-                else oauth_client
+                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type)) if oauth_client is None else oauth_client
             )
 
             try:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -149,8 +149,7 @@ class StagedSessionBackupService(SessionBackupService):
                         existing = self._read_existing_snapshot_state(destination, session_id)
                         if existing is not None:
                             completed_next = (
-                                base_state.status == "succeeded"
-                                and existing.parent_generation == base_state.generation
+                                base_state.status == "succeeded" and existing.parent_generation == base_state.generation
                             )
                             if not completed_next and not existing.same_lineage(committed_state):
                                 raise SessionBackupConflict(

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -3788,12 +3788,10 @@ class TestResolveCandidatePresentation:
         executor = self._make_executor()
 
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}}) == "rich-v1"
         )
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}}) == "rich-v1"
         )
 
     def test_rejects_unknown_or_missing_presentation(self) -> None:

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -240,9 +240,7 @@ def test_ros_deployment_permission_is_localized_and_preserves_safe_plan_summary(
                         "stackName": "demo-stack",
                         "template": "templates/demo.yml",
                         "totalMonthlyCost": "¥88/月",
-                        "resources": [
-                            {"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}
-                        ],
+                        "resources": [{"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}],
                     },
                 },
             ),
@@ -388,9 +386,7 @@ async def test_pipeline_permission_uses_same_input_envelope_and_waits_serially(m
 async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(monkeypatch, tmp_path) -> None:
     registry = PermissionInputRegistry()
     store = A2ATaskStore()
-    await store.save(
-        Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING))
-    )
+    await store.save(Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)))
     queue = FakeEventQueue()
     publisher = PipelineA2AEventPublisher(
         event_queue=queue,
@@ -466,9 +462,7 @@ async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(m
     task = await store.get("task-1")
     assert task is not None
     task_metadata = MessageToDict(task.metadata, preserving_proto_field_name=False)
-    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [
-        requests[1]["inputId"]
-    ]
+    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [requests[1]["inputId"]]
     remaining = task_metadata["iac_code"]["pendingPermissions"][0]
     assert remaining["language"] == "zh"
     assert remaining["prompt"] == "是否允许本次操作：运行本地 Shell 命令？"

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1744,3 +1744,106 @@ class TestNullNormalization:
         valid, error = tool.validate_input(tool_input)
         assert not valid
         assert "name" in error
+
+
+class TestTemplateResourceTypeConsistencyGuard:
+    GUARD = {
+        "always": True,
+        "require_template_resource_type_consistency": {
+            "template_field": "template",
+            "resource_intents_field": "candidate.resource_intents",
+        },
+        "message_key": "template_resource_type_consistency_required",
+    }
+    INTENTS = [
+        {"product": "SecurityGroup", "action": "create"},
+        {"product": "VPC", "action": "use_existing"},
+    ]
+
+    def _tool(self):
+        return CompleteStepTool(
+            StepConfig(step_id="template_generating", conclusion_field="template", forward=None),
+            completion_guards=[self.GUARD],
+            completion_guard_state={
+                "context_snapshot": {"candidate": {"resource_intents": self.INTENTS}},
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_template_creating_a_use_existing_product_is_rejected(self):
+        conclusion = {
+            "template": (
+                "Resources:\n"
+                "  AppVpc:\n"
+                "    Type: ALIYUN::ECS::VPC\n"
+                "    Properties: {}\n"
+                "  AppSecurityGroup:\n"
+                "    Type: ALIYUN::ECS::SecurityGroup\n"
+                "    Properties: {}\n"
+            ),
+            "file_path": "templates/1-secure.yml",
+            "region": "cn-hangzhou",
+            "description": "security group in an existing VPC",
+        }
+
+        result = await self._tool().execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+
+        assert result.is_error is True
+        assert "use_existing_resource_created" in result.content
+        assert "AppVpc" in result.content
+
+    @pytest.mark.asyncio
+    async def test_compliant_template_passes_the_guard(self):
+        conclusion = {
+            "template": (
+                "Parameters:\n"
+                "  VpcId:\n"
+                "    Type: String\n"
+                "Resources:\n"
+                "  AppSecurityGroup:\n"
+                "    Type: ALIYUN::ECS::SecurityGroup\n"
+                "    Properties:\n"
+                "      VpcId: !Ref VpcId\n"
+            ),
+            "file_path": "templates/1-secure.yml",
+            "region": "cn-hangzhou",
+            "description": "security group in an existing VPC",
+        }
+
+        result = await self._tool().execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+
+        assert result.is_error is False
+        assert result.metadata is not None
+        assert result.metadata["step_result"].status is StepStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_unknown_resource_type_is_rejected(self):
+        conclusion = {
+            "template": "Resources:\n  AppVpc:\n    Type: ALIYUN::VPC::VPC\n    Properties: {}\n",
+            "file_path": "templates/1-secure.yml",
+            "region": "cn-hangzhou",
+            "description": "hallucinated resource type",
+        }
+
+        result = await self._tool().execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+
+        assert result.is_error is True
+        assert "unknown_resource_type" in result.content
+
+    @pytest.mark.asyncio
+    async def test_candidate_without_resource_intents_is_not_blocked(self):
+        tool = CompleteStepTool(
+            StepConfig(step_id="template_generating", conclusion_field="template", forward=None),
+            completion_guards=[self.GUARD],
+            completion_guard_state={"context_snapshot": {"candidate": {}}},
+        )
+        conclusion = {
+            "template": "Resources:\n  AppBucket:\n    Type: ALIYUN::OSS::Bucket\n    Properties: {}\n",
+            "file_path": "templates/1-bucket.yml",
+            "region": "cn-hangzhou",
+            "description": "bucket only",
+        }
+
+        result = await tool.execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+
+        assert result.is_error is False

--- a/tests/pipeline/engine/test_resource_type_consistency.py
+++ b/tests/pipeline/engine/test_resource_type_consistency.py
@@ -1,0 +1,210 @@
+"""Tests for deterministic resource type consistency checks."""
+
+from __future__ import annotations
+
+import pytest
+
+from iac_code.pipeline.engine.resource_type_consistency import (
+    format_resource_type_issues,
+    known_resource_types,
+    validate_template_resource_types,
+)
+
+EXISTING_VPC_INTENTS = [
+    {"product": "SecurityGroup", "action": "create"},
+    {"product": "VPC", "action": "use_existing"},
+]
+
+SECURITY_GROUP_ONLY = """
+Parameters:
+  VpcId:
+    Type: String
+Resources:
+  AppSecurityGroup:
+    Type: ALIYUN::ECS::SecurityGroup
+    Properties:
+      VpcId: !Ref VpcId
+Outputs:
+  SecurityGroupId:
+    Value: !GetAtt AppSecurityGroup.SecurityGroupId
+"""
+
+
+def _codes(issues) -> list[str]:
+    return sorted(issue.code for issue in issues)
+
+
+class TestResourceTypeCatalog:
+    def test_catalog_contains_real_types(self):
+        catalog = known_resource_types()
+        assert "ALIYUN::ECS::VPC" in catalog
+        assert "ALIYUN::ECS::SecurityGroup" in catalog
+        assert "ALIYUN::OSS::Bucket" in catalog
+
+    def test_catalog_excludes_hallucinated_types(self):
+        catalog = known_resource_types()
+        assert "ALIYUN::VPC::VPC" not in catalog
+        assert "ALIYUN::VPC::VSwitch" not in catalog
+
+
+class TestIntentConsistency:
+    def test_compliant_template_has_no_issues(self):
+        assert validate_template_resource_types(SECURITY_GROUP_ONLY, EXISTING_VPC_INTENTS) == []
+
+    def test_creating_a_use_existing_product_is_rejected(self):
+        template = """
+Resources:
+  AppVpc:
+    Type: ALIYUN::ECS::VPC
+    Properties:
+      CidrBlock: 192.168.0.0/16
+  AppSecurityGroup:
+    Type: ALIYUN::ECS::SecurityGroup
+    Properties:
+      VpcId: !Ref AppVpc
+"""
+        issues = validate_template_resource_types(template, EXISTING_VPC_INTENTS)
+        assert _codes(issues) == ["use_existing_resource_created"]
+        assert issues[0].resource_name == "AppVpc"
+        assert issues[0].resource_type == "ALIYUN::ECS::VPC"
+
+    def test_reference_action_is_treated_like_use_existing(self):
+        template = """
+Resources:
+  AppVpc:
+    Type: ALIYUN::ECS::VPC
+    Properties:
+      CidrBlock: 192.168.0.0/16
+"""
+        issues = validate_template_resource_types(template, [{"product": "VPC", "action": "reference"}])
+        assert _codes(issues) == ["use_existing_resource_created"]
+
+    def test_missing_create_product_is_reported(self):
+        issues = validate_template_resource_types(
+            SECURITY_GROUP_ONLY,
+            [{"product": "SecurityGroup", "action": "create"}, {"product": "OSS", "action": "create"}],
+        )
+        assert _codes(issues) == ["missing_required_resource"]
+        assert issues[0].product == "OSS"
+
+    def test_forbidden_product_is_reported(self):
+        template = """
+Resources:
+  AppSecurityGroup:
+    Type: ALIYUN::ECS::SecurityGroup
+    Properties: {}
+  AppVSwitch:
+    Type: ALIYUN::ECS::VSwitch
+    Properties: {}
+"""
+        issues = validate_template_resource_types(
+            template,
+            [{"product": "SecurityGroup", "action": "create"}, {"product": "VSwitch", "action": "forbid"}],
+        )
+        assert _codes(issues) == ["forbidden_resource_created"]
+        assert issues[0].resource_name == "AppVSwitch"
+
+    def test_undeclared_product_is_reported_as_extra(self):
+        template = """
+Resources:
+  AppServer:
+    Type: ALIYUN::ECS::Instance
+    Properties: {}
+  AppBucket:
+    Type: ALIYUN::OSS::Bucket
+    Properties: {}
+"""
+        issues = validate_template_resource_types(template, [{"product": "ECS", "action": "create"}])
+        assert _codes(issues) == ["extra_resource_product"]
+        assert issues[0].resource_name == "AppBucket"
+
+    def test_unknown_resource_type_is_reported(self):
+        template = """
+Resources:
+  AppVpc:
+    Type: ALIYUN::VPC::VPC
+    Properties: {}
+"""
+        issues = validate_template_resource_types(template, [{"product": "VPC", "action": "create"}])
+        assert "unknown_resource_type" in _codes(issues)
+
+    def test_templates_without_intents_only_check_type_existence(self):
+        template = """
+Resources:
+  AppServer:
+    Type: ALIYUN::ECS::Instance
+    Properties: {}
+  AppBucket:
+    Type: ALIYUN::OSS::Bucket
+    Properties: {}
+"""
+        assert validate_template_resource_types(template, []) == []
+        assert validate_template_resource_types(template, None) == []
+
+    @pytest.mark.parametrize(
+        "product",
+        ["ECS", "ecs", "Instance", "ALIYUN::ECS::Instance", "ECS Instance"],
+    )
+    def test_product_spelling_variants_match_the_same_resource(self, product):
+        template = """
+Resources:
+  AppServer:
+    Type: ALIYUN::ECS::Instance
+    Properties: {}
+"""
+        assert validate_template_resource_types(template, [{"product": product, "action": "create"}]) == []
+
+    def test_vswitch_belongs_to_the_vpc_product(self):
+        template = """
+Resources:
+  AppVSwitch:
+    Type: ALIYUN::ECS::VSwitch
+    Properties: {}
+"""
+        assert validate_template_resource_types(template, [{"product": "VPC", "action": "create"}]) == []
+
+
+class TestMalformedInput:
+    @pytest.mark.parametrize("template", ["", "   ", None, 42, []])
+    def test_non_template_values_are_rejected(self, template):
+        issues = validate_template_resource_types(template, EXISTING_VPC_INTENTS)
+        assert _codes(issues) == ["invalid_template_structure"]
+
+    def test_invalid_yaml_is_rejected(self):
+        issues = validate_template_resource_types("Resources: [unclosed", EXISTING_VPC_INTENTS)
+        assert _codes(issues) == ["invalid_template_structure"]
+
+    def test_missing_resources_section_is_rejected(self):
+        issues = validate_template_resource_types("Parameters:\n  VpcId:\n    Type: String\n", EXISTING_VPC_INTENTS)
+        assert _codes(issues) == ["invalid_template_structure"]
+
+    def test_resource_without_type_is_rejected(self):
+        issues = validate_template_resource_types("Resources:\n  App:\n    Properties: {}\n", EXISTING_VPC_INTENTS)
+        assert _codes(issues) == ["invalid_template_structure"]
+
+    def test_malformed_intent_entries_are_reported(self):
+        issues = validate_template_resource_types(
+            SECURITY_GROUP_ONLY,
+            [{"product": "SecurityGroup", "action": "create"}, {"action": "create"}],
+        )
+        assert "invalid_resource_intent" in _codes(issues)
+
+
+class TestIssueFormatting:
+    def test_summary_mentions_resource_and_code(self):
+        template = """
+Resources:
+  AppVpc:
+    Type: ALIYUN::ECS::VPC
+    Properties: {}
+  AppSecurityGroup:
+    Type: ALIYUN::ECS::SecurityGroup
+    Properties: {}
+"""
+        summary = format_resource_type_issues(validate_template_resource_types(template, EXISTING_VPC_INTENTS))
+        assert "use_existing_resource_created" in summary
+        assert "AppVpc" in summary
+        assert "ALIYUN::ECS::VPC" in summary
+
+    def test_empty_issue_list_renders_empty_summary(self):
+        assert format_resource_type_issues([]) == ""

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -2776,11 +2776,15 @@ class TestStepExecutorSchemaWiring:
             surface="a2a_rich",
         )
 
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=True,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=True,
+            )
+            .get("complete_step")
+            .input_schema
+        )
         conclusion_schema = tool_schema["properties"]["conclusion"]
         assert conclusion_schema["required"] == [
             "selected_candidate_name",
@@ -2863,11 +2867,15 @@ class TestStepExecutorSchemaWiring:
             context,
             resume_candidate_selection=True,
         )
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=preserved is not None,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=preserved is not None,
+            )
+            .get("complete_step")
+            .input_schema
+        )
 
         assert preserved is None
         conclusion_schema = tool_schema["properties"]["conclusion"]

--- a/tests/pipeline/selling/skills/test_template_generating_skill.py
+++ b/tests/pipeline/selling/skills/test_template_generating_skill.py
@@ -120,6 +120,12 @@ class TestSkillContentRosOnly:
         assert "已有 VPC 中创建安全组" in body
         assert "forbidden_resources" not in body
 
+    def test_requires_resource_type_self_check_before_completing(self, body):
+        assert "## 资源类型自检" in body
+        assert "ALIYUN::VPC::VPC" in body
+        assert "GetResourceType" in body
+        assert "complete_step` 会在代码层复核" in body
+
     def test_preserves_product_neutral_user_hard_constraints(self, body):
         assert "candidate" in body
         assert "hard_constraints" in body

--- a/tests/pipeline/selling/test_template_generating_guards.py
+++ b/tests/pipeline/selling/test_template_generating_guards.py
@@ -1,0 +1,65 @@
+"""The template generation step must enforce resource type consistency in code."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from iac_code.pipeline.engine.loader import load_pipeline_dir
+
+
+def _template_generating_guards() -> list[dict]:
+    selling_dir = Path(__file__).resolve().parents[3] / "src" / "iac_code" / "pipeline" / "selling"
+    pipeline = load_pipeline_dir(selling_dir)
+    step = next(
+        step for step in pipeline.sub_pipelines["evaluate_candidate"].steps if step.step_id == "template_generating"
+    )
+    return step.completion_guards
+
+
+@pytest.fixture(scope="module")
+def guards() -> list[dict]:
+    return _template_generating_guards()
+
+
+def test_step_has_completion_guards(guards):
+    assert guards, "template_generating must not rely on prompt wording alone"
+
+
+def test_resource_type_consistency_guard_always_applies(guards):
+    guard = next(guard for guard in guards if "require_template_resource_type_consistency" in guard)
+    requirement = guard["require_template_resource_type_consistency"]
+
+    assert guard["always"] is True
+    assert requirement["template_field"] == "template"
+    assert requirement["resource_intents_field"] == "candidate.resource_intents"
+    assert guard["message_key"] == "template_resource_type_consistency_required"
+
+
+def test_validate_template_result_is_required_for_the_generated_file(guards):
+    guard = next(guard for guard in guards if "require_tool_result" in guard)
+    requirement = guard["require_tool_result"]
+
+    assert guard["always"] is True
+    assert requirement["tool"] == "ros_validate_template"
+    assert requirement["match_conclusion_field"] == "file_path"
+    assert requirement["match_result_field"] == "input.template_url"
+
+
+def test_rewriting_the_template_after_validation_is_rejected(guards):
+    guard = next(guard for guard in guards if "require_tool_result" in guard)
+    rules = guard["require_tool_result"]["disallow_tool_results_after_match"]
+
+    assert any(set(rule.get("tools", [])) == {"write_file", "edit_file"} for rule in rules)
+
+
+def test_guard_message_keys_are_translatable():
+    from iac_code.pipeline.engine.complete_step_tool import (
+        _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY,
+        _completion_guard_message_i18n_markers,
+    )
+
+    for key in ("template_resource_type_consistency_required", "template_generating_validate_template_required"):
+        assert key in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY
+        assert _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY[key] in set(_completion_guard_message_i18n_markers())

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -133,9 +133,7 @@ def test_confirm_prompt_tells_model_to_preserve_parameter_overrides():
 def test_confirm_prompts_share_selection_contract_structure():
     repl_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.md").read_text(encoding="utf-8")
     a2a_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.md").read_text(encoding="utf-8")
-    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(
-        encoding="utf-8"
-    )
+    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(encoding="utf-8")
 
     shared_fragments = [
         "## 首次执行",

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -1676,9 +1676,7 @@ class TestProviderManagerCompleteRetry:
 
     async def test_complete_attributes_bailian_openai_endpoint_to_dashscope_on_all_signals(self):
         mock_provider = AsyncMock()
-        mock_provider._base_url = (
-            "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
-        )
+        mock_provider._base_url = "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
         mock_provider.complete = AsyncMock(
             return_value=NonStreamingResponse(
                 message_id="complete-response",

--- a/tests/skill_bridge/test_iac_code_bridge.py
+++ b/tests/skill_bridge/test_iac_code_bridge.py
@@ -542,12 +542,10 @@ def test_bridge_automatically_runs_cleanup_only_task_and_restores_pipeline_resul
 
     assert len(captured_payloads) == 2
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True for payload in captured_payloads
     )
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host"
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host" for payload in captured_payloads
     )
     assert captured_payloads[0]["params"]["message"]["contextId"] == "ctx-pipeline-1"
     assert result["state"] == "completed"
@@ -1138,9 +1136,7 @@ def test_candidate_presentation_survives_bounded_bridge_projection() -> None:
                                     "summary": "单 ECS 低成本方案。",
                                     "architectureDiagram": "flowchart LR\nU[用户] --> E[ECS]",
                                     "totalMonthlyCost": "¥88/月",
-                                    "costItems": [
-                                        {"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}
-                                    ],
+                                    "costItems": [{"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}],
                                 }
                             ],
                             "required": True,

--- a/tests/skill_bridge/test_runtime_release.py
+++ b/tests/skill_bridge/test_runtime_release.py
@@ -104,9 +104,7 @@ def test_runtime_archive_and_version_marker_are_rooted_consistently(tmp_path: Pa
     assert "artifactRevision" not in marker
 
 
-def test_runtime_a2a_smoke_checks_health_and_agent_card(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_runtime_a2a_smoke_checks_health_and_agent_card(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module("skill_runtime_smoke", BUILD_SCRIPT)
     server = tmp_path / "server.py"
     server.write_text(

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -2547,7 +2547,7 @@ def test_completed_turn_collapses_process_into_summary() -> None:
     # 「已处理」组的展开态必须跨重建保留:openKey 让 toggle 记录器登记用户操作、
     # applyDetailsOpenOverrides 在重建后恢复;键取 turnId,缺 turnId 时回退首条消息 id。
     assert 'const turnKey = turnId || text(agentMessages[0]?.messageId || agentMessages[0]?.id || "");' in app_source
-    assert 'details.dataset.openKey = `turnproc:${turnKey}`;' in app_source
+    assert "details.dataset.openKey = `turnproc:${turnKey}`;" in app_source
 
     # 只有最后一次工具调用之后的文本才是「最终回答」;此前每个步骤的文本旁白
     # (夹在工具调用之间的 text delta)连同思考、工具一起折进「已处理」,不平铺成答案。


### PR DESCRIPTION
## 问题

selling pipeline 的模板生成步骤可以输出与候选架构方案资源类型不一致的模板，且不会被任何环节拦截：

- `template_generating` 没有任何 `completion_guards`，其 `conclusion_schema` 只校验
  `template` / `file_path` / `region` / `description` 是不是字符串，不校验资源类型是否正确
- `resource_intents` 的 `create` / `use_existing` / `reference` / `forbid` 生命周期约束
  只以自然语言写在 `SKILL.md` 里，完全依赖模型自觉遵守
- `SKILL.md` 要求生成后调用 `ros_validate_template`，但没有守卫强制，模型可以跳过校验直接 `complete_step`
- 唯一带真实守卫的 `reviewing` 步骤默认关闭（`enable_reviewing.default: false`），
  它的 `ros_validate_template` + `infraguard_scan` 守卫在默认链路上根本不生效

结果是默认链路上从模板生成到候选评估之间没有任何一处代码校验资源类型，
`resource_type_mismatch` 可以无声通过，生成出把 `use_existing` / `forbid` 资源当成新建资源的模板。

## 改动

新增离线、确定性的资源类型一致性校验，在 `complete_step` 被接受之前运行：

- `src/iac_code/pipeline/engine/resource_type_consistency.py`
  用仓库既有的 `ros_yaml_load`（支持 `!Ref` / `!GetAtt` 等 ROS 短标签）解析生成的模板，
  将实际资源类型与 `candidate.resource_intents` 比对，输出以下诊断：

  | 诊断码 | 含义 |
  |--------|------|
  | `unknown_resource_type` | 资源类型不存在，例如 `ALIYUN::VPC::VPC`（真实类型是 `ALIYUN::ECS::VPC`）|
  | `missing_required_resource` | `action=create` 的 product 在模板里没有对应资源 |
  | `forbidden_resource_created` | `action=forbid` 的 product 出现在 `Resources` |
  | `use_existing_resource_created` | `use_existing` / `reference` 的 product 被建成新建资源 |
  | `extra_resource_product` | 出现了 `resource_intents` 未声明的 product |
  | `invalid_template_structure` | 模板不是合法 YAML 或 `Resources` 结构非法 |

- 资源类型权威清单取仓库内两份既有离线数据的并集
  （`ros_official_resource_index.json` + `architecture_metas/config.json`，共 1299 个类型），
  **不涉及网络、云账号或 LLM**
- 注册新守卫 `require_template_resource_type_consistency`，并在 `template_generating` 挂上；
  同时补上 `ros_validate_template` 的 `require_tool_result`，
  让「先校验、再输出」成为硬约束而不是提示语
- `SKILL.md` 补充「资源类型自检」章节，说明 `complete_step` 会在代码层复核

## 兼容性

- `resource_intents` 为空的候选只做资源类型存在性校验，保持原有行为，不引入新失败模式
- product 名称同时接受 ROS 命名空间段（`ECS`）、product code（`vpc`/`kvstore`）、
  产品展示名和资源类型全名，大小写无关，避免因书写差异误报
- `extra_resource_product` 仅在 `resource_intents` 非空时生效；
  `ALIYUN::ECS::VSwitch` 归属 `vpc` product，因此「已有 VPC + 新建 VSwitch」不会被误判
- 守卫只挂在 `template_generating`，其余步骤配置不变

## 测试

- 新增 `tests/pipeline/engine/test_resource_type_consistency.py`（27 项），
  覆盖全部诊断码、评测报告中的真实场景（「已有 VPC 中创建安全组」误建 VPC + VSwitch）、
  拼错类型、product 书写变体，以及无 `resource_intents` 时不误报
- 新增 `tests/pipeline/selling/test_template_generating_guards.py`（5 项）断言守卫已挂载
- `tests/pipeline/engine/test_complete_step_tool.py` 新增守卫集成测试（冲突模板被驳回 / 合规模板通过）
- 相关测试合计 128 项全部通过；`make test` 全量 14371 passed
- `make lint`（`ruff check` + `ty check`）通过
- 已执行 `make translate` 并为两条新守卫文案补齐 zh/es/fr/de/ja/pt 翻译

> `make test` 仍有 3 项失败，均与本次改动无关，且已在同一基线的干净工作区复现：
> `test_prerequisites`（需要真实网络下载 infraguard）、
> `test_run_pipeline_contract_scenario`（依赖文件 mtime 粒度的既有 flake）、
> `test_i18n::test_message_catalogs_pass_gnu_msgfmt_checks`
> （`i18n/__init__.py` 中既有的 `{n} day{s}` 复数条目被 msgfmt 拒绝）。
