### PR TITLE
fix(a2a): 收敛取消/回滚/候选重跑后 Pipeline 快照的非终态悬挂节点

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1731,9 +1731,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             raise ValueError("Invalid A2A workspace metadata.")
         logical_cwd = os.path.normpath(cwd)
         resolved_cwd = resolve_workspace_path(Path(logical_cwd))
-        if not trust_request_cwd() and not any(
-            _is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()
-        ):
+        if not trust_request_cwd() and not any(_is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()):
             raise ValueError("Invalid A2A workspace metadata.")
         if resolved_cwd.exists():
             if not resolved_cwd.is_dir():

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -178,35 +178,29 @@ def permission_display_fields(request: PermissionRequestEvent, *, language: str 
             command = safe_input.get("command") or safe_input.get("cmd")
         if isinstance(command, str) and command.strip():
             command_fallback = translate_message("shell command", language=language)
-            target = translate_message(
-                "the current local workspace; command: {command}", language=language
-            ).format(command=_display_text(command, fallback=command_fallback, maximum=240))
+            target = translate_message("the current local workspace; command: {command}", language=language).format(
+                command=_display_text(command, fallback=command_fallback, maximum=240)
+            )
         else:
             target = translate_message("the current local workspace", language=language)
         effect = "read" if is_read_only else ("local_execution" if read_only_known else "unknown")
     elif tool_name in {"write_file", "edit_file"}:
         title = translate_message("Change a workspace file", language=language)
-        purpose = translate_message(
-            "Write a file needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Write a file needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "a file in the current workspace", language=language
         )
         effect = "file_change"
     elif tool_name in {"read_file", "glob", "grep"} or is_read_only:
         title = translate_message("Read workspace data with {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Read local data needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Read local data needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current local workspace", language=language
         )
         effect = "read"
     else:
         title = translate_message("Run {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Run this operation for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Run this operation for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current task workspace or cloud account", language=language
         )
@@ -319,9 +313,7 @@ def _cloud_operation_title(product: str, action: str, *, is_read_only: bool, lan
     if action == "CreateStack":
         return translate_message("Create {product} stack", language=language).format(product=product_label)
     if action == "ContinueCreateStack":
-        return translate_message("Continue creating {product} stack", language=language).format(
-            product=product_label
-        )
+        return translate_message("Continue creating {product} stack", language=language).format(product=product_label)
     if action == "UpdateStack":
         return translate_message("Update {product} stack", language=language).format(product=product_label)
     if action == "DeleteStack":
@@ -344,9 +336,7 @@ def _safe_input_target(value: Any, *, language: str) -> str:
     for key in ("file_path", "filePath", "path", "region_id", "regionId", "resource_id", "resourceId"):
         candidate = value.get(key)
         if isinstance(candidate, str) and candidate.strip():
-            return _display_text(
-                candidate, fallback=translate_message("the current task scope", language=language)
-            )
+            return _display_text(candidate, fallback=translate_message("the current task scope", language=language))
     return ""
 
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -1235,11 +1235,7 @@ class IacCodeA2APipelineExecutor:
             def permission_context_getter() -> Any:
                 return getattr(agent_loop, "_permission_context", None)
 
-        surface = (
-            A2A_RICH_CANDIDATE_SURFACE
-            if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION
-            else "a2a"
-        )
+        surface = A2A_RICH_CANDIDATE_SURFACE if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION else "a2a"
         return create_pipeline(
             pipeline_name,
             provider_manager=runtime.provider_manager,

--- a/src/iac_code/a2a/pipeline_snapshot.py
+++ b/src/iac_code/a2a/pipeline_snapshot.py
@@ -36,6 +36,18 @@ _CLEANUP_STATUS_BY_EVENT_TYPE = {
     PIPELINE_EVENT_CLEANUP_FAILED: "failed",
 }
 _KNOWN_CLEANUP_STATUSES = {"pending", "started", "in_progress", "completed", "failed", "skipped"}
+# Terminal statuses for steps/candidates/candidate steps inside the snapshot tree.
+# Anything else (``working``, ``pending``, ``waiting_input``, ``restarting``, missing)
+# is a dangling non-terminal node that must be finalized when the run terminates or
+# when the node gets superseded by a rollback / candidate restart.
+_TERMINAL_NODE_STATUSES = {"completed", "failed", "canceled", "superseded"}
+_SUPERSEDED_NODE_STATUS = "superseded"
+_FINALIZED_TIME_KEY_BY_STATUS = {
+    "canceled": "canceledAt",
+    "completed": "completedAt",
+    "failed": "failedAt",
+    "superseded": "supersededAt",
+}
 _PENDING_BACKUP_VISIBILITY = "pending_backup"
 _COMMITTED_BACKUP_VISIBILITY = "committed"
 _BACKUP_COMMITTED_EVENT_TYPE = "backup_committed"
@@ -501,6 +513,7 @@ class _PipelineSnapshotReducer:
             self._apply_cleanup_event(event)
         elif event_type == "rollback_completed":
             self._append_rollback(event)
+            self._supersede_rolled_back_steps(event)
         elif event_type == "candidate_restart_requested":
             self._append_candidate_restart(event)
         elif event_type == "input_required":
@@ -529,6 +542,7 @@ class _PipelineSnapshotReducer:
             self._snapshot["pendingTerminal"] = None
             self._snapshot["pendingInput"] = None
             self._snapshot["control"]["activeCandidateRunIds"] = []
+            self._finalize_non_terminal_nodes(terminal_status, event)
         elif (
             event_type not in {"input_required", "input_received", *_CLEANUP_STATUS_BY_EVENT_TYPE}
             and not _is_pending_backup_publication(event)
@@ -538,6 +552,109 @@ class _PipelineSnapshotReducer:
             )
         ):
             self._apply_event_status(event)
+
+    def _finalize_non_terminal_nodes(self, status: str, event: dict[str, Any]) -> None:
+        """Converge every dangling step/candidate/candidate step when the run terminates.
+
+        Only ``canceled``/``failed`` propagate. A successful run emits ``step_completed``
+        per step, so pushing ``completed`` onto a node that never reported completion
+        would fabricate a success that did not happen.
+        """
+        if status not in {"canceled", "failed"}:
+            return
+        reason = _string_or_none(event.get("eventType")) or status
+        for step in self._snapshot["steps"]:
+            _finalize_node(step, status, event, reason=reason, finalized_by="run_termination")
+            for candidate in _dict_list(step.get("candidates")):
+                _finalize_node(candidate, status, event, reason=reason, finalized_by="run_termination")
+                for candidate_step in _dict_list(candidate.get("steps")):
+                    _finalize_node(candidate_step, status, event, reason=reason, finalized_by="run_termination")
+
+    def _supersede_rolled_back_steps(self, event: dict[str, Any]) -> None:
+        """Collapse the pre-rollback attempts of the rollback target step.
+
+        ``pipeline_events`` bumps the step ``attempt`` on rollback, so the replayed step
+        lands as a new record while the interrupted attempt would otherwise stay
+        ``working`` with a ``null`` conclusion next to it.
+        """
+        coordinate = _dict_or_none(event.get("step"))
+        if coordinate is None:
+            return
+        step_id = _string_or_none(coordinate.get("id"))
+        attempt = _int_or_none(coordinate.get("attempt"))
+        if step_id is None or attempt is None:
+            return
+        for step in self._snapshot["steps"]:
+            if _string_or_none(step.get("id")) != step_id:
+                continue
+            if (_int_or_none(step.get("attempt")) or 1) >= attempt:
+                continue
+            _finalize_node(
+                step,
+                _SUPERSEDED_NODE_STATUS,
+                event,
+                reason="rollback_completed",
+                finalized_by="rollback_collapse",
+            )
+            for candidate in _dict_list(step.get("candidates")):
+                _finalize_node(
+                    candidate,
+                    _SUPERSEDED_NODE_STATUS,
+                    event,
+                    reason="rollback_completed",
+                    finalized_by="rollback_collapse",
+                )
+                for candidate_step in _dict_list(candidate.get("steps")):
+                    _finalize_node(
+                        candidate_step,
+                        _SUPERSEDED_NODE_STATUS,
+                        event,
+                        reason="rollback_completed",
+                        finalized_by="rollback_collapse",
+                    )
+
+    def _supersede_earlier_candidate_attempts(self, candidate: dict[str, Any], event: dict[str, Any]) -> None:
+        """Terminate the previous attempts of the candidate that just (re)started."""
+        candidate_id = _string_or_none(candidate.get("id"))
+        candidate_index = _int_or_none(candidate.get("index"))
+        attempt = _int_or_none(candidate.get("attempt"))
+        if candidate_id is None or candidate_index is None or attempt is None:
+            return
+        for other in self._candidates_by_run_id.values():
+            if other is candidate:
+                continue
+            if _string_or_none(other.get("id")) != candidate_id:
+                continue
+            if _int_or_none(other.get("index")) != candidate_index:
+                continue
+            if (_int_or_none(other.get("attempt")) or 1) >= attempt:
+                continue
+            _finalize_node(
+                other,
+                _SUPERSEDED_NODE_STATUS,
+                event,
+                reason="candidate_restarted",
+                finalized_by="candidate_restart",
+            )
+            for candidate_step in _dict_list(other.get("steps")):
+                _finalize_node(
+                    candidate_step,
+                    _SUPERSEDED_NODE_STATUS,
+                    event,
+                    reason="candidate_restarted",
+                    finalized_by="candidate_restart",
+                )
+
+    def _supersede_restarted_candidate(self, candidate: dict[str, Any], event: dict[str, Any]) -> None:
+        """Terminate the sub-steps of a candidate that is being restarted."""
+        for candidate_step in _dict_list(candidate.get("steps")):
+            _finalize_node(
+                candidate_step,
+                _SUPERSEDED_NODE_STATUS,
+                event,
+                reason="candidate_restart_requested",
+                finalized_by="candidate_restart",
+            )
 
     def _merge_pipeline_identity(self, event: dict[str, Any]) -> None:
         for key in ("pipelineRunId", "taskId", "contextId", "pipelineName"):
@@ -672,6 +789,7 @@ class _PipelineSnapshotReducer:
             candidate["status"] = "working"
             _set_time(candidate, "startedAt", created_at)
             self._remove_active_candidate_attempts(candidate)
+            self._supersede_earlier_candidate_attempts(candidate, event)
             _append_unique(self._snapshot["control"]["activeCandidateRunIds"], run_id)
         elif event_type == "candidate_completed":
             candidate["status"] = "completed"
@@ -687,6 +805,7 @@ class _PipelineSnapshotReducer:
             candidate["status"] = "restarting"
             _set_time(candidate, "restartingAt", created_at)
             _remove_value(self._snapshot["control"]["activeCandidateRunIds"], run_id)
+            self._supersede_restarted_candidate(candidate, event)
 
     def _remove_active_candidate_attempts(self, candidate: dict[str, Any]) -> None:
         candidate_id = _string_or_none(candidate.get("id"))
@@ -1053,6 +1172,37 @@ class _PipelineSnapshotReducer:
         if data:
             pending["backupBlocked"] = data
         return pending
+
+
+def _is_terminal_node(node: dict[str, Any]) -> bool:
+    return _string_or_none(node.get("status")) in _TERMINAL_NODE_STATUSES
+
+
+def _finalize_node(
+    node: dict[str, Any],
+    status: str,
+    event: dict[str, Any],
+    *,
+    reason: str,
+    finalized_by: str,
+) -> None:
+    """Move a dangling snapshot node to ``status`` and give it an explicit conclusion.
+
+    Already-terminal nodes keep their own status and conclusion, and a node that carries
+    a real conclusion never has it overwritten, so the projection stays idempotent and
+    never rewrites a result the pipeline actually reported.
+    """
+    if _is_terminal_node(node):
+        return
+    node["status"] = status
+    created_at = _string_or_none(event.get("createdAt"))
+    _set_time(node, _FINALIZED_TIME_KEY_BY_STATUS.get(status, "finalizedAt"), created_at)
+    if node.get("conclusion") is None:
+        node["conclusion"] = {
+            "status": status,
+            "terminationReason": reason,
+            "finalizedBy": finalized_by,
+        }
 
 
 def _normal_handoff(event: dict[str, Any]) -> dict[str, Any]:

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -864,9 +864,7 @@ class A2ATaskStore(TaskStore):
                 any(record.active_task is not None and not record.active_task.done() for record in self._tasks.values())
                 or any(not task.done() for task in self._context_runtime_tasks.values())
                 or any(
-                    not task.done()
-                    for starts in self._context_execution_starts.values()
-                    for task in starts.values()
+                    not task.done() for starts in self._context_execution_starts.values() for task in starts.values()
                 )
                 or any(self._context_reconciliation_waiters.values())
                 or any(lock.locked() for lock in self._reconciliation_locks.values())

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -343,9 +343,7 @@ def _parse_surface_overrides(raw: object, step_id: str) -> dict[str, StepSurface
 
         conclusion_schema = override.get("conclusion_schema")
         if conclusion_schema is not None and not isinstance(conclusion_schema, dict):
-            raise ValueError(
-                f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping"
-            )
+            raise ValueError(f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping")
 
         overrides[surface] = StepSurfaceOverride(
             prompt_file=prompt,

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -93,6 +93,8 @@ _REAL_RESTORE_FAILURE_REASONS = {
 
 def _is_a2a_surface(surface: str) -> bool:
     return surface == "a2a" or surface.startswith("a2a_")
+
+
 _SIDECAR_ROOT_DIRS = {"a2a", "image-cache", "pipeline", "tool-results"}
 _SIDECAR_ROOT_FILES = {
     ".backup-state.json",

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -298,9 +298,7 @@ class AliyunCredentials:
 
             owns_client = oauth_client is None
             client = (
-                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type))
-                if oauth_client is None
-                else oauth_client
+                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type)) if oauth_client is None else oauth_client
             )
 
             try:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -149,8 +149,7 @@ class StagedSessionBackupService(SessionBackupService):
                         existing = self._read_existing_snapshot_state(destination, session_id)
                         if existing is not None:
                             completed_next = (
-                                base_state.status == "succeeded"
-                                and existing.parent_generation == base_state.generation
+                                base_state.status == "succeeded" and existing.parent_generation == base_state.generation
                             )
                             if not completed_next and not existing.same_lineage(committed_state):
                                 raise SessionBackupConflict(

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -3788,12 +3788,10 @@ class TestResolveCandidatePresentation:
         executor = self._make_executor()
 
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}}) == "rich-v1"
         )
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}}) == "rich-v1"
         )
 
     def test_rejects_unknown_or_missing_presentation(self) -> None:

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -240,9 +240,7 @@ def test_ros_deployment_permission_is_localized_and_preserves_safe_plan_summary(
                         "stackName": "demo-stack",
                         "template": "templates/demo.yml",
                         "totalMonthlyCost": "¥88/月",
-                        "resources": [
-                            {"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}
-                        ],
+                        "resources": [{"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}],
                     },
                 },
             ),
@@ -388,9 +386,7 @@ async def test_pipeline_permission_uses_same_input_envelope_and_waits_serially(m
 async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(monkeypatch, tmp_path) -> None:
     registry = PermissionInputRegistry()
     store = A2ATaskStore()
-    await store.save(
-        Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING))
-    )
+    await store.save(Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)))
     queue = FakeEventQueue()
     publisher = PipelineA2AEventPublisher(
         event_queue=queue,
@@ -466,9 +462,7 @@ async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(m
     task = await store.get("task-1")
     assert task is not None
     task_metadata = MessageToDict(task.metadata, preserving_proto_field_name=False)
-    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [
-        requests[1]["inputId"]
-    ]
+    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [requests[1]["inputId"]]
     remaining = task_metadata["iac_code"]["pendingPermissions"][0]
     assert remaining["language"] == "zh"
     assert remaining["prompt"] == "是否允许本次操作：运行本地 Shell 命令？"

--- a/tests/a2a/test_pipeline_snapshot.py
+++ b/tests/a2a/test_pipeline_snapshot.py
@@ -1338,7 +1338,9 @@ def test_reduce_candidate_restart_removes_old_run_from_active_when_next_attempt_
 
     candidates = snapshot["steps"][0]["candidates"]
     assert [candidate["runId"] for candidate in candidates] == ["candidate-eval-0-1", "candidate-eval-0-2"]
-    assert candidates[0]["status"] == "restarting"
+    # Once attempt 2 starts, attempt 1 is superseded instead of dangling on ``restarting``.
+    assert candidates[0]["status"] == "superseded"
+    assert candidates[0].get("conclusion") is not None
     assert candidates[1]["status"] == "working"
     assert snapshot["control"]["activeCandidateRunIds"] == ["candidate-eval-0-2"]
 
@@ -1480,3 +1482,132 @@ def test_store_returns_none_for_invalid_utf8_snapshot(tmp_path) -> None:
 def test_snapshot_schema_version_is_exported() -> None:
     assert SNAPSHOT_SCHEMA_VERSION == "1.1"
     assert "SNAPSHOT_SCHEMA_VERSION" in pipeline_snapshot.__all__
+
+
+def test_reduce_pipeline_canceled_finalizes_dangling_nodes() -> None:
+    """Cancel evidence (session afb47b236ee54db5a22d295609b69de6): an in-flight step
+    used to keep ``working``/``conclusion: null`` forever after the run was canceled."""
+    step = _base("evt-step", 1, "step_started", scope="step")
+    step["step"] = {"runId": "step-architecture_planning-1", "id": "architecture_planning", "attempt": 1}
+    candidate_started = _base("evt-cand", 2, "candidate_started", scope="candidate")
+    candidate_started["step"] = step["step"]
+    candidate_started["candidate"] = {"runId": "candidate-plan-0-1", "id": "plan", "index": 0, "attempt": 1}
+    candidate_step = _base("evt-cand-step", 3, "candidate_step_started", scope="candidate_step")
+    candidate_step["step"] = step["step"]
+    candidate_step["candidate"] = candidate_started["candidate"]
+    candidate_step["candidateStep"] = {"runId": "candidate-plan-0-1-template-1", "id": "template", "attempt": 1}
+    canceled = _base("evt-cancel", 4, "pipeline_canceled", status="canceled")
+
+    snapshot = reduce_pipeline_events([step, candidate_started, candidate_step, canceled])
+
+    assert snapshot["status"] == "canceled"
+    tree_step = snapshot["steps"][0]
+    assert tree_step["status"] == "canceled"
+    assert tree_step.get("conclusion") is not None
+    assert tree_step["conclusion"]["terminationReason"] == "pipeline_canceled"
+    tree_candidate = tree_step["candidates"][0]
+    assert tree_candidate["status"] == "canceled"
+    assert tree_candidate.get("conclusion") is not None
+    assert tree_candidate["steps"][0]["status"] == "canceled"
+    assert tree_candidate["steps"][0].get("conclusion") is not None
+    assert snapshot["control"]["activeCandidateRunIds"] == []
+
+
+def test_reduce_pipeline_failed_finalizes_dangling_nodes() -> None:
+    step = _base("evt-step", 1, "step_started", scope="step")
+    step["step"] = {"runId": "step-a-1", "id": "a", "attempt": 1}
+    failed = _base("evt-failed", 2, "pipeline_failed", status="failed")
+
+    snapshot = reduce_pipeline_events([step, failed])
+
+    assert snapshot["status"] == "failed"
+    assert snapshot["steps"][0]["status"] == "failed"
+    assert snapshot["steps"][0]["conclusion"]["status"] == "failed"
+
+
+def test_reduce_pipeline_completed_does_not_fabricate_step_success() -> None:
+    step = _base("evt-step", 1, "step_started", scope="step")
+    step["step"] = {"runId": "step-a-1", "id": "a", "attempt": 1}
+    completed = _base("evt-done", 2, "pipeline_completed", status="completed")
+
+    snapshot = reduce_pipeline_events([step, completed])
+
+    assert snapshot["status"] == "completed"
+    assert snapshot["steps"][0]["status"] == "working"
+    assert snapshot["steps"][0].get("conclusion") is None
+
+
+def test_reduce_rollback_completed_supersedes_previous_step_attempt() -> None:
+    """Rollback evidence (session e0c70d3197184b49826469b509a6fd21): the interrupted
+    attempt stayed ``working`` next to the replayed attempt of the same step."""
+    first = _base("evt-step-1", 1, "step_started", scope="step")
+    first["step"] = {"runId": "step-a-1", "id": "a", "attempt": 1}
+    candidate_started = _base("evt-cand", 2, "candidate_started", scope="candidate")
+    candidate_started["step"] = first["step"]
+    candidate_started["candidate"] = {"runId": "candidate-a-0-1", "id": "a-cand", "index": 0, "attempt": 1}
+    rollback = _base("evt-rollback", 3, "rollback_completed")
+    rollback["step"] = {"runId": "step-a-2", "id": "a", "attempt": 2}
+    second = _base("evt-step-2", 4, "step_started", scope="step")
+    second["step"] = rollback["step"]
+
+    snapshot = reduce_pipeline_events([first, candidate_started, rollback, second])
+
+    steps = snapshot["steps"]
+    assert [step["runId"] for step in steps] == ["step-a-1", "step-a-2"]
+    assert steps[0]["status"] == "superseded"
+    assert steps[0]["conclusion"]["terminationReason"] == "rollback_completed"
+    assert steps[0]["candidates"][0]["status"] == "superseded"
+    assert steps[1]["status"] == "working"
+    assert steps[1].get("conclusion") is None
+
+
+def test_reduce_candidate_restart_finalizes_candidate_sub_steps() -> None:
+    """Candidate restart evidence (session 7eaff0d9bcff4de7a1ba510ed030f017): the
+    superseded candidate kept ``working``/``pending`` sub-steps."""
+    step = _base("evt-step", 1, "step_started", scope="step")
+    step["step"] = {"runId": "step-evaluate_candidates-1", "id": "evaluate_candidates", "attempt": 1}
+    candidate_started = _base("evt-cand", 2, "candidate_started", scope="candidate")
+    candidate_started["step"] = step["step"]
+    candidate_started["candidate"] = {"runId": "candidate-eval-0-1", "id": "eval", "index": 0, "attempt": 1}
+    candidate_step = _base("evt-cand-step", 3, "candidate_step_started", scope="candidate_step")
+    candidate_step["step"] = step["step"]
+    candidate_step["candidate"] = candidate_started["candidate"]
+    candidate_step["candidateStep"] = {"runId": "candidate-eval-0-1-template-1", "id": "template", "attempt": 1}
+    restart = _base("evt-restart", 4, "candidate_restart_requested", scope="candidate")
+    restart["step"] = step["step"]
+    restart["candidate"] = candidate_started["candidate"]
+
+    snapshot = reduce_pipeline_events([step, candidate_started, candidate_step, restart])
+
+    candidate = snapshot["steps"][0]["candidates"][0]
+    assert candidate["status"] == "restarting"
+    sub_step = candidate["steps"][0]
+    assert sub_step["status"] == "superseded"
+    assert sub_step["conclusion"]["terminationReason"] == "candidate_restart_requested"
+    assert snapshot["control"]["activeCandidateRunIds"] == []
+
+
+def test_finalize_keeps_existing_terminal_status_and_conclusion() -> None:
+    step = _base("evt-step", 1, "step_started", scope="step")
+    step["step"] = {"runId": "step-a-1", "id": "a", "attempt": 1}
+    step_failed = _base("evt-step-failed", 2, "step_failed", scope="step", status="failed")
+    step_failed["step"] = step["step"]
+    step_failed["data"] = {"error": "boom"}
+    canceled = _base("evt-cancel", 3, "pipeline_canceled", status="canceled")
+
+    snapshot = reduce_pipeline_events([step, step_failed, canceled])
+
+    assert snapshot["status"] == "canceled"
+    assert snapshot["steps"][0]["status"] == "failed"
+
+
+def test_finalize_non_terminal_nodes_is_idempotent_on_replay() -> None:
+    step = _base("evt-step", 1, "step_started", scope="step")
+    step["step"] = {"runId": "step-a-1", "id": "a", "attempt": 1}
+    canceled = _base("evt-cancel", 2, "pipeline_canceled", status="canceled")
+
+    once = reduce_pipeline_events([step, canceled])
+    twice = reduce_pipeline_events([step, canceled], existing_snapshot=once)
+
+    assert twice["steps"] == once["steps"]
+    assert twice["status"] == "canceled"

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -2776,11 +2776,15 @@ class TestStepExecutorSchemaWiring:
             surface="a2a_rich",
         )
 
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=True,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=True,
+            )
+            .get("complete_step")
+            .input_schema
+        )
         conclusion_schema = tool_schema["properties"]["conclusion"]
         assert conclusion_schema["required"] == [
             "selected_candidate_name",
@@ -2863,11 +2867,15 @@ class TestStepExecutorSchemaWiring:
             context,
             resume_candidate_selection=True,
         )
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=preserved is not None,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=preserved is not None,
+            )
+            .get("complete_step")
+            .input_schema
+        )
 
         assert preserved is None
         conclusion_schema = tool_schema["properties"]["conclusion"]

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -133,9 +133,7 @@ def test_confirm_prompt_tells_model_to_preserve_parameter_overrides():
 def test_confirm_prompts_share_selection_contract_structure():
     repl_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.md").read_text(encoding="utf-8")
     a2a_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.md").read_text(encoding="utf-8")
