### PR TITLE
fix(selling): 部署失败后必须重新发起 ros_deploy 才能结束 deploying

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4079,6 +4079,26 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"deploying repaired or revalidated the template but never re-issued the "
+"deployment; call ros_deploy again and report the deployment outcome "
+"instead of ending the step."
+msgstr ""
+"deploying hat die Vorlage repariert oder erneut validiert, aber die "
+"Bereitstellung nie erneut ausgelöst; rufe ros_deploy erneut auf und melde"
+" das Bereitstellungsergebnis, anstatt den Schritt zu beenden."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"deploying may only report status cancelled when the user explicitly "
+"cancelled; a failed deployment must be retried with ros_deploy or "
+"reported as status failed."
+msgstr ""
+"deploying darf status cancelled nur melden, wenn der Benutzer "
+"ausdrücklich abgebrochen hat; eine fehlgeschlagene Bereitstellung muss "
+"mit ros_deploy wiederholt oder als status failed gemeldet werden."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Every explicit user hard constraint must be covered by a satisfied check "
 "with matching parameters and evidence."
 msgstr ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4057,6 +4057,26 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"deploying repaired or revalidated the template but never re-issued the "
+"deployment; call ros_deploy again and report the deployment outcome "
+"instead of ending the step."
+msgstr ""
+"deploying reparó o revalidó la plantilla, pero nunca volvió a lanzar el "
+"despliegue; llama de nuevo a ros_deploy e informa del resultado del "
+"despliegue en lugar de finalizar el paso."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"deploying may only report status cancelled when the user explicitly "
+"cancelled; a failed deployment must be retried with ros_deploy or "
+"reported as status failed."
+msgstr ""
+"deploying solo puede informar status cancelled cuando el usuario canceló "
+"explícitamente; un despliegue fallido debe reintentarse con ros_deploy o "
+"informarse como status failed."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Every explicit user hard constraint must be covered by a satisfied check "
 "with matching parameters and evidence."
 msgstr ""

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4065,6 +4065,26 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"deploying repaired or revalidated the template but never re-issued the "
+"deployment; call ros_deploy again and report the deployment outcome "
+"instead of ending the step."
+msgstr ""
+"deploying a réparé ou revalidé le modèle, mais n'a jamais relancé le "
+"déploiement ; appelez à nouveau ros_deploy et signalez le résultat du "
+"déploiement au lieu de terminer l'étape."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"deploying may only report status cancelled when the user explicitly "
+"cancelled; a failed deployment must be retried with ros_deploy or "
+"reported as status failed."
+msgstr ""
+"deploying ne peut signaler status cancelled que si l'utilisateur a "
+"explicitement annulé ; un déploiement en échec doit être relancé avec "
+"ros_deploy ou signalé comme status failed."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Every explicit user hard constraint must be covered by a satisfied check "
 "with matching parameters and evidence."
 msgstr ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3870,6 +3870,24 @@ msgstr "デプロイ成功には、ros_deploy が CREATE_COMPLETE を返すま�
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"deploying repaired or revalidated the template but never re-issued the "
+"deployment; call ros_deploy again and report the deployment outcome "
+"instead of ending the step."
+msgstr ""
+"deploying はテンプレートを修復または再検証しましたが、デプロイを再実行していません。ros_deploy "
+"を再度呼び出してデプロイ結果を報告し、ステップを終了しないでください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"deploying may only report status cancelled when the user explicitly "
+"cancelled; a failed deployment must be retried with ros_deploy or "
+"reported as status failed."
+msgstr ""
+"deploying が status cancelled を返せるのは、ユーザーが明示的に取消した場合のみです。デプロイ失敗は "
+"ros_deploy で再試行するか、status failed として報告してください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Every explicit user hard constraint must be covered by a satisfied check "
 "with matching parameters and evidence."
 msgstr "ユーザーが明示した各ハード制約は、パラメーターと根拠が一致する「満たしている」チェックで網羅する必要があります。"

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4038,6 +4038,26 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"deploying repaired or revalidated the template but never re-issued the "
+"deployment; call ros_deploy again and report the deployment outcome "
+"instead of ending the step."
+msgstr ""
+"deploying corrigiu ou revalidou o modelo, mas nunca reiniciou a "
+"implantação; chame ros_deploy novamente e relate o resultado da "
+"implantação em vez de encerrar a etapa."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"deploying may only report status cancelled when the user explicitly "
+"cancelled; a failed deployment must be retried with ros_deploy or "
+"reported as status failed."
+msgstr ""
+"deploying só pode relatar status cancelled quando o usuário cancelou "
+"explicitamente; uma implantação com falha deve ser repetida com "
+"ros_deploy ou relatada como status failed."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Every explicit user hard constraint must be covered by a satisfied check "
 "with matching parameters and evidence."
 msgstr ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3834,6 +3834,22 @@ msgstr "部署成功必须等待 ros_deploy 返回 CREATE_COMPLETE。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"deploying repaired or revalidated the template but never re-issued the "
