### PR TITLE
fix(pipeline): 触及回滚上限时提供根因诊断与降级方案

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4349,16 +4349,6 @@ msgstr "<fehlt>"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
-msgid ""
-"Rollback count cannot exceed {max_rollbacks}. Complete the current step "
-"or ask the user for help."
-msgstr ""
-"Die Anzahl der Zurücksetzungen darf {max_rollbacks} nicht überschreiten. "
-"Schließen Sie den aktuellen Schritt ab oder bitten Sie den Benutzer um "
-"Hilfe."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
 msgid "Candidate count cannot exceed {limit}; {count} were submitted."
 msgstr ""
 "Die Anzahl der Kandidaten darf {limit} nicht überschreiten; {count} "
@@ -4374,6 +4364,29 @@ msgstr ""
 "Die Anzahl der Rücksetzungsziele darf {limit} nicht überschreiten; es "
 "gibt {count}. Bitten Sie den Benutzer um Hilfe oder grenzen Sie die Ziele"
 " ein, bevor Sie complete_step aufrufen."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "no reason was provided"
+msgstr "es wurde kein Grund angegeben"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Rollback count cannot exceed {max_rollbacks}. The deployment kept rolling"
+" back to {target_step} because: {reason}. Do not roll back again. Finish "
+"this step with status: failed and, in the error field, explain to the "
+"user that the deployment did not complete, give this root-cause "
+"diagnosis, and offer follow-up options: retry the deployment, change the "
+"specification (return to candidate selection), or ask for human help."
+msgstr ""
+"Die Anzahl der Rollbacks darf {max_rollbacks} nicht überschreiten. Die "
+"Bereitstellung wurde wiederholt zu {target_step} zurückgesetzt, weil: "
+"{reason}. Führen Sie keinen weiteren Rollback durch. Schließen Sie diesen "
+"Schritt mit status: failed ab und erklären Sie dem Benutzer im Feld error, "
+"dass die Bereitstellung nicht abgeschlossen wurde, geben Sie diese "
+"Ursachendiagnose an und bieten Sie Folgeoptionen an: Bereitstellung "
+"erneut versuchen, Spezifikation ändern (zur Kandidatenauswahl "
+"zurückkehren) oder menschliche Hilfe anfordern."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
@@ -13087,4 +13100,14 @@ msgstr "Bash zulassen?"
 #~ msgstr ""
 #~ "Tool-Aufruf genehmigen: {tool}\n"
 #~ "Eingabezusammenfassung: {summary}"
+
+#~ msgid ""
+#~ "Rollback count cannot exceed {max_rollbacks}."
+#~ " Complete the current step or ask "
+#~ "the user for help."
+#~ msgstr ""
+#~ "Die Anzahl der Zurücksetzungen darf "
+#~ "{max_rollbacks} nicht überschreiten. Schließen "
+#~ "Sie den aktuellen Schritt ab oder "
+#~ "bitten Sie den Benutzer um Hilfe."
 

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4317,15 +4317,6 @@ msgstr "<faltante>"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
-msgid ""
-"Rollback count cannot exceed {max_rollbacks}. Complete the current step "
-"or ask the user for help."
-msgstr ""
-"La cantidad de reversiones no puede superar {max_rollbacks}. Completa el "
-"paso actual o pide ayuda al usuario."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
 msgid "Candidate count cannot exceed {limit}; {count} were submitted."
 msgstr "La cantidad de candidatos no puede superar {limit}; se enviaron {count}."
 
@@ -4339,6 +4330,28 @@ msgstr ""
 "La cantidad de destinos de reversión no puede superar {limit}; hay "
 "{count}. Pide ayuda al usuario o reduce los destinos antes de llamar a "
 "complete_step."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "no reason was provided"
+msgstr "no se proporcionó ningún motivo"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Rollback count cannot exceed {max_rollbacks}. The deployment kept rolling"
+" back to {target_step} because: {reason}. Do not roll back again. Finish "
+"this step with status: failed and, in the error field, explain to the "
+"user that the deployment did not complete, give this root-cause "
+"diagnosis, and offer follow-up options: retry the deployment, change the "
+"specification (return to candidate selection), or ask for human help."
+msgstr ""
+"El número de reversiones no puede superar {max_rollbacks}. El despliegue "
+"siguió revirtiendo a {target_step} porque: {reason}. No vuelvas a revertir. "
+"Finaliza este paso con status: failed y, en el campo error, explica al "
+"usuario que el despliegue no se completó, ofrece este diagnóstico de causa "
+"raíz y las opciones de seguimiento: reintentar el despliegue, cambiar la "
+"especificación (volver a la selección de candidatos) o solicitar ayuda "
+"humana."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
@@ -13001,4 +13014,13 @@ msgstr "¿Permitir Bash?"
 #~ msgstr ""
 #~ "Aprobar llamada de herramienta: {tool}\n"
 #~ "Resumen de entrada: {summary}"
