### PR TITLE
fix(a2a): wait for terminal backups to reach shared storage

### DIFF
--- a/src/iac_code/a2a/backup.py
+++ b/src/iac_code/a2a/backup.py
@@ -12,6 +12,8 @@ from iac_code.services.session_backup_state import BackupPublicationProof
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_SHARED_COMMIT_TIMEOUT_SECONDS = 30.0
+
 
 async def run_sync_fenced(function: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
     """Delay coroutine cancellation until the synchronous mutation has actually stopped."""
@@ -41,6 +43,7 @@ async def backup_session_async(
     critical: bool,
     metrics: Any | None = None,
     publication_proofs: dict[str, BackupPublicationProof] | None = None,
+    shared_commit_timeout: float = _DEFAULT_SHARED_COMMIT_TIMEOUT_SECONDS,
 ) -> Any | None:
     failed_recorded = False
     try:
@@ -64,7 +67,19 @@ async def backup_session_async(
                 retry_count,
                 message,
             )
-        elif getattr(result, "enabled", False):
+        elif (
+            getattr(result, "enabled", False)
+            and critical
+            and reason in {BackupReason.TERMINAL, BackupReason.HANDOFF_READY}
+        ):
+            wait_for_shared_commit = getattr(backup_service, "wait_for_shared_commit", None)
+            if callable(wait_for_shared_commit):
+                result = await run_sync_fenced(
+                    wait_for_shared_commit,
+                    result,
+                    timeout=shared_commit_timeout,
+                )
+        if getattr(result, "enabled", False) and getattr(result, "succeeded", True):
             _record_backup_succeeded(metrics, reason=reason, critical=critical, retry_count=retry_count)
         return result
     except Exception as exc:

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -851,6 +851,7 @@ class A2ATaskStore(TaskStore):
                 raise
         except TimeoutError:
             logger.warning("Timed out waiting for canceled A2A task %s to finish", task_id)
+            return False
         return True
 
     async def is_task_active(self, task_id: str) -> bool:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -69,6 +69,83 @@ class StagedSessionBackupService(SessionBackupService):
     def staging_root(self) -> Path:
         return self._staging_root
 
+    def wait_for_shared_commit(
+        self,
+        result: BackupResult,
+        *,
+        timeout: float | None = None,
+        poll_interval: float = 0.05,
+    ) -> BackupResult:
+        """Wait until the staged snapshot is published to the existing shared layout."""
+        if result.shared_committed:
+            return result
+        if (
+            not result.succeeded
+            or not result.staged_committed
+            or result.destination is None
+            or result.generation is None
+            or result.commit_id is None
+        ):
+            raise SessionBackupBlocked(
+                "Staged session backup is missing publication identity.",
+                retry_count=result.retry_count,
+                result=result,
+            )
+
+        snapshot = Path(result.destination)
+        try:
+            project, snapshot_name = snapshot.relative_to(
+                self._staging_root / "projects"
+            ).parts
+        except (ValueError, TypeError):
+            raise SessionBackupBlocked(
+                "Staged session backup has an invalid publication path.",
+                retry_count=result.retry_count,
+                result=result,
+            ) from None
+        parsed = parse_staged_snapshot_name(snapshot_name)
+        if parsed is None or parsed[1] != result.generation:
+            raise SessionBackupBlocked(
+                "Staged session backup has an invalid publication identity.",
+                retry_count=result.retry_count,
+                result=result,
+            )
+        session_id = parsed[0]
+        shared = self._backup_root_required() / "projects" / project / session_id
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while snapshot.exists():
+            if deadline is not None and time.monotonic() >= deadline:
+                raise SessionBackupBlocked(
+                    "Timed out waiting for staged session backup publication.",
+                    retry_count=result.retry_count,
+                    result=result,
+                )
+            time.sleep(poll_interval)
+
+        try:
+            shared_state = self._read_state(
+                shared,
+                session_id=session_id,
+                shared=True,
+            )
+        except SessionBackupError:
+            raise SessionBackupBlocked(
+                "Shared session backup could not be verified.",
+                retry_count=result.retry_count,
+                result=result,
+            ) from None
+        if (
+            shared_state is None
+            or shared_state.generation != result.generation
+            or shared_state.commit_id != result.commit_id
+        ):
+            raise SessionBackupBlocked(
+                "Shared session backup does not match the staged publication.",
+                retry_count=result.retry_count,
+                result=result,
+            )
+        return replace(result, destination=shared, shared_committed=True)
+
     @_log_backup_session_elapsed
     def backup_session(
         self,

--- a/tests/a2a/test_backup.py
+++ b/tests/a2a/test_backup.py
@@ -1,0 +1,113 @@
+import asyncio
+import threading
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from iac_code.a2a.backup import backup_session_async
+from iac_code.services.session_backup import BackupReason, BackupResult, SessionBackupBlocked
+
+
+class RecordingStagedBackupService:
+    def __init__(self) -> None:
+        self.wait_started = threading.Event()
+        self.allow_shared_commit = threading.Event()
+        self.wait_calls = 0
+        self.wait_timeout: float | None = None
+
+    def backup_session(self, *_args, **_kwargs) -> BackupResult:
+        return BackupResult(
+            enabled=True,
+            destination=Path("/tmp/staging/projects/project/session_v1"),
+            generation=1,
+            commit_id="commit-1",
+            staged_committed=True,
+            shared_committed=False,
+        )
+
+    def wait_for_shared_commit(
+        self,
+        result: BackupResult,
+        *,
+        timeout: float | None = None,
+    ) -> BackupResult:
+        self.wait_calls += 1
+        self.wait_timeout = timeout
+        self.wait_started.set()
+        if not self.allow_shared_commit.wait(timeout=timeout):
+            raise SessionBackupBlocked(
+                "Timed out waiting for staged session backup publication.",
+                retry_count=result.retry_count,
+                result=result,
+            )
+        return replace(
+            result,
+            destination=Path("/oss/projects/project/session"),
+            shared_committed=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_backup_waits_for_staged_snapshot_shared_commit() -> None:
+    service = RecordingStagedBackupService()
+
+    backup_task = asyncio.create_task(
+        backup_session_async(
+            service,
+            "/repo",
+            "session",
+            reason=BackupReason.TERMINAL,
+            critical=True,
+        )
+    )
+
+    assert await asyncio.to_thread(service.wait_started.wait, 1.0)
+    assert backup_task.done() is False
+    service.allow_shared_commit.set()
+    result = await asyncio.wait_for(backup_task, timeout=1.0)
+
+    assert result.shared_committed is True
+    assert result.destination == Path("/oss/projects/project/session")
+    assert service.wait_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_backup_bounds_stalled_shared_publication() -> None:
+    service = RecordingStagedBackupService()
+
+    with pytest.raises(
+        SessionBackupBlocked,
+        match="Timed out waiting for staged session backup publication",
+    ):
+        await asyncio.wait_for(
+            backup_session_async(
+                service,
+                "/repo",
+                "session",
+                reason=BackupReason.TERMINAL,
+                critical=True,
+                shared_commit_timeout=0.01,
+            ),
+            timeout=0.5,
+        )
+
+    assert service.wait_timeout == 0.01
+    assert service.wait_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_non_terminal_backup_keeps_existing_local_staging_behavior() -> None:
+    service = RecordingStagedBackupService()
+
+    result = await backup_session_async(
+        service,
+        "/repo",
+        "session",
+        reason=BackupReason.NORMAL_TURN_END,
+        critical=False,
+    )
+
+    assert result.staged_committed is True
+    assert result.shared_committed is False
+    assert service.wait_calls == 0

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -682,6 +682,33 @@ async def test_cancel_active_task_does_not_need_context_lock() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancel_task_and_wait_reports_unfinished_task_after_timeout() -> None:
+    store = A2ATaskStore(
+        metrics=NoOpA2AMetrics(),
+        idle_timeout_seconds=60,
+        cleanup_interval_seconds=300,
+    )
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    release = asyncio.Event()
+
+    async def ignore_cancel_until_released() -> None:
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    active = asyncio.create_task(ignore_cancel_until_released())
+    task.active_task = active
+    await asyncio.sleep(0)
+
+    assert await store.cancel_task_and_wait("task-1", timeout=0.01) is False
+    assert active.done() is False
+
+    release.set()
+    await active
+
+
+@pytest.mark.asyncio
 async def test_task_status_access_waits_for_mutation_lock() -> None:
     store = A2ATaskStore(metrics=NoOpA2AMetrics(), idle_timeout_seconds=60, cleanup_interval_seconds=300)
     task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")

--- a/tests/services/test_session_backup_staging.py
+++ b/tests/services/test_session_backup_staging.py
@@ -311,6 +311,80 @@ def test_staging_worker_publishes_versions_in_order_and_empties_staging_root(
     assert list(staging_root.iterdir()) == []
 
 
+def test_terminal_publication_waits_for_oss_and_restores_in_another_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service, session_dir, staging_root, backup_root = _create_staged_service(
+        monkeypatch,
+        tmp_path,
+    )
+    expected_files = {
+        "session.jsonl": '{"role":"user","content":"restore-me"}\n',
+        "a2a/pipeline/a2a-snapshot.json": '{"status":"canceled"}\n',
+    }
+    for relative, content in expected_files.items():
+        path = session_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    staged = service.backup_session(
+        "/repo",
+        "s1",
+        reason=BackupReason.TERMINAL,
+        critical=True,
+    )
+    committed: list[object] = []
+    wait_started = threading.Event()
+
+    def wait_for_publication() -> None:
+        wait_started.set()
+        committed.append(
+            service.wait_for_shared_commit(
+                staged,
+                timeout=1.0,
+                poll_interval=0.005,
+            )
+        )
+
+    waiter = threading.Thread(target=wait_for_publication)
+    waiter.start()
+    assert wait_started.wait(timeout=1.0)
+    assert waiter.is_alive()
+
+    assert SessionBackupStagingWorker(staging_root, backup_root).run_once() == 1
+    waiter.join(timeout=1.0)
+
+    assert waiter.is_alive() is False
+    published = committed[0]
+    assert published.shared_committed is True
+    assert published.generation == staged.generation
+    assert published.commit_id == staged.commit_id
+
+    sandbox_b_storage = SessionStorage(projects_dir=tmp_path / "sandbox-b-config" / "projects")
+    sandbox_b_service = StagedSessionBackupService(
+        tmp_path / "sandbox-b-staging",
+        sandbox_b_storage,
+        retry_delays=(),
+    )
+    restored = sandbox_b_service.restore_session("/repo", "s1")
+    restored_dir = sandbox_b_storage.session_dir("/repo", "s1")
+
+    assert restored.restored is True
+    for relative, content in expected_files.items():
+        assert (restored_dir / relative).read_text(encoding="utf-8") == content
+
+    shared_dir = backup_root / "projects" / session_dir.parent.name / "s1"
+    assert Path(published.destination) == shared_dir
+    assert not (shared_dir / "generations").exists()
+    assert sorted(path.name for path in shared_dir.iterdir()) == [
+        ".backup-state.json",
+        "a2a",
+        "metadata.json",
+        "session.jsonl",
+    ]
+
+
 def test_staging_worker_does_not_skip_failed_version_for_same_session(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
- verify staged terminal and handoff snapshots before publishing terminal state
- report cancellation drain timeouts instead of treating unfinished tasks as stopped
- cover shared publication timeout, cross-sandbox restore, and cancellation behavior