### PR TITLE
fix(selling): 以解析出的意图资源为约束校验候选覆盖

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4088,6 +4088,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource parsed into the intent must be covered by a candidate, or "
+"explicitly excluded with a reason in that candidate."
+msgstr ""
+"Jede in der Absicht erkannte Ressource muss von einem Kandidaten abgedeckt "
+"oder in diesem Kandidaten mit einer Begründung explizit ausgeschlossen werden."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4065,6 +4065,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource parsed into the intent must be covered by a candidate, or "
+"explicitly excluded with a reason in that candidate."
+msgstr ""
+"Todos los recursos analizados en la intención deben estar cubiertos por un "
+"candidato o excluidos explícitamente con un motivo en ese candidato."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4074,6 +4074,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource parsed into the intent must be covered by a candidate, or "
+"explicitly excluded with a reason in that candidate."
+msgstr ""
+"Chaque ressource analysée dans l'intention doit être couverte par un "
+"candidat, ou explicitement exclue avec un motif dans ce candidat."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3876,6 +3876,13 @@ msgstr "ユーザーが明示した各ハード制約は、パラメーターと
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource parsed into the intent must be covered by a candidate, or "
+"explicitly excluded with a reason in that candidate."
+msgstr ""
+"インテントで解析された各リソースは、いずれかの候補で網羅するか、その候補で理由を示して明示的に除外する必要があります。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4046,6 +4046,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource parsed into the intent must be covered by a candidate, or "
+"explicitly excluded with a reason in that candidate."
+msgstr ""
+"Todo recurso analisado na intenção deve ser coberto por um candidato ou "
+"explicitamente excluído com um motivo nesse candidato."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3840,6 +3840,12 @@ msgstr "每个用户明确提出的硬约束都必须由一条状态为满足的
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource parsed into the intent must be covered by a candidate, or "
+"explicitly excluded with a reason in that candidate."
+msgstr "意图中解析出的每个资源都必须被某个候选方案覆盖，或在该候选方案中给出原因并显式排除。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr "调用此工具提交结论以完成当前步骤。如需回滚到较早步骤，请设置 rollback_request。"

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -14,6 +14,7 @@ import jsonschema
 from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
 from iac_code.pipeline.engine.hard_constraints import collect_hard_constraints, validate_hard_constraint_checks
+from iac_code.pipeline.engine.intent_coverage import collect_resource_intents, validate_intent_coverage
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.utils.public_errors import sanitize_strict_text
@@ -60,6 +61,10 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
     ),
+    "intent_resource_coverage_required": (
+        "Every resource parsed into the intent must be covered by a candidate, or explicitly excluded with a "
+        "reason in that candidate."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -99,6 +104,10 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
         _(
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
+        ),
+        _(
+            "Every resource parsed into the intent must be covered by a candidate, or explicitly excluded with a "
+            "reason in that candidate."
         ),
     )
 
@@ -324,6 +333,7 @@ class CompleteStepTool(Tool):
             required_tool_result = guard.get("require_tool_result")
             required_conclusion_sha256 = guard.get("require_conclusion_sha256")
             required_constraint_coverage = guard.get("require_context_constraint_coverage")
+            required_intent_coverage = guard.get("require_context_intent_coverage")
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
@@ -383,7 +393,48 @@ class CompleteStepTool(Tool):
                 )
                 if validation_error is not None:
                     return validation_error
+            if isinstance(required_intent_coverage, dict):
+                validation_error = self._validate_context_intent_coverage(
+                    required_intent_coverage,
+                    conclusion,
+                    self._completion_guard_message(guard, None),
+                )
+                if validation_error is not None:
+                    return validation_error
         return None
