### PR TITLE
fix(pipeline): 拒绝空 conclusion，避免 intent_parsing 以 null 结论静默成功

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1731,9 +1731,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             raise ValueError("Invalid A2A workspace metadata.")
         logical_cwd = os.path.normpath(cwd)
         resolved_cwd = resolve_workspace_path(Path(logical_cwd))
-        if not trust_request_cwd() and not any(
-            _is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()
-        ):
+        if not trust_request_cwd() and not any(_is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()):
             raise ValueError("Invalid A2A workspace metadata.")
         if resolved_cwd.exists():
             if not resolved_cwd.is_dir():

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -178,35 +178,29 @@ def permission_display_fields(request: PermissionRequestEvent, *, language: str 
             command = safe_input.get("command") or safe_input.get("cmd")
         if isinstance(command, str) and command.strip():
             command_fallback = translate_message("shell command", language=language)
-            target = translate_message(
-                "the current local workspace; command: {command}", language=language
-            ).format(command=_display_text(command, fallback=command_fallback, maximum=240))
+            target = translate_message("the current local workspace; command: {command}", language=language).format(
+                command=_display_text(command, fallback=command_fallback, maximum=240)
+            )
         else:
             target = translate_message("the current local workspace", language=language)
         effect = "read" if is_read_only else ("local_execution" if read_only_known else "unknown")
     elif tool_name in {"write_file", "edit_file"}:
         title = translate_message("Change a workspace file", language=language)
-        purpose = translate_message(
-            "Write a file needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Write a file needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "a file in the current workspace", language=language
         )
         effect = "file_change"
     elif tool_name in {"read_file", "glob", "grep"} or is_read_only:
         title = translate_message("Read workspace data with {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Read local data needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Read local data needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current local workspace", language=language
         )
         effect = "read"
     else:
         title = translate_message("Run {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Run this operation for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Run this operation for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current task workspace or cloud account", language=language
         )
@@ -319,9 +313,7 @@ def _cloud_operation_title(product: str, action: str, *, is_read_only: bool, lan
     if action == "CreateStack":
         return translate_message("Create {product} stack", language=language).format(product=product_label)
     if action == "ContinueCreateStack":
-        return translate_message("Continue creating {product} stack", language=language).format(
-            product=product_label
-        )
+        return translate_message("Continue creating {product} stack", language=language).format(product=product_label)
     if action == "UpdateStack":
         return translate_message("Update {product} stack", language=language).format(product=product_label)
     if action == "DeleteStack":
@@ -344,9 +336,7 @@ def _safe_input_target(value: Any, *, language: str) -> str:
     for key in ("file_path", "filePath", "path", "region_id", "regionId", "resource_id", "resourceId"):
         candidate = value.get(key)
         if isinstance(candidate, str) and candidate.strip():
-            return _display_text(
-                candidate, fallback=translate_message("the current task scope", language=language)
-            )
+            return _display_text(candidate, fallback=translate_message("the current task scope", language=language))
     return ""
 
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -1235,11 +1235,7 @@ class IacCodeA2APipelineExecutor:
             def permission_context_getter() -> Any:
                 return getattr(agent_loop, "_permission_context", None)
 
-        surface = (
-            A2A_RICH_CANDIDATE_SURFACE
-            if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION
-            else "a2a"
-        )
+        surface = A2A_RICH_CANDIDATE_SURFACE if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION else "a2a"
         return create_pipeline(
             pipeline_name,
             provider_manager=runtime.provider_manager,

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -864,9 +864,7 @@ class A2ATaskStore(TaskStore):
                 any(record.active_task is not None and not record.active_task.done() for record in self._tasks.values())
                 or any(not task.done() for task in self._context_runtime_tasks.values())
                 or any(
-                    not task.done()
-                    for starts in self._context_execution_starts.values()
-                    for task in starts.values()
+                    not task.done() for starts in self._context_execution_starts.values() for task in starts.values()
                 )
                 or any(self._context_reconciliation_waiters.values())
                 or any(lock.locked() for lock in self._reconciliation_locks.values())

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -64,6 +64,33 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
 
+def is_empty_conclusion(conclusion: Any) -> bool:
+    """Return True when a conclusion carries no field at all.
+
+    ``None``, a non-mapping value and ``{}`` all mean the step produced nothing
+    usable for downstream steps, so they must never be accepted as a successful
+    outcome. A conclusion that declares fields (even with empty values such as
+    ``candidates: []``) is a real answer and stays valid.
+    """
+    return not isinstance(conclusion, dict) or not conclusion
+
+
+def empty_conclusion_error(step_id: str, conclusion_field: str) -> str:
+    """Diagnostic message for a complete_step call that submitted a blank conclusion."""
+    return _(
+        "Step {step_id} submitted an empty conclusion, so {conclusion_field} cannot be derived. "
+        "Submit a non-empty conclusion; when the result cannot be derived, state the explicit reason "
+        "in the conclusion instead of leaving it blank."
+    ).format(step_id=step_id, conclusion_field=conclusion_field)
+
+
+def missing_conclusion_error(step_id: str, conclusion_field: str) -> str:
+    """Diagnostic message for a step that ended without any complete_step conclusion."""
+    return _(
+        "Step {step_id} ended without a complete_step conclusion, so {conclusion_field} was never produced."
+    ).format(step_id=step_id, conclusion_field=conclusion_field)
+
+
 def _completion_guard_message_from_key(key: str) -> str | None:
     text = _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.get(key)
     return _(text) if text is not None else None
@@ -300,6 +327,12 @@ class CompleteStepTool(Tool):
 
     def _validate_conclusion(self, conclusion: dict) -> str | None:
         """Validate conclusion against schema. Returns error message or None."""
+        if is_empty_conclusion(conclusion):
+            logger.warning(
+                "Empty conclusion rejected for step %s",
+                sanitize_strict_text(self._step_config.step_id),
+            )
+            return empty_conclusion_error(self._step_config.step_id, self._step_config.conclusion_field)
         schema = self._step_config.conclusion_schema
         if not schema:
             return None

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -343,9 +343,7 @@ def _parse_surface_overrides(raw: object, step_id: str) -> dict[str, StepSurface
 
         conclusion_schema = override.get("conclusion_schema")
         if conclusion_schema is not None and not isinstance(conclusion_schema, dict):
-            raise ValueError(
-                f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping"
-            )
+            raise ValueError(f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping")
 
         overrides[surface] = StepSurfaceOverride(
             prompt_file=prompt,

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -93,6 +93,8 @@ _REAL_RESTORE_FAILURE_REASONS = {
 
 def _is_a2a_surface(surface: str) -> bool:
     return surface == "a2a" or surface.startswith("a2a_")
+
+
 _SIDECAR_ROOT_DIRS = {"a2a", "image-cache", "pipeline", "tool-results"}
 _SIDECAR_ROOT_FILES = {
     ".backup-state.json",

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -16,7 +16,12 @@ from typing import Any
 from iac_code.agent.message import ContentBlock, Message
 from iac_code.agent.system_prompt import SECTION_BUILDERS, build_base_sections
 from iac_code.mcp.prompt_dispatch import mcp_prompt_command_stream
-from iac_code.pipeline.engine.complete_step_tool import CompleteStepTool
+from iac_code.pipeline.engine.complete_step_tool import (
+    CompleteStepTool,
+    empty_conclusion_error,
+    is_empty_conclusion,
+    missing_conclusion_error,
+)
 from iac_code.pipeline.engine.completion_guard_state import (
     ensure_completion_guard_state,
     record_completion_guard_tool_result,
@@ -428,22 +433,29 @@ class StepExecutor:
         elif complete_step_input is not None:
             conclusion = complete_step_input.get("conclusion", {})
             conclusion = self._merge_preserved_candidate_selection(preserved_selection, conclusion)
-            rollback = complete_step_input.get("rollback_request")
-            rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
-            step_result = StepResult(
-                step_id=step.step_id,
-                status=StepStatus.COMPLETED,
-                conclusion=conclusion,
-                rollback_request=rollback_tuple,
-            )
-            context.set_conclusion(step.conclusion_field, conclusion)
-            if step.on_exit:
-                step.on_exit(context, conclusion)
+            if is_empty_conclusion(conclusion):
+                step_result = StepResult(
+                    step_id=step.step_id,
+                    status=StepStatus.FAILED,
+                    error=empty_conclusion_error(step.step_id, step.conclusion_field),
+                )
+            else:
+                rollback = complete_step_input.get("rollback_request")
+                rollback_tuple = (rollback["target_step"], rollback["reason"]) if rollback else None
+                step_result = StepResult(
+                    step_id=step.step_id,
+                    status=StepStatus.COMPLETED,
+                    conclusion=conclusion,
+                    rollback_request=rollback_tuple,
+                )
+                context.set_conclusion(step.conclusion_field, conclusion)
+                if step.on_exit:
+                    step.on_exit(context, conclusion)
         else:
             step_result = StepResult(
                 step_id=step.step_id,
                 status=StepStatus.FAILED,
-                error="No conclusion extracted",
+                error=missing_conclusion_error(step.step_id, step.conclusion_field),
             )
 
         yield step_result

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -298,9 +298,7 @@ class AliyunCredentials:
 
             owns_client = oauth_client is None
             client = (
-                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type))
-                if oauth_client is None
-                else oauth_client
+                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type)) if oauth_client is None else oauth_client
             )
 
             try:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -149,8 +149,7 @@ class StagedSessionBackupService(SessionBackupService):
                         existing = self._read_existing_snapshot_state(destination, session_id)
                         if existing is not None:
                             completed_next = (
-                                base_state.status == "succeeded"
-                                and existing.parent_generation == base_state.generation
+                                base_state.status == "succeeded" and existing.parent_generation == base_state.generation
                             )
                             if not completed_next and not existing.same_lineage(committed_state):
                                 raise SessionBackupConflict(

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -3788,12 +3788,10 @@ class TestResolveCandidatePresentation:
         executor = self._make_executor()
 
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}}) == "rich-v1"
         )
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}}) == "rich-v1"
         )
 
     def test_rejects_unknown_or_missing_presentation(self) -> None:

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -240,9 +240,7 @@ def test_ros_deployment_permission_is_localized_and_preserves_safe_plan_summary(
                         "stackName": "demo-stack",
                         "template": "templates/demo.yml",
                         "totalMonthlyCost": "¥88/月",
-                        "resources": [
-                            {"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}
-                        ],
+                        "resources": [{"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}],
                     },
                 },
             ),
@@ -388,9 +386,7 @@ async def test_pipeline_permission_uses_same_input_envelope_and_waits_serially(m
 async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(monkeypatch, tmp_path) -> None:
     registry = PermissionInputRegistry()
     store = A2ATaskStore()
-    await store.save(
-        Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING))
-    )
+    await store.save(Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)))
     queue = FakeEventQueue()
     publisher = PipelineA2AEventPublisher(
         event_queue=queue,
@@ -466,9 +462,7 @@ async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(m
     task = await store.get("task-1")
     assert task is not None
     task_metadata = MessageToDict(task.metadata, preserving_proto_field_name=False)
-    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [
-        requests[1]["inputId"]
-    ]
+    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [requests[1]["inputId"]]
     remaining = task_metadata["iac_code"]["pendingPermissions"][0]
     assert remaining["language"] == "zh"
     assert remaining["prompt"] == "是否允许本次操作：运行本地 Shell 命令？"

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from iac_code.pipeline.engine.complete_step_tool import CompleteStepTool
+from iac_code.pipeline.engine.complete_step_tool import CompleteStepTool, empty_conclusion_error
 from iac_code.pipeline.engine.types import StepConfig, StepStatus
 from iac_code.tools.base import ToolContext
 
@@ -1672,6 +1672,44 @@ class TestSchemaValidation:
             context=ToolContext(),
         )
         assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_empty_conclusion_rejected_without_schema(self):
+        """A schema-less step must still refuse an empty conclusion instead of completing with null."""
+        config = StepConfig(step_id="intent_parsing", conclusion_field="intent", forward=None)
+        tool = CompleteStepTool(config)
+        result = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
+        assert result.is_error
+        assert result.metadata is None
+        assert empty_conclusion_error("intent_parsing", "intent") in result.content
+
+    @pytest.mark.asyncio
+    async def test_explicit_failure_reason_conclusion_accepted(self):
+        """When no intent can be derived, an explicit reason is a valid, diagnosable conclusion."""
+        config = StepConfig(
+            step_id="intent_parsing",
+            conclusion_field="intent",
+            forward=None,
+            conclusion_schema={
+                "type": "object",
+                "required": ["is_infra_intent", "confidence"],
+                "properties": {
+                    "is_infra_intent": {"type": "boolean"},
+                    "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
+                    "rejection_reason": {"type": "string"},
+                },
+            },
+        )
+        tool = CompleteStepTool(config)
+        conclusion = {
+            "is_infra_intent": False,
+            "confidence": "high",
+            "rejection_reason": "无法从用户请求中派生部署目标",
+        }
+        result = await tool.execute(tool_input={"conclusion": conclusion}, context=ToolContext())
+        assert not result.is_error
+        assert result.metadata["step_result"].status == StepStatus.COMPLETED
+        assert result.metadata["step_result"].conclusion == conclusion
 
 
 class TestNullNormalization:

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -8,6 +8,7 @@ import pytest
 
 from iac_code.agent.message import Message, ToolResultBlock, ToolUseBlock
 from iac_code.commands.registry import PromptCommand
+from iac_code.pipeline.engine.complete_step_tool import empty_conclusion_error, missing_conclusion_error
 from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.step_executor import StepExecutor
 from iac_code.pipeline.engine.step_spec import IncludeExcludeConfig, LoadedPipeline, StepSpec, StepSurfaceOverride
@@ -636,7 +637,31 @@ class TestStepExecutor:
 
         results = [e for e in collected if isinstance(e, StepResult)]
         assert len(results) == 1
-        assert results[0].error == "No conclusion extracted"
+        assert results[0].error == missing_conclusion_error("intent_parsing", "intent")
+
+    @pytest.mark.asyncio
+    async def test_failed_when_complete_step_succeeds_with_empty_conclusion(self, tmp_path):
+        """A successful complete_step carrying an empty conclusion must fail loudly, not complete with null."""
+        events = [
+            ToolUseStartEvent(tool_use_id="tu_1", name="complete_step"),
+            ToolUseEndEvent(tool_use_id="tu_1", name="complete_step", input={"conclusion": {}}),
+            ToolResultEvent(tool_use_id="tu_1", tool_name="complete_step", result="ok"),
+        ]
+        fake_loop = _make_fake_agent_loop_class(events)
+        executor = _make_executor(tmp_path)
+        step = _make_step()
+        ctx = PipelineContext(SIMPLE_DEPS)
+
+        collected = []
+        with patch("iac_code.agent.agent_loop.AgentLoop", fake_loop):
+            async for event in executor.execute(step, ctx, "test_session"):
+                collected.append(event)
+
+        results = [e for e in collected if isinstance(e, StepResult)]
+        assert len(results) == 1
+        assert results[0].status == StepStatus.FAILED
+        assert results[0].error == empty_conclusion_error("intent_parsing", "intent")
+        assert ctx.get_conclusion(step.conclusion_field) is None
 
     @pytest.mark.asyncio
     async def test_nudge_retry_succeeds_on_second_attempt(self, tmp_path, caplog):
@@ -991,7 +1016,8 @@ class TestStepExecutor:
         results = [e for e in collected if isinstance(e, StepResult)]
         assert len(results) == 1
         assert results[0].status == StepStatus.FAILED
-        assert results[0].error == "No conclusion extracted"
+        assert results[0].error == missing_conclusion_error("intent_parsing", "intent")
+
         assert call_count[0] == 3
         assert executor._observability.step_nudged.call_args_list == [
             call(step_id="intent_parsing", nudge_count=1, max_nudges=2, session_id="test_session"),
@@ -2564,7 +2590,7 @@ class TestStepExecutorValidationRespect:
         results = [e for e in collected if isinstance(e, StepResult)]
         assert len(results) == 1
         assert results[0].status == StepStatus.FAILED
-        assert results[0].error == "No conclusion extracted"
+        assert results[0].error == missing_conclusion_error("intent_parsing", "intent")
 
     @pytest.mark.asyncio
     async def test_terminal_failed_step_result_stops_without_nudge(self, tmp_path):
@@ -3151,13 +3177,8 @@ async def test_resumed_step_returns_reconstructed_complete_step(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
-async def test_resumed_completed_step_sets_empty_conclusion_and_calls_on_exit(monkeypatch, tmp_path):
-    class FailIfAgentLoopIsCreated:
-        def __init__(self, *args, **kwargs):
-            raise AssertionError("AgentLoop should not be created for already-completed transcript")
-
-    monkeypatch.setattr("iac_code.agent.agent_loop.AgentLoop", FailIfAgentLoopIsCreated)
-
+async def test_resumed_empty_conclusion_is_not_restored_as_completed(tmp_path):
+    """An empty resumed conclusion must not be replayed as a silent COMPLETED null result."""
     executor = _make_executor(tmp_path)
     step = _make_step()
     step.on_exit = MagicMock()
@@ -3170,23 +3191,34 @@ async def test_resumed_completed_step_sets_empty_conclusion_and_calls_on_exit(mo
         Message(role="user", content=[ToolResultBlock(tool_use_id="tu_complete", content="ok", is_error=False)]),
     ]
 
+    class FakeAgentLoopNoConclusion:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def continue_streaming(self):
+            yield TextDeltaEvent(text="no conclusion this time")
+
+        async def run_streaming(self, user_input):
+            yield TextDeltaEvent(text="still no conclusion")
+
     results = []
-    async for event in executor.execute(
-        step,
-        ctx,
-        session_id="root",
-        attempt_id="att_0001",
-        transcript_id="transcript_att_0001",
-        resume_messages=resume_messages,
-    ):
-        if isinstance(event, StepResult):
-            results.append(event)
+    with patch("iac_code.agent.agent_loop.AgentLoop", FakeAgentLoopNoConclusion):
+        async for event in executor.execute(
+            step,
+            ctx,
+            session_id="root",
+            attempt_id="att_0001",
+            transcript_id="transcript_att_0001",
+            resume_messages=resume_messages,
+        ):
+            if isinstance(event, StepResult):
+                results.append(event)
 
     assert len(results) == 1
-    assert results[0].status == StepStatus.COMPLETED
-    assert results[0].conclusion == {}
-    assert ctx.get_conclusion(step.conclusion_field) == {}
-    step.on_exit.assert_called_once_with(ctx, {})
+    assert results[0].status == StepStatus.FAILED
+    assert results[0].error == missing_conclusion_error("intent_parsing", "intent")
+    assert ctx.get_conclusion(step.conclusion_field) is None
+    step.on_exit.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -2776,11 +2776,15 @@ class TestStepExecutorSchemaWiring:
             surface="a2a_rich",
         )
 
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=True,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=True,
+            )
+            .get("complete_step")
+            .input_schema
+        )
         conclusion_schema = tool_schema["properties"]["conclusion"]
         assert conclusion_schema["required"] == [
             "selected_candidate_name",
@@ -2863,11 +2867,15 @@ class TestStepExecutorSchemaWiring:
             context,
             resume_candidate_selection=True,
         )
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=preserved is not None,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=preserved is not None,
+            )
+            .get("complete_step")
+            .input_schema
+        )
 
         assert preserved is None
         conclusion_schema = tool_schema["properties"]["conclusion"]