+"deployment; call ros_deploy again and report the deployment outcome "
+"instead of ending the step."
+msgstr "deploying 修复或重新校验了模板，却没有重新发起部署；请再次调用 ros_deploy 并报告部署结果，不要直接结束该步骤。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"deploying may only report status cancelled when the user explicitly "
+"cancelled; a failed deployment must be retried with ros_deploy or "
+"reported as status failed."
+msgstr ""
+"只有用户明确取消时，deploying 才能返回 status cancelled；部署失败必须用 ros_deploy 重试，或返回 "
+"status failed。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Every explicit user hard constraint must be covered by a satisfied check "
 "with matching parameters and evidence."
 msgstr "每个用户明确提出的硬约束都必须由一条状态为满足的检查覆盖，且参数和证据一致。"

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -56,6 +56,14 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "or confirm that it should not be handled for now."
     ),
     "deploy_wait_create_complete": ("A successful deployment must wait until ros_deploy returns CREATE_COMPLETE."),
+    "deploy_retry_after_template_fix": (
+        "deploying repaired or revalidated the template but never re-issued the deployment; "
+        "call ros_deploy again and report the deployment outcome instead of ending the step."
+    ),
+    "deploy_cancel_requires_user_request": (
+        "deploying may only report status cancelled when the user explicitly cancelled; "
+        "a failed deployment must be retried with ros_deploy or reported as status failed."
+    ),
     "hard_constraint_verification_required": (
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
@@ -96,6 +104,14 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
             "or confirm that it should not be handled for now."
         ),
         _("A successful deployment must wait until ros_deploy returns CREATE_COMPLETE."),