+
+#~ msgid ""
+#~ "Rollback count cannot exceed {max_rollbacks}."
+#~ " Complete the current step or ask "
+#~ "the user for help."
+#~ msgstr ""
+#~ "La cantidad de reversiones no puede "
+#~ "superar {max_rollbacks}. Completa el paso "
+#~ "actual o pide ayuda al usuario."
 

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4324,15 +4324,6 @@ msgstr "<manquant>"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
-msgid ""
-"Rollback count cannot exceed {max_rollbacks}. Complete the current step "
-"or ask the user for help."
-msgstr ""
-"Le nombre de retours arrière ne peut pas dépasser {max_rollbacks}. "
-"Terminez l’étape actuelle ou demandez l’aide de l’utilisateur."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
 msgid "Candidate count cannot exceed {limit}; {count} were submitted."
 msgstr ""
 "Le nombre de candidats ne peut pas dépasser {limit} ; {count} ont été "
@@ -4348,6 +4339,29 @@ msgstr ""
 "Le nombre de cibles de retour arrière ne peut pas dépasser {limit} ; il y"
 " en a {count}. Demandez l’aide de l’utilisateur ou réduisez les cibles "
 "avant d’appeler complete_step."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "no reason was provided"
+msgstr "aucune raison n'a été fournie"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Rollback count cannot exceed {max_rollbacks}. The deployment kept rolling"
+" back to {target_step} because: {reason}. Do not roll back again. Finish "
+"this step with status: failed and, in the error field, explain to the "
+"user that the deployment did not complete, give this root-cause "
+"diagnosis, and offer follow-up options: retry the deployment, change the "
+"specification (return to candidate selection), or ask for human help."
+msgstr ""
+"Le nombre de retours en arrière ne peut pas dépasser {max_rollbacks}. Le "
+"déploiement a continué de revenir à {target_step} pour la raison suivante : "
+"{reason}. Ne revenez plus en arrière. Terminez cette étape avec status: "
+"failed et, dans le champ error, expliquez à l'utilisateur que le "
+"déploiement ne s'est pas terminé, fournissez ce diagnostic de cause racine "
+"et proposez des options : réessayer le déploiement, changer de "
+"spécification (revenir à la sélection des candidats) ou demander une aide "
+"humaine."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
@@ -13059,4 +13073,14 @@ msgstr "Autoriser Bash ?"
 #~ msgstr ""
 #~ "Approuver l'appel d'outil : {tool}\n"
 #~ "Résumé de l'entrée : {summary}"
+
+#~ msgid ""
+#~ "Rollback count cannot exceed {max_rollbacks}."
+#~ " Complete the current step or ask "
+#~ "the user for help."
+#~ msgstr ""
+#~ "Le nombre de retours arrière ne "
+#~ "peut pas dépasser {max_rollbacks}. Terminez"
+#~ " l’étape actuelle ou demandez l’aide "
+#~ "de l’utilisateur."
 

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -4105,13 +4105,6 @@ msgstr "<欠落>"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
-msgid ""
-"Rollback count cannot exceed {max_rollbacks}. Complete the current step "
-"or ask the user for help."
-msgstr "ロールバック回数は {max_rollbacks} を超えられません。現在のステップを完了するか、ユーザーに支援を求めてください。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
 msgid "Candidate count cannot exceed {limit}; {count} were submitted."
 msgstr "候補数は {limit} を超えられません。{count} 件が送信されました。"
 
@@ -4124,6 +4117,26 @@ msgid ""
 msgstr ""
 "ロールバック対象数は {limit} を超えられません。現在 {count} 件あります。complete_step "
 "を呼ぶ前にユーザーに支援を求めるか、対象を絞ってください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "no reason was provided"
