### PR TITLE
fix(a2a): propagate terminal and rollback outcomes to pipeline snapshot items

### DIFF
--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -36,6 +36,16 @@ _CLEANUP_STATUS_BY_EVENT_TYPE = {
     PIPELINE_EVENT_CLEANUP_FAILED: "failed",
 }
 _KNOWN_CLEANUP_STATUSES = {"pending", "started", "in_progress", "completed", "failed", "skipped"}
+# A step/candidate/sub-step in one of these states has already reached its own
+# conclusion, so run-level termination and rollback must leave it untouched.
+_TERMINAL_ITEM_STATUSES = {"completed", "failed", "canceled", "rolled_back"}
+_ROLLED_BACK_ITEM_STATUS = "rolled_back"
+_TERMINAL_ITEM_TIME_KEYS = {
+    "completed": "completedAt",
+    "failed": "failedAt",
+    "canceled": "canceledAt",
+    _ROLLED_BACK_ITEM_STATUS: "rolledBackAt",
+}
 _PENDING_BACKUP_VISIBILITY = "pending_backup"
 _COMMITTED_BACKUP_VISIBILITY = "committed"
 _BACKUP_COMMITTED_EVENT_TYPE = "backup_committed"
@@ -501,6 +511,7 @@ class _PipelineSnapshotReducer:
             self._apply_cleanup_event(event)
         elif event_type == "rollback_completed":
             self._append_rollback(event)
+            self._finalize_non_terminal_items(_ROLLED_BACK_ITEM_STATUS, event)
         elif event_type == "candidate_restart_requested":
             self._append_candidate_restart(event)
         elif event_type == "input_required":
@@ -529,6 +540,7 @@ class _PipelineSnapshotReducer:
             self._snapshot["pendingTerminal"] = None
             self._snapshot["pendingInput"] = None
             self._snapshot["control"]["activeCandidateRunIds"] = []
+            self._finalize_non_terminal_items(terminal_status, event)
         elif (
             event_type not in {"input_required", "input_received", *_CLEANUP_STATUS_BY_EVENT_TYPE}
             and not _is_pending_backup_publication(event)
@@ -749,6 +761,27 @@ class _PipelineSnapshotReducer:
             candidate_step["status"] = "failed"
             _set_time(candidate_step, "failedAt", created_at)
             _merge_completion_data(candidate_step, event)
+
+    def _finalize_non_terminal_items(self, terminal_status: str, event: dict[str, Any]) -> None:
+        """Propagate a run-level terminal (or rollback) outcome down to every
+        step/candidate/sub-step that never reached its own conclusion.
+
+        Per-item terminal events (``step_failed``, ``candidate_completed`` ...) stop
+        arriving once the run is canceled/rolled back, so without this pass an
+        in-flight ``intent_parsing`` / ``evaluate_candidates`` / ``cost_estimating``
+        stays ``working`` with a ``null`` conclusion forever and the snapshot
+        contradicts the run status. ``web/pipeline_transcript.py`` already does the
+        equivalent via ``_finalize_active_markers``; this keeps the A2A snapshot
+        projection consistent with it.
+
+        Items that already carry a terminal status keep their real conclusion.
+        """
+        for step in _dict_list(self._snapshot.get("steps")):
+            _finalize_item(step, terminal_status, event)
+            for candidate in _dict_list(step.get("candidates")):
+                _finalize_item(candidate, terminal_status, event)
+                for candidate_step in _dict_list(candidate.get("steps")):
+                    _finalize_item(candidate_step, terminal_status, event)
 
     def _apply_text_delta(self, event: dict[str, Any]) -> None:
         text = _dict_or_empty(event.get("data")).get("text")
@@ -1756,6 +1789,31 @@ def _merge_completion_data(target: dict[str, Any], event: dict[str, Any]) -> Non
     ):
         if key in data:
             target[key] = copy.deepcopy(data[key])
