### PR TITLE
fix(prompt): require a user-facing result summary after tool calls

### DIFF
--- a/iac-code-rs/crates/iac-code-core/src/system_prompt.rs
+++ b/iac-code-rs/crates/iac-code-core/src/system_prompt.rs
@@ -27,6 +27,7 @@ pub fn build_system_prompt(cwd: &str, memory_content: &str, skill_listing: &str)
     if !memory_content.trim().is_empty() {
         dynamic_sections.push(format!("# Memory\n{}", memory_content.trim()));
     }
+    dynamic_sections.push(build_final_response_section());
     dynamic_sections.push(build_output_style_section());
 
     let mut sections = static_sections;
@@ -139,6 +140,16 @@ fn build_actions_section() -> String {
 - Freely take local, reversible actions like editing files or running tests.\n\
 - For hard-to-reverse or shared-system actions, check with the user first.\n\
 - Never use destructive git operations (push --force, reset --hard) unless the user explicitly requests them."
+        .to_owned()
+}
+
+fn build_final_response_section() -> String {
+    "# Final Response\n\
+- Announcing an action is not doing it. If you say you will query, fetch or check something, complete it in the same turn and report what you found.\n\
+- After tool calls succeed, end the turn with a user-facing summary of the actual results, never with an intent statement or a transitional phrase.\n\
+- When results are paginated, keep fetching until the pages are exhausted, then summarize the complete set, including the concrete items and their total count.\n\
+- Tool completion is not task completion. The user only sees your final message, so the data they asked for must appear there.\n\
+- Brevity applies to your prose, not to the data the user asked for. Never drop or truncate the result listing to keep the answer short."
         .to_owned()
 }
 

--- a/src/iac_code/agent/system_prompt.py
+++ b/src/iac_code/agent/system_prompt.py
@@ -310,6 +310,22 @@ def _build_cloud_config_section() -> str:
         return ""
 
 
+def _build_final_response_section() -> str:
+    return (
+        "# Final Response\n"
+        "- Announcing an action is not doing it. If you say you will query, fetch or check something, "
+        "complete it in the same turn and report what you found.\n"
+        "- After tool calls succeed, end the turn with a user-facing summary of the actual results, "
+        "never with an intent statement or a transitional phrase.\n"
+        "- When results are paginated, keep fetching until the pages are exhausted, then summarize the "
+        "complete set, including the concrete items and their total count.\n"
+        "- Tool completion is not task completion. The user only sees your final message, so the data "
+        "they asked for must appear there.\n"
+        "- Brevity applies to your prose, not to the data the user asked for. Never drop or truncate the "
+        "result listing to keep the answer short."
+    )
+
+
 def _build_output_style_section() -> str:
     return (
         "# Output Style\n"
@@ -330,6 +346,7 @@ SECTION_BUILDERS: dict[str, Callable[..., str]] = {
     "tools": _build_tools_section,
     "doing_tasks": _build_doing_tasks_section,
     "actions": _build_actions_section,
+    "final_response": _build_final_response_section,
     "output_style": _build_output_style_section,
 }
 
@@ -342,6 +359,7 @@ SECTION_PRIORITIES: dict[str, int] = {
     "doing_tasks": 80,
     "actions": 75,
     "runtime_context": 72,
+    "final_response": 55,
     "output_style": 50,
 }
 
@@ -471,6 +489,7 @@ def build_system_prompt(
             priority=60,
             is_static=False,
         )
+    builder.add_cached_section("final_response", _build_final_response_section, priority=55, is_static=False)
     builder.add_cached_section("output_style", _build_output_style_section, priority=50, is_static=False)
 
     return builder.build()

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -109,6 +109,17 @@ class TestBuildSystemPrompt:
         prompt = build_system_prompt(cwd=_TMP)
         assert "concise" in prompt.lower() or "brief" in prompt.lower()
 
+    def test_contains_final_response_closing_contract(self):
+        prompt = build_system_prompt(cwd=_TMP)
+        assert "# Final Response" in prompt
+        assert "user-facing summary of the actual results" in prompt
+        assert "never with an intent statement or a transitional phrase" in prompt
+        assert "keep fetching until the pages are exhausted" in prompt
+
+    def test_final_response_precedes_output_style(self):
+        prompt = build_system_prompt(cwd=_TMP)
+        assert prompt.index("# Final Response") < prompt.index("# Output Style")
+
     def test_memory_section_included_when_content(self):
         prompt = build_system_prompt(cwd=_TMP, memory_content="Remember: user prefers Python")
         assert "user prefers Python" in prompt
@@ -427,6 +438,7 @@ class TestBuildBaseSections:
             "tools",
             "doing_tasks",
             "actions",
+            "final_response",
             "output_style",
         }
         assert set(SECTION_BUILDERS.keys()) == expected_keys


### PR DESCRIPTION
## 背景

证据 Session `aa70833e15d7427fa38c41a1afd9d10e` / `c95f495b062546389a7629c749ff050c` 中，资源栈清查类查询的工具调用（含分页）全部成功，但最终响应停留在「我来查询」「将获取剩余资源栈」这类意图宣告 / 过渡语，实际查到的各地域及全部 21 个资源栈清单从未汇总给用户。

## 根因

`AgentLoop` 在某轮模型输出不含 `tool_use` 时结束回合（`src/iac_code/agent/agent_loop.py` 中 `if not completed_tools: ... break`），这是设计使然。真正缺失的是提示层的收尾契约：`# System Rules` 与 `# Output Style` 只强调简洁，全篇没有任何一条要求「工具/分页完成后必须补一条面向用户的结果汇总」。在简洁性压力下，以一句过渡语结束回合反而符合提示的字面要求。

## 变更

- `src/iac_code/agent/system_prompt.py`：新增 `_build_final_response_section()`（`# Final Response`），明确要求：宣告即执行；工具成功后必须以面向用户的实际结果汇总收尾，不得以意图宣告/过渡语结束；分页需取尽后汇总完整集合（条目 + 总数）；简洁性作用于叙述文字而非用户请求的数据本身。注册进 `SECTION_BUILDERS` / `SECTION_PRIORITIES`（priority 55），并在 `build_system_prompt()` 中同优先级加入，保证与 `build_base_sections()` 顺序一致（位于 `# Output Style` 之前）。`DEFAULT_PIPELINE_SECTIONS` 不变。
- `iac-code-rs/crates/iac-code-core/src/system_prompt.rs`：同步等价段落，避免双实现漂移。
- `tests/agent/test_system_prompt.py`：段落注册表断言补 `final_response`；新增 `test_contains_final_response_closing_contract`、`test_final_response_precedes_output_style`。

未改动 `AgentLoop`：在循环层做「是否已汇总」的启发式判定会误判追轮、破坏所有非查询任务的回合语义，并与 `max_turns` / 注入消息 / compaction 逻辑深度耦合。

## 测试

- `uv run pytest tests/agent tests/pipeline -q` → 1926 passed, 1 failed。
- 唯一失败 `tests/pipeline/engine/test_prerequisites.py::test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` 与本次变更无关：用例断言 urllib 抛 `InvalidURL`，当前环境实际抛 `HTTPError`；该用例与 `system_prompt` 无任何引用关系。
- `uv run ruff check` / `ruff format --check` 变更文件通过。环境无 cargo 工具链，Rust 侧未执行 `cargo test`（改动为纯字符串常量新增）。

## 验收

复跑两个证据 Session，最终响应应包含各地域及全部 21 个资源栈的实际清单，而非过渡语。
