### PR TITLE
fix(a2a): 候选进入终态时收敛仍为 pending 的子步骤

### DIFF
--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -36,6 +36,9 @@ _CLEANUP_STATUS_BY_EVENT_TYPE = {
     PIPELINE_EVENT_CLEANUP_FAILED: "failed",
 }
 _KNOWN_CLEANUP_STATUSES = {"pending", "started", "in_progress", "completed", "failed", "skipped"}
+_CANDIDATE_TERMINAL_STATUSES = {"completed", "failed"}
+_CANDIDATE_STEP_TERMINAL_STATUSES = {"completed", "failed", "skipped"}
+_SKIPPED_CANDIDATE_STEP_CONCLUSION = "Step did not run before the candidate reached a terminal state."
 _PENDING_BACKUP_VISIBILITY = "pending_backup"
 _COMMITTED_BACKUP_VISIBILITY = "committed"
 _BACKUP_COMMITTED_EVENT_TYPE = "backup_committed"
@@ -266,6 +269,8 @@ class _PipelineSnapshotReducer:
                     valid_candidate_steps.append(candidate_step)
                     self._candidate_steps_by_run_id[candidate_step_run_id] = candidate_step
                 candidate["steps"] = valid_candidate_steps
+                if _string_or_none(candidate.get("status")) in _CANDIDATE_TERMINAL_STATUSES:
+                    _reconcile_candidate_steps(candidate, _string_or_none(candidate.get("completedAt")))
             step["candidates"] = valid_candidates
         self._snapshot["steps"] = valid_steps
         self._sanitize_active_candidate_run_ids()
@@ -661,8 +666,35 @@ class _PipelineSnapshotReducer:
         self._candidate_parent_step_run_ids[run_id] = step["runId"]
 
         _merge_coordinate(candidate, coordinate)
+        self._index_candidate_steps(candidate)
         self._apply_candidate_lifecycle(candidate, event)
         return candidate
+
+    def _index_candidate_steps(self, candidate: dict[str, Any]) -> None:
+        """Register the candidate step skeleton carried by ``candidate_started``.
+
+        Without this, later ``candidate_step_*`` events cannot find the skeleton
+        entry and append a second object with the same ``runId``, leaving a
+        duplicated ``pending`` row next to the real terminal one.
+        """
+        unique_steps: list[dict[str, Any]] = []
+        seen_run_ids: set[str] = set()
+        for candidate_step in _dict_list(candidate.get("steps")):
+            run_id = _string_or_none(candidate_step.get("runId"))
+            if run_id is None or run_id in seen_run_ids:
+                continue
+            seen_run_ids.add(run_id)
+            known = self._candidate_steps_by_run_id.get(run_id)
+            if known is None:
+                self._candidate_steps_by_run_id[run_id] = candidate_step
+                unique_steps.append(candidate_step)
+                continue
+            # A skeleton must never regress an already tracked step.
+            for key, value in candidate_step.items():
+                if key != "status":
+                    known.setdefault(key, copy.deepcopy(value))
+            unique_steps.append(known)
+        candidate["steps"] = unique_steps
 
     def _apply_candidate_lifecycle(self, candidate: dict[str, Any], event: dict[str, Any]) -> None:
         event_type = event.get("eventType")
@@ -678,11 +710,13 @@ class _PipelineSnapshotReducer:
             _set_time(candidate, "completedAt", created_at)
             _merge_completion_data(candidate, event)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
+            _reconcile_candidate_steps(candidate, created_at)
         elif event_type == "candidate_failed":
             candidate["status"] = "failed"
             _set_time(candidate, "failedAt", created_at)
             _merge_completion_data(candidate, event)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
+            _reconcile_candidate_steps(candidate, created_at)
         elif event_type == "candidate_restart_requested":
             candidate["status"] = "restarting"
             _set_time(candidate, "restartingAt", created_at)
@@ -1756,6 +1790,24 @@ def _merge_completion_data(target: dict[str, Any], event: dict[str, Any]) -> Non
     ):
         if key in data:
             target[key] = copy.deepcopy(data[key])
