### PR TITLE
fix(a2a): Pipeline 取消/失败时收敛未结束的步骤与候选子步骤状态

### DIFF
--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -36,6 +36,11 @@ _CLEANUP_STATUS_BY_EVENT_TYPE = {
     PIPELINE_EVENT_CLEANUP_FAILED: "failed",
 }
 _KNOWN_CLEANUP_STATUSES = {"pending", "started", "in_progress", "completed", "failed", "skipped"}
+# Statuses a step/candidate/sub-step can hold while it is still in flight. A
+# pipeline-level cancel/failure never emits per-node ``*_completed`` events, so
+# these have to be sunk into an explicit terminal status by the reducer itself.
+_NON_TERMINAL_NODE_STATUSES = {None, "working", "waiting_input", "restarting"}
+_NODE_TERMINAL_TIME_KEYS = {"canceled": "canceledAt", "failed": "failedAt"}
 _PENDING_BACKUP_VISIBILITY = "pending_backup"
 _COMMITTED_BACKUP_VISIBILITY = "committed"
 _BACKUP_COMMITTED_EVENT_TYPE = "backup_committed"
@@ -529,6 +534,7 @@ class _PipelineSnapshotReducer:
             self._snapshot["pendingTerminal"] = None
             self._snapshot["pendingInput"] = None
             self._snapshot["control"]["activeCandidateRunIds"] = []
+            self._finalize_unfinished_nodes(terminal_status, event)
         elif (
             event_type not in {"input_required", "input_received", *_CLEANUP_STATUS_BY_EVENT_TYPE}
             and not _is_pending_backup_publication(event)
@@ -538,6 +544,45 @@ class _PipelineSnapshotReducer:
             )
         ):
             self._apply_event_status(event)
+
+    def _finalize_unfinished_nodes(self, terminal_status: str, event: dict[str, Any]) -> None:
+        """Sink every still-running step/candidate/sub-step into ``terminal_status``.
+
+        A cancel/failure at the pipeline level never emits per-node
+        ``*_completed`` / ``*_failed`` events, so nodes keep the ``working``
+        status written by their ``*_started`` event and their conclusion stays
+        ``null`` forever — the step result becomes undecidable on reload.
+        ``pipeline_completed`` is deliberately excluded: a normal completion
+        already closes each node, and forcing a status there would mask real
+        anomalies.
+        """
+        time_key = _NODE_TERMINAL_TIME_KEYS.get(terminal_status)
+        if time_key is None:
+            return
+
+        created_at = _string_or_none(event.get("createdAt"))
+        event_type = _string_or_none(event.get("eventType"))
+        for step in self._snapshot["steps"]:
+            self._finalize_node(step, terminal_status, time_key, created_at, event_type)
+            for candidate in _dict_list(step.get("candidates")):
+                self._finalize_node(candidate, terminal_status, time_key, created_at, event_type)
+                for candidate_step in _dict_list(candidate.get("steps")):
+                    self._finalize_node(candidate_step, terminal_status, time_key, created_at, event_type)
+
+    @staticmethod
+    def _finalize_node(
+        node: dict[str, Any],
+        terminal_status: str,
+        time_key: str,
+        created_at: str | None,
+        event_type: str | None,
+    ) -> None:
+        if _string_or_none(node.get("status")) not in _NON_TERMINAL_NODE_STATUSES:
+            return
+        node["status"] = terminal_status
+        _set_time(node, time_key, created_at)
+        if event_type is not None:
+            node["terminalReason"] = event_type
 
     def _merge_pipeline_identity(self, event: dict[str, Any]) -> None:
         for key in ("pipelineRunId", "taskId", "contextId", "pipelineName"):

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -816,6 +816,110 @@ def test_reduce_completion_events_keep_conclusions_on_pipeline_state_nodes() -> 
     assert step["candidates"][0]["steps"][0]["conclusion"] == {"body": "ros"}
 
 