+        _(
+            "deploying repaired or revalidated the template but never re-issued the deployment; "
+            "call ros_deploy again and report the deployment outcome instead of ending the step."
+        ),
+        _(
+            "deploying may only report status cancelled when the user explicitly cancelled; "
+            "a failed deployment must be retried with ros_deploy or reported as status failed."
+        ),
         _(
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
@@ -534,7 +550,7 @@ class CompleteStepTool(Tool):
                 continue
             if actions and self._first_string(tool_input, ("action", "Action")) not in actions:
                 continue
-            if record.get("is_error"):
+            if record.get("is_error") and not self._error_records_allowed(requirement):
                 continue
             result = record.get("result")
             if not isinstance(result, dict):
@@ -644,7 +660,7 @@ class CompleteStepTool(Tool):
             return False
         if actions and self._first_string(tool_input, ("action", "Action")) not in actions:
             return False
-        if record.get("is_error"):
+        if record.get("is_error") and not self._error_records_allowed(requirement):
             return False
         result = record.get("result")
         if not isinstance(result, dict):
@@ -701,7 +717,9 @@ class CompleteStepTool(Tool):
             if field_mismatch is not None:
                 mismatch_message = self._format_match_field_mismatch(base_message, field_mismatch)
                 continue
-            if record.get("is_error") or not isinstance(raw_result, dict):
+            if record.get("is_error") and not self._error_records_allowed(requirement):
+                break
+            if not isinstance(raw_result, dict):
                 break
             if expected_success is not None and self._bool_from_result(result) is not bool(expected_success):
                 break
@@ -1101,6 +1119,15 @@ class CompleteStepTool(Tool):
         if left is None or right is None:
             return left == right
         return left.lower() == right.lower()
+
+    @staticmethod
+    def _error_records_allowed(requirement: dict[str, Any]) -> bool:
+        """Allow matching failed tool results only when the guard explicitly opts in.
+
+        Needed for guards that require evidence of an *attempt* (e.g. a ros_deploy call that
+        returned CREATE_FAILED), because failed tool results are recorded with is_error=True.
+        """
+        return requirement.get("allow_error_result") is True
 
     @classmethod
     def _expected_actions(cls, requirement: dict[str, Any]) -> set[str]:

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -600,6 +600,38 @@ steps:
           status_in: [CREATE_COMPLETE]
           match_conclusion_field: stack_id
         message_key: deploy_wait_create_complete
+      - when_conclusion_field_equals:
+          status: failed
+        when_tool_result_exists:
+          tools: [edit_file, ros_validate_template]
+        require_tool_result:
+          tool: ros_deploy
+          action_in: [create, continue_create, delete_and_create, wait]
+          allow_error_result: true
+          latest_match: true
+          disallow_tool_results_after_match:
+            - tools: [edit_file, ros_validate_template]
+              message_key: deploy_retry_after_template_fix
+        message_key: deploy_retry_after_template_fix
+      - when_conclusion_field_equals:
+          status: cancelled
+        when_tool_result_exists:
+          tools: [edit_file, ros_validate_template]
+        unless_user_message_matches_any:
+          - 取消部署
+          - 不要部署
+          - 停止部署
+          - cancel the deployment
+          - stop the deployment
+        require_tool_result:
+          tool: ros_deploy
+          action_in: [create, continue_create, delete_and_create, wait]
+          allow_error_result: true
+          latest_match: true
+          disallow_tool_results_after_match:
+            - tools: [edit_file, ros_validate_template]
+              message_key: deploy_cancel_requires_user_request
+        message_key: deploy_cancel_requires_user_request
     tools:
       include: []
       exclude:

--- a/src/iac_code/pipeline/selling/prompts/deploying.md
+++ b/src/iac_code/pipeline/selling/prompts/deploying.md
@@ -47,6 +47,8 @@
 ## 错误处理
 - 模板校验失败 → 就地修复模板后重试（最多 5 轮）
 - 部署失败或等待超时 → 按技能的参数补全与 `ros_deploy` 恢复策略处理
+- `CREATE_FAILED` → 按技能的恢复闭环定位失败资源、修复后重新调用 `ros_deploy`；只修模板并重新校验不算完成本步骤
+- 本步骤必须以部署终态收尾：成功返回真实 `stack_id`，确认不可恢复时返回 `status: failed` 并说明原因
 - 架构层面必须变更（如产品组合不可行）→ rollback_request 到 `architecture_planning`
 
 ## 注意事项

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/SKILL.md
@@ -142,6 +142,15 @@ conclusion_schema:
 - 模板/参数 → 修复后调用 `ros_deploy` 的 `continue_create`
 - `continue_create` 返回 `ContinueCreateStackValidationFailed` → 告知用户需要重建本步骤创建的失败 Stack，再调用 `ros_deploy` 的 `delete_and_create`
 
+### CREATE_FAILED 恢复闭环
+`ros_deploy` 返回 `CREATE_FAILED` 时按下面的闭环恢复，不得中途结束本步骤：
+1. 从结果的 `status_reason` 和失败资源列表定位具体失败资源与失败原因。
+2. 原因指向模板时，就地修复 `selected_plan.template_url` 指向的原模板文件，然后重新调用 `ros_validate_template`；原因指向参数时按「部署前参数补全」调整参数。
+3. 修复并校验通过后**必须**重新发起部署：调用 `ros_deploy` 的 `continue_create`（或按 `ContinueCreateStackValidationFailed` 走 `delete_and_create`），直到 Stack 达到 `CREATE_COMPLETE` 或恢复手段耗尽。
+4. 只做 `edit_file` 与 `ros_validate_template` 不构成本步骤的结论；最后一个部署相关动作必须是 `ros_deploy`，不得在模板修复或校验之后直接调用 `complete_step`。
+
+本步骤必须以部署终态收尾：成功时返回 `status: success` 与真实 `stack_id`；确认不可恢复时返回 `status: failed`，`error` 写明失败资源、失败原因与已尝试的恢复动作。不得用 `status: cancelled` 表示部署失败或恢复放弃。
+
 ### 删除并重建
 仅在 `continue_create` 返回 `ContinueCreateStackValidationFailed` 后使用 `delete_and_create`。调用时：
 - `stack_id` 指向本步骤创建的旧失败 Stack，不得使用通过查询发现的其他 Stack

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-deploying/evals.json
@@ -223,6 +223,28 @@
         {"name": "skips_routine_availability_query", "check": "跳过例行可用性查询"},
         {"name": "uses_template_url", "check": "ros_deploy 参数中使用 template_url，不使用 TemplateBody"}
       ]