+
+
+def _reconcile_candidate_steps(candidate: dict[str, Any], created_at: str | None) -> None:
+    """Converge a terminal candidate's non-terminal steps.
+
+    A candidate can reach ``completed``/``failed`` while some of its steps never
+    emitted a lifecycle event (skipped branch, early exit).  Those steps stay on
+    the ``candidate_started`` skeleton value ``pending`` with a ``null``
+    conclusion, which contradicts the candidate conclusion.  Mark them
+    ``skipped`` with an explicit conclusion, never overwriting real outcomes.
+    """
+    for candidate_step in _dict_list(candidate.get("steps")):
+        if _string_or_none(candidate_step.get("status")) in _CANDIDATE_STEP_TERMINAL_STATUSES:
+            continue
+        candidate_step["status"] = "skipped"
+        _set_time(candidate_step, "completedAt", created_at)
+        if candidate_step.get("conclusion") is None:
+            candidate_step["conclusion"] = _SKIPPED_CANDIDATE_STEP_CONCLUSION
 
 
 def _append_unique(values: list[Any], value: Any) -> None:

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -816,6 +816,213 @@ def test_reduce_completion_events_keep_conclusions_on_pipeline_state_nodes() -> 
     assert step["candidates"][0]["steps"][0]["conclusion"] == {"body": "ros"}
 
 