+msgstr "理由は提供されていません"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Rollback count cannot exceed {max_rollbacks}. The deployment kept rolling"
+" back to {target_step} because: {reason}. Do not roll back again. Finish "
+"this step with status: failed and, in the error field, explain to the "
+"user that the deployment did not complete, give this root-cause "
+"diagnosis, and offer follow-up options: retry the deployment, change the "
+"specification (return to candidate selection), or ask for human help."
+msgstr ""
+"ロールバック回数は {max_rollbacks} 回を超えられません。デプロイは {target_step} "
+"へ繰り返しロールバックされました。理由: {reason}。これ以上ロールバックしないでください。"
+"このステップを status: failed で終了し、error フィールドでデプロイが完了しなかったこと"
+"をユーザーに説明し、この根本原因の診断と、次の選択肢を提示してください: デプロイの再試行、"
+"仕様の変更（候補選択に戻る）、または人によるサポートの依頼。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
@@ -12073,4 +12086,10 @@ msgstr "Bash を許可しますか？"
 #~ msgstr ""
 #~ "ツール呼び出しを承認: {tool}\n"
 #~ "入力サマリー: {summary}"
+
+#~ msgid ""
+#~ "Rollback count cannot exceed {max_rollbacks}."
+#~ " Complete the current step or ask "
+#~ "the user for help."
+#~ msgstr "ロールバック回数は {max_rollbacks} を超えられません。現在のステップを完了するか、ユーザーに支援を求めてください。"
 

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4293,15 +4293,6 @@ msgstr "<ausente>"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
-msgid ""
-"Rollback count cannot exceed {max_rollbacks}. Complete the current step "
-"or ask the user for help."
-msgstr ""
-"A quantidade de reversões não pode exceder {max_rollbacks}. Conclua a "
-"etapa atual ou peça ajuda ao usuário."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
 msgid "Candidate count cannot exceed {limit}; {count} were submitted."
 msgstr ""
 "A quantidade de candidatos não pode exceder {limit}; {count} foram "
@@ -4317,6 +4308,28 @@ msgstr ""
 "A quantidade de destinos de reversão não pode exceder {limit}; há "
 "{count}. Peça ajuda ao usuário ou reduza os destinos antes de chamar "
 "complete_step."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "no reason was provided"
+msgstr "nenhum motivo foi fornecido"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Rollback count cannot exceed {max_rollbacks}. The deployment kept rolling"
+" back to {target_step} because: {reason}. Do not roll back again. Finish "
+"this step with status: failed and, in the error field, explain to the "
+"user that the deployment did not complete, give this root-cause "
+"diagnosis, and offer follow-up options: retry the deployment, change the "
+"specification (return to candidate selection), or ask for human help."
+msgstr ""
+"O número de reversões não pode exceder {max_rollbacks}. A implantação "
+"continuou revertendo para {target_step} porque: {reason}. Não reverta "
+"novamente. Encerre esta etapa com status: failed e, no campo error, "
+"explique ao usuário que a implantação não foi concluída, forneça este "
+"diagnóstico de causa raiz e ofereça opções de continuidade: repetir a "
+"implantação, alterar a especificação (voltar à seleção de candidatos) ou "
+"solicitar ajuda humana."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
@@ -12893,4 +12906,13 @@ msgstr "Permitir Bash?"
 #~ msgstr ""
 #~ "Aprovar chamada de ferramenta: {tool}\n"
 #~ "Resumo da entrada: {summary}"
+
+#~ msgid ""
+#~ "Rollback count cannot exceed {max_rollbacks}."
+#~ " Complete the current step or ask "
+#~ "the user for help."
+#~ msgstr ""
+#~ "A quantidade de reversões não pode "
+#~ "exceder {max_rollbacks}. Conclua a etapa "
+#~ "atual ou peça ajuda ao usuário."
 

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -4058,13 +4058,6 @@ msgstr "<缺失>"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
-msgid ""
-"Rollback count cannot exceed {max_rollbacks}. Complete the current step "
-"or ask the user for help."
-msgstr "回滚次数不能超过 {max_rollbacks} 次。请完成当前步骤或请求用户介入。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
 msgid "Candidate count cannot exceed {limit}; {count} were submitted."
 msgstr "候选方案数量不能超过 {limit} 个，当前提交了 {count} 个。"
 
@@ -4075,6 +4068,25 @@ msgid ""
 "user for help or narrow the rollback targets before calling "
 "complete_step."
 msgstr "可回滚目标数量不能超过 {limit} 个，当前有 {count} 个。请请求用户介入或收窄回滚目标后再调用 complete_step。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid "no reason was provided"