--- a/tests/pipeline/engine/test_sub_pipeline_executor.py
+++ b/tests/pipeline/engine/test_sub_pipeline_executor.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from iac_code.agent.message import ImageBlock, Message, ToolResultBlock, ToolUseBlock
+from iac_code.pipeline.engine.complete_step_tool import missing_conclusion_error
 from iac_code.pipeline.engine.context import PipelineContext
 from iac_code.pipeline.engine.events import PipelineEvent, PipelineEventType
 from iac_code.pipeline.engine.state_machine import StateMachine
@@ -1171,7 +1172,7 @@ class TestSubPipelineExecutor:
             )
 
         assert result.failed is True
-        assert result.error == "No conclusion extracted"
+        assert result.error == missing_conclusion_error("template_generating", "template")
 
     @pytest.mark.asyncio
     async def test_execute_streaming_failed_step_emits_sub_step_failed_before_terminal(self, tmp_path, monkeypatch):

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -133,9 +133,7 @@ def test_confirm_prompt_tells_model_to_preserve_parameter_overrides():
 def test_confirm_prompts_share_selection_contract_structure():
     repl_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.md").read_text(encoding="utf-8")
     a2a_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.md").read_text(encoding="utf-8")
-    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(
-        encoding="utf-8"
-    )
+    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(encoding="utf-8")
 
     shared_fragments = [
         "## 首次执行",

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -1676,9 +1676,7 @@ class TestProviderManagerCompleteRetry:
 
     async def test_complete_attributes_bailian_openai_endpoint_to_dashscope_on_all_signals(self):
         mock_provider = AsyncMock()
-        mock_provider._base_url = (
-            "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
-        )
+        mock_provider._base_url = "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
         mock_provider.complete = AsyncMock(
             return_value=NonStreamingResponse(
                 message_id="complete-response",

--- a/tests/skill_bridge/test_iac_code_bridge.py
+++ b/tests/skill_bridge/test_iac_code_bridge.py
@@ -542,12 +542,10 @@ def test_bridge_automatically_runs_cleanup_only_task_and_restores_pipeline_resul
 
     assert len(captured_payloads) == 2
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True for payload in captured_payloads
     )
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host"
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host" for payload in captured_payloads
     )
     assert captured_payloads[0]["params"]["message"]["contextId"] == "ctx-pipeline-1"
     assert result["state"] == "completed"
@@ -1138,9 +1136,7 @@ def test_candidate_presentation_survives_bounded_bridge_projection() -> None:
                                     "summary": "单 ECS 低成本方案。",
                                     "architectureDiagram": "flowchart LR\nU[用户] --> E[ECS]",
                                     "totalMonthlyCost": "¥88/月",
-                                    "costItems": [
-                                        {"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}
-                                    ],
+                                    "costItems": [{"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}],
                                 }
                             ],
                             "required": True,

--- a/tests/skill_bridge/test_runtime_release.py
+++ b/tests/skill_bridge/test_runtime_release.py
@@ -104,9 +104,7 @@ def test_runtime_archive_and_version_marker_are_rooted_consistently(tmp_path: Pa
     assert "artifactRevision" not in marker
 
 
-def test_runtime_a2a_smoke_checks_health_and_agent_card(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_runtime_a2a_smoke_checks_health_and_agent_card(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module("skill_runtime_smoke", BUILD_SCRIPT)
     server = tmp_path / "server.py"
     server.write_text(

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -2547,7 +2547,7 @@ def test_completed_turn_collapses_process_into_summary() -> None:
     # 「已处理」组的展开态必须跨重建保留:openKey 让 toggle 记录器登记用户操作、
     # applyDetailsOpenOverrides 在重建后恢复;键取 turnId,缺 turnId 时回退首条消息 id。
     assert 'const turnKey = turnId || text(agentMessages[0]?.messageId || agentMessages[0]?.id || "");' in app_source
-    assert 'details.dataset.openKey = `turnproc:${turnKey}`;' in app_source
+    assert "details.dataset.openKey = `turnproc:${turnKey}`;" in app_source
 
     # 只有最后一次工具调用之后的文本才是「最终回答」;此前每个步骤的文本旁白
     # (夹在工具调用之间的 text delta)连同思考、工具一起折进「已处理」,不平铺成答案。


### PR DESCRIPTION
## 背景

关联 Harness 工作项 `b89a60c0-31aa-4bee-8c60-658dddf54e96`（Aone #84646336）。

证据 Session `04bcd1547fc2401faa9a44feacfae93d` / `9f723005c4dc42eda19043ad40d5b41d` / `7c847f02694d4c718db85a29c20fc391` 中，`intent_parsing` 步骤的 `conclusion` 与 session `intent` 同时为 `null`，但步骤状态是 `completed`、`complete_step` 工具结果 `is_error=false`，解析失败被完全静默化。

## 根因

1. `CompleteStepTool._validate_conclusion` 只做 JSON Schema 校验。空对象 `{}` 在没有 `conclusion_schema`、或 schema 未把字段列入 `required` 的情况下都能通过校验，工具因此返回 `is_error=false`。
2. `StepExecutor` 拿到 `complete_step_input` 后无条件构造 `StepStatus.COMPLETED`，并把空 conclusion 写进 `PipelineContext`。
3. 于是 `STEP_COMPLETED` 事件把空 conclusion 传播下去，下游 `architecture_planning`（`context_fields: [intent]`）拿不到 intent，既无候选/产物输出，链路上也没有任何 `failed` 信号可供定位。
4. 兜底失败分支的 `error` 是固定串 `"No conclusion extracted"`，不含 step_id 与期望字段，同样无法诊断。

## 改动

- **`complete_step_tool.py`**：新增 `is_empty_conclusion` / `empty_conclusion_error` / `missing_conclusion_error` 三个共享 helper。`_validate_conclusion` 在 schema 校验**之前**拒绝空 conclusion，无 `conclusion_schema` 的步骤同样不再放行；复用既有 `max_conclusion_retries` 预算，让模型能在本步内自行修正，超限则落到 `StepStatus.FAILED`。
- **`step_executor.py`**：成功分支遇到空 conclusion 时不再 `set_conclusion`、不再触发 `on_exit`，直接产出带可诊断原因的 `FAILED`；失败分支的固定串换成含 `step_id` 与 `conclusion_field` 的诊断文案，经 `step_failed` / `STEP_FAILED` 传播供下游决策。

文案按 `AGENTS.md` 使用 `_()` + `str.format`，未用 f-string 包裹 `_()`。

## 影响范围控制

只拒绝**完全没有字段**的 conclusion（`None` / 非 dict / `{}`）。`candidates: []` 这类已明确表态的结论仍然有效，避免误伤正常步骤。

## 验证

- 新增用例：`complete_step` 提交 `{"conclusion": {}}` 被拒；无 schema 步骤的空 conclusion 被拒；resume 场景的空 conclusion 不再被重放成 `COMPLETED`；`is_infra_intent: false` + `rejection_reason` 的显式失败原因正常通过。
- 更新既有 4 处对 `"No conclusion extracted"` 的固定串断言。
- 回归 `tests/pipeline` `tests/a2a` `tests/a2a_e2e` `tests/web/test_pipeline_transcript.py`：**3225 passed**。
- `make lint`（`ruff check` + `ty check`）全部通过。

唯一失败项 `test_prerequisites.py::test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` 与本次改动无关：在 base commit `88ed89c` 上同样失败，原因是环境内 urllib3 版本对非法 URL 抛 `HTTPError` 而非 `InvalidURL`。

## 附带提交

`e212d6e` 是纯格式化提交。仓库内 16 个文件仍是旧版 ruff 格式化的结果，而 `uv.lock` 锁定的 ruff 已是 0.15.10，导致 pre-commit 的 `format` 钩子在**任何**提交上都会改动这些无关文件而失败。单独提交格式化结果以保证钩子通过，并让业务提交的 diff 保持干净；该提交无逻辑变更。