+    },
+    {
+      "id": 11,
+      "name": "create-failed-redeploy-closes-loop",
+      "prompt": "部署失败了，SAE 应用创建报错，请继续处理",
+      "selected_plan": {
+        "selection_valid": true,
+        "template_url": "{TMPDIR}/ros-sae-template.yml",
+        "region": "cn-hangzhou",
+        "stack_id": "stack-sae-1",
+        "stack_status": "CREATE_FAILED",
+        "status_reason": "The resource ALIYUN::SAE::Application is CREATE_FAILED: invalid PackageType"
+      },
+      "expected_behavior": "定位失败资源与原因，就地修复同一个模板文件并重新 ros_validate_template 后，必须重新调用 ros_deploy 完成部署；不得只做 edit_file+ros_validate_template 就结束步骤，也不得以 cancelled 收尾",
+      "assertions": [
+        {"name": "identifies_failed_resource", "check": "从 status_reason 定位失败资源 ALIYUN::SAE::Application 与失败原因"},
+        {"name": "repairs_same_template", "check": "使用 edit_file 就地修复 selected_plan.template_url 指向的模板文件"},
+        {"name": "revalidates_template", "check": "修复后重新调用 ros_validate_template"},
+        {"name": "redeploys_after_repair", "check": "重新调用 ros_deploy 的 continue_create 或 delete_and_create 发起部署"},
+        {"name": "no_stop_after_revalidate", "check": "未在 ros_validate_template 之后直接结束步骤"},
+        {"name": "terminal_status", "check": "以 status success 或 status failed 收尾，不使用 status cancelled"}
+      ]
     }
   ]
 }

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -808,6 +808,72 @@ class TestCompletionGuards:
 
         assert not result.is_error
 
+    @staticmethod
+    def _allow_error_result_tool(*, allow_error_result: bool) -> CompleteStepTool:
+        requirement = {
+            "tool": "ros_deploy",
+            "action_in": ["create", "continue_create"],
+            "latest_match": True,
+        }
+        if allow_error_result:
+            requirement["allow_error_result"] = True
+        return CompleteStepTool(
+            StepConfig(
+                step_id="deploying",
+                conclusion_field="deployment",
+                forward=None,
+                conclusion_schema={
+                    "type": "object",
+                    "required": ["status"],
+                    "properties": {
+                        "status": {"type": "string", "enum": ["success", "failed", "cancelled"]},
+                        "error": {"type": "string"},
+                    },
+                },
+            ),
+            completion_guards=[
+                {
+                    "when_conclusion_field_equals": {"status": "failed"},
+                    "require_tool_result": requirement,
+                }
+            ],
+            completion_guard_state={
+                "successful_tools": set(),
+                "tool_results": {},
+                "tool_result_records": [
+                    {
+                        "tool_name": "ros_deploy",
+                        "input": {"action": "create", "stack_id": "stack-123"},
+                        "result": {"stack_id": "stack-123", "status": "CREATE_FAILED", "is_success": False},
+                        "is_error": True,
+                    }
+                ],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_allow_error_result_matches_failed_tool_result(self):
+        tool = self._allow_error_result_tool(allow_error_result=True)
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"status": "failed", "error": "CREATE_FAILED"}},
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_failed_tool_result_is_ignored_without_allow_error_result(self):
+        tool = self._allow_error_result_tool(allow_error_result=False)
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"status": "failed", "error": "CREATE_FAILED"}},
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "ros_deploy" in result.content
+
     @pytest.mark.asyncio
     async def test_required_conclusion_any_of_accepts_clarification_text(self):
         config = StepConfig(step_id="intent_parsing", conclusion_field="intent", forward=None)

