### PR TITLE
fix(pipeline): complete_step 校验失败后的恢复与失败终态

### DIFF
--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 MAX_PARALLEL_CANDIDATES = 5
 MAX_ROLLBACK_TARGETS = 5
+# Marks a complete_step tool result whose failure came from conclusion schema /
+# completion_guard validation, so the step executor can pick a recovery strategy
+# without matching localized error text.
+CONCLUSION_VALIDATION_FAILED_METADATA_KEY = "conclusion_validation_failed"
 _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
     "reviewing_rerun_after_validate_template_write": (
         "reviewing ran write_file/edit_file after ros_validate_template; "
@@ -1171,6 +1175,7 @@ class CompleteStepTool(Tool):
                     error=validation_error
                 ),
                 is_error=True,
+                metadata={CONCLUSION_VALIDATION_FAILED_METADATA_KEY: True},
             )
 
         step_result = StepResult(

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -1152,6 +1152,12 @@ class PipelineRunner:
             return
         self._execution[_PENDING_INPUT_KIND_KEY] = kind
 
+    def _discard_pending_ask_user_question(self) -> None:
+        """Drop an unanswered question so a failed step cannot look like waiting_input."""
+        self._execution.pop(_PENDING_ASK_USER_QUESTION_INPUT_KEY, None)
+        if self.pending_input_kind() == _ASK_USER_QUESTION_KIND:
+            self._set_pending_input_kind(None)
+
     async def restore_from_sidecar(self) -> RestoreResult:
         return self.restore_from_sidecar_sync()
 
@@ -4056,6 +4062,7 @@ class PipelineRunner:
                     extra_details={"step_id": step.step_id},
                 )
                 error_summary = failure.summary
+                self._discard_pending_ask_user_question()
                 try:
                     await self._save_failed(step.step_id, reason)
                 except PipelineStatePersistenceError as exc:

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -16,7 +16,10 @@ from typing import Any
 from iac_code.agent.message import ContentBlock, Message
 from iac_code.agent.system_prompt import SECTION_BUILDERS, build_base_sections
 from iac_code.mcp.prompt_dispatch import mcp_prompt_command_stream