+
+
+def _finalize_item(item: dict[str, Any], terminal_status: str, event: dict[str, Any]) -> None:
+    """Move one non-terminal snapshot item to ``terminal_status`` with a non-empty
+    conclusion. Already-terminal items are left exactly as they are."""
+    if _string_or_none(item.get("status")) in _TERMINAL_ITEM_STATUSES:
+        return
+
+    previous_status = _string_or_none(item.get("status")) or "working"
+    item["status"] = terminal_status
+    _set_time(item, _TERMINAL_ITEM_TIME_KEYS[terminal_status], _string_or_none(event.get("createdAt")))
+    item["conclusionField"] = "conclusion"
+    item["conclusion"] = {
+        "outcome": terminal_status,
+        "previousStatus": previous_status,
+        "terminatedBy": _string_or_none(event.get("eventType")),
+        "terminatedBySequence": _sequence_value(event),
+        "reason": _finalize_reason(terminal_status),
+    }
+
+
+def _finalize_reason(terminal_status: str) -> str:
+    if terminal_status == _ROLLED_BACK_ITEM_STATUS:
+        return "Superseded by a pipeline rollback before this item reached a conclusion."
+    return f"Pipeline reached terminal status '{terminal_status}' before this item reached a conclusion."
 
 
 def _append_unique(values: list[Any], value: Any) -> None:

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -1480,3 +1480,197 @@ def test_store_returns_none_for_invalid_utf8_snapshot(tmp_path) -> None:
 def test_snapshot_schema_version_is_exported() -> None:
     assert SNAPSHOT_SCHEMA_VERSION == "1.1"
     assert "SNAPSHOT_SCHEMA_VERSION" in pipeline_snapshot.__all__