--- a/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_deploying_skill.py
@@ -223,6 +223,17 @@ class TestSkillContentRosOnly:
     def test_contains_error_handling(self, body):
         assert "部署失败" in body
 
+    def test_create_failed_recovery_loop_requires_redeploy(self, body):
+        assert "CREATE_FAILED 恢复闭环" in body
+        assert "status_reason" in body
+        assert "必须**重新发起部署" in body
+        assert "只做 `edit_file` 与 `ros_validate_template` 不构成本步骤的结论" in body
+        assert "最后一个部署相关动作必须是 `ros_deploy`" in body
+
+    def test_deploying_must_end_in_deployment_terminal_state(self, body):
+        assert "本步骤必须以部署终态收尾" in body
+        assert "不得用 `status: cancelled` 表示部署失败或恢复放弃" in body
+
     def test_no_template_generation(self, body):
         assert "模板生成流程" not in body
         assert "参数化规则" not in body
@@ -418,6 +429,17 @@ class TestEvalsJson:
         assert "确认" in confirmed_eval["prompt"]
         assert "uses_delete_stack" not in confirmed_assertions
         assert "no_delete_stack" in confirmed_assertions
+
+    def test_create_failed_eval_requires_redeploy_after_repair(self):
+        data = json.loads(EVALS_JSON.read_text(encoding="utf-8"))
+        evals_by_name = {ev["name"]: ev for ev in data["evals"]}
+        recovery_eval = evals_by_name["create-failed-redeploy-closes-loop"]
+        assertion_names = {assertion["name"] for assertion in recovery_eval["assertions"]}
+
+        assert "CREATE_FAILED" in recovery_eval["selected_plan"]["stack_status"]
+        assert "redeploys_after_repair" in assertion_names
+        assert "no_stop_after_revalidate" in assertion_names
+        assert "terminal_status" in assertion_names
 
     def test_template_validation_eval_uses_dedicated_tool(self):
         data = json.loads(EVALS_JSON.read_text(encoding="utf-8"))

