### PR TITLE
fix(pipeline): complete_step 成功前必须写入非空 conclusion 并与步骤状态机对齐

### DIFF
--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -300,6 +300,9 @@ class CompleteStepTool(Tool):
 
     def _validate_conclusion(self, conclusion: dict) -> str | None:
         """Validate conclusion against schema. Returns error message or None."""
+        non_empty_error = self._validate_conclusion_non_empty(conclusion)
+        if non_empty_error is not None:
+            return non_empty_error
         schema = self._step_config.conclusion_schema
         if not schema:
             return None
@@ -314,6 +317,26 @@ class CompleteStepTool(Tool):
                 sanitize_strict_text(str(e.validator)),
             )
             return public_message
+
+    def _validate_conclusion_non_empty(self, conclusion: Any) -> str | None:
+        """Reject conclusions that carry no content at all.
+
+        Steps without a ``conclusion_schema`` would otherwise skip validation
+        entirely, letting ``complete_step`` report success while persisting a
+        null/empty conclusion and leaving the step stuck in ``working``.
+        ``normalize_input`` strips ``None`` values, so ``{"field": None}``
+        reaches this check as ``{}``.
+        """
+        if not isinstance(conclusion, dict):
+            return _(
+                "complete_step.conclusion must be a non-empty object describing the outcome of step {step_id}."
+            ).format(step_id=self._step_config.step_id)
+        if not conclusion:
+            return _(
+                "complete_step.conclusion for step {step_id} is empty. "
+                "Submit the actual step outcome; an empty conclusion cannot complete the step."
+            ).format(step_id=self._step_config.step_id)
+        return None
 
     def _validate_completion_guards(self, conclusion: dict) -> str | None:
         for guard in self._completion_guards:
@@ -943,7 +966,7 @@ class CompleteStepTool(Tool):
         if rollback_target_error is not None:
             return rollback_target_error
 
-        conclusion = tool_input["conclusion"]
+        conclusion = tool_input.get("conclusion")
         rollback = tool_input.get("rollback_request")
         rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
         if rollback_tuple and self._step_config.rollback_count >= self._step_config.max_rollbacks:
@@ -1123,7 +1146,7 @@ class CompleteStepTool(Tool):
         if rollback_target_error is not None:
             return ToolResult(content=rollback_target_error, is_error=True)
 
-        conclusion = tool_input["conclusion"]
+        conclusion = tool_input.get("conclusion")
         rollback = tool_input.get("rollback_request")
         rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
 

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -110,6 +110,13 @@ def _strict_log_value(value: Any) -> Any:
     return value
 
 
+def _has_substantive_conclusion(step_result: StepResult) -> bool:
+    """Guard the state machine against tool success that persisted no conclusion."""
+    if step_result.rollback_request:
+        return True
+    return isinstance(step_result.conclusion, dict) and bool(step_result.conclusion)
+
+
 def _entry_exists_no_follow(path: Path) -> bool:
     try:
         path.stat(follow_symlinks=False)
@@ -4041,15 +4048,20 @@ class PipelineRunner:
                                 return
                         yield event
 
-            if (
-                step_result is not None
-                and step_result.status == StepStatus.COMPLETED
-                and not step_result.rollback_request
-            ):
-                self._mark_attempt_status(attempt.get("attempt_id"), "completed")
-
             if step_result is None or step_result.status == StepStatus.FAILED:
                 reason = (step_result.error if step_result else None) or "No result"
