### PR TITLE
fix(pipeline): 消除 complete_step 缺失 conclusion 的重复无效调用与重试

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4117,6 +4117,20 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
+msgid "Schema validation failed after {attempts} attempts: {error}"
+msgstr "Schema-Validierung nach {attempts} Versuchen fehlgeschlagen: {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"conclusion validation failed after exceeding the maximum retry count "
+"({max_retries}): {error}"
+msgstr ""
+"Validierung von conclusion nach Überschreiten der maximalen "
+"Wiederholungen ({max_retries}) fehlgeschlagen: {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
 msgid ""
 "{error}\n"
 "Current step: {step_id}\n"
@@ -4135,6 +4149,22 @@ msgstr ""
 "auf oberster Ebene ab.\n"
 "{schema_hint}\n"
 "Beispiel für äußere Argumente: {example}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message}\n"
+"You already submitted these exact arguments and they were rejected for "
+"the same reason; resubmitting them will fail again. Build the conclusion "
+"object from the schema above before calling complete_step. Remaining "
+"attempts before this step fails: {remaining}."
+msgstr ""
+"{message}\n"
+"Sie haben genau diese Argumente bereits eingereicht und sie wurden aus "
+"demselben Grund abgelehnt; ein erneutes Einreichen wird wieder "
+"fehlschlagen. Erstellen Sie das conclusion-Objekt anhand des obigen "
+"Schemas, bevor Sie complete_step aufrufen. Verbleibende Versuche, bevor "
+"dieser Schritt fehlschlägt: {remaining}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -4374,20 +4404,6 @@ msgstr ""
 "Die Anzahl der Rücksetzungsziele darf {limit} nicht überschreiten; es "
 "gibt {count}. Bitten Sie den Benutzer um Hilfe oder grenzen Sie die Ziele"
 " ein, bevor Sie complete_step aufrufen."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid "Schema validation failed after {attempts} attempts: {error}"
-msgstr "Schema-Validierung nach {attempts} Versuchen fehlgeschlagen: {error}"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid ""
-"conclusion validation failed after exceeding the maximum retry count "
-"({max_retries}): {error}"
-msgstr ""
-"Validierung von conclusion nach Überschreiten der maximalen "
-"Wiederholungen ({max_retries}) fehlgeschlagen: {error}"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4092,6 +4092,20 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
+msgid "Schema validation failed after {attempts} attempts: {error}"
+msgstr "La validación del esquema falló tras {attempts} intentos: {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"conclusion validation failed after exceeding the maximum retry count "
+"({max_retries}): {error}"
+msgstr ""
+"La validación de conclusion falló tras superar el máximo de reintentos "
+"({max_retries}): {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
 msgid ""
 "{error}\n"
 "Current step: {step_id}\n"
@@ -4109,6 +4123,21 @@ msgstr ""
 "superior.\n"
 "{schema_hint}\n"
 "Ejemplo de argumentos externos: {example}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message}\n"
+"You already submitted these exact arguments and they were rejected for "
+"the same reason; resubmitting them will fail again. Build the conclusion "
+"object from the schema above before calling complete_step. Remaining "
+"attempts before this step fails: {remaining}."
+msgstr ""
+"{message}\n"
+"Ya enviaste exactamente estos argumentos y fueron rechazados por el mismo"
+" motivo; volver a enviarlos fallará de nuevo. Construye el objeto "
+"conclusion a partir del esquema anterior antes de llamar a complete_step."
+" Intentos restantes antes de que este paso falle: {remaining}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -4339,20 +4368,6 @@ msgstr ""
 "La cantidad de destinos de reversión no puede superar {limit}; hay "
 "{count}. Pide ayuda al usuario o reduce los destinos antes de llamar a "
 "complete_step."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid "Schema validation failed after {attempts} attempts: {error}"