+def _canceled_evidence_events() -> list[dict]:
+    """Rebuild the shape of the evidence session: ``evaluate_candidates`` and its
+    candidate ``cost_estimating`` sub-step only ever announced ``*_started``
+    before the pipeline was canceled."""
+    parent = _base("evt-1", 1, "step_started", scope="step")
+    parent["step"] = {
+        "runId": "step-evaluate_candidates-1",
+        "id": "evaluate_candidates",
+        "index": 3,
+        "total": 5,
+        "attempt": 1,
+    }
+    candidate = _base("evt-2", 2, "candidate_started", scope="candidate")
+    candidate["step"] = parent["step"]
+    candidate["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}
+    candidate_step = _base("evt-3", 3, "candidate_step_started", scope="candidate_step")
+    candidate_step["step"] = parent["step"]
+    candidate_step["candidate"] = candidate["candidate"]
+    candidate_step["candidateStep"] = {
+        "runId": "candidate-eval-0-1-cost_estimating-1",
+        "id": "cost_estimating",
+        "index": 2,
+        "total": 3,
+        "attempt": 1,
+    }
+    return [parent, candidate, candidate_step]
+
+
+def test_reduce_pipeline_canceled_finalizes_unfinished_steps_and_candidates() -> None:
+    canceled = _base("evt-4", 4, "pipeline_canceled", status="canceled")
+    canceled["createdAt"] = "2026-06-08T10:05:00Z"
+
+    snapshot = reduce_pipeline_events([*_canceled_evidence_events(), canceled])
+
+    assert snapshot["status"] == "canceled"
+    step = snapshot["steps"][0]
+    assert step["id"] == "evaluate_candidates"
+    assert step["status"] == "canceled"
+    assert step["canceledAt"] == "2026-06-08T10:05:00Z"
+    assert step["terminalReason"] == "pipeline_canceled"
+
+    candidate = step["candidates"][0]
+    assert candidate["status"] == "canceled"
+    assert candidate["canceledAt"] == "2026-06-08T10:05:00Z"
+
+    candidate_step = candidate["steps"][0]
+    assert candidate_step["id"] == "cost_estimating"
+    assert candidate_step["status"] == "canceled"
+    assert candidate_step["canceledAt"] == "2026-06-08T10:05:00Z"
+    assert candidate_step["terminalReason"] == "pipeline_canceled"
+    assert snapshot["control"]["activeCandidateRunIds"] == []
+
+
+def test_reduce_pipeline_canceled_keeps_completed_nodes_and_conclusions() -> None:
+    intent = _base("evt-0a", 1, "step_started", scope="step")
+    intent["step"] = {"runId": "step-intent_parsing-1", "id": "intent_parsing", "index": 1, "total": 5, "attempt": 1}
+    intent_done = _base("evt-0b", 2, "step_completed", scope="step")
+    intent_done["step"] = intent["step"]
+    intent_done["data"] = {"conclusionField": "intent", "conclusion": {"region": "cn-hangzhou"}}
+    canceled = _base("evt-9", 9, "pipeline_canceled", status="canceled")
+
+    events = [intent, intent_done, *_canceled_evidence_events(), canceled]
+    snapshot = reduce_pipeline_events(events)
+
+    by_id = {step["id"]: step for step in snapshot["steps"]}
+    assert by_id["intent_parsing"]["status"] == "completed"
+    assert by_id["intent_parsing"]["conclusion"] == {"region": "cn-hangzhou"}
+    assert "canceledAt" not in by_id["intent_parsing"]
+    assert by_id["evaluate_candidates"]["status"] == "canceled"
+
+
+def test_reduce_pipeline_failed_finalizes_unfinished_nodes_as_failed() -> None:
+    failed = _base("evt-4", 4, "pipeline_failed", status="failed")
+
+    snapshot = reduce_pipeline_events([*_canceled_evidence_events(), failed])
+
+    assert snapshot["status"] == "failed"
+    step = snapshot["steps"][0]
+    assert step["status"] == "failed"
+    assert step["failedAt"] == "2026-06-08T10:00:00Z"
+    assert step["terminalReason"] == "pipeline_failed"
+    assert step["candidates"][0]["steps"][0]["status"] == "failed"
+
+
+def test_reduce_pipeline_canceled_pending_backup_leaves_nodes_untouched() -> None:
+    pending = _base("evt-4", 4, "pipeline_canceled", status="canceled")
+    pending["visibility"] = "pending_backup"
+
+    snapshot = reduce_pipeline_events([*_canceled_evidence_events(), pending])
+
+    assert snapshot["pendingTerminal"]["eventType"] == "pipeline_canceled"
+    assert snapshot["steps"][0]["status"] == "working"
+    assert snapshot["steps"][0]["candidates"][0]["steps"][0]["status"] == "working"
+
+
+def test_reduce_pipeline_completed_does_not_force_unfinished_nodes() -> None:
+    completed = _base("evt-4", 4, "pipeline_completed", status="completed")
+
+    snapshot = reduce_pipeline_events([*_canceled_evidence_events(), completed])
+
+    assert snapshot["status"] == "completed"
+    assert snapshot["steps"][0]["status"] == "working"
+
+
 def test_reduce_candidate_without_parent_step_does_not_create_none_step() -> None:
     candidate = _base("evt-1", 1, "candidate_started", scope="candidate")
     candidate["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}


### PR DESCRIPTION
## 问题

针对 Session `2289b86b6ec84a039c83903ad8b4f011`：Pipeline 取消后，步骤与候选子步骤仍停留在 `working`，`conclusion` 为 `null`。

证据快照中：
- `pipeline_snapshot.steps.2`（`evaluate_candidates`）
- `pipeline_snapshot.steps.2.candidates.0.steps.1`（`cost_estimating`）

均只发出过 `*_started`，取消后状态未收敛，重新加载后步骤结果无法判定。

## 根因

`_PipelineSnapshotReducer` 在处理已提交的 `pipeline_canceled` / `pipeline_failed` 时，只写入 pipeline 级 `status`、清理 `pendingTerminal` / `pendingInput` / `activeCandidateRunIds`，**并未把终态下推到仍在执行的节点**。

而各节点的生命周期处理器（`_apply_step_lifecycle`、`_apply_candidate_lifecycle`、`_apply_candidate_step_lifecycle`）只响应自身的 `*_started` / `*_completed` / `*_failed`。由于取消不会再补发这些逐节点事件，节点会一直保留 `step_started` 时写入的 `working` 状态，`conclusion` 也永远不会被合并。

Web transcript 链路本来就有 `_on_pipeline_canceled`（`src/iac_code/web/pipeline_transcript.py:1239`）做同样的收敛，本次补齐的是 A2A 快照（恢复 / 外部）链路缺失的另一半。

## 改动

`src/iac_code/a2a/pipeline_snapshot.py`

- 新增 `_finalize_unfinished_nodes` / `_finalize_node`，遍历 `steps` → `candidates` → `candidates[].steps` 三层，把非终态节点沉降到 `canceled` / `failed`，并写入 `canceledAt` / `failedAt`。
- 记录 `terminalReason`（即触发事件类型），便于可观测性区分「步骤自身失败」与「被 pipeline 取消带走」。
- **幂等**：已处于终态的节点不做修改，增量 reduce 安全可重复执行。
- **刻意排除 `pipeline_completed`**：正常完成已逐节点收口，强制写入会掩盖真实异常。
- **尊重 backup-ack 语义**：`pending_backup` 的终态在 `backup_committed` 之前不收敛，仅挂在 `pendingTerminal` 上。

## 测试

`tests/a2a/test_pipeline_snapshot.py` 新增 5 个用例（按证据 session 的事件形状构造）：

| 用例 | 覆盖点 |
| --- | --- |
| `test_reduce_pipeline_canceled_finalizes_unfinished_steps_and_candidates` | 三层节点全部收敛为 `canceled`，`canceledAt` / `terminalReason` 正确，`activeCandidateRunIds` 清空 |
| `test_reduce_pipeline_canceled_keeps_completed_nodes_and_conclusions` | 已完成节点及其 `conclusion` 不被覆盖，且不写入 `canceledAt` |
| `test_reduce_pipeline_failed_finalizes_unfinished_nodes_as_failed` | `pipeline_failed` 收敛为 `failed` + `failedAt` |
| `test_reduce_pipeline_canceled_pending_backup_leaves_nodes_untouched` | `pending_backup` 可见性下节点保持 `working` |
| `test_reduce_pipeline_completed_does_not_force_unfinished_nodes` | 正常完成不强制改写 |

验证结果：

- 目标套件：`tests/a2a/test_pipeline_snapshot.py` → **57 passed**（基线 52，+5）
- 回归套件：`tests/a2a` + `tests/web/test_pipeline_transcript.py` + `tests/web/test_pipeline.py` → **536 passed**（基线 531），collection errors **34 == 基线 34**
- `ruff check` / `ruff format --check` 通过；`ty check` 的 50 条 `unresolved-import` 全部源于本环境未安装可选 a2a SDK extra，与本次改动无关（已通过 `HEAD~1` 基线对比确认）