+
+    def _validate_context_intent_coverage(
+        self,
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        message: str | None,
+    ) -> str | None:
+        source_fields = requirement.get("source_fields") or []
+        if not isinstance(source_fields, list) or not all(isinstance(field, str) for field in source_fields):
+            return message or _("A completion guard is misconfigured.")
+        context_snapshot = self._completion_guard_state.get("context_snapshot")
+        if not isinstance(context_snapshot, dict):
+            context_snapshot = {}
+        intents, source_issues = collect_resource_intents(context_snapshot, source_fields)
+        candidates = self._resolve_dotted(conclusion, str(requirement.get("candidates_field") or "candidates"))
+        issues = source_issues + validate_intent_coverage(intents, candidates)
+        if not issues:
+            return None
+        base_message = message or _(
+            "Every resource parsed into the intent must be covered by a candidate, or explicitly excluded with a "
+            "reason in that candidate."
+        )
+        issue_summaries = []
+        for issue in issues:
+            specifics = ", ".join(value for value in (issue.product, issue.detail) if value)
+            issue_summaries.append(f"{issue.code}[{specifics}]" if specifics else issue.code)
+        code = issues[0].code if len(issues) == 1 else "multiple_intent_coverage_issues"
+        detail = "; ".join(issue_summaries)
+        return _("{message} Validation issue: {code} ({detail}).").format(
+            message=base_message,
+            code=code,
+            detail=detail,
+        )
 
     def _validate_context_constraint_coverage(
         self,

--- a/src/iac_code/pipeline/engine/intent_coverage.py
+++ b/src/iac_code/pipeline/engine/intent_coverage.py
@@ -1,0 +1,186 @@
+"""Generic validation that architecture candidates cover parsed intent resources."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+REQUIRED_COVERAGE_ACTIONS = frozenset({"create", "use_existing", "reference"})
+FORBIDDEN_ACTION = "forbid"
+
+
+@dataclass(frozen=True)
+class IntentCoverageIssue:
+    code: str
+    product: str = ""
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {key: value for key, value in asdict(self).items() if value}
+
+
+def collect_resource_intents(
+    context_snapshot: dict[str, Any],
+    source_fields: list[str],
+) -> tuple[list[dict[str, Any]], list[IntentCoverageIssue]]:
+    """Merge resource intents from oldest to newest source, with later sources winning by product."""
+
+    merged: dict[str, dict[str, Any]] = {}
+    issues: list[IntentCoverageIssue] = []
+    for source_field in source_fields:
+        raw_intents = _resolve_dotted(context_snapshot, source_field)
+        if raw_intents is None:
+            continue
+        if not isinstance(raw_intents, list):
+            issues.append(IntentCoverageIssue("invalid_intent_source", detail=source_field))
+            continue
+        for raw_intent in raw_intents:
+            if not isinstance(raw_intent, dict):
+                issues.append(IntentCoverageIssue("invalid_resource_intent"))
+                continue
+            product = raw_intent.get("product")
+            if not isinstance(product, str) or not product.strip():
+                issues.append(IntentCoverageIssue("missing_intent_product"))
+                continue
+            merged[_normalize_product(product)] = raw_intent
+    return list(merged.values()), issues
+
+
+def validate_intent_coverage(intents: list[dict[str, Any]], candidates: Any) -> list[IntentCoverageIssue]:
+    """Require every parsed intent resource to be covered by a candidate or explicitly excluded."""
+
+    if not intents:
+        return []
+    if not isinstance(candidates, list) or not candidates:
+        return [IntentCoverageIssue("invalid_candidates")]
+
+    issues: list[IntentCoverageIssue] = []
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            issues.append(IntentCoverageIssue("invalid_candidate", detail=f"candidates.{index}"))
+            continue
+        issues.extend(_validate_candidate(intents, candidate, index))
+    return issues
+
+
+def _validate_candidate(
+    intents: list[dict[str, Any]],
+    candidate: Any,
+    index: int,
+) -> list[IntentCoverageIssue]:
+    location = f"candidates.{index}"
+    issues: list[IntentCoverageIssue] = []
+    covered = _candidate_covered_products(candidate)
+    created = _candidate_created_products(candidate)
+    excluded = _candidate_excluded_reasons(candidate)
+
+    for intent in intents:
+        product = str(intent.get("product") or "")
+        key = _normalize_product(product)
+        action = intent.get("action")
+        if action == FORBIDDEN_ACTION:
+            if key in created:
+                issues.append(IntentCoverageIssue("forbidden_intent_resource_present", product, location))
+            continue
+        if action not in REQUIRED_COVERAGE_ACTIONS:
+            continue
+        if key in covered:
+            continue
+        if key not in excluded:
+            issues.append(IntentCoverageIssue("intent_resource_not_covered", product, location))
+            continue
+        if not excluded[key]:
+            issues.append(IntentCoverageIssue("intent_resource_exclusion_reason_missing", product, location))
+
+    intent_keys = {_normalize_product(str(intent.get("product") or "")) for intent in intents}
+    for key, product in _candidate_excluded_products(candidate).items():
+        if key not in intent_keys:
+            issues.append(IntentCoverageIssue("unexpected_intent_exclusion", product, location))
+    return issues
+
+
+def _candidate_covered_products(candidate: Any) -> set[str]:
+    covered: set[str] = set()
+    for raw_intent in _list_value(candidate.get("resource_intents")):
+        if not isinstance(raw_intent, dict):
+            continue
+        if raw_intent.get("action") == FORBIDDEN_ACTION:
+            continue
+        product = raw_intent.get("product")
+        if isinstance(product, str) and product.strip():
+            covered.add(_normalize_product(product))
+    for product in _list_value(candidate.get("products")):
+        if isinstance(product, str) and product.strip():
+            covered.add(_normalize_product(product))
+    return covered
+
+
+def _candidate_created_products(candidate: Any) -> set[str]:
+    created: set[str] = set()
+    for raw_intent in _list_value(candidate.get("resource_intents")):
+        if not isinstance(raw_intent, dict) or raw_intent.get("action") != "create":
+            continue
+        product = raw_intent.get("product")
+        if isinstance(product, str) and product.strip():
+            created.add(_normalize_product(product))
+    declared_intents = {
+        _normalize_product(str(raw_intent.get("product") or ""))
+        for raw_intent in _list_value(candidate.get("resource_intents"))
+        if isinstance(raw_intent, dict) and isinstance(raw_intent.get("product"), str)
+    }
+    for product in _list_value(candidate.get("products")):
+        if not isinstance(product, str) or not product.strip():
+            continue
+        key = _normalize_product(product)
+        if key not in declared_intents:
+            created.add(key)
+    return created
+
+
+def _candidate_excluded_reasons(candidate: Any) -> dict[str, str]:
+    reasons: dict[str, str] = {}
+    for raw_exclusion in _list_value(candidate.get("excluded_resource_intents")):
+        if not isinstance(raw_exclusion, dict):
+            continue
+        product = raw_exclusion.get("product")
+        if not isinstance(product, str) or not product.strip():
+            continue
+        reason = raw_exclusion.get("reason")
+        reasons[_normalize_product(product)] = reason.strip() if isinstance(reason, str) else ""
+    return reasons
+
+
+def _candidate_excluded_products(candidate: Any) -> dict[str, str]:
+    products: dict[str, str] = {}
+    for raw_exclusion in _list_value(candidate.get("excluded_resource_intents")):
+        if not isinstance(raw_exclusion, dict):
+            continue
+        product = raw_exclusion.get("product")
+        if isinstance(product, str) and product.strip():
+            products[_normalize_product(product)] = product
+    return products
+
+
+def _normalize_product(value: str) -> str:
+    return re.sub(r"[\s_\-:]+", "", value).casefold()
+
+
+def _list_value(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _resolve_dotted(value: Any, path: str) -> Any:
+    if not path:
+        return None
+    for part in path.split("."):
+        if isinstance(value, dict):
+            value = value.get(part)
+        elif isinstance(value, list) and part.isdigit():
+            index = int(part)
+            value = value[index] if 0 <= index < len(value) else None
+        else:
+            return None
+        if value is None:
+            return None
+    return value

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -43,6 +43,7 @@ _SUPPORTED_COMPLETION_GUARD_KEYS = {
     "message_key",
     "require_conclusion_sha256",
     "require_context_constraint_coverage",
+    "require_context_intent_coverage",
     "require_tool",
     "require_tool_result",
     "required_conclusion_any_of",

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -453,6 +453,13 @@ steps:
     skill: iac-aliyun-architecture
     prompt: prompts/architecture_planning.md
     context_fields: [intent]
+    max_conclusion_retries: 3
+    completion_guards:
+      - always: true
+        require_context_intent_coverage:
+          source_fields: [intent.resource_intents]
+          candidates_field: candidates
+        message_key: intent_resource_coverage_required
     tools:
       include: [read_memory, read_file, list_files, glob, grep, web_fetch, aliyun_doc_search]
       exclude: []

--- a/src/iac_code/pipeline/selling/prompts/architecture_planning.md
+++ b/src/iac_code/pipeline/selling/prompts/architecture_planning.md
@@ -26,4 +26,5 @@
 - 你可以按需自主使用 `read_memory` 补充规划上下文：在生成方案前，如用户意图涉及已有资源、默认地域、已有 VPC/Zone、网段约束、成本偏好、高可用偏好、架构偏好、命名规范或历史项目约束，先调用 `read_memory({})` 查看索引，再读取相关 name。
 - 记忆只用于补充方案设计背景；若记忆与当前用户意图冲突，以当前用户意图为准。
 - 直接根据已知意图设计架构方案。
+- `intent.resource_intents` 中 `action` 为 `create`/`use_existing`/`reference` 的资源是候选集的覆盖约束：每个候选要么包含该资源，要么在 `excluded_resource_intents` 中给出非空 `reason` 说明排除原因。不要静默丢弃已解析出的资源意图（如 OSS）。
 - 如果意图信息不足以设计架构，可在 rollback_request 中请求回退到 intent_parsing。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
@@ -42,6 +42,21 @@ conclusion_schema:
                 notes:
                   type: string
             description: 本方案中每个资源的新建、复用、引用或禁止语义；从 intent.resource_intents 继承或收窄
+          excluded_resource_intents:
+            type: array
+            items:
+              type: object
+              required: [product, reason]
+              additionalProperties: false
+              properties:
+                product:
+                  type: string
+                  description: intent.resource_intents 中被本方案排除的资源或产品名称
+                reason:
+                  type: string
+                  minLength: 1
+                  description: 本方案不包含该意图资源的具体原因；不得为空
+            description: 本方案未覆盖的意图资源及排除原因；意图资源既未覆盖也未在此说明时方案不合法
           hard_constraints:
             type: array
             description: 当前候选采用的用户硬约束完整快照；以进入本步骤后的最新用户要求为准，不得加入推断规格或方案推荐值
@@ -130,6 +145,7 @@ conclusion_schema:
 - 方案名称（体现核心差异，如"Serverless 轻量方案"而非泛泛的"方案一"）
 - 核心阿里云产品组合（只列必要的产品）
 - 资源生命周期：`resource_intents`
+- 未覆盖的意图资源及原因：`excluded_resource_intents`（全部覆盖时省略）
 - 拓扑描述（简述部署架构）
 - 月度费用估算范围
 - 优势和局限
@@ -144,6 +160,17 @@ conclusion_schema:
 - 将 `resource_intents` 原样或按方案收窄后写入每个 candidate，供模板生成步骤继续执行同一约束。
 
 示例：intent 表示“已有 VPC 中创建安全组”时，candidate 应包含 `resource_intents: [{"product": "VPC", "action": "use_existing"}, {"product": "SecurityGroup", "action": "create"}]`。不得生成 VSwitch，也不得设计成“创建 VPC + VSwitch + SecurityGroup”。
+
+## 意图资源覆盖约束
+
+`intent.resource_intents` 同时是候选集的**覆盖约束**，不只是禁止约束。每个 `action` 为 `create`、`use_existing` 或 `reference` 的意图资源，在每个候选中都必须满足其中之一：
+
+- 被该候选覆盖：出现在 `candidate.resource_intents` 或 `candidate.products` 中；
+- 或在 `candidate.excluded_resource_intents` 中显式列出，并给出非空 `reason` 说明本方案为什么不包含它。
+
+不允许静默丢弃已解析的意图资源。例如 intent 解析出 OSS 静态托管意图时，候选要么包含 OSS 方案，要么在 `excluded_resource_intents` 写明排除原因（如“本方案改用 ECS 承载动态渲染，静态资源不单独使用 OSS”）；只给 ECS、SAE 候选而完全不提 OSS 是错误输出。
+
+`excluded_resource_intents` 只能出现 `intent.resource_intents` 里已有的资源，不要把用户没提过的产品写进排除列表。
 
 ## 用户硬约束
 

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -381,6 +381,88 @@ class TestCompletionGuards:
         assert "constraint_parameter_mismatch[db-storage-min, DBInstanceStorage]" in error
         assert "missing_constraint_check[db-engine-version]" in error
 
+    def test_requires_candidates_to_cover_parsed_intent_resources(self):
+        guard = {
+            "always": True,
+            "require_context_intent_coverage": {
+                "source_fields": ["intent.resource_intents"],
+                "candidates_field": "candidates",
+            },
+            "message_key": "intent_resource_coverage_required",
+        }
+        tool = CompleteStepTool(
+            StepConfig(step_id="architecture_planning", conclusion_field="architecture", forward=None),
+            completion_guards=[guard],
+            completion_guard_state={
+                "context_snapshot": {
+                    "intent": {
+                        "resource_intents": [
+                            {"product": "OSS", "action": "create", "source": "user"},
+                            {"product": "CDN", "action": "create", "source": "user"},
+                        ]
+                    }
+                }
+            },
+        )
+
+        dropped_oss = {
+            "candidates": [
+                {"name": "ecs-web", "products": ["ECS", "VPC"]},
+                {"name": "sae-web", "products": ["SAE"]},
+            ]
+        }
+        error = tool.validate_completion_input({"conclusion": dropped_oss})
+        assert error is not None
+        assert "multiple_intent_coverage_issues" in error
+        assert "intent_resource_not_covered[OSS, candidates.0]" in error
+        assert "intent_resource_not_covered[CDN, candidates.1]" in error
+
+        covered = {"candidates": [{"name": "oss-cdn-static", "products": ["OSS", "CDN"]}]}
+        assert tool.validate_completion_input({"conclusion": covered}) is None
+
+        explicitly_excluded = {
+            "candidates": [
+                {
+                    "name": "ecs-web",
+                    "products": ["ECS", "CDN"],
+                    "excluded_resource_intents": [
+                        {"product": "OSS", "reason": "本方案由 ECS 承载动态渲染，静态资源不单独使用 OSS"}
+                    ],
+                }
+            ]
+        }
+        assert tool.validate_completion_input({"conclusion": explicitly_excluded}) is None
+
+        excluded_without_reason = {
+            "candidates": [
+                {
+                    "name": "ecs-web",
+                    "products": ["ECS", "CDN"],
+                    "excluded_resource_intents": [{"product": "OSS", "reason": ""}],
+                }
+            ]
+        }
+        error = tool.validate_completion_input({"conclusion": excluded_without_reason})
+        assert error is not None
+        assert "intent_resource_exclusion_reason_missing[OSS, candidates.0]" in error
+
+    def test_intent_coverage_guard_passes_when_intent_has_no_resource_intents(self):
+        tool = CompleteStepTool(
+            StepConfig(step_id="architecture_planning", conclusion_field="architecture", forward=None),
+            completion_guards=[
+                {
+                    "always": True,
+                    "require_context_intent_coverage": {"source_fields": ["intent.resource_intents"]},
+                    "message_key": "intent_resource_coverage_required",
+                }
+            ],
+            completion_guard_state={"context_snapshot": {"intent": {"core_requirements": ["ECS"]}}},
+        )
+
+        conclusion = {"candidates": [{"name": "ecs-web", "products": ["ECS"]}]}
+
+        assert tool.validate_completion_input({"conclusion": conclusion}) is None
+
     @pytest.mark.asyncio
     async def test_constraint_guard_returns_repairable_error_before_failing_step(self):
         constraint = {

--- a/tests/pipeline/engine/test_intent_coverage.py
+++ b/tests/pipeline/engine/test_intent_coverage.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from iac_code.pipeline.engine.intent_coverage import (
+    IntentCoverageIssue,
+    collect_resource_intents,
+    validate_intent_coverage,
+)
+
+
+def _intent(product, action="create", **overrides):
+    intent = {"product": product, "action": action, "source": "user"}
+    intent.update(overrides)
+    return intent
+
+
+def _candidate(name="ecs-single", products=None, resource_intents=None, excluded=None):
+    candidate = {
+        "name": name,
+        "output_path": "templates/1-ecs-single.yml",
+        "products": products if products is not None else ["ECS", "VPC"],
+        "hard_constraints": [],
+        "topology": "single ECS behind EIP",
+        "monthly_estimate": "100-200 CNY",
+        "pros": ["simple"],
+        "cons": ["single point"],
+    }
+    if resource_intents is not None:
+        candidate["resource_intents"] = resource_intents
+    if excluded is not None:
+        candidate["excluded_resource_intents"] = excluded
+    return candidate
+
+
+def test_collect_resource_intents_merges_sources_and_reports_invalid_entries():
+    intents, issues = collect_resource_intents(
+        {"intent": {"resource_intents": [_intent("OSS"), _intent("CDN")]}},
+        ["intent.resource_intents"],
+    )
+    assert [item["product"] for item in intents] == ["OSS", "CDN"]
+    assert issues == []
+
+    intents, issues = collect_resource_intents(
+        {
+            "intent": {"resource_intents": [_intent("OSS", action="create")]},
+            "candidate": {"resource_intents": [_intent("OSS", action="use_existing")]},
+        },
+        ["intent.resource_intents", "candidate.resource_intents"],
+    )
+    assert intents == [_intent("OSS", action="use_existing")]
+
+    intents, issues = collect_resource_intents(
+        {"intent": {"resource_intents": "OSS"}},
+        ["intent.resource_intents"],
+    )
+    assert intents == []
+    assert issues == [IntentCoverageIssue("invalid_intent_source", detail="intent.resource_intents")]
+
+    intents, issues = collect_resource_intents(
+        {"intent": {"resource_intents": ["OSS", {"action": "create"}]}},
+        ["intent.resource_intents"],
+    )
+    assert intents == []
+    assert [issue.code for issue in issues] == ["invalid_resource_intent", "missing_intent_product"]
+
+
+def test_empty_intents_allow_any_candidate_set():
+    assert validate_intent_coverage([], [_candidate()]) == []
+    assert validate_intent_coverage([], []) == []
+
+
+def test_reports_intent_resource_dropped_from_candidates():
+    intents = [_intent("OSS"), _intent("CDN")]
+    candidates = [_candidate(products=["ECS", "VPC"]), _candidate(name="sae", products=["SAE"])]
+
+    issues = validate_intent_coverage(intents, candidates)
+
+    assert [(issue.code, issue.product, issue.detail) for issue in issues] == [
+        ("intent_resource_not_covered", "OSS", "candidates.0"),
+        ("intent_resource_not_covered", "CDN", "candidates.0"),
+        ("intent_resource_not_covered", "OSS", "candidates.1"),
+        ("intent_resource_not_covered", "CDN", "candidates.1"),
+    ]
+
+
+def test_candidate_covers_intent_resource_via_products_or_resource_intents():
+    intents = [_intent("OSS"), _intent("CDN")]
+
+    via_products = _candidate(products=["OSS", "CDN"])
+    assert validate_intent_coverage(intents, [via_products]) == []
+
+    via_resource_intents = _candidate(
+        products=[],
+        resource_intents=[_intent("OSS"), _intent("CDN", action="reference")],
+    )
+    assert validate_intent_coverage(intents, [via_resource_intents]) == []
+
+
+def test_product_name_matching_ignores_case_and_separators():
+    intents = [_intent("Object-Storage")]
+    candidate = _candidate(products=["object storage"])
+
+    assert validate_intent_coverage(intents, [candidate]) == []
+
+
+def test_explicit_exclusion_requires_non_empty_reason():
+    intents = [_intent("OSS")]
+
+    with_reason = _candidate(
+        products=["ECS"],
+        excluded=[{"product": "OSS", "reason": "本方案由 ECS 承载动态渲染，静态资源不单独使用 OSS"}],
+    )
+    assert validate_intent_coverage(intents, [with_reason]) == []
+
+    without_reason = _candidate(products=["ECS"], excluded=[{"product": "OSS", "reason": "  "}])
+    issues = validate_intent_coverage(intents, [without_reason])
+    assert [(issue.code, issue.product) for issue in issues] == [
+        ("intent_resource_exclusion_reason_missing", "OSS")
+    ]
+
+
+def test_exclusion_list_cannot_introduce_products_outside_the_intent():
+    intents = [_intent("OSS")]
+    candidate = _candidate(
+        products=["OSS"],
+        excluded=[{"product": "PolarDB", "reason": "成本过高"}],
+    )
+
+    issues = validate_intent_coverage(intents, [candidate])
+
+    assert [(issue.code, issue.product) for issue in issues] == [("unexpected_intent_exclusion", "PolarDB")]
+
+
+def test_forbidden_intent_resource_must_not_be_created():
+    intents = [_intent("VSwitch", action="forbid"), _intent("SecurityGroup")]
+
+    violating = _candidate(products=["SecurityGroup", "VSwitch"])
+    issues = validate_intent_coverage(intents, [violating])
+    assert [(issue.code, issue.product) for issue in issues] == [
+        ("forbidden_intent_resource_present", "VSwitch")
+    ]
+
+    compliant = _candidate(
+        products=[],
+        resource_intents=[_intent("SecurityGroup"), _intent("VSwitch", action="forbid")],
+    )
+    assert validate_intent_coverage(intents, [compliant]) == []
+
+
+def test_forbidden_resource_referenced_as_existing_is_not_a_creation():
+    intents = [_intent("VPC", action="forbid"), _intent("SecurityGroup")]
+    candidate = _candidate(
+        products=[],
+        resource_intents=[_intent("SecurityGroup"), _intent("VPC", action="use_existing")],
+    )
+
+    assert validate_intent_coverage(intents, [candidate]) == []
+
+
+def test_malformed_candidate_payloads_are_reported():
+    intents = [_intent("OSS")]
+
+    assert validate_intent_coverage(intents, []) == [IntentCoverageIssue("invalid_candidates")]
+    assert validate_intent_coverage(intents, "candidates") == [IntentCoverageIssue("invalid_candidates")]
+    assert validate_intent_coverage(intents, ["oops"]) == [
+        IntentCoverageIssue("invalid_candidate", detail="candidates.0")
+    ]

--- a/tests/pipeline/selling/skills/test_iac_aliyun_architecture_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_architecture_skill.py
@@ -58,6 +58,26 @@ def test_architecture_prompt_guides_optional_memory_lookup_for_planning_context(
     assert "当前用户意图为准" in body
 
 
+def test_architecture_requires_intent_resource_coverage_or_explicit_exclusion():
+    body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    end = body.index("---", 3)
+    schema = yaml.safe_load(body[3:end])["conclusion_schema"]
+    candidate_properties = schema["properties"]["candidates"]["items"]["properties"]
+    exclusion = candidate_properties["excluded_resource_intents"]["items"]
+
+    assert set(exclusion["required"]) == {"product", "reason"}
+    assert exclusion["properties"]["reason"]["minLength"] == 1
+    assert "不允许静默丢弃已解析的意图资源" in body
+    assert "excluded_resource_intents" in body
+
+
+def test_architecture_prompt_states_intent_resource_coverage_constraint():
+    body = PROMPT_FILE.read_text(encoding="utf-8")
+
+    assert "excluded_resource_intents" in body
+    assert "不要静默丢弃已解析出的资源意图" in body
+
+
 def test_architecture_keeps_iac_code_web_candidate_on_fixed_entry_topology():
     body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 背景

Aone 需求 #84638235（Session `4a2b12c104474095a850a2ceab6a9e3b`）：`intent_parsing` 已解析出 OSS 资源意图，但 `architecture_planning` / `evaluate_candidates` 产出的 ECS、SAE 两个候选均未包含 OSS，也未说明排除 OSS 的原因，候选集与用户意图脱节。

## 根因

`src/iac_code/pipeline/selling/pipeline.yaml` 中 `architecture_planning` 只声明了 `context_fields: [intent]`，没有任何 `completion_guards`。候选是否覆盖已解析的意图资源，仅靠 `iac-aliyun-architecture/SKILL.md` 的 prompt 软约束表达，因此模型丢掉 OSS 也能通过 `complete_step`。仓库中唯一的覆盖类校验 `require_context_constraint_coverage` 挂在 `cost_estimating`，且只校验 `hard_constraints`。

## 改动

- 新增 `src/iac_code/pipeline/engine/intent_coverage.py`：通用的意图覆盖校验器。`intent.resource_intents` 中 `action` 为 `create` / `use_existing` / `reference` 的资源必须被每个候选覆盖（来自 `candidate.products` 或 `candidate.resource_intents`），否则必须在 `candidate.excluded_resource_intents` 中给出非空 `reason`；`forbid` 的资源不得出现在候选创建的产品中。产品名比较忽略大小写与 `空格/_/-/:` 分隔符。
- `pipeline.yaml`：为 `architecture_planning` 增加 `require_context_intent_coverage` guard，`message_key: intent_resource_coverage_required`。
- `loader.py`：将 `require_context_intent_coverage` 加入 `_SUPPORTED_COMPLETION_GUARD_KEYS`。
- `complete_step_tool.py`：接入校验，从 `context_snapshot` 读取意图，返回可修复的校验错误（受 `max_conclusion_retries: 3` 约束，不会硬失败会话）。
- `iac-aliyun-architecture/SKILL.md`：`conclusion_schema` 增加 `excluded_resource_intents`（`reason` 必填、`minLength: 1`），补充「意图资源覆盖约束」章节。
- `prompts/architecture_planning.md`：显式声明不得静默丢弃已解析的资源意图。
- 6 个 locale 的 `messages.po` 补充新增文案翻译。

## 兼容性

`intent.resource_intents` 为空时直接通过，历史 pipeline 行为不变。

## 测试

- 新增 `tests/pipeline/engine/test_intent_coverage.py`（10 个用例）。
- `tests/pipeline/engine/test_complete_step_tool.py`、`tests/pipeline/selling/skills/test_iac_aliyun_architecture_skill.py` 补充 guard 行为断言。
- `uv run pytest tests/pipeline tests/test_i18n.py -q` → 1652 passed；2 个失败为改动前既有问题，已用 `git stash` 验证：`test_prerequisites.py`（InvalidURL vs HTTPError）与 `test_i18n.py` msgfmt（zh `messages.po:2505-2525` 既有 format specification 错误）。
- `uv run ruff check src/iac_code tests/pipeline` 与 `uv run ty check src/` 均通过。

## 验收

复跑 Session `4a2b12c104474095a850a2ceab6a9e3b`，候选集应包含 OSS 资源方案，或在 `excluded_resource_intents` 中明确说明排除 OSS 的原因。