-msgstr "La validación del esquema falló tras {attempts} intentos: {error}"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid ""
-"conclusion validation failed after exceeding the maximum retry count "
-"({max_retries}): {error}"
-msgstr ""
-"La validación de conclusion falló tras superar el máximo de reintentos "
-"({max_retries}): {error}"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4099,6 +4099,20 @@ msgstr "Conclusion structurée pour l’étape actuelle. Obligatoire et non vide
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
+msgid "Schema validation failed after {attempts} attempts: {error}"
+msgstr "La validation du schéma a échoué après {attempts} tentatives : {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"conclusion validation failed after exceeding the maximum retry count "
+"({max_retries}): {error}"
+msgstr ""
+"La validation de conclusion a échoué après dépassement du nombre maximal "
+"de tentatives ({max_retries}) : {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
 msgid ""
 "{error}\n"
 "Current step: {step_id}\n"
@@ -4116,6 +4130,22 @@ msgstr ""
 "conclusion au niveau supérieur.\n"
 "{schema_hint}\n"
 "Exemple d’arguments externes : {example}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message}\n"
+"You already submitted these exact arguments and they were rejected for "
+"the same reason; resubmitting them will fail again. Build the conclusion "
+"object from the schema above before calling complete_step. Remaining "
+"attempts before this step fails: {remaining}."
+msgstr ""
+"{message}\n"
+"Vous avez déjà soumis exactement ces arguments et ils ont été rejetés "
+"pour la même raison ; les resoumettre échouera de nouveau. Construisez "
+"l’objet conclusion à partir du schéma ci-dessus avant d’appeler "
+"complete_step. Tentatives restantes avant l’échec de cette étape : "
+"{remaining}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -4348,20 +4378,6 @@ msgstr ""
 "Le nombre de cibles de retour arrière ne peut pas dépasser {limit} ; il y"
 " en a {count}. Demandez l’aide de l’utilisateur ou réduisez les cibles "
 "avant d’appeler complete_step."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid "Schema validation failed after {attempts} attempts: {error}"
-msgstr "La validation du schéma a échoué après {attempts} tentatives : {error}"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid ""
-"conclusion validation failed after exceeding the maximum retry count "
-"({max_retries}): {error}"
-msgstr ""
-"La validation de conclusion a échoué après dépassement du nombre maximal "
-"de tentatives ({max_retries}) : {error}"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3900,6 +3900,18 @@ msgstr "現在のステップの構造化された結論。必須で、空には
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
+msgid "Schema validation failed after {attempts} attempts: {error}"
+msgstr "{attempts} 回の試行後にスキーマ検証が失敗しました: {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"conclusion validation failed after exceeding the maximum retry count "
+"({max_retries}): {error}"
+msgstr "最大再試行回数 ({max_retries}) を超えた後、conclusion の検証に失敗しました: {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
 msgid ""
 "{error}\n"
 "Current step: {step_id}\n"
@@ -3916,6 +3928,20 @@ msgstr ""
 "である必要があります。空の引数を送信したり、conclusion のフィールドをトップレベルに置いたりしないでください。\n"
 "{schema_hint}\n"
 "外側の引数例: {example}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message}\n"
+"You already submitted these exact arguments and they were rejected for "
+"the same reason; resubmitting them will fail again. Build the conclusion "
+"object from the schema above before calling complete_step. Remaining "
+"attempts before this step fails: {remaining}."
+msgstr ""
+"{message}\n"
+"まったく同じ引数を既に送信しており、同じ理由で拒否されました。再送信しても再び失敗します。complete_step "
+"を呼ぶ前に、上記のスキーマに基づいて conclusion オブジェクトを構築してください。このステップが失敗するまでの残り試行回数: "
+"{remaining}。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -4124,18 +4150,6 @@ msgid ""
 msgstr ""
 "ロールバック対象数は {limit} を超えられません。現在 {count} 件あります。complete_step "
 "を呼ぶ前にユーザーに支援を求めるか、対象を絞ってください。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid "Schema validation failed after {attempts} attempts: {error}"
