### PR TITLE
fix(aliyun): 仅持有 StackName 时阻断需 StackId 的 ROS 接口调用

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1731,9 +1731,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             raise ValueError("Invalid A2A workspace metadata.")
         logical_cwd = os.path.normpath(cwd)
         resolved_cwd = resolve_workspace_path(Path(logical_cwd))
-        if not trust_request_cwd() and not any(
-            _is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()
-        ):
+        if not trust_request_cwd() and not any(_is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()):
             raise ValueError("Invalid A2A workspace metadata.")
         if resolved_cwd.exists():
             if not resolved_cwd.is_dir():

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -178,35 +178,29 @@ def permission_display_fields(request: PermissionRequestEvent, *, language: str 
             command = safe_input.get("command") or safe_input.get("cmd")
         if isinstance(command, str) and command.strip():
             command_fallback = translate_message("shell command", language=language)
-            target = translate_message(
-                "the current local workspace; command: {command}", language=language
-            ).format(command=_display_text(command, fallback=command_fallback, maximum=240))
+            target = translate_message("the current local workspace; command: {command}", language=language).format(
+                command=_display_text(command, fallback=command_fallback, maximum=240)
+            )
         else:
             target = translate_message("the current local workspace", language=language)
         effect = "read" if is_read_only else ("local_execution" if read_only_known else "unknown")
     elif tool_name in {"write_file", "edit_file"}:
         title = translate_message("Change a workspace file", language=language)
-        purpose = translate_message(
-            "Write a file needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Write a file needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "a file in the current workspace", language=language
         )
         effect = "file_change"
     elif tool_name in {"read_file", "glob", "grep"} or is_read_only:
         title = translate_message("Read workspace data with {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Read local data needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Read local data needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current local workspace", language=language
         )
         effect = "read"
     else:
         title = translate_message("Run {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Run this operation for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Run this operation for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current task workspace or cloud account", language=language
         )
@@ -319,9 +313,7 @@ def _cloud_operation_title(product: str, action: str, *, is_read_only: bool, lan
     if action == "CreateStack":
         return translate_message("Create {product} stack", language=language).format(product=product_label)
     if action == "ContinueCreateStack":
-        return translate_message("Continue creating {product} stack", language=language).format(
-            product=product_label
-        )
+        return translate_message("Continue creating {product} stack", language=language).format(product=product_label)
     if action == "UpdateStack":
         return translate_message("Update {product} stack", language=language).format(product=product_label)
     if action == "DeleteStack":
@@ -344,9 +336,7 @@ def _safe_input_target(value: Any, *, language: str) -> str:
     for key in ("file_path", "filePath", "path", "region_id", "regionId", "resource_id", "resourceId"):
         candidate = value.get(key)
         if isinstance(candidate, str) and candidate.strip():
-            return _display_text(
-                candidate, fallback=translate_message("the current task scope", language=language)
-            )
+            return _display_text(candidate, fallback=translate_message("the current task scope", language=language))
     return ""
 
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -1235,11 +1235,7 @@ class IacCodeA2APipelineExecutor:
             def permission_context_getter() -> Any:
                 return getattr(agent_loop, "_permission_context", None)
 
-        surface = (
-            A2A_RICH_CANDIDATE_SURFACE
-            if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION
-            else "a2a"
-        )
+        surface = A2A_RICH_CANDIDATE_SURFACE if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION else "a2a"
         return create_pipeline(
             pipeline_name,
             provider_manager=runtime.provider_manager,

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -864,9 +864,7 @@ class A2ATaskStore(TaskStore):
                 any(record.active_task is not None and not record.active_task.done() for record in self._tasks.values())
                 or any(not task.done() for task in self._context_runtime_tasks.values())
                 or any(
-                    not task.done()
-                    for starts in self._context_execution_starts.values()
-                    for task in starts.values()
+                    not task.done() for starts in self._context_execution_starts.values() for task in starts.values()
                 )
                 or any(self._context_reconciliation_waiters.values())
                 or any(lock.locked() for lock in self._reconciliation_locks.values())

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -6111,6 +6111,17 @@ msgstr ""
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} requires parameter StackId. When only the "
+"stack name is known, call ListStacks filtered by StackName to read "
+"StackId first."
+msgstr ""
+"Die Alibaba Cloud API {operation} erfordert den Parameter StackId. Wenn "
+"nur der Stack-Name bekannt ist, rufen Sie zuerst ListStacks mit einem "
+"Filter auf StackName auf, um die StackId zu lesen."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
 msgid "Alibaba Cloud API {operation} requires parameter {parameter}."
 msgstr "Die Alibaba-Cloud-API {operation} benötigt den Parameter {parameter}."
 
@@ -6735,6 +6746,33 @@ msgstr ""
 "Speichern Sie die Vorlage in einer Datei und übergeben Sie "
 "params.TemplateURL, zum Beispiel einen lokalen Dateipfad oder eine OSS"
 "/HTTP-URL."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides only StackName."
+msgstr "{} erfordert StackId, aber die Anfrage liefert nur StackName."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides no stack identifier."
+msgstr "{} erfordert StackId, aber die Anfrage liefert keine Stack-Kennung."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+msgid ""
+"This operation targets a stack by StackId only; StackName is not an "
+"accepted target."
+msgstr ""
+"Dieser Vorgang adressiert einen Stack ausschließlich über StackId; "
+"StackName ist kein zulässiges Ziel."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid ""
+"Call ListStacks filtered by StackName first, read StackId from the "
+"result, then call {} with it."
+msgstr ""
+"Rufen Sie zuerst ListStacks mit einem Filter auf StackName auf, lesen Sie"
+" die StackId aus dem Ergebnis und rufen Sie damit {} auf."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -6074,6 +6074,17 @@ msgstr ""
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} requires parameter StackId. When only the "
+"stack name is known, call ListStacks filtered by StackName to read "
+"StackId first."
+msgstr ""
+"La API de Alibaba Cloud {operation} requiere el parámetro StackId. Si "
+"solo se conoce el nombre de la pila, llame primero a ListStacks filtrando"
+" por StackName para obtener el StackId."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
 msgid "Alibaba Cloud API {operation} requires parameter {parameter}."
 msgstr "La API de Alibaba Cloud {operation} requiere el parámetro {parameter}."
 
@@ -6703,6 +6714,35 @@ msgstr ""
 "params.TemplateURL. Guarda la plantilla en un archivo y pasa "
 "params.TemplateURL, por ejemplo una ruta de archivo local o una URL "
 "OSS/HTTP."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides only StackName."
+msgstr "{} requiere StackId, pero la solicitud solo proporciona StackName."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides no stack identifier."
+msgstr ""
+"{} requiere StackId, pero la solicitud no proporciona ningún "
+"identificador de pila."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+msgid ""
+"This operation targets a stack by StackId only; StackName is not an "
+"accepted target."
+msgstr ""
+"Esta operación identifica la pila únicamente por StackId; StackName no es"
+" un destino admitido."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid ""
+"Call ListStacks filtered by StackName first, read StackId from the "
+"result, then call {} with it."
+msgstr ""
+"Llame primero a ListStacks filtrando por StackName, obtenga el StackId "
+"del resultado y luego use ese valor para llamar a {}."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -6093,6 +6093,17 @@ msgstr ""
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} requires parameter StackId. When only the "
+"stack name is known, call ListStacks filtered by StackName to read "
+"StackId first."
+msgstr ""
+"L’API Alibaba Cloud {operation} exige le paramètre StackId. Si seul le "
+"nom de la pile est connu, appelez d’abord ListStacks en filtrant sur "
+"StackName pour lire le StackId."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
 msgid "Alibaba Cloud API {operation} requires parameter {parameter}."
 msgstr "L'API Alibaba Cloud {operation} nécessite le paramètre {parameter}."
 