+
+
+def _step_event(event_id: str, sequence: int, event_type: str, step_id: str, index: int) -> dict:
+    event = _base(event_id, sequence, event_type, scope="step")
+    event["step"] = {
+        "runId": f"step-{step_id}-1",
+        "id": step_id,
+        "index": index,
+        "total": 3,
+        "attempt": 1,
+    }
+    return event
+
+
+def _non_terminal_residue(snapshot: dict) -> list[dict]:
+    """Every step/candidate/sub-step still ``working`` without a conclusion — the
+    acceptance criterion for this fix."""
+    residue = []
+    for step in snapshot["steps"]:
+        items = [step]
+        for candidate in step.get("candidates", []):
+            items.append(candidate)
+            items.extend(candidate.get("steps", []))
+        for item in items:
+            if item.get("status") == "working" and not item.get("conclusion"):
+                residue.append(item)
+    return residue
+
+
+def test_pipeline_canceled_moves_working_step_to_terminal_with_conclusion() -> None:
+    started = _step_event("evt-1", 1, "step_started", "intent_parsing", 1)
+    canceled = _base("evt-2", 2, "pipeline_canceled", status="canceled")
+
+    snapshot = reduce_pipeline_events([started, canceled])
+
+    assert snapshot["status"] == "canceled"
+    step = snapshot["steps"][0]
+    assert step["id"] == "intent_parsing"
+    assert step["status"] == "canceled"
+    assert step["canceledAt"] == "2026-06-08T10:00:00Z"
+    assert step["conclusionField"] == "conclusion"
+    assert step["conclusion"]["outcome"] == "canceled"
+    assert step["conclusion"]["previousStatus"] == "working"
+    assert step["conclusion"]["terminatedBy"] == "pipeline_canceled"
+    assert step["conclusion"]["reason"]
+    assert _non_terminal_residue(snapshot) == []
+
+
+def test_pipeline_canceled_propagates_to_candidates_and_candidate_steps() -> None:
+    done = _step_event("evt-1", 1, "step_completed", "intent_parsing", 1)
+    done["data"] = {"conclusion": {"intent": "add vswitch"}}
+    evaluating = _step_event("evt-2", 2, "step_started", "evaluate_candidates", 2)
+    candidate_started = _base("evt-3", 3, "candidate_started", scope="candidate")
+    candidate_started["step"] = evaluating["step"]
+    candidate_started["candidate"] = {"runId": "cand-0-1", "id": "candidate-0", "index": 0, "attempt": 1}
+    cost = _base("evt-4", 4, "candidate_step_started", scope="candidate_step")
+    cost["step"] = evaluating["step"]
+    cost["candidate"] = candidate_started["candidate"]
+    cost["candidateStep"] = {"runId": "cstep-cost-1", "id": "cost_estimating", "index": 1, "attempt": 1}
+    canceled = _base("evt-5", 5, "pipeline_canceled", status="canceled")
+
+    snapshot = reduce_pipeline_events([done, evaluating, candidate_started, cost, canceled])
+
+    intent, evaluate = snapshot["steps"]
+    # A step that reached its own conclusion keeps it untouched.
+    assert intent["status"] == "completed"
+    assert intent["conclusion"] == {"intent": "add vswitch"}
+
+    assert evaluate["status"] == "canceled"
+    candidate = evaluate["candidates"][0]
+    assert candidate["status"] == "canceled"
+    assert candidate["conclusion"]["outcome"] == "canceled"
+    candidate_step = candidate["steps"][0]
+    assert candidate_step["id"] == "cost_estimating"
+    assert candidate_step["status"] == "canceled"
+    assert candidate_step["conclusion"]["outcome"] == "canceled"
+    assert snapshot["control"]["activeCandidateRunIds"] == []
+    assert _non_terminal_residue(snapshot) == []
+
+
+def test_pipeline_canceled_twice_keeps_first_terminal_conclusion() -> None:
+    started = _step_event("evt-1", 1, "step_started", "intent_parsing", 1)
+    first = _base("evt-2", 2, "pipeline_canceled", status="canceled")
+    second = _base("evt-3", 3, "pipeline_canceled", status="canceled")
+    second["createdAt"] = "2026-06-08T11:00:00Z"
+
+    snapshot = reduce_pipeline_events([started, first, second])
+
+    step = snapshot["steps"][0]
+    assert step["status"] == "canceled"
+    assert step["canceledAt"] == "2026-06-08T10:00:00Z"
+    assert step["conclusion"]["terminatedBySequence"] == 2
+    assert _non_terminal_residue(snapshot) == []
+
+
+def test_pipeline_failed_propagates_failed_status_to_working_items() -> None:
+    started = _step_event("evt-1", 1, "step_started", "deploying", 3)
+    failed = _base("evt-2", 2, "pipeline_failed", status="failed")
+
+    snapshot = reduce_pipeline_events([started, failed])
+
+    step = snapshot["steps"][0]
+    assert snapshot["status"] == "failed"
+    assert step["status"] == "failed"
+    assert step["failedAt"] == "2026-06-08T10:00:00Z"
+    assert step["conclusion"]["outcome"] == "failed"
+    assert _non_terminal_residue(snapshot) == []
+
+
+def test_pipeline_canceled_finalizes_step_waiting_on_input() -> None:
+    started = _step_event("evt-1", 1, "step_started", "confirm_and_select", 2)
+    waiting = _base("evt-2", 2, "input_required", scope="input", status="waiting_input")
+    waiting["step"] = started["step"]
+    waiting["input"] = {"inputId": "input-1", "kind": "candidate_selection", "prompt": "请选择方案"}
+    canceled = _base("evt-3", 3, "pipeline_canceled", status="canceled")
+
+    snapshot = reduce_pipeline_events([started, waiting, canceled])
+
+    step = snapshot["steps"][0]
+    assert step["status"] == "canceled"
+    assert step["conclusion"]["previousStatus"] == "waiting_input"
+    assert snapshot["pendingInput"] is None
+    assert _non_terminal_residue(snapshot) == []
+
+
+def test_rollback_completed_marks_superseded_items_rolled_back() -> None:
+    started = _step_event("evt-1", 1, "step_started", "evaluate_candidates", 2)
+    candidate_started = _base("evt-2", 2, "candidate_started", scope="candidate")
+    candidate_started["step"] = started["step"]
+    candidate_started["candidate"] = {"runId": "cand-0-1", "id": "candidate-0", "index": 0, "attempt": 1}
+    rollback = _base("evt-3", 3, "rollback_completed", scope="interrupt")
+    rollback["data"] = {"rollbackScope": "parent", "toStepId": "confirm_and_select", "reason": "重新选择"}
+
+    snapshot = reduce_pipeline_events([started, candidate_started, rollback])
+
+    step = snapshot["steps"][0]
+    assert step["status"] == "rolled_back"
+    assert step["rolledBackAt"] == "2026-06-08T10:00:00Z"
+    assert step["conclusion"]["outcome"] == "rolled_back"
+    assert step["conclusion"]["terminatedBy"] == "rollback_completed"
+    assert step["candidates"][0]["status"] == "rolled_back"
+    # Rollback still records exactly one history entry.
+    assert len(snapshot["control"]["rollbackHistory"]) == 1
+    assert _non_terminal_residue(snapshot) == []
+
+
+def test_rollback_then_rerun_keeps_new_attempt_working() -> None:
+    started = _step_event("evt-1", 1, "step_started", "evaluate_candidates", 2)
+    rollback = _base("evt-2", 2, "rollback_completed", scope="interrupt")
+    rerun = _base("evt-3", 3, "step_started", scope="step")
+    rerun["step"] = {
+        "runId": "step-evaluate_candidates-2",
+        "id": "evaluate_candidates",
+        "index": 2,
+        "total": 3,
+        "attempt": 2,
+    }
+
+    snapshot = reduce_pipeline_events([started, rollback, rerun])
+
+    first, second = snapshot["steps"]
+    assert first["attempt"] == 1
+    assert first["status"] == "rolled_back"
+    assert second["attempt"] == 2
+    assert second["status"] == "working"
+    assert snapshot["status"] == "working"
+
+
+def test_pending_backup_terminal_does_not_finalize_steps_yet() -> None:
+    started = _step_event("evt-1", 1, "step_started", "deploying", 3)
+    pending = _base("evt-2", 2, "pipeline_canceled", status="canceled")
+    pending["visibility"] = "pending_backup"
+
+    snapshot = reduce_pipeline_events([started, pending])
+
+    step = snapshot["steps"][0]
+    assert snapshot["pendingTerminal"] is not None
+    assert snapshot["status"] != "canceled"
+    assert step["status"] == "working"
+    assert "conclusion" not in step
+
+
+def test_incremental_reduce_finalizes_steps_from_existing_snapshot() -> None:
+    started = _step_event("evt-1", 1, "step_started", "cost_estimating", 2)
+    existing = reduce_pipeline_events([started])
+    assert existing["steps"][0]["status"] == "working"
+
+    canceled = _base("evt-2", 2, "pipeline_canceled", status="canceled")
+    snapshot = reduce_pipeline_events([canceled], existing)
+
+    step = snapshot["steps"][0]
+    assert step["status"] == "canceled"
+    assert step["conclusion"]["outcome"] == "canceled"
+    assert _non_terminal_residue(snapshot) == []