-msgstr "{attempts} 回の試行後にスキーマ検証が失敗しました: {error}"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid ""
-"conclusion validation failed after exceeding the maximum retry count "
-"({max_retries}): {error}"
-msgstr "最大再試行回数 ({max_retries}) を超えた後、conclusion の検証に失敗しました: {error}"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4070,6 +4070,20 @@ msgstr "Conclusão estruturada da etapa atual. Obrigatória e não vazia."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
+msgid "Schema validation failed after {attempts} attempts: {error}"
+msgstr "A validação do esquema falhou após {attempts} tentativas: {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"conclusion validation failed after exceeding the maximum retry count "
+"({max_retries}): {error}"
+msgstr ""
+"A validação de conclusion falhou após exceder a contagem máxima de "
+"tentativas ({max_retries}): {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
 msgid ""
 "{error}\n"
 "Current step: {step_id}\n"
@@ -4087,6 +4101,21 @@ msgstr ""
 "superior.\n"
 "{schema_hint}\n"
 "Exemplo de argumentos externos: {example}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message}\n"
+"You already submitted these exact arguments and they were rejected for "
+"the same reason; resubmitting them will fail again. Build the conclusion "
+"object from the schema above before calling complete_step. Remaining "
+"attempts before this step fails: {remaining}."
+msgstr ""
+"{message}\n"
+"Você já enviou exatamente esses argumentos e eles foram rejeitados pelo "
+"mesmo motivo; reenviá-los falhará novamente. Construa o objeto conclusion"
+" a partir do esquema acima antes de chamar complete_step. Tentativas "
+"restantes antes de esta etapa falhar: {remaining}."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -4317,20 +4346,6 @@ msgstr ""
 "A quantidade de destinos de reversão não pode exceder {limit}; há "
 "{count}. Peça ajuda ao usuário ou reduza os destinos antes de chamar "
 "complete_step."
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid "Schema validation failed after {attempts} attempts: {error}"
-msgstr "A validação do esquema falhou após {attempts} tentativas: {error}"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid ""
-"conclusion validation failed after exceeding the maximum retry count "
-"({max_retries}): {error}"
-msgstr ""
-"A validação de conclusion falhou após exceder a contagem máxima de "
-"tentativas ({max_retries}): {error}"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3862,6 +3862,18 @@ msgstr "当前步骤的结构化结论。必填且不能为空。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format
+msgid "Schema validation failed after {attempts} attempts: {error}"
+msgstr "Schema 校验在 {attempts} 次尝试后失败: {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"conclusion validation failed after exceeding the maximum retry count "
+"({max_retries}): {error}"
+msgstr "conclusion 校验失败，已超过最大重试次数 ({max_retries}): {error}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
 msgid ""
 "{error}\n"
 "Current step: {step_id}\n"
@@ -3878,6 +3890,19 @@ msgstr ""
 "字段放在顶层。\n"
 "{schema_hint}\n"
 "外层参数示例: {example}"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"{message}\n"
+"You already submitted these exact arguments and they were rejected for "
+"the same reason; resubmitting them will fail again. Build the conclusion "
+"object from the schema above before calling complete_step. Remaining "
+"attempts before this step fails: {remaining}."
+msgstr ""
+"{message}\n"
+"你已经提交过完全相同的参数，并因同样的原因被拒绝；再次提交仍会失败。请先根据上方 schema 构造 conclusion 对象，再调用 "
+"complete_step。此步骤失败前的剩余尝试次数：{remaining}。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
@@ -4075,18 +4100,6 @@ msgid ""
 "user for help or narrow the rollback targets before calling "
 "complete_step."
 msgstr "可回滚目标数量不能超过 {limit} 个，当前有 {count} 个。请请求用户介入或收窄回滚目标后再调用 complete_step。"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid "Schema validation failed after {attempts} attempts: {error}"
-msgstr "Schema 校验在 {attempts} 次尝试后失败: {error}"
-
-#: src/iac_code/pipeline/engine/complete_step_tool.py
-#, python-brace-format
-msgid ""
-"conclusion validation failed after exceeding the maximum retry count "
-"({max_retries}): {error}"
-msgstr "conclusion 校验失败，已超过最大重试次数 ({max_retries}): {error}"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 #, python-brace-format

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -128,6 +128,12 @@ class CompleteStepTool(Tool):
         # P-I17: _validation_attempts resets each new step (see class docstring) —
         # max_conclusion_retries is a per-step budget, not a pipeline-wide one.
         self._validation_attempts = 0