-from iac_code.pipeline.engine.complete_step_tool import CompleteStepTool
+from iac_code.pipeline.engine.complete_step_tool import (
+    CONCLUSION_VALIDATION_FAILED_METADATA_KEY,
+    CompleteStepTool,
+)
 from iac_code.pipeline.engine.completion_guard_state import (
     ensure_completion_guard_state,
     record_completion_guard_tool_result,
@@ -272,6 +275,7 @@ class StepExecutor:
         max_nudges = 2
         last_complete_step_error: str | None = None
         last_complete_step_input: dict | None = None
+        last_complete_step_validation_failed = False
 
         async def consume_complete_step_events(
             stream: AsyncIterator[Any],
@@ -279,6 +283,7 @@ class StepExecutor:
             nonlocal complete_step_input
             nonlocal last_complete_step_error
             nonlocal last_complete_step_input
+            nonlocal last_complete_step_validation_failed
             nonlocal terminal_failed_step_result
             try:
                 async for event in stream:
@@ -326,6 +331,9 @@ class StepExecutor:
                             else:
                                 last_complete_step_error = event.result
                                 last_complete_step_input = pending_complete_input.get(event.tool_use_id)
+                                last_complete_step_validation_failed = bool(
+                                    (event.metadata or {}).get(CONCLUSION_VALIDATION_FAILED_METADATA_KEY)
+                                )
                     yield event
                     if isinstance(event, MessageEndEvent) and self._current_agent_loop is not None:
                         yield ContextUsageEvent(usage=self._current_agent_loop.get_context_usage())
@@ -393,6 +401,7 @@ class StepExecutor:
                 and self._should_try_fresh_complete_step_recovery(
                     last_complete_step_error,
                     last_complete_step_input,
+                    conclusion_validation_failed=last_complete_step_validation_failed,
                 )
             ):
                 recovery_context = self.build_agent_loop_context(
@@ -443,7 +452,7 @@ class StepExecutor:
             step_result = StepResult(
                 step_id=step.step_id,
                 status=StepStatus.FAILED,
-                error="No conclusion extracted",
+                error=self._no_conclusion_error(last_complete_step_error),
             )
 
         yield step_result
@@ -791,10 +800,27 @@ class StepExecutor:
         )
 
     @staticmethod
-    def _should_try_fresh_complete_step_recovery(error: str | None, invalid_input: dict | None) -> bool:
+    def _no_conclusion_error(last_complete_step_error: str | None) -> str:
+        """Keep the last complete_step error in the terminal reason so failures stay diagnosable."""
+        if not last_complete_step_error:
+            return "No conclusion extracted"
+        return f"No conclusion extracted; last complete_step error: {last_complete_step_error}"
+
+    @staticmethod
+    def _should_try_fresh_complete_step_recovery(
+        error: str | None,
+        invalid_input: dict | None,
+        *,
+        conclusion_validation_failed: bool = False,
+    ) -> bool:
         if not error:
             return False
         if invalid_input == {}:
+            return True
+        # conclusion schema / completion_guard 校验失败同样值得一次 fresh 恢复：
+        # 否则 guard 类失败（例如需要先调用 ask_user_question）在 nudge 用尽后
+        # 直接以 FAILED 收场，步骤没有任何恢复入口。
+        if conclusion_validation_failed:
             return True
         return (
             "'conclusion' is a required property" in error

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -225,7 +225,7 @@ class TestCompleteStepToolExecute:
 
         assert result.is_error
         assert "Candidate count cannot exceed 5" in result.content
-        assert result.metadata is None
+        assert "step_result" not in (result.metadata or {})
 
     @pytest.mark.asyncio
     async def test_rejects_rollback_when_budget_is_exhausted_before_step_result(self):
@@ -419,11 +419,11 @@ class TestCompletionGuards:
         second = await tool.execute(tool_input={"conclusion": invalid_conclusion}, context=ToolContext())
 
         assert first.is_error is True
-        assert first.metadata is None
+        assert "step_result" not in (first.metadata or {})
         assert "fix it and call complete_step again" in first.content
         assert "missing_constraint_check" in first.content
         assert second.is_error is True
-        assert second.metadata is None
+        assert "step_result" not in (second.metadata or {})
 
         valid_conclusion = {
             "deployment_parameters": {"NodeCount": 2},
@@ -1534,7 +1534,7 @@ class TestSchemaValidation:
         )
         assert result.is_error
         assert "name" in result.content
-        assert result.metadata is None
+        assert "step_result" not in (result.metadata or {})
 
     def test_invalid_tool_input_error_preserves_previous_invalid_input_for_llm_retry(self):
         config = StepConfig(
@@ -1656,7 +1656,7 @@ class TestSchemaValidation:
         # First call: invalid (attempt 1)
         r1 = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
         assert r1.is_error
-        assert r1.metadata is None
+        assert "step_result" not in (r1.metadata or {})
         # Second call: still invalid (attempt 2 = max_retries exceeded)
         r2 = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
         assert r2.is_error

--- a/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
+++ b/tests/pipeline/engine/test_pipeline_runner_sidecar_path.py
@@ -1560,6 +1560,33 @@ async def test_pending_ask_user_question_answer_is_durable_until_resume_stream_s
     assert restored.pending_ask_user_question()["answer"] == answer
 
 
+@pytest.mark.asyncio
+async def test_failed_step_clears_pending_ask_user_question(tmp_path):
+    """步骤失败后不能再残留未应答的问题，否则外部只看到 waiting_input。"""
+    runner = _build_two_step_runner(tmp_path)
+    await runner.persist_pending_ask_user_question(
+        AskUserQuestionEvent(
+            tool_use_id="ask-1",
+            question="请提供部署目标",
+            options=[{"id": "skip", "label": "暂不处理"}],
+        )
+    )
+    assert runner.sidecar_status == "waiting_input"
+    assert runner.pending_ask_user_question() is not None
+
+    async def fake_execute(step, context, session_id, user_message=None, **kwargs):
+        yield StepResult(step_id=step.step_id, status=StepStatus.FAILED, error="guard 校验失败")
+
+    runner._step_executor.execute = fake_execute
+
+    async for _event in runner._continue_from_current():
+        pass
+
+    assert runner.sidecar_status == "failed"
+    assert runner.pending_ask_user_question() is None
+    assert runner.pending_input_kind() is None
+
+
 def test_resume_from_sidecar_accepts_list_valued_context_fields(tmp_path):
     runner = _build_two_step_runner(tmp_path)
     sidecar_dir = runner.session.session_dir

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -2564,7 +2564,7 @@ class TestStepExecutorValidationRespect:
         results = [e for e in collected if isinstance(e, StepResult)]
         assert len(results) == 1
         assert results[0].status == StepStatus.FAILED
-        assert results[0].error == "No conclusion extracted"
+        assert results[0].error == "No conclusion extracted; last complete_step error: 校验失败"
 
     @pytest.mark.asyncio
     async def test_terminal_failed_step_result_stops_without_nudge(self, tmp_path):
@@ -3326,3 +3326,113 @@ async def test_resumed_step_rebuilds_ask_user_question_guard_state(monkeypatch, 
 
     assert captured_guard_state["successful_tools"] == {"ask_user_question"}
     assert captured_guard_state["tool_results"]["ask_user_question"]["free_text"] == "budget 500"
+
+
+class TestCompleteStepValidationRecovery:
+    """complete_step 结论校验失败（含 completion_guard）后必须有恢复入口和可诊断终态。"""
+
+    def test_guard_validation_failure_allows_fresh_recovery(self):
+        assert StepExecutor._should_try_fresh_complete_step_recovery(
+            "conclusion 校验失败；请修正后重新调用 complete_step: 需要先调用 ask_user_question",
+            {"conclusion": {"is_infra_intent": False}},
+            conclusion_validation_failed=True,
+        )
+
+    def test_unrelated_tool_error_still_skips_fresh_recovery(self):
+        assert not StepExecutor._should_try_fresh_complete_step_recovery(
+            "回滚次数不能超过 3 次",
+            {"conclusion": {"is_infra_intent": False}},
+        )
+
+    def test_wrapper_shape_error_still_allows_fresh_recovery(self):
+        assert StepExecutor._should_try_fresh_complete_step_recovery(
+            "'conclusion' is a required property",
+            {"is_infra_intent": False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_guard_failure_recovers_in_fresh_loop(self, tmp_path):
+        """guard 校验失败在 nudge 用尽后仍应获得一次 fresh loop 恢复并成功收口。"""
+        attempts = [0]
+
+        class FakeAgentLoop:
+            def __init__(self, **kwargs):
+                self.system_prompt = kwargs.get("system_prompt", "")
+                self.tool_registry = kwargs.get("tool_registry")
+
+            async def run_streaming(self, user_input):
+                attempts[0] += 1
+                tool_use_id = f"tu_{attempts[0]}"
+                yield ToolUseStartEvent(tool_use_id=tool_use_id, name="complete_step")
+                yield ToolUseEndEvent(
+                    tool_use_id=tool_use_id,
+                    name="complete_step",
+                    input={"conclusion": {"is_infra_intent": False}},
+                )
+                if attempts[0] <= 3:
+                    yield ToolResultEvent(
+                        tool_use_id=tool_use_id,
+                        tool_name="complete_step",
+                        result="conclusion 校验失败；请修正后重新调用 complete_step: 需要先调用 ask_user_question",
+                        is_error=True,
+                        metadata={"conclusion_validation_failed": True},
+                    )
+                else:
+                    yield ToolResultEvent(
+                        tool_use_id=tool_use_id,
+                        tool_name="complete_step",
+                        result="ok",
+                    )
+
+        executor = _make_executor(tmp_path)
+        step = _make_step()
+        ctx = PipelineContext(SIMPLE_DEPS)
+
+        collected = []
+        with patch("iac_code.agent.agent_loop.AgentLoop", FakeAgentLoop):
+            async for event in executor.execute(step, ctx, "test_session"):
+                collected.append(event)
+
+        results = [event for event in collected if isinstance(event, StepResult)]
+        # 1 次初始 + 2 次 nudge + 1 次 fresh 恢复
+        assert attempts[0] == 4
+        assert results[-1].status == StepStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_unrecoverable_guard_failure_reports_last_error(self, tmp_path):
+        """恢复用尽后失败终态必须带上最后一次 complete_step 错误，而不是只有通用文案。"""
+        guard_error = "conclusion 校验失败；请修正后重新调用 complete_step: 需要先调用 ask_user_question"
+
+        class FakeAgentLoop:
+            def __init__(self, **kwargs):
+                self.system_prompt = kwargs.get("system_prompt", "")
+                self.tool_registry = kwargs.get("tool_registry")
+
+            async def run_streaming(self, user_input):
+                yield ToolUseStartEvent(tool_use_id="tu_1", name="complete_step")
+                yield ToolUseEndEvent(
+                    tool_use_id="tu_1",
+                    name="complete_step",
+                    input={"conclusion": {"is_infra_intent": False}},
+                )
+                yield ToolResultEvent(
+                    tool_use_id="tu_1",
+                    tool_name="complete_step",
+                    result=guard_error,
+                    is_error=True,
+                    metadata={"conclusion_validation_failed": True},
+                )
+
+        executor = _make_executor(tmp_path)
+        step = _make_step()
+        ctx = PipelineContext(SIMPLE_DEPS)
+
+        collected = []
+        with patch("iac_code.agent.agent_loop.AgentLoop", FakeAgentLoop):
+            async for event in executor.execute(step, ctx, "test_session"):
+                collected.append(event)
+
+        results = [event for event in collected if isinstance(event, StepResult)]
+        assert len(results) == 1
+        assert results[0].status == StepStatus.FAILED
+        assert guard_error in results[0].error


### PR DESCRIPTION
## 背景
证据 Session `1f650b08485d40b7a8b4ca2513ad05c5`：`intent_parsing` 调用 `complete_step` 触发 completion_guard `intent_not_deployment_request` 校验失败后，没有任何恢复动作，步骤长期停留 `waiting_input` 且 `conclusion` 为 null，流程停滞。

## 根因
1. `CompleteStepTool.execute` 在重试预算内返回 `is_error` 但不带 `step_result`，不产生终态。
2. `StepExecutor._should_try_fresh_complete_step_recovery` 只白名单 wrapper/schema 形状错误，guard 类失败拿不到 fresh 恢复。
3. `AskUserQuestionTool` 先把 sidecar 落成 `waiting_input`，步骤失败分支只调 `_save_failed`，残留的 pending question 让终态对外仍像「等用户输入」。

## 改动
- `complete_step_tool.py`：校验失败的 ToolResult 带上 `conclusion_validation_failed` 标记（避免下游匹配本地化文案）。
- `step_executor.py`：guard/schema 校验失败也放行一次 fresh loop 恢复；恢复用尽后的 FAILED 终态带上最后一次 complete_step 错误，取代无信息量的 `No conclusion extracted`。
- `pipeline_runner.py`：步骤失败分支先清理未应答的 `ask_user_question` 与 `pending_input_kind`，再落 `failed`。

## 验证
- 新增 5 个单测（guard 失败可 fresh 恢复、恢复用尽后终态含原始错误、失败清空 pending question）。
- `tests/pipeline` + `tests/ui` + `tests/tools`：6177 passed / 2 skipped。
- `ruff check src tests` 通过；`ty check` 在改动文件上无新增诊断。
- 已知无关失败：`test_prerequisites::test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` 在基线 commit 上同样失败（环境相关，urllib 抛 HTTPError 而非 InvalidURL）。