@@ -6718,6 +6729,33 @@ msgstr ""
 "params.TemplateURL. Enregistrez le modèle dans un fichier et transmettez "
 "params.TemplateURL, par exemple un chemin de fichier local ou une URL "
 "OSS/HTTP."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides only StackName."
+msgstr "{} exige StackId, mais la requête ne fournit que StackName."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides no stack identifier."
+msgstr "{} exige StackId, mais la requête ne fournit aucun identifiant de pile."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+msgid ""
+"This operation targets a stack by StackId only; StackName is not an "
+"accepted target."
+msgstr ""
+"Cette opération cible une pile uniquement par StackId ; StackName n’est "
+"pas une cible acceptée."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid ""
+"Call ListStacks filtered by StackName first, read StackId from the "
+"result, then call {} with it."
+msgstr ""
+"Appelez d’abord ListStacks en filtrant sur StackName, lisez le StackId "
+"dans le résultat, puis appelez {} avec celui-ci."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -5779,6 +5779,16 @@ msgstr "Alibaba Cloud API {operation} のバイナリリクエストボディに
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} requires parameter StackId. When only the "
+"stack name is known, call ListStacks filtered by StackName to read "
+"StackId first."
+msgstr ""
+"Alibaba Cloud API {operation} にはパラメーター StackId が必要です。スタック名しか分からない場合は、まず "
+"StackName でフィルターした ListStacks を呼び出して StackId を取得してください。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
 msgid "Alibaba Cloud API {operation} requires parameter {parameter}."
 msgstr "Alibaba Cloud API {operation} にはパラメーター {parameter} が必要です。"
 