+        # Fingerprint of the last rejected tool_input. Schema-level rejections
+        # (e.g. a missing ``conclusion``) never reach execute(), so without this
+        # the model gets a byte-identical error for every repeat of the same
+        # invalid arguments and keeps resubmitting them.
+        self._last_invalid_fingerprint: str | None = None
+        self._last_rejection: tuple[str, str] | None = None
 
     @property
     def name(self) -> str:
@@ -205,17 +211,77 @@ class CompleteStepTool(Tool):
             return False, rollback_target_error
         try:
             jsonschema.validate(instance=tool_input, schema=self.input_schema)
-            return True, ""
         except jsonschema.ValidationError as e:
-            return False, self._format_input_validation_error(self._public_validation_error(e), tool_input)
+            return False, self._reject_input(self._public_validation_error(e), tool_input)
+        self._last_invalid_fingerprint = None
+        self._last_rejection = None
+        return True, ""
 
-    def _format_input_validation_error(self, error: str, tool_input: dict[str, Any]) -> str:
+    def _reject_input(self, error: str, tool_input: dict[str, Any]) -> str:
+        """Account for a schema-level rejection and build an escalating hint.
+
+        ``ToolExecutor`` calls ``validate_input`` and then ``validation_error_result``
+        for the same rejected call, so the outcome is memoized under the input
+        fingerprint to keep one rejected call worth exactly one attempt. The memo
+        is one-shot: ``validation_error_result`` clears it so that a genuinely new
+        call repeating the same arguments still escalates.
+        """
+        fingerprint = self._input_fingerprint(tool_input)
+        cached = self._last_rejection
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
+        repeated = fingerprint == self._last_invalid_fingerprint
+        self._last_invalid_fingerprint = fingerprint
+        self._validation_attempts += 1
+        message = self._format_input_validation_error(error, tool_input, repeated=repeated)
+        self._last_rejection = (fingerprint, message)
+        return message
+
+    def validation_error_result(self, tool_input: dict[str, Any]) -> ToolResult | None:
+        """Surface the escalating hint, and terminate the step once the budget is spent."""
+        valid, error = self.validate_input(tool_input)
+        self._last_rejection = None
+        if valid:
+            return None
+        if self._validation_attempts <= self._step_config.max_conclusion_retries:
+            return ToolResult(content=error, is_error=True)
+        max_retries = self._step_config.max_conclusion_retries
+        step_result = StepResult(
+            step_id=self._step_config.step_id,
+            status=StepStatus.FAILED,
+            error=_("Schema validation failed after {attempts} attempts: {error}").format(
+                attempts=self._validation_attempts,
+                error=error,
+            ),
+        )
+        return ToolResult(
+            content=_(
+                "conclusion validation failed after exceeding the maximum retry count ({max_retries}): {error}"
+            ).format(max_retries=max_retries, error=error),
+            is_error=True,
+            metadata={"step_result": step_result},
+        )
+
+    @staticmethod
+    def _input_fingerprint(tool_input: dict[str, Any]) -> str:
+        try:
+            return json.dumps(tool_input or {}, ensure_ascii=False, sort_keys=True, default=repr)
+        except (TypeError, ValueError):
+            return repr(tool_input)
+
+    def _format_input_validation_error(
+        self,
+        error: str,
+        tool_input: dict[str, Any],
+        *,
+        repeated: bool = False,
+    ) -> str:
         invalid_json = json.dumps(tool_input or {}, ensure_ascii=False)
         example = json.dumps(
             {"conclusion": self._example_from_schema(self._step_config.conclusion_schema)},
             ensure_ascii=False,
         )