+msgstr "未提供原因"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Rollback count cannot exceed {max_rollbacks}. The deployment kept rolling"
+" back to {target_step} because: {reason}. Do not roll back again. Finish "
+"this step with status: failed and, in the error field, explain to the "
+"user that the deployment did not complete, give this root-cause "
+"diagnosis, and offer follow-up options: retry the deployment, change the "
+"specification (return to candidate selection), or ask for human help."
+msgstr ""
+"回滚次数不能超过 {max_rollbacks} 次。部署反复回滚到 {target_step}，原因："
+"{reason}。请不要再回滚。请以 status: failed 结束本步骤，并在 error 字段中向用户"
+"说明部署未完成、给出该根因诊断，并提供后续选项：重试部署、换规格（回到候选选择）"
+"或请求人工协助。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
@@ -11842,4 +11854,10 @@ msgstr "允许 Bash?"
 #~ msgstr ""
 #~ "批准工具调用：{tool}\n"
 #~ "输入摘要：{summary}"
+
+#~ msgid ""
+#~ "Rollback count cannot exceed {max_rollbacks}."
+#~ " Complete the current step or ask "
+#~ "the user for help."
+#~ msgstr "回滚次数不能超过 {max_rollbacks} 次。请完成当前步骤或请求用户介入。"
 

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -947,10 +947,7 @@ class CompleteStepTool(Tool):
         rollback = tool_input.get("rollback_request")
         rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
         if rollback_tuple and self._step_config.rollback_count >= self._step_config.max_rollbacks:
-            max_rollbacks = self._step_config.max_rollbacks
-            return _(
-                "Rollback count cannot exceed {max_rollbacks}. Complete the current step or ask the user for help."
-            ).format(max_rollbacks=max_rollbacks)
+            return self._rollback_budget_exhausted_message(rollback_tuple)
 
         validation_error = self._validate_conclusion(conclusion)
         if validation_error is None:
@@ -1028,6 +1025,31 @@ class CompleteStepTool(Tool):
             "Rollback target count cannot exceed {limit}; there are {count}. "
             "Ask the user for help or narrow the rollback targets before calling complete_step."
         ).format(limit=MAX_ROLLBACK_TARGETS, count=target_count)
+
+    def _rollback_budget_exhausted_message(self, rollback_tuple: tuple[str, str]) -> str:
+        """Explain a rollback-limit failure with root cause and follow-up options.
+
+        The first sentence keeps the historical "Rollback count cannot exceed
+        {max_rollbacks}" wording, then a root-cause diagnosis (the last rollback
+        target and reason) and the user-facing follow-up options (retry, change
+        spec / return to candidate selection, or ask for human help) are appended
+        so the deployment failure is explained instead of only surfacing the
+        terse limit error.
+        """
+        target_step, reason = rollback_tuple
+        target_label = display_step_name(target_step)
+        clean_reason = sanitize_strict_text(str(reason)).strip() or _("no reason was provided")
+        return _(
+            "Rollback count cannot exceed {max_rollbacks}. The deployment kept rolling back to {target_step} "
+            "because: {reason}. Do not roll back again. Finish this step with status: failed and, in the error "
+            "field, explain to the user that the deployment did not complete, give this root-cause diagnosis, and "
+            "offer follow-up options: retry the deployment, change the specification (return to candidate "
+            "selection), or ask for human help."
+        ).format(
+            max_rollbacks=self._step_config.max_rollbacks,
+            target_step=target_label,
+            reason=clean_reason,
+        )
 
     @staticmethod
     def _matches(pattern: str, value: str) -> bool:
@@ -1134,11 +1156,8 @@ class CompleteStepTool(Tool):
         )
 
         if rollback_tuple and self._step_config.rollback_count >= self._step_config.max_rollbacks:
-            max_rollbacks = self._step_config.max_rollbacks
             return ToolResult(
-                content=_(
-                    "Rollback count cannot exceed {max_rollbacks}. Complete the current step or ask the user for help."
-                ).format(max_rollbacks=max_rollbacks),
+                content=self._rollback_budget_exhausted_message(rollback_tuple),
                 is_error=True,
             )
 

--- a/src/iac_code/pipeline/selling/prompts/deploying.md
+++ b/src/iac_code/pipeline/selling/prompts/deploying.md
@@ -48,6 +48,7 @@
 - 模板校验失败 → 就地修复模板后重试（最多 5 轮）
 - 部署失败或等待超时 → 按技能的参数补全与 `ros_deploy` 恢复策略处理
 - 架构层面必须变更（如产品组合不可行）→ rollback_request 到 `architecture_planning`