@@ -6351,6 +6361,31 @@ msgstr ""
 "ROS パイプラインで {action} を呼び出す場合は、params.TemplateURL "
 "を渡す必要があります。テンプレートをファイルに保存し、ローカルファイルパスまたは OSS/HTTP URL などを "
 "params.TemplateURL として渡してください。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides only StackName."
+msgstr "{} には StackId が必要ですが、リクエストには StackName しか指定されていません。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides no stack identifier."
+msgstr "{} には StackId が必要ですが、リクエストにスタック識別子が指定されていません。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+msgid ""
+"This operation targets a stack by StackId only; StackName is not an "
+"accepted target."
+msgstr "この操作はスタックを StackId でのみ指定します。StackName は対象として受け付けられません。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid ""
+"Call ListStacks filtered by StackName first, read StackId from the "
+"result, then call {} with it."
+msgstr ""
+"まず StackName でフィルターした ListStacks を呼び出し、結果から StackId を取得してから、それを使って {} "
+"を呼び出してください。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -6035,6 +6035,17 @@ msgstr ""
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} requires parameter StackId. When only the "
+"stack name is known, call ListStacks filtered by StackName to read "
+"StackId first."
+msgstr ""
+"A API da Alibaba Cloud {operation} requer o parâmetro StackId. Se apenas "
+"o nome da pilha for conhecido, chame primeiro ListStacks filtrando por "
+"StackName para obter o StackId."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
 msgid "Alibaba Cloud API {operation} requires parameter {parameter}."
 msgstr "A API do Alibaba Cloud {operation} requer o parâmetro {parameter}."
 
@@ -6660,6 +6671,35 @@ msgstr ""
 "params.TemplateURL. Salve o modelo em um arquivo e passe "
 "params.TemplateURL, por exemplo um caminho de arquivo local ou uma URL "
 "OSS/HTTP."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides only StackName."
+msgstr "{} requer StackId, mas a solicitação fornece apenas StackName."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides no stack identifier."
+msgstr ""
+"{} requer StackId, mas a solicitação não fornece nenhum identificador de "
+"pilha."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+msgid ""
+"This operation targets a stack by StackId only; StackName is not an "
+"accepted target."
+msgstr ""
+"Esta operação identifica a pilha somente por StackId; StackName não é um "
+"destino aceito."
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid ""
+"Call ListStacks filtered by StackName first, read StackId from the "
+"result, then call {} with it."
+msgstr ""
+"Chame primeiro ListStacks filtrando por StackName, obtenha o StackId do "
+"resultado e depois chame {} com ele."
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -5700,6 +5700,16 @@ msgstr "阿里云 API {operation} 的二进制请求体需要 body_file。"
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} requires parameter StackId. When only the "
+"stack name is known, call ListStacks filtered by StackName to read "
+"StackId first."
+msgstr ""
+"阿里云 API {operation} 需要参数 StackId。若仅知道资源栈名称，请先调用 ListStacks 并按 StackName "
+"过滤以获取 StackId。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
 msgid "Alibaba Cloud API {operation} requires parameter {parameter}."
 msgstr "阿里云 API {operation} 需要参数 {parameter}。"
 
@@ -6190,6 +6200,29 @@ msgid ""
 msgstr ""
 "ROS pipeline 调用 {action} 必须传入 params.TemplateURL。请将模板保存到文件，并传入 "
 "params.TemplateURL，例如本地文件路径或 OSS/HTTP URL。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides only StackName."