-        return _(
+        message = _(
             "{error}\n"
             "Current step: {step_id}\n"
             "Do not repeat the previous invalid arguments: {invalid_json}\n"
@@ -230,6 +296,15 @@ class CompleteStepTool(Tool):
             schema_hint=self._complete_step_schema_hint(),
             example=example,
         )
+        if not repeated:
+            return message
+        remaining = max(self._step_config.max_conclusion_retries - self._validation_attempts + 1, 0)
+        return _(
+            "{message}\n"
+            "You already submitted these exact arguments and they were rejected for the same reason; "
+            "resubmitting them will fail again. Build the conclusion object from the schema above before "
+            "calling complete_step. Remaining attempts before this step fails: {remaining}."
+        ).format(message=message, remaining=remaining)
 
     @classmethod
     def _public_validation_error(cls, error: jsonschema.ValidationError) -> str:

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -79,6 +79,14 @@ def _completion_guard_tool_result_content(event: ToolResultEvent) -> str:
         return event.result
 
 
+def _complete_step_input_fingerprint(tool_input: dict | None) -> str:
+    """Stable fingerprint of complete_step arguments, used to detect repeats."""
+    try:
+        return json.dumps(tool_input or {}, ensure_ascii=False, sort_keys=True, default=repr)
+    except (TypeError, ValueError):
+        return repr(tool_input)
+
+
 @dataclass
 class StepAgentLoopContext:
     """AgentLoop context built by the same path used for step execution."""
@@ -272,6 +280,11 @@ class StepExecutor:
         max_nudges = 2
         last_complete_step_error: str | None = None
         last_complete_step_input: dict | None = None
+        # Invalid complete_step arguments already seen in this step, so a repeat of
+        # the same rejected payload is nudged with a hard "stop resubmitting this"
+        # instruction instead of the same generic hint.
+        seen_invalid_complete_inputs: set[str] = set()
+        last_complete_step_repeated = False
 
         async def consume_complete_step_events(
             stream: AsyncIterator[Any],
@@ -279,6 +292,7 @@ class StepExecutor:
             nonlocal complete_step_input
             nonlocal last_complete_step_error
             nonlocal last_complete_step_input
+            nonlocal last_complete_step_repeated
             nonlocal terminal_failed_step_result
             try:
                 async for event in stream:
@@ -326,6 +340,9 @@ class StepExecutor:
                             else:
                                 last_complete_step_error = event.result
                                 last_complete_step_input = pending_complete_input.get(event.tool_use_id)
+                                fingerprint = _complete_step_input_fingerprint(last_complete_step_input)
+                                last_complete_step_repeated = fingerprint in seen_invalid_complete_inputs
+                                seen_invalid_complete_inputs.add(fingerprint)
                     yield event
                     if isinstance(event, MessageEndEvent) and self._current_agent_loop is not None:
                         yield ContextUsageEvent(usage=self._current_agent_loop.get_context_usage())
@@ -383,7 +400,12 @@ class StepExecutor:
                         "session_id": session_id,
                     },
                 )
-                nudge_msg = self._build_complete_step_nudge(last_complete_step_error, last_complete_step_input, step)
+                nudge_msg = self._build_complete_step_nudge(
+                    last_complete_step_error,
+                    last_complete_step_input,
+                    step,
+                    repeated=last_complete_step_repeated,
+                )
                 async for event in consume_complete_step_events(agent_loop.run_streaming(nudge_msg)):
                     yield event
             if (
@@ -754,6 +776,8 @@ class StepExecutor:
         error: str | None,
         invalid_input: dict | None,
         step: StepSpec | None = None,
+        *,
+        repeated: bool = False,
     ) -> str:
         step_line = f"当前步骤：{step.step_id}\n" if step is not None else ""
         schema_hint = StepExecutor._complete_step_schema_hint(step)
@@ -782,6 +806,14 @@ class StepExecutor:
                 "请先调用 ask_user_question 向用户澄清；收到 ask_user_question 的工具结果后，"
                 '再用 {"conclusion": {...}} 调用 complete_step。\n'
                 "不要再次直接调用 complete_step。"