+def _candidate_step_skeleton(candidate_run_id: str, step_ids: list[str]) -> list[dict]:
+    total = len(step_ids)
+    return [
+        {
+            "id": step_id,
+            "name": step_id,
+            "runId": f"{candidate_run_id}-{step_id}-1",
+            "attempt": 1,
+            "index": index,
+            "total": total,
+            "status": "pending",
+        }
+        for index, step_id in enumerate(step_ids, start=1)
+    ]
+
+
+def _candidate_step_event(
+    event_id: str,
+    sequence: int,
+    event_type: str,
+    parent: dict,
+    candidate: dict,
+    step_id: str,
+    *,
+    data: dict | None = None,
+) -> dict:
+    event = _base(event_id, sequence, event_type, scope="candidate_step")
+    event["step"] = parent
+    event["candidate"] = {key: value for key, value in candidate.items() if key != "steps"}
+    event["candidateStep"] = {
+        "runId": f"{candidate['runId']}-{step_id}-1",
+        "id": step_id,
+        "index": 1,
+        "total": 4,
+        "attempt": 1,
+    }
+    event["data"] = data or {}
+    return event
+
+
+def test_reduce_candidate_started_skeleton_does_not_duplicate_candidate_steps() -> None:
+    parent = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    started = _base("evt-parent", 1, "step_started", scope="step")
+    started["step"] = parent
+    candidate_coordinate = {
+        "runId": "candidate-eval-0-1",
+        "id": "eval",
+        "index": 0,
+        "attempt": 1,
+        "steps": _candidate_step_skeleton(
+            "candidate-eval-0-1",
+            ["template_generating", "validating", "cost_estimating", "reviewing"],
+        ),
+    }
+    candidate = _base("evt-candidate", 2, "candidate_started", scope="candidate")
+    candidate["step"] = parent
+    candidate["candidate"] = candidate_coordinate
+    validating_started = _candidate_step_event(
+        "evt-validating-start", 3, "candidate_step_started", parent, candidate_coordinate, "validating"
+    )
+    validating_completed = _candidate_step_event(
+        "evt-validating-done",
+        4,
+        "candidate_step_completed",
+        parent,
+        candidate_coordinate,
+        "validating",
+        data={"conclusionField": "validated", "conclusion": {"ok": True}},
+    )
+
+    snapshot = reduce_pipeline_events([started, candidate, validating_started, validating_completed])
+
+    candidate_steps = snapshot["steps"][0]["candidates"][0]["steps"]
+    run_ids = [candidate_step["runId"] for candidate_step in candidate_steps]
+    assert len(run_ids) == len(set(run_ids))
+    assert [candidate_step["id"] for candidate_step in candidate_steps] == [
+        "template_generating",
+        "validating",
+        "cost_estimating",
+        "reviewing",
+    ]
+    validating = candidate_steps[1]
+    assert validating["status"] == "completed"
+    assert validating["conclusion"] == {"ok": True}
+
+
+def test_reduce_candidate_completed_converges_pending_candidate_steps() -> None:
+    parent = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    started = _base("evt-parent", 1, "step_started", scope="step")
+    started["step"] = parent
+    candidate_coordinate = {
+        "runId": "candidate-eval-0-1",
+        "id": "eval",
+        "index": 0,
+        "attempt": 1,
+        "steps": _candidate_step_skeleton(
+            "candidate-eval-0-1",
+            ["template_generating", "validating", "cost_estimating", "reviewing"],
+        ),
+    }
+    candidate = _base("evt-candidate", 2, "candidate_started", scope="candidate")
+    candidate["step"] = parent
+    candidate["candidate"] = candidate_coordinate
+    validating_completed = _candidate_step_event(
+        "evt-validating-done",
+        3,
+        "candidate_step_completed",
+        parent,
+        candidate_coordinate,
+        "validating",
+        data={"conclusionField": "validated", "conclusion": {"ok": True}},
+    )
+    completed = _base("evt-candidate-done", 4, "candidate_completed", scope="candidate")
+    completed["step"] = parent
+    completed["candidate"] = {key: value for key, value in candidate_coordinate.items() if key != "steps"}
+    completed["data"] = {"conclusions": {"validated": {"ok": True}}}
+
+    snapshot = reduce_pipeline_events([started, candidate, validating_completed, completed])
+
+    candidate_state = snapshot["steps"][0]["candidates"][0]
+    assert candidate_state["status"] == "completed"
+    candidate_steps = {item["id"]: item for item in candidate_state["steps"]}
+    assert candidate_steps["validating"]["status"] == "completed"
+    assert candidate_steps["validating"]["conclusion"] == {"ok": True}
+    for step_id in ("template_generating", "cost_estimating", "reviewing"):
+        assert candidate_steps[step_id]["status"] == "skipped"
+        assert candidate_steps[step_id]["conclusion"] is not None
+        assert candidate_steps[step_id]["completedAt"] == "2026-06-08T10:00:00Z"
+
+
+def test_reduce_candidate_failed_converges_pending_candidate_steps() -> None:
+    parent = {"runId": "step-evaluate-1", "id": "evaluate", "index": 1, "total": 1, "attempt": 1}
+    started = _base("evt-parent", 1, "step_started", scope="step")
+    started["step"] = parent
+    candidate_coordinate = {
+        "runId": "candidate-eval-0-1",
+        "id": "eval",
+        "index": 0,
+        "attempt": 1,
+        "steps": _candidate_step_skeleton("candidate-eval-0-1", ["template_generating", "validating"]),
+    }
+    candidate = _base("evt-candidate", 2, "candidate_started", scope="candidate")
+    candidate["step"] = parent
+    candidate["candidate"] = candidate_coordinate
+    template_failed = _candidate_step_event(
+        "evt-template-failed",
+        3,
+        "candidate_step_failed",
+        parent,
+        candidate_coordinate,
+        "template_generating",
+        data={"errorSummary": "quota exceeded"},
+    )
+    failed = _base("evt-candidate-failed", 4, "candidate_failed", scope="candidate")
+    failed["step"] = parent
+    failed["candidate"] = {key: value for key, value in candidate_coordinate.items() if key != "steps"}
+
+    snapshot = reduce_pipeline_events([started, candidate, template_failed, failed])
+
+    candidate_state = snapshot["steps"][0]["candidates"][0]
+    assert candidate_state["status"] == "failed"
+    candidate_steps = {item["id"]: item for item in candidate_state["steps"]}
+    assert candidate_steps["template_generating"]["status"] == "failed"
+    assert candidate_steps["validating"]["status"] == "skipped"
+    assert candidate_steps["validating"]["conclusion"] is not None
+
+
+def test_reduce_hydrates_stored_terminal_candidate_with_pending_candidate_steps() -> None:
+    existing = reduce_pipeline_events([])
+    existing["steps"] = [
+        {
+            "runId": "step-evaluate-1",
+            "id": "evaluate",
+            "candidates": [
+                {
+                    "runId": "candidate-eval-0-1",
+                    "id": "eval",
+                    "status": "completed",
+                    "completedAt": "2026-06-08T09:00:00Z",
+                    "steps": [
+                        {
+                            "runId": "candidate-eval-0-1-template_generating-1",
+                            "id": "template_generating",
+                            "status": "pending",
+                        },
+                        {
+                            "runId": "candidate-eval-0-1-validating-1",
+                            "id": "validating",
+                            "status": "completed",
+                            "conclusion": {"ok": True},
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+
+    snapshot = reduce_pipeline_events([], existing_snapshot=existing)
+
+    candidate_steps = {item["id"]: item for item in snapshot["steps"][0]["candidates"][0]["steps"]}
+    assert candidate_steps["template_generating"]["status"] == "skipped"
+    assert candidate_steps["template_generating"]["conclusion"] is not None
+    assert candidate_steps["template_generating"]["completedAt"] == "2026-06-08T09:00:00Z"
+    assert candidate_steps["validating"]["status"] == "completed"
+    assert candidate_steps["validating"]["conclusion"] == {"ok": True}
+
+
 def test_reduce_candidate_without_parent_step_does_not_create_none_step() -> None:
     candidate = _base("evt-1", 1, "candidate_started", scope="candidate")
     candidate["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}


### PR DESCRIPTION
## 问题

针对 Session `77dd459d824b42cba4f7f217be798164`：候选（candidate）已被标记为 `completed`，但其子步骤仍停留在 `pending` 且 `conclusion` 为 `null`，与候选自身的结论互相矛盾；同时部分子步骤在快照中出现同 `runId` 的重复行（一条 `pending` + 一条终态）。

## 根因

复现后定位到 `src/iac_code/a2a/pipeline_snapshot.py` 中两个缺陷：

1. **骨架子步骤未登记，导致重复行。** `candidate_started` 事件的 `candidate.steps` 携带了子步骤骨架（`status="pending"`）。`_upsert_candidate` 通过 `_merge_coordinate` 把该列表写到候选上，但从未把这些条目登记进 `self._candidate_steps_by_run_id`。后续 `candidate_step_started/completed` 在 `_upsert_candidate_step` 里查不到骨架，于是**追加**了一个同 `runId` 的第二个对象。

2. **候选进入终态时不做收敛。** `_apply_candidate_lifecycle` 在 `candidate_completed` 分支只更新候选自身的 `status`/`completedAt`/结论，从不检查 `candidate["steps"]`。因此从未发出过生命周期事件的子步骤（跳过分支 / 提前退出）永久停留在 `pending` + `conclusion: null`。

## 修复

- 新增 `_index_candidate_steps`：按 `runId` 对 `candidate_started` 骨架去重，并登记到 `_candidate_steps_by_run_id`，使后续 `candidate_step_*` 事件**原地更新**而不是追加；骨架不会回退已跟踪步骤的 `status`。
- 新增模块级 `_reconcile_candidate_steps`：候选进入 `completed`/`failed` 时，把非终态子步骤收敛为 `skipped` 并写入显式 `conclusion`，**不覆盖**已有的真实结论。
- `_hydrate_steps` 对存量快照中已处于终态的候选执行同样收敛，自愈历史数据。

## 验证

- 复现脚本在修复前重现了工单症状；修复后子步骤数为 4、无重复 `runId`、全部终态且 `conclusion` 非空。
- 新增 4 个回归用例（`tests/a2a/test_pipeline_snapshot.py`）：骨架 + 真实事件不产生重复；`candidate_completed` 后全部收敛；`candidate_failed` 同样收敛；存量 `pending` 残留经 hydrate 被修复。
- `tests/a2a/test_pipeline_snapshot.py` + `tests/a2a/test_pipeline_events.py`：144 passed。
- `make test`：14324 passed / 16 failed。16 个失败在**未改动的干净树**上以完全相同方式失败，均为环境原因（`tests/test_i18n.py` 缺少 GNU `msgfmt`；`test_prerequisites` / `test_manager` / `repl_e2e` 需要网络），与本次变更无关。
- `ruff check` 与 `ruff format --check` 对改动文件全部通过；`ty check src/` 诊断数在改动前后均为 50，无新增。