+msgstr "{} 需要 StackId，但请求只提供了 StackName。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid "{} requires StackId, but the request provides no stack identifier."
+msgstr "{} 需要 StackId，但请求没有提供任何资源栈标识。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+msgid ""
+"This operation targets a stack by StackId only; StackName is not an "
+"accepted target."
+msgstr "该操作只能通过 StackId 定位资源栈，不接受 StackName 作为目标。"
+
+#: src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+#, python-brace-format
+msgid ""
+"Call ListStacks filtered by StackName first, read StackId from the "
+"result, then call {} with it."
+msgstr "请先调用按 StackName 过滤的 ListStacks，从结果中取出 StackId，再用它调用 {}。"
 
 #: src/iac_code/tools/cloud/aliyun/hooks/ros_validate.py
 msgid "The local ROS template file cannot be read."

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -343,9 +343,7 @@ def _parse_surface_overrides(raw: object, step_id: str) -> dict[str, StepSurface
 
         conclusion_schema = override.get("conclusion_schema")
         if conclusion_schema is not None and not isinstance(conclusion_schema, dict):
-            raise ValueError(
-                f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping"
-            )
+            raise ValueError(f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping")
 
         overrides[surface] = StepSurfaceOverride(
             prompt_file=prompt,

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -93,6 +93,8 @@ _REAL_RESTORE_FAILURE_REASONS = {
 
 def _is_a2a_surface(surface: str) -> bool:
     return surface == "a2a" or surface.startswith("a2a_")
+
+
 _SIDECAR_ROOT_DIRS = {"a2a", "image-cache", "pipeline", "tool-results"}
 _SIDECAR_ROOT_FILES = {
     ".backup-state.json",

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -298,9 +298,7 @@ class AliyunCredentials:
 
             owns_client = oauth_client is None
             client = (
-                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type))
-                if oauth_client is None
-                else oauth_client
+                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type)) if oauth_client is None else oauth_client
             )
 
             try:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -149,8 +149,7 @@ class StagedSessionBackupService(SessionBackupService):
                         existing = self._read_existing_snapshot_state(destination, session_id)
                         if existing is not None:
                             completed_next = (
-                                base_state.status == "succeeded"
-                                and existing.parent_generation == base_state.generation
+                                base_state.status == "succeeded" and existing.parent_generation == base_state.generation
                             )
                             if not completed_next and not existing.same_lineage(committed_state):
                                 raise SessionBackupConflict(

--- a/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
@@ -166,6 +166,17 @@ auto_trigger:
 - 使用 ros_stack 工具执行 CreateStack/UpdateStack/ContinueCreateStack/DeleteStack，禁止用 Bash
 - CreateStack 必须传 `DisableRollback: true`
 
+## 按 StackName 查询资源栈
+
+`GetStack`、`ListStackResources`、`ListStackEvents`、`DeleteStack`、`UpdateStack` 等资源栈操作只接受 `StackId`，不接受 `StackName`。
+
+用户只给出资源栈名称（无 StackId）时：
+1. 先调用 `aliyun_api(product="ros", action="ListStacks", params={"StackName": "<名称>"})`，不要先调用 `GetStack`
+2. 从返回的 `Stacks` 中取 `StackId`
+3. 再用该 `StackId` 调用目标操作
+
+`ListStacks` 返回 `TotalCount=0` 时说明该地域下不存在同名资源栈，直接告知用户并确认地域，不要改用其他接口重试。
+
 ## 参考文件
 
 | 文件 | 内容 |

--- a/src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
+++ b/src/iac_code/tools/cloud/aliyun/hooks/ros_stack_identifier.py
@@ -1,0 +1,82 @@
+"""Pre-call hook rejecting ROS stack actions that lack the required StackId."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from iac_code.i18n import _
+from iac_code.tools.base import ToolContext
+from iac_code.tools.cloud.aliyun.api_hooks import before_call
+from iac_code.tools.cloud.aliyun.ros_validation.model import (
+    Category,
+    Severity,
+    ValidationReport,
+    make_diagnostic,
+)
+from iac_code.tools.cloud.aliyun.ros_validation.outcome import (
+    RosPreflightOutcome,
+    outcome_from_report,
+)
+
+# Actions of the locked ROS 2019-09-10 API (SDK 3.6.0) whose request model
+# requires StackId and does not accept StackName as an alternative target.
+STACK_ID_REQUIRED_ACTIONS = (
+    "CancelStackOperation",
+    "CancelUpdateStack",
+    "ContinueCreateStack",
+    "DeleteStack",
+    "DetectStackDrift",
+    "DetectStackResourceDrift",
+    "GetStack",
+    "GetStackPolicy",
+    "GetStackResource",
+    "ListChangeSets",
+    "ListStackEvents",
+    "ListStackResourceDrifts",
+    "ListStackResources",
+    "SetDeletionProtection",
+    "SetStackPolicy",
+    "SignalResource",
+    "UpdateStack",
+    "UpdateStackTemplateByResources",
+)
+
+
+def _present(params: Mapping[str, Any], field: str) -> bool:
+    value = params.get(field)
+    if isinstance(value, str):
+        return bool(value.strip())
+    return value is not None and value != [] and value != {}
+
+
+@before_call("ros", list(STACK_ID_REQUIRED_ACTIONS))
+def check_stack_identifier(
+    product: str,
+    action: str,
+    params: dict[str, Any],
+    *,
+    context: ToolContext | None = None,
+) -> RosPreflightOutcome | None:
+    """Block a stack action when the caller holds no StackId to target it with."""
+
+    del product, context
+    if _present(params, "StackId"):
+        return None
+    has_stack_name = _present(params, "StackName")
+    diagnostic = make_diagnostic(
+        code="ROS1203",
+        severity=Severity.ERROR,
+        category=Category.COMPATIBILITY,
+        summary=_("{} requires StackId, but the request provides only StackName.").format(action)
+        if has_stack_name
+        else _("{} requires StackId, but the request provides no stack identifier.").format(action),
+        detail=_("This operation targets a stack by StackId only; StackName is not an accepted target."),
+        subject="stack-identifier",
+        stable_args=(action, "stack-name-only" if has_stack_name else "no-stack-identifier"),
+        expected="StackId",
+        suggestion=_(
+            "Call ListStacks filtered by StackName first, read StackId from the result, then call {} with it."
+        ).format(action),
+    )
+    return outcome_from_report(ValidationReport.build([diagnostic], analysis_incomplete=False))

--- a/src/iac_code/tools/cloud/aliyun/public_errors.py
+++ b/src/iac_code/tools/cloud/aliyun/public_errors.py
@@ -158,6 +158,11 @@ def public_aliyun_error(
             return _("Alibaba Cloud API {operation} requires body_file for its binary request body.").format(
                 operation=operation
             )
+        if parameter == "StackId" and safe_product.casefold() in {"ros", "resourceorchestrationservice"}:
+            return _(
+                "Alibaba Cloud API {operation} requires parameter StackId. "
+                "When only the stack name is known, call ListStacks filtered by StackName to read StackId first."
+            ).format(operation=operation)
         if parameter is not None and "," not in parameter:
             return _("Alibaba Cloud API {operation} requires parameter {parameter}.").format(
                 operation=operation,

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -3788,12 +3788,10 @@ class TestResolveCandidatePresentation:
         executor = self._make_executor()
 
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}}) == "rich-v1"
         )
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}}) == "rich-v1"
         )
 
     def test_rejects_unknown_or_missing_presentation(self) -> None:

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -240,9 +240,7 @@ def test_ros_deployment_permission_is_localized_and_preserves_safe_plan_summary(
                         "stackName": "demo-stack",
                         "template": "templates/demo.yml",
                         "totalMonthlyCost": "¥88/月",
-                        "resources": [
-                            {"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}
-                        ],
+                        "resources": [{"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}],
                     },
                 },
             ),
@@ -388,9 +386,7 @@ async def test_pipeline_permission_uses_same_input_envelope_and_waits_serially(m
 async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(monkeypatch, tmp_path) -> None:
     registry = PermissionInputRegistry()
     store = A2ATaskStore()
-    await store.save(
-        Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING))
-    )
+    await store.save(Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)))
     queue = FakeEventQueue()
     publisher = PipelineA2AEventPublisher(
         event_queue=queue,
@@ -466,9 +462,7 @@ async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(m
     task = await store.get("task-1")
     assert task is not None
     task_metadata = MessageToDict(task.metadata, preserving_proto_field_name=False)
-    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [
-        requests[1]["inputId"]
-    ]
+    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [requests[1]["inputId"]]
     remaining = task_metadata["iac_code"]["pendingPermissions"][0]
     assert remaining["language"] == "zh"
     assert remaining["prompt"] == "是否允许本次操作：运行本地 Shell 命令？"

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -2776,11 +2776,15 @@ class TestStepExecutorSchemaWiring:
             surface="a2a_rich",
         )
 
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=True,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=True,
+            )
+            .get("complete_step")
+            .input_schema
+        )
         conclusion_schema = tool_schema["properties"]["conclusion"]
         assert conclusion_schema["required"] == [
             "selected_candidate_name",
@@ -2863,11 +2867,15 @@ class TestStepExecutorSchemaWiring:
             context,
             resume_candidate_selection=True,
         )
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=preserved is not None,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=preserved is not None,
+            )
+            .get("complete_step")
+            .input_schema
+        )
 
         assert preserved is None
         conclusion_schema = tool_schema["properties"]["conclusion"]

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -133,9 +133,7 @@ def test_confirm_prompt_tells_model_to_preserve_parameter_overrides():
 def test_confirm_prompts_share_selection_contract_structure():
     repl_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.md").read_text(encoding="utf-8")
     a2a_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.md").read_text(encoding="utf-8")
-    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(
-        encoding="utf-8"
-    )
+    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(encoding="utf-8")
 
     shared_fragments = [
         "## 首次执行",

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -1676,9 +1676,7 @@ class TestProviderManagerCompleteRetry:
 
     async def test_complete_attributes_bailian_openai_endpoint_to_dashscope_on_all_signals(self):
         mock_provider = AsyncMock()
-        mock_provider._base_url = (
-            "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
-        )
+        mock_provider._base_url = "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
         mock_provider.complete = AsyncMock(
             return_value=NonStreamingResponse(
                 message_id="complete-response",

--- a/tests/skill_bridge/test_iac_code_bridge.py
+++ b/tests/skill_bridge/test_iac_code_bridge.py
@@ -542,12 +542,10 @@ def test_bridge_automatically_runs_cleanup_only_task_and_restores_pipeline_resul
 
     assert len(captured_payloads) == 2
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True for payload in captured_payloads
     )
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host"
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host" for payload in captured_payloads
     )
     assert captured_payloads[0]["params"]["message"]["contextId"] == "ctx-pipeline-1"
     assert result["state"] == "completed"
@@ -1138,9 +1136,7 @@ def test_candidate_presentation_survives_bounded_bridge_projection() -> None:
                                     "summary": "单 ECS 低成本方案。",
                                     "architectureDiagram": "flowchart LR\nU[用户] --> E[ECS]",
                                     "totalMonthlyCost": "¥88/月",
-                                    "costItems": [
-                                        {"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}
-                                    ],
+                                    "costItems": [{"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}],
                                 }
                             ],
                             "required": True,

--- a/tests/skill_bridge/test_runtime_release.py
+++ b/tests/skill_bridge/test_runtime_release.py
@@ -104,9 +104,7 @@ def test_runtime_archive_and_version_marker_are_rooted_consistently(tmp_path: Pa
     assert "artifactRevision" not in marker
 
 
-def test_runtime_a2a_smoke_checks_health_and_agent_card(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_runtime_a2a_smoke_checks_health_and_agent_card(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module("skill_runtime_smoke", BUILD_SCRIPT)
     server = tmp_path / "server.py"
     server.write_text(

--- a/tests/tools/cloud/aliyun/test_public_errors.py
+++ b/tests/tools/cloud/aliyun/test_public_errors.py
@@ -136,6 +136,8 @@ def test_aliyun_public_error_templates_are_directly_extractable(tmp_path: Path) 
         "Alibaba Cloud API {operation} received multiple template sources. Provide only one.",
         "Alibaba Cloud API {operation} requires a body source compatible with its API contract.",
         "Alibaba Cloud API {operation} requires parameter {parameter}.",
+        "Alibaba Cloud API {operation} requires parameter StackId. "
+        "When only the stack name is known, call ListStacks filtered by StackName to read StackId first.",
         "Alibaba Cloud API {operation} template file is invalid. Use a readable regular template file.",
         "Alibaba Cloud API {operation} template validation failed. Check the template syntax and resource definitions.",
         "Alibaba Cloud API {operation} was not found. Check the product, version, and action.",
@@ -236,6 +238,17 @@ def test_missing_required_parameter_error_reports_every_safe_name_without_values
 
     assert message == "Alibaba Cloud API Ecs/DescribeInstances requires parameters InstanceId,RegionId."
     assert "business-value" not in message
+
+
+def test_missing_ros_stack_id_error_points_at_list_stacks_by_name() -> None:
+    error = ApiContractError("missing_required_parameters:StackId")
+
+    message = public_aliyun_error(error, product="ros", action="GetStack")
+
+    assert message == (
+        "Alibaba Cloud API ros/GetStack requires parameter StackId. "
+        "When only the stack name is known, call ListStacks filtered by StackName to read StackId first."
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/cloud/aliyun/test_ros_stack_identifier_hook.py
+++ b/tests/tools/cloud/aliyun/test_ros_stack_identifier_hook.py
@@ -1,0 +1,66 @@
+"""Tests for the ROS stack identifier pre-call hook."""
+
+from __future__ import annotations
+
+import pytest
+
+from iac_code.tools.base import ToolContext
+from iac_code.tools.cloud.aliyun.api_hooks import run_hooks
+from iac_code.tools.cloud.aliyun.hooks.ros_stack_identifier import (
+    STACK_ID_REQUIRED_ACTIONS,
+    check_stack_identifier,
+)
+
+
+@pytest.mark.parametrize("action", STACK_ID_REQUIRED_ACTIONS)
+def test_stack_name_only_is_blocked_for_every_stack_id_action(action: str) -> None:
+    outcome = check_stack_identifier("ros", action, {"StackName": "demo-stack", "RegionId": "cn-hangzhou"})
+
+    assert outcome is not None
+    assert outcome.is_error
+    diagnostic = outcome.report.diagnostics[0]
+    assert diagnostic.code == "ROS1203"
+    assert diagnostic.expected == "StackId"
+    assert "ListStacks" in (diagnostic.suggestion or "")
+
+
+def test_missing_both_identifiers_is_blocked_with_a_distinct_reason() -> None:
+    outcome = check_stack_identifier("ros", "GetStack", {"RegionId": "cn-hangzhou"})
+
+    assert outcome is not None and outcome.is_error
+    assert "no stack identifier" in outcome.report.diagnostics[0].summary
+
+
+def test_blank_stack_id_counts_as_missing() -> None:
+    outcome = check_stack_identifier("ros", "GetStack", {"StackId": "   ", "StackName": "demo-stack"})
+
+    assert outcome is not None and outcome.is_error
+
+
+def test_present_stack_id_passes() -> None:
+    assert check_stack_identifier("ros", "GetStack", {"StackId": "stack-id", "StackName": "demo-stack"}) is None
+
+
+def test_stage_zero_chain_blocks_get_stack_by_name_without_mutating_params() -> None:
+    params = {"StackName": "it-s03-20260728-192023-f2a57221", "RegionId": "cn-hangzhou"}
+    context = ToolContext()
+
+    result = run_hooks("ros", "GetStack", params, context=context, read_only=True)
+
+    assert result is not None and result.is_error
+    assert "ROS1203" in result.content
+    assert "ListStacks" in result.content
+    assert params == {"StackName": "it-s03-20260728-192023-f2a57221", "RegionId": "cn-hangzhou"}
+    assert context.ros_preflight_outcome is not None
+
+
+def test_stage_zero_chain_allows_list_stacks_by_name() -> None:
+    params = {"StackName": "it-s03-20260728-192023-f2a57221", "RegionId": "cn-hangzhou"}
+
+    assert run_hooks("ros", "ListStacks", params, context=ToolContext(), read_only=True) is None
+
+
+def test_stage_zero_chain_allows_get_stack_with_stack_id() -> None:
+    params = {"StackId": "stack-id", "RegionId": "cn-hangzhou"}
+
+    assert run_hooks("ros", "GetStack", params, context=ToolContext(), read_only=True) is None

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -2547,7 +2547,7 @@ def test_completed_turn_collapses_process_into_summary() -> None:
     # 「已处理」组的展开态必须跨重建保留:openKey 让 toggle 记录器登记用户操作、
     # applyDetailsOpenOverrides 在重建后恢复;键取 turnId,缺 turnId 时回退首条消息 id。
     assert 'const turnKey = turnId || text(agentMessages[0]?.messageId || agentMessages[0]?.id || "");' in app_source
-    assert 'details.dataset.openKey = `turnproc:${turnKey}`;' in app_source
+    assert "details.dataset.openKey = `turnproc:${turnKey}`;" in app_source
 
     # 只有最后一次工具调用之后的文本才是「最终回答」;此前每个步骤的文本旁白
     # (夹在工具调用之间的 text delta)连同思考、工具一起折进「已处理」,不平铺成答案。


### PR DESCRIPTION
## 背景

关联 Session `a39e2559776a4d7f8ea13fd1442984bb`（Aone 84817171）：用户只提供 StackName
`it-s03-...`、未提供 StackId，首次 `aliyun_api` 调用却选择了 ROS `GetStack`。该接口必填
`StackId`，请求在 `RequestBuilder._encode_wire_parts` 才失败并抛出通用错误
`missing_required_parameters:StackId`，Agent 随后才兜底改用 `ListStacks` 按名称查询。
结果是一次可避免的错误往返 + 观测噪声。

## 根因

`ros_validation/action_policy.py` 的 `ACTION_POLICIES` 只覆盖 18 个 TemplateBody 类 action，
`GetStack` 这类「按栈标识定位」的操作没有任何 stage-zero 前置校验，因此只能等到组装报文时
才暴露；且错误文案没有给出「改用 ListStacks + StackName」的可操作引导。

## 改动

1. 新增 `tools/cloud/aliyun/hooks/ros_stack_identifier.py`
   - `@before_call("ros", ...)` 注册 stage-zero 只读 hook（`hooks/` 目录自动发现）。
   - 覆盖锁定 SDK `alibabacloud_ros20190910==3.6.0` 中「StackId 必填且请求模型不接受
     StackName」的 18 个 action（GetStack、ListStackResources、ListStackEvents、
     DeleteStack、UpdateStack、SignalResource 等）。
   - 缺少可用 StackId 时产出 ERROR 诊断 `ROS1203` 阻断调用，`suggestion` 明确指向
     `ListStacks` 按 StackName 过滤取回 StackId；StackId/StackName 均缺失时走独立分支。
   - hook 不写回 `params`，满足 `hook_call_shape_changed` 不变量；诊断文案不含用户值，
     `stable_args` 只含 action 与固定分支标识。
2. `tools/cloud/aliyun/public_errors.py`：ROS 产品下 `missing_required_parameters:StackId`
   补充稳定引导文案，兜住绕过 stage-zero 的路径（如 `pipeline_mode`）。
3. `skills/bundled/iac_aliyun/SKILL.md`：新增「按 StackName 查询资源栈」规则——仅持有名称时
   首个调用必须是 `ListStacks(StackName=...)`。
4. 6 语种 `messages.po` 已补齐新 msgid 翻译（`.mo` 为构建产物，未提交）。

第一个提交 `d457858` 是纯 `make format` 结果：仓库 HEAD 在锁定的 ruff 0.15.10 下并非
format-clean，pre-commit 的 format hook 会对任何提交失败，因此单独成一个可审阅的提交，
未使用 `--no-verify`。

## 验证

- 新增 `tests/tools/cloud/aliyun/test_ros_stack_identifier_hook.py`：24 passed
  （18 action 参数化阻断、空白 StackId、双缺失分支、stage-zero 只读不变性、
  ListStacks 与带 StackId 的 GetStack 放行）。
- `tests/tools/cloud/aliyun` 2325 passed；`uv run pytest tests -q -n auto`
  14358 passed / 4 skipped / 4 failed。
- 4 个失败均为存量或沙箱环境问题，已用 baseline `88ed89c` 的同名文件复跑确认：
  zh `messages.po` 存量 `{s:.0}` 被 GNU msgfmt 拒绝、direct-binary 下载异常类型受网络影响、
  repl_e2e sidecar 依赖 `st_mtime_ns` 严格递增、providers 流式回退用例。
- `make lint`（ruff + ty）全绿。

## 预期效果

仅持有 StackName 时不再调用 `GetStack`，而是在调用前即被引导到 `ListStacks`，
消除无效错误往返。