+            )
+        if repeated:
+            return (
+                f"你已经用同一份无效参数调用过 complete_step，并且再次因为同样的原因失败：{error}\n"
+                f"禁止再次提交这份参数：{invalid_json}\n"
+                "不要解释、不要闲聊、不要重复无效工具调用。\n"
+                "请先按下面的 schema 逐字段构造完整的 conclusion 对象，再调用 complete_step。\n"
+                f"{wrapper_instruction}"
             )
         return (
             f"上一次 complete_step 调用失败：{error}\n"

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -1674,6 +1674,94 @@ class TestSchemaValidation:
         assert not result.is_error
 
 
+class TestRepeatedInvalidInput:
+    """Schema-level rejections must consume the retry budget and escalate on repeats.
+
+    Regression for the observed loop where the model resubmitted byte-identical
+    invalid complete_step arguments (empty/missing ``conclusion``) and got the
+    same error every time, retrying without bound.
+    """
+
+    @staticmethod
+    def _config(max_conclusion_retries: int = 2) -> StepConfig:
+        return StepConfig(
+            step_id="architecture_planning",
+            conclusion_field="architecture",
+            forward=None,
+            conclusion_schema={
+                "type": "object",
+                "required": ["candidates"],
+                "properties": {"candidates": {"type": "array"}},
+            },
+            max_conclusion_retries=max_conclusion_retries,
+        )
+
+    def test_repeated_identical_invalid_input_escalates_hint(self):
+        tool = CompleteStepTool(self._config())
+
+        first = tool.validation_error_result({})
+        second = tool.validation_error_result({})
+
+        assert first is not None and first.is_error
+        assert second is not None and second.is_error
+        assert "already submitted these exact arguments" not in first.content
+        assert "already submitted these exact arguments" in second.content
+        assert "Remaining attempts" in second.content
+
+    def test_validation_error_result_terminates_step_after_budget(self):
+        tool = CompleteStepTool(self._config(max_conclusion_retries=1))
+
+        r1 = tool.validation_error_result({})
+        r2 = tool.validation_error_result({})
+
+        assert r1 is not None and r1.is_error
+        assert r1.metadata is None
+        assert r2 is not None and r2.is_error
+        assert r2.metadata is not None
+        assert r2.metadata["step_result"].status == StepStatus.FAILED
+
+    def test_repeated_invalid_input_counts_once_per_rejected_call(self):
+        # ToolExecutor calls validate_input then validation_error_result for the
+        # same rejected call; that pair must cost exactly one attempt.
+        tool = CompleteStepTool(self._config(max_conclusion_retries=1))
+
+        valid, _error = tool.validate_input({})
+        assert not valid
+        result = tool.validation_error_result({})
+
+        assert result is not None and result.is_error
+        # One rejected call → not yet terminal.
+        assert result.metadata is None
+        assert tool._validation_attempts == 1
+
+    def test_valid_input_clears_invalid_fingerprint(self):
+        tool = CompleteStepTool(self._config())
+
+        valid, _error = tool.validate_input({})
+        assert not valid
+        assert tool._last_invalid_fingerprint is not None
+
+        valid, _error = tool.validate_input({"conclusion": {"candidates": []}})
+
+        assert valid
+        assert tool._last_invalid_fingerprint is None
+        assert tool._last_rejection is None
+
+    def test_different_invalid_inputs_are_not_treated_as_repeats(self):
+        tool = CompleteStepTool(self._config())
+
+        first = tool.validation_error_result({})
+        second = tool.validation_error_result({"conclusion": {}})
+
+        assert first is not None and "already submitted these exact arguments" not in first.content
+        assert second is not None and "already submitted these exact arguments" not in second.content
+
+    def test_validation_error_result_returns_none_for_valid_input(self):
+        tool = CompleteStepTool(self._config())
+
+        assert tool.validation_error_result({"conclusion": {"candidates": []}}) is None
+
+
 class TestNullNormalization:
     """LLMs pass null for optional fields — normalization strips them before validation."""
 

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -943,6 +943,73 @@ class TestStepExecutor:
         assert "收到 ask_user_question 的工具结果后" in nudge
         assert "不要再次直接调用 complete_step" in nudge
 
+    def test_nudge_escalates_when_same_invalid_input_repeats(self):
+        error = "Invalid input for tool 'complete_step': 'conclusion' is a required property"
+
+        first = StepExecutor._build_complete_step_nudge(error, {}, _make_architecture_step())
+        repeated = StepExecutor._build_complete_step_nudge(
+            error,
+            {},
+            _make_architecture_step(),
+            repeated=True,
+        )
+
+        assert "你已经用同一份无效参数调用过 complete_step" not in first
+        assert "你已经用同一份无效参数调用过 complete_step" in repeated
+        assert "禁止再次提交这份参数" in repeated
+
+    @pytest.mark.asyncio
+    async def test_repeated_invalid_complete_step_triggers_escalated_nudge(self, tmp_path):
+        # First and second complete_step calls submit byte-identical invalid args;
+        # the second nudge must carry the hard "stop resubmitting" instruction.
+        events = [
+            ToolUseStartEvent(tool_use_id="tu_1", name="complete_step"),
+            ToolUseEndEvent(tool_use_id="tu_1", name="complete_step", input={"conclusion": {}}),
+            ToolResultEvent(
+                tool_use_id="tu_1",
+                tool_name="complete_step",
+                result="'conclusion' is a required property",
+                is_error=True,
+            ),
+            ToolUseStartEvent(tool_use_id="tu_2", name="complete_step"),
+            ToolUseEndEvent(tool_use_id="tu_2", name="complete_step", input={"conclusion": {}}),
+            ToolResultEvent(
+                tool_use_id="tu_2",
+                tool_name="complete_step",
+                result="'conclusion' is a required property",
+                is_error=True,
+            ),
+        ]
+
+        class RecordingAgentLoop:
+            def __init__(self, **kwargs):
+                self.prompts: list[str] = []
+
+            async def run_streaming(self, user_input):
+                self.prompts.append(user_input)
+                for event in events:
+                    yield event
+
+        created: list[RecordingAgentLoop] = []
+
+        def factory(**kwargs):
+            loop = RecordingAgentLoop(**kwargs)
+            created.append(loop)
+            return loop
+
+        executor = _make_executor(tmp_path)
+        step = _make_architecture_step()
+        step.prompt_file = "prompts/architecture_planning.md"
+        ctx = PipelineContext(SIMPLE_DEPS)
+
+        with patch("iac_code.agent.agent_loop.AgentLoop", factory):
+            async for _ in executor.execute(step, ctx, "test_session"):
+                pass
+
+        nudges = [prompt for loop in created for prompt in loop.prompts]
+        escalated = [prompt for prompt in nudges if "你已经用同一份无效参数调用过 complete_step" in prompt]
+        assert escalated, f"expected an escalated nudge, got: {nudges}"
+
     @pytest.mark.asyncio
     async def test_no_nudge_when_initial_attempt_completes(self, tmp_path, caplog):
         events = [


### PR DESCRIPTION
## 背景
关联 Session 分析（117bf3ff、5318eac7、ba09b28c）：Agent 反复以空参数或缺少必填 `conclusion` 属性调用 `complete_step`，触发 `'conclusion' is a required property` 校验错误并不断重试。

## 根因
`complete_step` 的 schema 层校验在 `CompleteStepTool.validate_input` 内完成，缺 `conclusion` 的调用在到达 `StepExecutor.execute` 前即被拒绝。此路径此前无状态：相同无效参数每次返回逐字节一致的错误；schema 拒绝绕过 `max_conclusion_retries` 预算；nudge 文案不升级。

## 改动
- `CompleteStepTool`：对被拒输入指纹化；重复提交升级提示；schema 拒绝计入每步重试预算；预算耗尽后以 `StepResult(status=FAILED)` 终止。拒绝结果按指纹 memoize，使 `validate_input` + `validation_error_result` 只计一次尝试，并一次性清除以便真正的新一轮重复仍升级。
- `StepExecutor`：记录本步内出现过的无效载荷，重复时发出强制"停止重复提交"的 nudge。
- 新增测试并补齐升级提示的本地化文案（zh/es/fr/de/ja/pt）。

首次即合法的调用行为保持不变，仅影响无效/重复路径。

## 验证
- 目标用例（test_complete_step_tool、test_step_executor、i18n）：171 passed。
- `tests/pipeline` + `tests/i18n` 全量：1656 passed（1 项网络依赖用例与本改动无关，已排除）。
- `make lint`（ruff + ty）全部通过。