+            elif not _has_substantive_conclusion(step_result):
+                reason = (
+                    f"Step {step.step_id} reported completion without a non-empty conclusion; "
+                    "refusing to advance the pipeline"
+                )
+            else:
+                reason = None
+
+            if reason is None and not step_result.rollback_request:
+                self._mark_attempt_status(attempt.get("attempt_id"), "completed")
+
+            if reason is not None:
                 failure = public_error(
                     message=reason,
                     error_type="StepFailed",

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -79,6 +79,11 @@ def _completion_guard_tool_result_content(event: ToolResultEvent) -> str:
         return event.result
 
 
+def _is_substantive_conclusion(conclusion: Any) -> bool:
+    """A step may only be marked completed when its conclusion carries content."""
+    return isinstance(conclusion, dict) and bool(conclusion)
+
+
 @dataclass
 class StepAgentLoopContext:
     """AgentLoop context built by the same path used for step execution."""
@@ -426,19 +431,26 @@ class StepExecutor:
         if terminal_failed_step_result is not None:
             step_result = terminal_failed_step_result
         elif complete_step_input is not None:
-            conclusion = complete_step_input.get("conclusion", {})
+            conclusion = complete_step_input.get("conclusion")
             conclusion = self._merge_preserved_candidate_selection(preserved_selection, conclusion)
-            rollback = complete_step_input.get("rollback_request")
-            rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
-            step_result = StepResult(
-                step_id=step.step_id,
-                status=StepStatus.COMPLETED,
-                conclusion=conclusion,
-                rollback_request=rollback_tuple,
-            )
-            context.set_conclusion(step.conclusion_field, conclusion)
-            if step.on_exit:
-                step.on_exit(context, conclusion)
+            if not _is_substantive_conclusion(conclusion):
+                step_result = StepResult(
+                    step_id=step.step_id,
+                    status=StepStatus.FAILED,
+                    error="complete_step reported success without a non-empty conclusion",
+                )
+            else:
+                rollback = complete_step_input.get("rollback_request")
+                rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
+                step_result = StepResult(
+                    step_id=step.step_id,
+                    status=StepStatus.COMPLETED,
+                    conclusion=conclusion,
+                    rollback_request=rollback_tuple,
+                )
+                context.set_conclusion(step.conclusion_field, conclusion)
+                if step.on_exit:
+                    step.on_exit(context, conclusion)
         else:
             step_result = StepResult(
                 step_id=step.step_id,
@@ -604,7 +616,9 @@ class StepExecutor:
         elif complete_step_tool is not None:
             complete_step_tool.normalize_input(normalized_input)
 
-        conclusion = normalized_input.get("conclusion", {})
+        conclusion = normalized_input.get("conclusion")
+        if not _is_substantive_conclusion(conclusion):
+            return None
         rollback = normalized_input.get("rollback_request")
         rollback_tuple = None
         if isinstance(rollback, dict) and rollback.get("target_step") and rollback.get("reason"):
@@ -613,7 +627,7 @@ class StepExecutor:
         return StepResult(
             step_id=step.step_id,
             status=StepStatus.COMPLETED,
-            conclusion=conclusion if isinstance(conclusion, dict) else {},
+            conclusion=conclusion,
             rollback_request=rollback_tuple,
         )
 

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -270,6 +270,54 @@ class TestCompleteStepToolExecute:
         assert result.metadata is None
         assert "Rollback target count cannot exceed 5" in result.content
 
+    @pytest.mark.asyncio
+    async def test_rejects_empty_conclusion_for_step_without_schema(self, tool):
+        result = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
+
+        assert result.is_error
+        assert result.metadata is None
+        assert "intent_parsing" in result.content
+
+    @pytest.mark.asyncio
+    async def test_rejects_conclusion_whose_fields_are_all_null(self, tool):
+        # normalize_input strips None values, so this reaches validation as {}.
+        result = await tool.execute(
+            tool_input={"conclusion": {"is_infra_intent": None, "confidence": None}},
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert result.metadata is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_object_conclusion(self, tool):
+        result = await tool.execute(tool_input={"conclusion": "done"}, context=ToolContext())
+
+        assert result.is_error
+        assert result.metadata is None
+
+    @pytest.mark.asyncio
+    async def test_empty_conclusion_fails_the_step_after_retry_budget(self):
+        config = StepConfig(
+            step_id="intent_parsing",
+            conclusion_field="intent",
+            forward=None,
+            max_conclusion_retries=1,
+        )
+        tool = CompleteStepTool(config)
+
+        first = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
+        second = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
+
+        assert first.is_error
+        assert first.metadata is None
+        assert second.is_error
+        assert second.metadata["step_result"].status == StepStatus.FAILED
+
+    def test_validate_completion_input_rejects_empty_conclusion(self, tool):
+        assert tool.validate_completion_input({"conclusion": {}}) is not None
+        assert tool.validate_completion_input({"conclusion": {"is_infra_intent": True}}) is None
+
 
 class TestCompletionGuards:
     @staticmethod

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -1516,6 +1516,41 @@ async def test_final_completed_save_failure_yields_persistence_failure_event(tmp
 
 
 @pytest.mark.asyncio
+async def test_completed_step_without_conclusion_does_not_advance(tmp_path):
+    """A COMPLETED result with an empty conclusion must not move the state machine.
+
+    ``complete_step`` reporting success is not sufficient evidence that the step
+    really finished: without a persisted conclusion the step would advance while
+    its conclusion stayed null.
+    """
+    runner = _build_two_step_runner(tmp_path)
+    executed_steps = []
+
+    async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+        executed_steps.append(step.step_id)
+        yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={})
+
+    runner._step_executor.execute = fake_execute
+
+    events = []
+    async for event in runner._continue_from_current():
+        events.append(event)
+
+    assert executed_steps == ["a"]
+    assert runner.state_machine.current_step.step_id == "a"
+    assert any(
+        isinstance(event, PipelineEvent)
+        and event.type == PipelineEventType.STEP_FAILED
+        and event.step_id == "a"
+        and "non-empty conclusion" in str(event.data)
+        for event in events
+    )
+    assert not any(
+        isinstance(event, PipelineEvent) and event.type == PipelineEventType.STEP_COMPLETED for event in events
+    )
+
+
+@pytest.mark.asyncio
 async def test_resume_input_save_failure_stops_before_input_received_event(tmp_path):
     runner = _build_two_step_runner(tmp_path, auto_advance_first=False)
     runner.session = FailingUserInputCheckpointPipelineSession()

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -639,6 +639,36 @@ class TestStepExecutor:
         assert results[0].error == "No conclusion extracted"
 
     @pytest.mark.asyncio
+    async def test_failed_when_complete_step_succeeds_without_conclusion(self, tmp_path):
+        """A complete_step success carrying no conclusion must not complete the step.
+
+        The tool result is not an error, so the executor used to coerce the
+        missing conclusion to ``{}`` and still report ``COMPLETED``, leaving the
+        persisted conclusion null while the step never advanced.
+        """
+        events = [
+            ToolUseStartEvent(tool_use_id="tu_complete", name="complete_step"),
+            ToolUseEndEvent(tool_use_id="tu_complete", name="complete_step", input={}),
+            ToolResultEvent(tool_use_id="tu_complete", tool_name="complete_step", result="ok", is_error=False),
+        ]
+        fake_loop = _make_fake_agent_loop_class(events)
+        executor = _make_executor(tmp_path)
+        step = _make_step()
+        step.on_exit = MagicMock()
+        ctx = PipelineContext(SIMPLE_DEPS)
+
+        collected = []
+        with patch("iac_code.agent.agent_loop.AgentLoop", fake_loop):
+            async for event in executor.execute(step, ctx, "test_session"):
+                collected.append(event)
+
+        results = [e for e in collected if isinstance(e, StepResult)]
+        assert [result.status for result in results] == [StepStatus.FAILED]
+        assert results[0].error == "complete_step reported success without a non-empty conclusion"
+        assert ctx.get_conclusion(step.conclusion_field) is None
+        step.on_exit.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_nudge_retry_succeeds_on_second_attempt(self, tmp_path, caplog):
         """When LLM forgets complete_step on first attempt, nudge makes it call on retry."""
         call_count = [0]
@@ -3143,16 +3173,15 @@ async def test_resumed_step_returns_reconstructed_complete_step(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
-async def test_resumed_completed_step_sets_empty_conclusion_and_calls_on_exit(monkeypatch, tmp_path):
-    class FailIfAgentLoopIsCreated:
-        def __init__(self, *args, **kwargs):
-            raise AssertionError("AgentLoop should not be created for already-completed transcript")
+async def test_resumed_completed_step_rejects_empty_conclusion(tmp_path):
+    """An empty conclusion must not be restored as a completed step.
 
-    monkeypatch.setattr("iac_code.agent.agent_loop.AgentLoop", FailIfAgentLoopIsCreated)
-
+    ``complete_step`` returning success with no conclusion previously produced a
+    ``COMPLETED`` result carrying ``{}``, leaving the step's persisted
+    conclusion null while the step never really advanced.
+    """
     executor = _make_executor(tmp_path)
     step = _make_step()
-    step.on_exit = MagicMock()
     ctx = PipelineContext(SIMPLE_DEPS)
     resume_messages = [
         Message(
@@ -3161,24 +3190,9 @@ async def test_resumed_completed_step_sets_empty_conclusion_and_calls_on_exit(mo
         ),
         Message(role="user", content=[ToolResultBlock(tool_use_id="tu_complete", content="ok", is_error=False)]),
     ]
+    tool_registry = executor._build_step_tools(step, ctx, "start", {})
 
-    results = []
-    async for event in executor.execute(
-        step,
-        ctx,
-        session_id="root",
-        attempt_id="att_0001",
-        transcript_id="transcript_att_0001",
-        resume_messages=resume_messages,
-    ):
-        if isinstance(event, StepResult):
-            results.append(event)
-
-    assert len(results) == 1
-    assert results[0].status == StepStatus.COMPLETED
-    assert results[0].conclusion == {}
-    assert ctx.get_conclusion(step.conclusion_field) == {}
-    step.on_exit.assert_called_once_with(ctx, {})
+    assert executor._restore_completed_step_result(step, tool_registry, resume_messages) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

`complete_step` 可能返回 `is_error=false` / `status=completed`，但步骤的
`conclusion` 仍为 null，步骤长期停留在 `working`，工具成功信号与持久化步骤状态不一致。
下游/重放逻辑一旦信任 complete_step 的成功信号就会被误导，需求无法推进，可观测性失真。

证据 Session：`3a4b8d0b0e4a445fab3334963780a7f7`、`6587fe30a3bc44c9a54c78dad9abdb4d`
（UserId `1754580903499898`，来源 `tool_call`，AnalysisId `sarpt-auto-2026072318`，
窗口 2026-07-23 12:00–18:00 Asia/Shanghai）。
报告 `session-analysis-report-9b2ceb6e-7467-4f49-a738-01c9c793b37b.md`
→ `## Pipeline 步骤与状态问题` → `pipeline_step_result`（`a2a_events.2`）。
受影响步骤：`intent_parsing`（未配置 `conclusion_schema`）。

## 根因

三个层面共同允许了这种不一致：

1. **工具层** `CompleteStepTool._validate_conclusion()` 在步骤没有
   `conclusion_schema` 时直接短路放行；而 `normalize_input()` 会剔除 dict 结论中
   所有值为 `None` 的键，于是 `{}` 与 `{"field": None}` 都能通过校验，
   最终产出 `StepResult(status=COMPLETED)` 且结论实质为空。
2. **执行器层** `StepExecutor.execute()` 用
   `complete_step_input.get("conclusion", {})` 把缺失结论静默降级为 `{}`，
   却仍然 yield `COMPLETED`，并把空结论写进 context、触发 `on_exit`；
   `_restore_completed_step_result()` 在恢复/重放路径上有同样的问题。
3. **聚合层** `PipelineRunner` 仅凭 `status == COMPLETED` 就调用
   `state_machine.advance()` 并持久化，从不校验结论是否真的被记录。

`StateMachine.advance()` 是唯一的前向迁移入口，工具自身无法推进状态 ——
这正是"工具成功信号未与步骤状态机对齐"的结构性来源。

## 改动

- `complete_step_tool.py`：`_validate_conclusion()` 前置
  `_validate_conclusion_non_empty()`，非 dict 或（剔除 None 后）空 dict 返回错误。
  `execute()` 与 `validate_completion_input()` 共享该校验，
  失败沿用既有 `_validation_attempts` / `max_conclusion_retries` 与 nudge 通道，
  超限后返回带 `StepResult(FAILED)` 的错误 —— **不再返回成功**。
- `step_executor.py`：新增 `_is_substantive_conclusion()`；`execute()` 在结论
  缺失/无效时产出 `StepResult(FAILED)`，不写 context、不调用 `on_exit`；
  `_restore_completed_step_result()` 对无效结论返回 `None`，
  不再伪造 `COMPLETED` + `{}`。
- `pipeline_runner.py`：新增 `_has_substantive_conclusion()`（`rollback_request`
  场景豁免），并入失败判定链；`COMPLETED` + 空结论走既有
  `_save_failed()` / `STEP_FAILED` 分支，`state_machine.advance()`
  永不在结论缺失时被触发。

## 关于 a2a 事件状态

Clarify 阶段注意到 `pipeline_events.py:408` 把 `STEP_COMPLETED` 信封的 `status`
硬编码为 `"working"`，初版计划改为 `"completed"`。实施中核实该字段是
**A2A TaskState 投影**（`pipeline_stream.py::_a2a_task_state_name` 直接把
`completed` 映射为 `TASK_STATE_COMPLETED`），改动会让每个中间步骤完成时
把整个 A2A 任务标记为终态，属明确回归，因此**放弃该改动**。
真正的步骤状态由 `pipeline_snapshot.py` 的 reducer 按 `eventType` 正确推导；
结论一旦非空写入，该事件即携带真实 conclusion。

## 验证

- 定向单测 `tests/pipeline/engine/{test_complete_step_tool,test_step_executor,test_pipeline_runner}.py`：247 passed
- 扩展回归 `tests/pipeline/ tests/agent/ tests/state/ tests/integration/`：1964 passed
- `ruff check src/iac_code/pipeline/engine tests/pipeline/engine`：All checks passed
- 验收复现：以证据中的 `intent_parsing`（无 schema）构造 `complete_step`，
  空结论与全 `None` 结论均返回 `is_error=True` 且不再产出 `COMPLETED`；
  非空结论返回 `status=COMPLETED` 且 `conclusion` 非空。

新增用例覆盖三处缺陷点。原有
`test_resumed_completed_step_sets_empty_conclusion_and_calls_on_exit`
断言的正是缺陷行为（`COMPLETED` + `conclusion == {}` + `on_exit` 被调用），
已改写为 `test_resumed_completed_step_rejects_empty_conclusion`。

### 已知无关失败
- `test_prerequisites.py::test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token`：
  沙箱网络导致 `HTTPError` 而非 `InvalidURL`，基线验证同样失败。
- `tests/a2a` 多数模块因本环境缺少 `a2a-sdk` 可选依赖无法收集；本次未改动 a2a 代码。

## 行为影响

此前"空结论蒙混过关"的步骤现在会显式失败（失败前仍有
`max_conclusion_retries` 重试与 nudge）—— 这正是需求要求的行为：
宁可显式报错，不可静默停滞。未改动 `StepConfig` / `StepResult` 数据契约字段，
也未改动 `StateMachine.advance()` 语义，未引入开关或兼容层。