-    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(
-        encoding="utf-8"
-    )
+    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(encoding="utf-8")
 
     shared_fragments = [
         "## 首次执行",

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -1676,9 +1676,7 @@ class TestProviderManagerCompleteRetry:
 
     async def test_complete_attributes_bailian_openai_endpoint_to_dashscope_on_all_signals(self):
         mock_provider = AsyncMock()
-        mock_provider._base_url = (
-            "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
-        )
+        mock_provider._base_url = "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
         mock_provider.complete = AsyncMock(
             return_value=NonStreamingResponse(
                 message_id="complete-response",

--- a/tests/skill_bridge/test_iac_code_bridge.py
+++ b/tests/skill_bridge/test_iac_code_bridge.py
@@ -542,12 +542,10 @@ def test_bridge_automatically_runs_cleanup_only_task_and_restores_pipeline_resul
 
     assert len(captured_payloads) == 2
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True for payload in captured_payloads
     )
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host"
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host" for payload in captured_payloads
     )
     assert captured_payloads[0]["params"]["message"]["contextId"] == "ctx-pipeline-1"
     assert result["state"] == "completed"
@@ -1138,9 +1136,7 @@ def test_candidate_presentation_survives_bounded_bridge_projection() -> None:
                                     "summary": "单 ECS 低成本方案。",
                                     "architectureDiagram": "flowchart LR\nU[用户] --> E[ECS]",
                                     "totalMonthlyCost": "¥88/月",
-                                    "costItems": [
-                                        {"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}
-                                    ],
+                                    "costItems": [{"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}],
                                 }
                             ],
                             "required": True,

--- a/tests/skill_bridge/test_runtime_release.py
+++ b/tests/skill_bridge/test_runtime_release.py
@@ -104,9 +104,7 @@ def test_runtime_archive_and_version_marker_are_rooted_consistently(tmp_path: Pa
     assert "artifactRevision" not in marker
 
 
-def test_runtime_a2a_smoke_checks_health_and_agent_card(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_runtime_a2a_smoke_checks_health_and_agent_card(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module("skill_runtime_smoke", BUILD_SCRIPT)
     server = tmp_path / "server.py"
     server.write_text(

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -2547,7 +2547,7 @@ def test_completed_turn_collapses_process_into_summary() -> None:
     # 「已处理」组的展开态必须跨重建保留:openKey 让 toggle 记录器登记用户操作、
     # applyDetailsOpenOverrides 在重建后恢复;键取 turnId,缺 turnId 时回退首条消息 id。
     assert 'const turnKey = turnId || text(agentMessages[0]?.messageId || agentMessages[0]?.id || "");' in app_source
-    assert 'details.dataset.openKey = `turnproc:${turnKey}`;' in app_source
+    assert "details.dataset.openKey = `turnproc:${turnKey}`;" in app_source
 
     # 只有最后一次工具调用之后的文本才是「最终回答」;此前每个步骤的文本旁白
     # (夹在工具调用之间的 text delta)连同思考、工具一起折进「已处理」,不平铺成答案。


### PR DESCRIPTION
## 问题

取消、回滚、候选重跑之后，`a2a-snapshot.json` 中被打断的 step / candidate /
candidate step 仍停留在 `working` 且 `conclusion` 为 `null`，导致：

- 前端永远渲染"进行中"（`architecture_planning` 在 run 已取消后仍为 `working`）；
- 同一 `step id + index` 出现新旧两条记录，旧的 `working`/`null` 与新的 `completed` 并存；
- 被新步骤取代的 `evaluate_candidates:1` 及其候选/子步骤停留在 `working`/`pending`；
- `quality_signals`（`failed=0`、`canceled=0`）与事件日志、步骤快照三方互相矛盾。

证据 Session：`afb47b236ee54db5a22d295609b69de6`（取消）、
`e0c70d3197184b49826469b509a6fd21`（回滚）、`7eaff0d9bcff4de7a1ba510ed030f017`（候选重启）。

## 根因

缺陷不在 `pipeline/engine/state_machine.py`（它已把中间态标为 `STALE`，但那是引擎内部
状态，不是快照投影面），而在 `a2a/pipeline_snapshot.py` 的 `_PipelineSnapshotReducer`：

| 事件 | 归约器原有行为 | 后果 |
| --- | --- | --- |
| `pipeline_canceled` / `pipeline_failed` | 只改写快照顶层 `status` 并清空 `activeCandidateRunIds`，从不下钻步骤树 | 进行中的节点保持 `working` + `conclusion: null` |
| `rollback_completed` | 只追加 `rollbackHistory`；而 `pipeline_events` 会 bump step `attempt` | 重放的 step 落成新记录，被打断的 attempt 仍是 `working` |
| `candidate_restart_requested` | 只把候选置为**非终态**的 `restarting`，不碰子步骤 | 被取代的候选与子步骤停留在 `working`/`pending` |

三条路径都不写 `conclusion`，所以它始终为 `null`。

## 改动

`src/iac_code/a2a/pipeline_snapshot.py`

- 新增 `_TERMINAL_NODE_STATUSES` / `_SUPERSEDED_NODE_STATUS` /
  `_FINALIZED_TIME_KEY_BY_STATUS` 词表与 `_is_terminal_node` / `_finalize_node` helper；
- `_finalize_non_terminal_nodes`：run 终止时下钻整棵步骤树收敛悬挂节点；
- `_supersede_rolled_back_steps`：`rollback_completed` 时把同一 step id 的旧 attempt 折叠为 `superseded`；
- `_supersede_earlier_candidate_attempts`：`candidate_started` 时终结同一候选（id + index）更早的 attempt；
- `_supersede_restarted_candidate`：`candidate_restart_requested` 时终结被重启候选的子步骤。

### 两条防伪造保护

1. **只传播 `canceled` / `failed`。** 成功的 run 会为每个步骤发 `step_completed`，
   若把 `completed` 下推给从未上报完成的节点，等于伪造一次没有发生的成功。
2. **`conclusion` 仅在为 `None` 时补写**，已终态节点直接跳过，绝不覆盖流水线真实上报的结论。

### 一致性与兼容性

- 语义对齐 `web/pipeline_transcript.py` 既有的 `_finalize_active_markers` /
  `_on_pipeline_canceled` 先例，而非另造一套状态模型，两个投影面保持一致；
- 归约是幂等纯函数，历史快照重放即自愈，**无需数据迁移**，`schemaVersion` 不变；
- 前端无需改动：`web/static/js/app.js:2641` 把任何非 `working` 状态视为已结束，
  2858 行已能渲染 `canceled`，`components/pipeline.js:431` 的活跃状态表也已覆盖。

## 测试

`tests/a2a/test_pipeline_snapshot.py` 新增 7 条用例，逐一对应证据 Session 与不变量：

| 用例 | 覆盖 |
| --- | --- |
| `test_reduce_pipeline_canceled_finalizes_dangling_nodes` | `afb47b236ee54db5a22d295609b69de6` 取消场景，step/candidate/子步骤三层收敛 |
| `test_reduce_pipeline_failed_finalizes_dangling_nodes` | 失败终止同样收敛 |
| `test_reduce_pipeline_completed_does_not_fabricate_step_success` | 成功 run 不伪造步骤成功 |
| `test_reduce_rollback_completed_supersedes_previous_step_attempt` | `e0c70d3197184b49826469b509a6fd21` 回滚折叠，新记录独立 |
| `test_reduce_candidate_restart_finalizes_candidate_sub_steps` | `7eaff0d9bcff4de7a1ba510ed030f017` 候选重启，子步骤终态化 |
| `test_finalize_keeps_existing_terminal_status_and_conclusion` | 已终态节点不被覆盖 |
| `test_finalize_non_terminal_nodes_is_idempotent_on_replay` | 重放幂等 |

另外更新了 1 条既有用例
`test_reduce_candidate_restart_removes_old_run_from_active_when_next_attempt_starts`：
它原本断言旧 attempt 永久保持 `restarting`，而这正是本工作项要消除的悬挂非终态，
故改为断言 `superseded` + 非空 `conclusion`。

验证：

- `uv run pytest tests/a2a/test_pipeline_snapshot.py -q` → 59 passed
- `uv run pytest tests/a2a/ -q` → 1496 passed
- `make lint`（ruff + ty）→ All checks passed
- `make test` → 14309 passed / 26 failed；26 项失败全部预置，与本改动无关
  （在未改动的基线提交 `88ed89c` 上复跑同一批用例得到相同失败集：i18n 缺 POT/msgfmt
  工具链、setup_packaging 与 selling skills 依赖 references 符号链接、desktop sidecar
  构建、prerequisites 二进制下载、repl_e2e 依赖 mtime 精度、providers 一条 30s 网络超时）。

## 关于第一个提交（`chore: normalize formatting`）

`pyproject.toml` 中 ruff 未固定版本（`"ruff>=0.4.0"`），`uv` 解析到 0.15.10，其
formatter 与提交树最后一次格式化所用版本不一致：在**未改动的 `88ed89c`** 上
`uv run ruff format --check src/ tests/` 即报 16 个无关文件需重排。而
`.pre-commit-config.yaml` 的 `format` 钩子是全树执行（`pass_filenames: false`），
因此任何提交都会被它改写并失败。

为了既不用 `--no-verify` 绕过钩子、也不把 16 个无关文件混进修复提交，这里把
`make format` 的机械输出单独放在第一个提交，使第二个提交的 diff 只含
`pipeline_snapshot.py` 与其测试，保持可评审。**建议仓库侧把 ruff 固定到具体版本
并全树 format 一次**，否则每个新环境解析到不同 ruff 都会重复遇到这个提交阻塞。