+- 回滚已触及上限（`complete_step` 返回 "Rollback count cannot exceed ..."）→ 不要再次 rollback_request。以 `status: failed` 收尾，并在 `error` 中向用户清晰说明：部署未完成、失败根因（反复回滚的目标步骤与原因），以及后续选项——重试部署、换规格（回到候选选择）或请求人工协助。
 
 ## 注意事项
 - 不要读取项目文件或记忆，所需的上下文已在上方提供。

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -149,6 +149,14 @@ conclusion_schema:
 - 工具会先确认替代创建参数和模板可用，再删除旧失败 Stack 后创建新的 Stack
 - 成功后最终结果使用新 Stack 的 `stack_id`，不要把旧 `stack_id` 当成部署成功结果
 
+### 回滚触及上限
+当反复回滚导致 `complete_step` 返回 "Rollback count cannot exceed ..." 时，回滚预算已耗尽，不要再次发起 `rollback_request`。此时以 `status: failed` 收尾，并在 `error` 中向用户清晰说明：
+- 部署未完成；
+- 失败根因诊断：反复回滚的目标步骤与原因；
+- 后续选项：重试部署、换规格（回到候选选择）或请求人工协助。
+
+不得仅把 `complete_step` 的报错原文抛给用户，必须给出可读的根因说明与后续选项。
+
 ## 资源和文档搜索
 
 - 不确定的 ROS 资源属性或 Schema → aliyun_api(product="ros", action="GetResourceType", params={"ResourceType": "<类型>"})

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -250,6 +250,38 @@ class TestCompleteStepToolExecute:
         assert result.is_error
         assert result.metadata is None
         assert "5" in result.content
+        # Root-cause diagnosis: the repeated rollback target and reason are surfaced.
+        assert "redo" in result.content
+        # Follow-up options are explained instead of only the terse limit error.
+        assert "failed" in result.content
+        assert "retry" in result.content
+        assert "candidate selection" in result.content
+
+    def test_validate_completion_input_reports_root_cause_when_budget_exhausted(self):
+        config = StepConfig(
+            step_id="cost_estimating",
+            conclusion_field="cost",
+            forward=None,
+            rollback_targets=["template_generating"],
+        )
+        config.rollback_count = 3
+        config.max_rollbacks = 3
+        tool = CompleteStepTool(config)
+
+        error = tool.validate_completion_input(
+            {
+                "conclusion": {"total": 200},
+                "rollback_request": {"target_step": "template_generating", "reason": "redo"},
+            }
+        )
+
+        assert error is not None
+        assert "3" in error
+        assert "redo" in error
+        assert "failed" in error
+        assert "retry" in error
+        assert "candidate selection" in error
+
 
     @pytest.mark.asyncio
     async def test_rejects_when_rollback_target_count_exceeds_limit(self):


### PR DESCRIPTION
## 背景

针对 Aone 需求 #84592957（Session e0a7623ad2934672b20a68b97d0a5982）：部署流程反复回滚触及上限（`complete_step` 报错 "Rollback count cannot exceed 3"）后，系统仅返回该终止报错，缺少失败根因诊断、降级方案与面向用户的说明，部署未完成。

## 改动

- `complete_step_tool.py`：新增 `_rollback_budget_exhausted_message()`，`execute()` 与 `validate_completion_input()` 两条路径统一调用。消息保留原有 "Rollback count cannot exceed {max_rollbacks}" 上限提示，并附加：
  - 根因诊断：反复回滚的目标步骤（本地化名称）与原因；
  - 后续选项：以 `status: failed` 收尾，并在 `error` 中向用户说明部署未完成、给出根因，并提供重试部署 / 换规格（回到候选选择）/ 请求人工协助。
- `prompts/deploying.md`、`skills/iac-aliyun-deploying/SKILL.md`：错误处理章节补充“回滚触及上限”场景的收尾与用户说明要求。
- 六语（zh/es/fr/de/ja/pt）翻译补齐新文案。
- 单测：扩展触及上限用例，断言根因（原因文本）与后续选项关键字，并新增 `validate_completion_input` 路径断言。

## 测试

`tests/pipeline/engine/test_complete_step_tool.py` 全部通过（59/59）。`make translate` 编译通过。

Aone: #84592957