--- a/tests/pipeline/selling/test_deploying_completion_guards.py
+++ b/tests/pipeline/selling/test_deploying_completion_guards.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from iac_code.pipeline.engine.complete_step_tool import CompleteStepTool
+from iac_code.pipeline.engine.loader import load_pipeline_dir
+from iac_code.pipeline.engine.types import StepConfig
+from iac_code.tools.base import ToolContext
+
+
+def _selling_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "src" / "iac_code" / "pipeline" / "selling"
+
+
+def _deploying_step():
+    loaded = load_pipeline_dir(_selling_dir())
+    return next(step for step in loaded.steps if step.step_id == "deploying")
+
+
+def _deploying_tool(records: list[dict], *, user_message: str = "") -> CompleteStepTool:
+    step = _deploying_step()
+    return CompleteStepTool(
+        StepConfig(
+            step_id=step.step_id,
+            conclusion_field=step.conclusion_field,
+            forward=step.forward,
+            conclusion_schema=step.conclusion_schema,
+        ),
+        completion_guards=step.completion_guards,
+        completion_guard_state={
+            "successful_tools": set(),
+            "tool_results": {},
+            "tool_result_records": list(records),
+        },
+        user_message=user_message,
+    )
+
+
+def _edit_file_record(file_path: str = "templates/sae.yml") -> dict:
+    return {
+        "tool_name": "edit_file",
+        "input": {"file_path": file_path},
+        "result": {"file_path": file_path},
+        "is_error": False,
+    }
+
+
+def _validate_template_record(file_path: str = "templates/sae.yml") -> dict:
+    return {
+        "tool_name": "ros_validate_template",
+        "input": {"template_url": file_path},
+        "result": {"Description": "Valid"},
+        "is_error": False,
+    }
+
+
+def _create_failed_record(action: str = "create", stack_id: str = "stack-sae-1") -> dict:
+    return {
+        "tool_name": "ros_deploy",
+        "input": {"action": action, "stack_id": stack_id},
+        "result": {
+            "stack_id": stack_id,
+            "status": "CREATE_FAILED",
+            "status_reason": "ALIYUN::SAE::Application CREATE_FAILED",
+            "is_success": False,
+        },
+        "is_error": True,
+    }
+
+
+def test_deploying_guards_cover_success_failed_and_cancelled() -> None:
+    guards = _deploying_step().completion_guards
+
+    assert [guard["when_conclusion_field_equals"]["status"] for guard in guards] == [
+        "success",
+        "failed",
+        "cancelled",
+    ]
+    assert [guard["message_key"] for guard in guards] == [
+        "deploy_wait_create_complete",
+        "deploy_retry_after_template_fix",
+        "deploy_cancel_requires_user_request",
+    ]
+    for guard in guards[1:]:
+        requirement = guard["require_tool_result"]
+        assert requirement["tool"] == "ros_deploy"
+        assert requirement["allow_error_result"] is True
+        assert requirement["latest_match"] is True
+        assert guard["when_tool_result_exists"]["tools"] == ["edit_file", "ros_validate_template"]
+
+
+@pytest.mark.asyncio
+async def test_failed_conclusion_after_edit_and_revalidate_requires_redeploy() -> None:
+    tool = _deploying_tool(
+        [
+            _create_failed_record(),
+            _edit_file_record(),
+            _validate_template_record(),
+        ]
+    )
+
+    result = await tool.execute(
+        tool_input={"conclusion": {"status": "failed", "error": "CREATE_FAILED"}},
+        context=ToolContext(),
+    )
+
+    assert result.is_error
+    assert "ros_deploy" in result.content
+
+
+@pytest.mark.asyncio
+async def test_failed_conclusion_accepted_after_redeploy_attempt() -> None:
+    tool = _deploying_tool(
+        [
+            _create_failed_record(),
+            _edit_file_record(),
+            _validate_template_record(),
+            _create_failed_record(action="continue_create"),
+        ]
+    )
+
+    result = await tool.execute(
+        tool_input={"conclusion": {"status": "failed", "error": "SAE quota exhausted after retry"}},
+        context=ToolContext(),
+    )
+
+    assert not result.is_error
+
+
+@pytest.mark.asyncio
+async def test_failed_conclusion_without_template_repair_is_not_blocked() -> None:
+    tool = _deploying_tool([])
+
+    result = await tool.execute(
+        tool_input={"conclusion": {"status": "failed", "error": "no permission to call SAE"}},
+        context=ToolContext(),
+    )
+
+    assert not result.is_error
+
+
+@pytest.mark.asyncio
+async def test_cancelled_conclusion_after_template_repair_is_rejected() -> None:
+    tool = _deploying_tool([_create_failed_record(), _edit_file_record(), _validate_template_record()])
+
+    result = await tool.execute(
+        tool_input={"conclusion": {"status": "cancelled"}},
+        context=ToolContext(),
+    )
+
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_cancelled_conclusion_allowed_when_user_cancelled() -> None:
+    tool = _deploying_tool(
+        [_create_failed_record(), _edit_file_record(), _validate_template_record()],
+        user_message="先取消部署，我再想想",
+    )
+
+    result = await tool.execute(
+        tool_input={"conclusion": {"status": "cancelled"}},
+        context=ToolContext(),
+    )
+
+    assert not result.is_error
+
+
+@pytest.mark.asyncio
+async def test_success_conclusion_still_requires_create_complete() -> None:
+    tool = _deploying_tool([_create_failed_record(), _edit_file_record(), _validate_template_record()])
+
+    result = await tool.execute(
+        tool_input={"conclusion": {"status": "success", "stack_id": "stack-sae-1"}},
+        context=ToolContext(),
+    )
+
+    assert result.is_error
+    assert "CREATE_COMPLETE" in result.content