### PR DESCRIPTION
## 背景

Session `960d2af78a864414b21d1b8434651b20` 等三次会话出现同一现象：Pipeline 被取消或回滚后，`a2a-snapshot.json` 中进行中的步骤 / 候选 / 候选子步骤仍长期停留在 `working`，且 `conclusion` 为空，导致前端与快照消费方看到"运行已终止但步骤还在跑"的矛盾状态。

## 根因

快照由 `iac_code.a2a.pipeline_snapshot._PipelineSnapshotReducer` 归约产生，存在三处缺陷：

1. `pipeline_canceled` / `pipeline_failed` / `pipeline_completed` 分支只改写运行级字段（`status`、`pendingTerminal`、`pendingInput`、`control.activeCandidateRunIds`），从不遍历 `steps[]` / `steps[].candidates[]` / `candidates[].steps[]`。运行一旦被打断，单条目的 `*_completed` / `*_failed` 事件不会再到达，因此在飞的 `intent_parsing`、`evaluate_candidates`、`cost_estimating` 永久停在 `working`。
2. `rollback_completed` 仅向 `control.rollbackHistory` 追加记录，被回滚取代的分支与重跑分支同时以 `working` 并存。
3. 上述收敛从未写入非空 `conclusion`，不满足需求的验收标准。

对照 `web/pipeline_transcript.py` 的 `_finalize_active_markers`：Web transcript 投影早已在取消/失败时收敛在飞分组，两个投影对同一次运行的结论并不一致。

## 改动

`src/iac_code/a2a/pipeline_snapshot.py`（+58）

- 新增 `_finalize_non_terminal_items(terminal_status, event)`，在终态分支与 `rollback_completed` 分支统一向下钻取 step → candidate → candidate step 三层，把非终态条目迁移到终态。
- 新增 `_finalize_item` / `_finalize_reason` 模块级辅助：写入终态 `status`、终态时间戳，以及结构化非空 `conclusion`（`outcome` / `previousStatus` / `terminatedBy` / `terminatedBySequence` / `reason`）。
- 新增 `rolled_back` 条目状态与 `_TERMINAL_ITEM_STATUSES`、`_TERMINAL_ITEM_TIME_KEYS`。

关键边界：

- 已达真实终态（`completed` / `failed` / `canceled` / `rolled_back`）的条目原样保留，绝不覆盖真实结论。
- `pending_backup` 延迟发布场景（`pendingTerminal`）不提前收敛——此时运行尚未真正终止。
- 回滚后重跑的新 attempt 保持 `working`，只有被取代的旧 attempt 变为 `rolled_back`。
- reducer 仍是纯函数，且 `_hydrate_steps()` 复用既有快照的 dict 引用，因此增量 reduce 同样生效；重放既有事件流即可修复历史快照，**无需数据迁移**。

## 验证

`tests/a2a/test_pipeline_snapshot.py`（+194）新增 9 个用例，覆盖取消收敛、向候选与子步骤传播（含已完成步骤保留原 `conclusion`）、双次取消保留首个结论、失败传播、等待输入时取消、回滚标记 `rolled_back`、回滚后重跑、`pending_backup` 不收敛、增量 reduce 修复历史快照。

- `uv run pytest tests/a2a/test_pipeline_snapshot.py -q` → 61 passed
- `uv run pytest tests/a2a tests/web -n auto -q` → 2916 passed, 0 failed
- `uv run ruff check`（改动文件）→ All checks passed
- `uv run ty check src/` → All checks passed