--- a/tests/pipeline/selling/test_deploying_prompt.py
+++ b/tests/pipeline/selling/test_deploying_prompt.py
@@ -86,3 +86,15 @@ def test_deploying_renders_stack_outputs_after_complete_step() -> None:
     assert deploying_step.complete_step_terminal is False
     assert "`complete_step` 成功返回后" in prompt
     assert "`complete_step.conclusion.outputs` 渲染 Stack Outputs" in prompt
+
+
+def test_deploying_prompt_requires_redeploy_and_terminal_state_after_create_failed() -> None:
+    selling_dir = _selling_dir()
+    loaded = load_pipeline_dir(selling_dir)
+    deploying_step = next(step for step in loaded.steps if step.step_id == "deploying")
+    prompt = (selling_dir / deploying_step.prompt_file).read_text(encoding="utf-8")
+
+    assert "`CREATE_FAILED`" in prompt
+    assert "重新调用 `ros_deploy`" in prompt
+    assert "只修模板并重新校验不算完成本步骤" in prompt
+    assert "本步骤必须以部署终态收尾" in prompt


### PR DESCRIPTION
## 问题
SAE `ros_deploy` 返回 `CREATE_FAILED` 后，agent 仅做 `edit_file` + `ros_validate_template` 就调用 `complete_step` 取消流水线，`deploying` 步骤停留在 `working` / `conclusion: null`。

## 根因
1. `deploying` 只有 `status: success` 一条 completion guard，`failed` / `cancelled` 结论完全不受校验。
2. guard DSL 无法表达“尝试过但失败的部署”：`_validate_required_tool_result` / `_tool_result_record_satisfies` / `_validate_latest_required_tool_result` 三处无条件跳过 `is_error=True` 的工具结果，而 `CREATE_FAILED` 正是以 `is_error=True` 记录的。

## 改动
- `pipeline/engine/complete_step_tool.py`：新增 opt-in 的 `allow_error_result` 需求字段，使 guard 可匹配失败的工具结果；注册 `deploy_retry_after_template_fix` / `deploy_cancel_requires_user_request` 两个 message key 并加入 i18n markers。
- `pipeline/selling/pipeline.yaml`：`deploying` 增加两条 guard —— `status: failed` 且发生过 `edit_file`/`ros_validate_template` 时必须存在 `ros_deploy`，且其后不得再出现模板修复/校验；`status: cancelled` 仅在用户明确取消时允许。
- `skills/iac-aliyun-deploying/SKILL.md`：新增「CREATE_FAILED 恢复闭环」章节（定位失败资源 → 就地修复原模板 → 重新校验 → **必须**重新 `ros_deploy` → 终态收尾）。
- `prompts/deploying.md`、`evals.json`：同步约束，新增 eval `create-failed-redeploy-closes-loop`。
- i18n：`zh/es/fr/de/ja/pt` 六语翻译。

## 测试
- 新增 `tests/pipeline/selling/test_deploying_completion_guards.py`（7 例）
- engine 层 `allow_error_result` 正反两例；SKILL/prompt/evals 措辞断言 4 例
- `tests/pipeline` + `tests/test_i18n.py` + `tests/i18n`：1691 passed，2 failed 均为基线已存在、与本改动无关（`test_prerequisites` 的 URL 断言、zh 目录 `{s:.0}` 复数写法被 GNU msgfmt 拒绝）
- `ruff check src/ tests/` 通过
