### PR TITLE
fix(tools): 同源终态失败后不再重发等价请求

### DIFF
--- a/src/iac_code/agent/system_prompt.py
+++ b/src/iac_code/agent/system_prompt.py
@@ -191,7 +191,10 @@ def _build_tools_section() -> str:
         "- Read files before modifying them.\n"
         "- Use EditFile for surgical edits to existing files.\n"
         "- Use WriteFile only for creating new files or complete rewrites.\n"
-        "- If a tool call fails, do not retry the same call. Adjust your approach."
+        "- If a tool call fails, do not retry the same call. Adjust your approach.\n"
+        "- Never resend an equivalent request after a failure: an error text is a symptom, not a diagnosis. "
+        "Identify the root cause first, then either switch to a path that does not depend on the failing "
+        "precondition, or state an explicit conclusion about why the goal cannot be reached."
     )
 
 

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -5482,6 +5482,15 @@ msgstr ""
 
 #: src/iac_code/tools/tool_executor.py
 #, python-brace-format
+msgid ""
+"Tool '{tool_name}' already failed terminally ({signature}) for this exact"
+" request. Resending an equivalent request will fail the same way. "
+"Diagnose the root cause, then switch to a different request or path, or "
+"report an explicit conclusion instead."
+msgstr "Das Tool „{tool_name}“ ist für genau diese Anfrage bereits endgültig fehlgeschlagen ({signature}). Eine gleichwertige Anfrage schlägt genauso fehl. Ermitteln Sie die Ursache und wechseln Sie dann die Anfrage oder den Pfad, oder nennen Sie eine ausdrückliche Schlussfolgerung."
+
+#: src/iac_code/tools/tool_executor.py
+#, python-brace-format
 msgid "Tool '{tool_name}' timed out after {timeout}s"
 msgstr "Zeitüberschreitung bei Tool „{tool_name}“ nach {timeout} s"
 
@@ -6527,6 +6536,23 @@ msgid ""
 msgstr ""
 "max_response_bytes der Alibaba-Cloud-API {operation} muss zwischen 1 und "
 "16777216 liegen."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status} and"
+" error code {code}. An equivalent request will be rejected again; fix the"
+" request or switch to an API path that does not depend on the rejected "
+"input."
+msgstr "Die Alibaba Cloud API {operation} hat die Anfrage mit HTTP {status} und Fehlercode {code} abgelehnt. Eine gleichwertige Anfrage wird erneut abgelehnt; korrigieren Sie die Anfrage oder wechseln Sie zu einem API-Pfad, der nicht von der abgelehnten Eingabe abhängt."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status}. An"
+" equivalent request will be rejected again; fix the request or switch to "
+"an API path that does not depend on the rejected input."
+msgstr "Die Alibaba Cloud API {operation} hat die Anfrage mit HTTP {status} abgelehnt. Eine gleichwertige Anfrage wird erneut abgelehnt; korrigieren Sie die Anfrage oder wechseln Sie zu einem API-Pfad, der nicht von der abgelehnten Eingabe abhängt."
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -5445,6 +5445,15 @@ msgstr ""
 
 #: src/iac_code/tools/tool_executor.py
 #, python-brace-format
+msgid ""
+"Tool '{tool_name}' already failed terminally ({signature}) for this exact"
+" request. Resending an equivalent request will fail the same way. "
+"Diagnose the root cause, then switch to a different request or path, or "
+"report an explicit conclusion instead."
+msgstr "La herramienta «{tool_name}» ya falló de forma definitiva ({signature}) para esta misma solicitud. Reenviar una solicitud equivalente fallará igual. Diagnostique la causa raíz y luego cambie de solicitud o de ruta, o informe una conclusión explícita."
+
+#: src/iac_code/tools/tool_executor.py
+#, python-brace-format
 msgid "Tool '{tool_name}' timed out after {timeout}s"
 msgstr "La herramienta «{tool_name}» agotó el tiempo de espera tras {timeout} s"
 
@@ -6495,6 +6504,23 @@ msgid ""
 msgstr ""
 "El max_response_bytes de la API de Alibaba Cloud {operation} debe estar "
 "entre 1 y 16777216."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status} and"
+" error code {code}. An equivalent request will be rejected again; fix the"
+" request or switch to an API path that does not depend on the rejected "
+"input."
+msgstr "La API de Alibaba Cloud {operation} rechazó la solicitud con HTTP {status} y el código de error {code}. Una solicitud equivalente será rechazada de nuevo; corrija la solicitud o cambie a una ruta de API que no dependa de la entrada rechazada."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status}. An"
+" equivalent request will be rejected again; fix the request or switch to "
+"an API path that does not depend on the rejected input."
+msgstr "La API de Alibaba Cloud {operation} rechazó la solicitud con HTTP {status}. Una solicitud equivalente será rechazada de nuevo; corrija la solicitud o cambie a una ruta de API que no dependa de la entrada rechazada."
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -5462,6 +5462,15 @@ msgstr ""
 
 #: src/iac_code/tools/tool_executor.py
 #, python-brace-format
+msgid ""
+"Tool '{tool_name}' already failed terminally ({signature}) for this exact"
+" request. Resending an equivalent request will fail the same way. "
+"Diagnose the root cause, then switch to a different request or path, or "
+"report an explicit conclusion instead."
+msgstr "L'outil « {tool_name} » a déjà échoué définitivement ({signature}) pour cette requête exacte. Renvoyer une requête équivalente échouera de la même manière. Diagnostiquez la cause racine, puis changez de requête ou de chemin, ou formulez une conclusion explicite."
+
+#: src/iac_code/tools/tool_executor.py
+#, python-brace-format
 msgid "Tool '{tool_name}' timed out after {timeout}s"
 msgstr "L’outil « {tool_name} » a expiré après {timeout} s"
 
@@ -6509,6 +6518,23 @@ msgid ""
 msgstr ""
 "Le max_response_bytes de l'API Alibaba Cloud {operation} doit être "
 "compris entre 1 et 16777216."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status} and"
+" error code {code}. An equivalent request will be rejected again; fix the"
+" request or switch to an API path that does not depend on the rejected "
+"input."
+msgstr "L'API Alibaba Cloud {operation} a rejeté la requête avec le code HTTP {status} et le code d'erreur {code}. Une requête équivalente sera de nouveau rejetée ; corrigez la requête ou passez à un chemin d'API qui ne dépend pas de l'entrée rejetée."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status}. An"
+" equivalent request will be rejected again; fix the request or switch to "
+"an API path that does not depend on the rejected input."
+msgstr "L'API Alibaba Cloud {operation} a rejeté la requête avec le code HTTP {status}. Une requête équivalente sera de nouveau rejetée ; corrigez la requête ou passez à un chemin d'API qui ne dépend pas de l'entrée rejetée."
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -5174,6 +5174,15 @@ msgstr "ツール「{tool_name}」への入力が無効です: {error}。ツー�
 
 #: src/iac_code/tools/tool_executor.py
 #, python-brace-format
+msgid ""
+"Tool '{tool_name}' already failed terminally ({signature}) for this exact"
+" request. Resending an equivalent request will fail the same way. "
+"Diagnose the root cause, then switch to a different request or path, or "
+"report an explicit conclusion instead."
+msgstr "ツール「{tool_name}」はこのリクエストで既に最終的な失敗（{signature}）となりました。同等のリクエストを再送しても同じように失敗します。根本原因を特定し、別のリクエストや経路に切り替えるか、明確な結論を示してください。"
+
+#: src/iac_code/tools/tool_executor.py
+#, python-brace-format
 msgid "Tool '{tool_name}' timed out after {timeout}s"
 msgstr "ツール「{tool_name}」は {timeout} 秒後にタイムアウトしました"
 
@@ -6160,6 +6169,23 @@ msgid ""
 msgstr ""
 "Alibaba Cloud API {operation} の max_response_bytes は 1 から 16777216 "
 "の範囲で指定してください。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status} and"
+" error code {code}. An equivalent request will be rejected again; fix the"
+" request or switch to an API path that does not depend on the rejected "
+"input."
+msgstr "Alibaba Cloud API {operation} は HTTP {status}、エラーコード {code} でリクエストを拒否しました。同等のリクエストは再び拒否されます。リクエストを修正するか、拒否された入力に依存しない API 経路に切り替えてください。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status}. An"
+" equivalent request will be rejected again; fix the request or switch to "
+"an API path that does not depend on the rejected input."
+msgstr "Alibaba Cloud API {operation} は HTTP {status} でリクエストを拒否しました。同等のリクエストは再び拒否されます。リクエストを修正するか、拒否された入力に依存しない API 経路に切り替えてください。"
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -5408,6 +5408,15 @@ msgstr ""
 
 #: src/iac_code/tools/tool_executor.py
 #, python-brace-format
+msgid ""
+"Tool '{tool_name}' already failed terminally ({signature}) for this exact"
+" request. Resending an equivalent request will fail the same way. "
+"Diagnose the root cause, then switch to a different request or path, or "
+"report an explicit conclusion instead."
+msgstr "A ferramenta \"{tool_name}\" já falhou definitivamente ({signature}) para esta mesma solicitação. Reenviar uma solicitação equivalente falhará da mesma forma. Diagnostique a causa raiz e então troque de solicitação ou de caminho, ou informe uma conclusão explícita."
+
+#: src/iac_code/tools/tool_executor.py
+#, python-brace-format
 msgid "Tool '{tool_name}' timed out after {timeout}s"
 msgstr "A ferramenta “{tool_name}” excedeu o tempo limite após {timeout} s"
 
@@ -6453,6 +6462,23 @@ msgid ""
 msgstr ""
 "O max_response_bytes da API do Alibaba Cloud {operation} deve estar entre"
 " 1 e 16777216."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status} and"
+" error code {code}. An equivalent request will be rejected again; fix the"
+" request or switch to an API path that does not depend on the rejected "
+"input."
+msgstr "A API da Alibaba Cloud {operation} rejeitou a solicitação com HTTP {status} e código de erro {code}. Uma solicitação equivalente será rejeitada novamente; corrija a solicitação ou mude para um caminho de API que não dependa da entrada rejeitada."
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status}. An"
+" equivalent request will be rejected again; fix the request or switch to "
+"an API path that does not depend on the rejected input."
+msgstr "A API da Alibaba Cloud {operation} rejeitou a solicitação com HTTP {status}. Uma solicitação equivalente será rejeitada novamente; corrija a solicitação ou mude para um caminho de API que não dependa da entrada rejeitada."
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -5109,6 +5109,15 @@ msgstr "工具“{tool_name}”的输入无效：{error}。请按照工具架构
 
 #: src/iac_code/tools/tool_executor.py
 #, python-brace-format
+msgid ""
+"Tool '{tool_name}' already failed terminally ({signature}) for this exact"
+" request. Resending an equivalent request will fail the same way. "
+"Diagnose the root cause, then switch to a different request or path, or "
+"report an explicit conclusion instead."
+msgstr "工具“{tool_name}”对该请求已终态失败（{signature}）。重发等价请求只会以同样方式失败。请先定位根因，然后换用其它请求或路径，或直接给出明确结论。"
+
+#: src/iac_code/tools/tool_executor.py
+#, python-brace-format
 msgid "Tool '{tool_name}' timed out after {timeout}s"
 msgstr "工具“{tool_name}”在 {timeout} 秒后超时"
 
@@ -6021,6 +6030,23 @@ msgid ""
 "Alibaba Cloud API {operation} max_response_bytes must be between 1 and "
 "16777216."
 msgstr "阿里云 API {operation} 的 max_response_bytes 必须介于 1 和 16777216 之间。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status} and"
+" error code {code}. An equivalent request will be rejected again; fix the"
+" request or switch to an API path that does not depend on the rejected "
+"input."
+msgstr "阿里云 API {operation} 以 HTTP {status} 和错误码 {code} 拒绝了该请求。等价请求会再次被拒绝；请修正请求，或改用不依赖被拒输入的 API 路径。"
+
+#: src/iac_code/tools/cloud/aliyun/public_errors.py
+#, python-brace-format
+msgid ""
+"Alibaba Cloud API {operation} rejected the request with HTTP {status}. An"
+" equivalent request will be rejected again; fix the request or switch to "
+"an API path that does not depend on the rejected input."
+msgstr "阿里云 API {operation} 以 HTTP {status} 拒绝了该请求。等价请求会再次被拒绝；请修正请求，或改用不依赖被拒输入的 API 路径。"
 
 #: src/iac_code/tools/cloud/aliyun/public_errors.py
 #, python-brace-format

--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -81,6 +81,7 @@ from iac_code.tools.cloud.aliyun.template_source import (
 )
 from iac_code.tools.cloud.aliyun.user_agent import build_user_agent
 from iac_code.tools.cloud.base_api import BaseCloudApi
+from iac_code.tools.failure_recovery import mark_terminal_failure, terminal_failure_signature
 from iac_code.tools.path_safety import check_read_path_with_resolution
 from iac_code.types.permissions import (
     MAX_PERMISSION_AUDIT_ITEMS,
@@ -501,6 +502,23 @@ def _target_http_error_message(response: Any) -> str:
             code = candidate
     suffix = f":{code}" if code is not None else ""
     return f"aliyun_target_http_error:{int(response.status)}{suffix}"
+
+
+def _target_terminal_failure_signature(response: Any) -> str | None:
+    """Signature for statuses that reject the request shape itself, else None.
+
+    408 and 429 depend on timing rather than the request shape, so an identical
+    request can legitimately succeed later and must stay repeatable.
+    """
+    status = int(response.status)
+    if not 400 <= status < 500 or status in {408, 429}:
+        return None
+    code = None
+    if isinstance(response.body, Mapping):
+        candidate = response.body.get("Code", response.body.get("code", response.body.get("error")))
+        if isinstance(candidate, str) and _TARGET_ERROR_CODE.fullmatch(candidate):
+            code = candidate
+    return terminal_failure_signature(status=status, code=code)
 
 
 def _redact_target_error_detail(value: str) -> str:
@@ -2553,6 +2571,7 @@ class AliyunApi(BaseCloudApi):
             target_outcome = "target_transport_failure"
             target_error_message: str | None = None
             target_error_detail: str | None = None
+            target_terminal_signature: str | None = None
             target_error: BaseException | None = None
             with start_span(
                 Spans.ALIYUN_API_CALL,
@@ -2564,6 +2583,7 @@ class AliyunApi(BaseCloudApi):
                         target_outcome = "http_error"
                         target_error_message = _target_http_error_message(response)
                         target_error_detail = _target_http_error_detail(response)
+                        target_terminal_signature = _target_terminal_failure_signature(response)
                     else:
                         target_outcome = "success"
                 except asyncio.CancelledError as error:
@@ -2622,7 +2642,10 @@ class AliyunApi(BaseCloudApi):
                 )
                 if target_error_detail is not None:
                     public_error = f"{public_error} Response: {target_error_detail}"
-                return ToolResult.error(public_error)
+                error_result = ToolResult.error(public_error)
+                if target_terminal_signature is not None:
+                    mark_terminal_failure(error_result, target_terminal_signature)
+                return error_result
             assert response is not None
             business_content, body_format = serialize_business_result(response, request, contract)
             aliyun_http = build_aliyun_http_metadata(

--- a/src/iac_code/tools/cloud/aliyun/public_errors.py
+++ b/src/iac_code/tools/cloud/aliyun/public_errors.py
@@ -423,6 +423,18 @@ def public_aliyun_error(
     target_http = _target_http_context(code)
     if target_http is not None:
         status, target_code = target_http
+        if _is_request_rejected_status(status):
+            if target_code is not None:
+                return _(
+                    "Alibaba Cloud API {operation} rejected the request with HTTP {status} and error code {code}. "
+                    "An equivalent request will be rejected again; fix the request or switch to an API path that "
+                    "does not depend on the rejected input."
+                ).format(operation=operation, status=status, code=target_code)
+            return _(
+                "Alibaba Cloud API {operation} rejected the request with HTTP {status}. "
+                "An equivalent request will be rejected again; fix the request or switch to an API path that "
+                "does not depend on the rejected input."
+            ).format(operation=operation, status=status)
         if target_code is not None:
             return _(
                 "Alibaba Cloud API {operation} returned HTTP {status} with error code {code}. "
@@ -532,6 +544,16 @@ def _target_http_context(code: str) -> tuple[str, str | None] | None:
     if not 100 <= int(status) <= 599:
         return None
     return status, match.group(2)
+
+
+def _is_request_rejected_status(status: str) -> bool:
+    """Client errors that reject the request shape, so resending is pointless.
+
+    408 and 429 are excluded: they depend on timing rather than the request, so
+    an identical request can legitimately succeed later.
+    """
+    value = int(status)
+    return 400 <= value < 500 and value not in {408, 429}
 
 
 def _safe_identifier(value: Any, fallback: str) -> str:

--- a/src/iac_code/tools/failure_recovery.py
+++ b/src/iac_code/tools/failure_recovery.py
@@ -1,0 +1,71 @@
+"""Terminal tool-failure memory so equivalent failing calls are not resent.
+
+A same-origin client error (for example an Alibaba Cloud HTTP 400 that rejects a
+template resource type) fails identically no matter how many times the exact
+same request is repeated. Transport retry deliberately excludes those statuses,
+so the repetition originates from the agent loop re-issuing an equivalent tool
+call. This module remembers those terminal failures per
+``(tool name, canonical input)`` so the second equivalent call is refused
+locally instead of hitting the cloud again.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from iac_code.tools.base import ToolResult
+
+TERMINAL_FAILURE_METADATA_KEY = "_iac_code_terminal_failure"
+
+_DEFAULT_MAX_ENTRIES = 128
+
+
+def terminal_failure_signature(*, status: int, code: str | None = None) -> str:
+    """Build the stable, value-free signature recorded for a terminal failure."""
+    suffix = f":{code}" if code else ""
+    return f"http_{int(status)}{suffix}"
+
+
+def mark_terminal_failure(result: ToolResult, signature: str) -> ToolResult:
+    """Tag an error result as terminal for its exact request shape."""
+    metadata = dict(result.metadata or {})
+    metadata[TERMINAL_FAILURE_METADATA_KEY] = signature
+    result.metadata = metadata
+    return result
+
+
+def take_terminal_failure(result: ToolResult) -> str | None:
+    """Read and remove the internal terminal marker so it never leaves the executor."""
+    metadata = result.metadata
+    if not isinstance(metadata, dict):
+        return None
+    signature = metadata.pop(TERMINAL_FAILURE_METADATA_KEY, None)
+    if not metadata:
+        result.metadata = None
+    return signature if isinstance(signature, str) and signature else None
+
+
+class TerminalFailureLedger:
+    """Bounded per-executor memory of terminally failed request shapes."""
+
+    def __init__(self, *, max_entries: int = _DEFAULT_MAX_ENTRIES) -> None:
+        self._max_entries = max_entries
+        self._entries: OrderedDict[tuple[str, str], str] = OrderedDict()
+
+    @staticmethod
+    def _key(tool_name: str, canonical_input_sha256: str) -> tuple[str, str]:
+        return (tool_name, canonical_input_sha256)
+
+    def record(self, *, tool_name: str, canonical_input_sha256: str, signature: str) -> None:
+        key = self._key(tool_name, canonical_input_sha256)
+        self._entries.pop(key, None)
+        self._entries[key] = signature
+        while len(self._entries) > self._max_entries:
+            self._entries.popitem(last=False)
+
+    def lookup(self, *, tool_name: str, canonical_input_sha256: str) -> str | None:
+        key = self._key(tool_name, canonical_input_sha256)
+        signature = self._entries.get(key)
+        if signature is not None:
+            self._entries.move_to_end(key)
+        return signature

--- a/src/iac_code/tools/tool_executor.py
+++ b/src/iac_code/tools/tool_executor.py
@@ -14,6 +14,7 @@ from iac_code.services.telemetry.content_serializer import serialize_tool_argume
 from iac_code.services.telemetry.names import Events, GenAiAttr, GenAiOperationName, GenAiSpanKind, Metrics, Spans
 from iac_code.services.telemetry.sanitize import sanitize_error_message, sanitize_tool_name
 from iac_code.tools.base import ToolContext, ToolResult
+from iac_code.tools.failure_recovery import TerminalFailureLedger, take_terminal_failure
 from iac_code.types.permissions import ExecutionClass, InvocationBinding
 
 if TYPE_CHECKING:
@@ -42,6 +43,7 @@ class ToolExecutor:
         self._registry = registry
         self._max_concurrency = max_concurrency
         self._tool_timeout = tool_timeout
+        self._terminal_failures = TerminalFailureLedger()
 
     def partition(self, calls: list[ToolCallRequest]) -> tuple[list[ToolCallRequest], list[ToolCallRequest]]:
         """Partition calls into concurrent (read-only) and serial (write) batches."""
@@ -109,6 +111,16 @@ class ToolExecutor:
         if timeout is None:
             timeout = self._tool_timeout
 
+        already_failed = self._recorded_terminal_failure(call)
+        if already_failed is not None:
+            return ToolResult.error(
+                _(
+                    "Tool '{tool_name}' already failed terminally ({signature}) for this exact request. "
+                    "Resending an equivalent request will fail the same way. Diagnose the root cause, then switch "
+                    "to a different request or path, or report an explicit conclusion instead."
+                ).format(tool_name=call.name, signature=already_failed)
+            )
+
         # Telemetry instrumentation
         tool_name = sanitize_tool_name(call.name)
         started = time.monotonic()
@@ -137,6 +149,7 @@ class ToolExecutor:
                     span.set_attribute(GenAiAttr.TOOL_CALL_RESULT, serialize_tool_result(result, tool_name=call.name))
                 log_event(Events.TOOL_USE_SUCCEEDED, {"tool_name": tool_name, "duration_ms": duration_ms})
                 add_metric(Metrics.TOOL_USE_COUNT, 1, {"tool_name": tool_name, "outcome": "success"})
+                self._consume_terminal_failure(call, result)
                 return result
         except asyncio.TimeoutError:
             log_event(
@@ -171,6 +184,27 @@ class ToolExecutor:
                 ToolResult.error(_("Tool '{tool_name}' failed: {error}").format(tool_name=call.name, error=e)),
                 context,
             )
+
+    def _recorded_terminal_failure(self, call: ToolCallRequest) -> str | None:
+        binding = call.invocation_binding
+        if binding is None:
+            return None
+        return self._terminal_failures.lookup(
+            tool_name=call.name,
+            canonical_input_sha256=binding.canonical_input_sha256,
+        )
+
+    def _consume_terminal_failure(self, call: ToolCallRequest, result: ToolResult) -> None:
+        """Record a terminal failure and strip its internal marker from the result."""
+        signature = take_terminal_failure(result)
+        binding = call.invocation_binding
+        if signature is None or binding is None:
+            return
+        self._terminal_failures.record(
+            tool_name=call.name,
+            canonical_input_sha256=binding.canonical_input_sha256,
+            signature=signature,
+        )
 
     @staticmethod
     def _attach_ros_preflight(result: ToolResult, context: ToolContext) -> ToolResult:

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -406,6 +406,13 @@ class TestBuildBaseSections:
         tools_pos = result.find("Using Tools")
         assert identity_pos < tools_pos
 
+    def test_tools_section_forbids_resending_equivalent_requests_after_a_failure(self):
+        result = build_base_sections(["tools"], cwd="/tmp")
+        assert "Never resend an equivalent request after a failure" in result
+        assert "an error text is a symptom, not a diagnosis" in result
+        assert "switch to a path that does not depend on the failing precondition" in result
+        assert "state an explicit conclusion" in result
+
     def test_empty_list_returns_empty_string(self):
         result = build_base_sections([], cwd="/tmp")
         assert result == ""

--- a/tests/tools/cloud/aliyun/test_aliyun_api.py
+++ b/tests/tools/cloud/aliyun/test_aliyun_api.py
@@ -40,6 +40,7 @@ from iac_code.tools.cloud.aliyun.product_resolver import ProductResolver
 from iac_code.tools.cloud.aliyun.public_errors import public_aliyun_error
 from iac_code.tools.cloud.aliyun.result_contract import ALIYUN_BODY_CONTRACT_VERSION, ALIYUN_HTTP_METADATA_KEY
 from iac_code.tools.cloud.aliyun.retry_policy import RetryBudget, RetryExhausted, RetryReason, TransportFailure
+from iac_code.tools.failure_recovery import TERMINAL_FAILURE_METADATA_KEY
 from iac_code.tools.tool_executor import ToolCallRequest, ToolExecutor
 from iac_code.types.permissions import InvocationBinding, ToolPermissionContext
 from iac_code.types.stream_events import ResourceObservedEvent
@@ -2645,10 +2646,19 @@ async def test_shared_target_boundary_converts_transport_http_errors_to_sanitize
     assert transport.calls[-1]["contract"].transport == expected_transport
     assert result.is_error is True
     product = "Oss" if action == "HeadObject" else "Ecs"
-    assert result.content.startswith(
-        f"Alibaba Cloud API {product}/{action} returned HTTP {status} with error code InvalidRequest. "
-        "Check the request and cloud permissions before retrying."
-    )
+    if status == 400:
+        assert result.content.startswith(
+            f"Alibaba Cloud API {product}/{action} rejected the request with HTTP {status} and error code "
+            "InvalidRequest. An equivalent request will be rejected again; fix the request or switch to an API path "
+            "that does not depend on the rejected input."
+        )
+        assert result.metadata == {TERMINAL_FAILURE_METADATA_KEY: "http_400:InvalidRequest"}
+    else:
+        assert result.content.startswith(
+            f"Alibaba Cloud API {product}/{action} returned HTTP {status} with error code InvalidRequest. "
+            "Check the request and cloud permissions before retrying."
+        )
+        assert result.metadata is None
     assert "Message: 该用户没有授权" in result.content
     assert "Description: Use a valid business authorization before retrying." in result.content
     assert len(result.content) < 768
@@ -2726,7 +2736,7 @@ async def test_target_boundary_preserves_oauth_style_business_error_semantics(mo
     result = await _production_execute(AliyunApi(services=services), _target_test_input("DescribeInstances"))
 
     assert result.is_error is True
-    assert "HTTP 404 with error code instance_not_found" in result.content
+    assert "HTTP 404 and error code instance_not_found" in result.content
     assert "Description: Instance not found by request." in result.content
     assert "request-private" not in result.content
 

--- a/tests/tools/cloud/aliyun/test_public_errors.py
+++ b/tests/tools/cloud/aliyun/test_public_errors.py
@@ -90,6 +90,12 @@ def test_aliyun_public_error_templates_are_directly_extractable(tmp_path: Path) 
         "Check the request and cloud permissions before retrying.",
         "Alibaba Cloud API {operation} returned HTTP {status} with error code {code}. "
         "Check the request and cloud permissions before retrying.",
+        "Alibaba Cloud API {operation} rejected the request with HTTP {status}. "
+        "An equivalent request will be rejected again; fix the request or switch to an API path that "
+        "does not depend on the rejected input.",
+        "Alibaba Cloud API {operation} rejected the request with HTTP {status} and error code {code}. "
+        "An equivalent request will be rejected again; fix the request or switch to an API path that "
+        "does not depend on the rejected input.",
         "Alibaba Cloud API {operation} received a retryable service response, but the retry deadline expired. "
         "Retry the read-only request later.",
         "Alibaba Cloud API {operation} read-only request did not complete before the retry deadline. "
@@ -163,6 +169,35 @@ def test_aliyun_public_error_templates_are_directly_extractable(tmp_path: Path) 
         "so {operation} cannot be signed. Check ECS metadata availability.",
     }
     assert msgids == required
+
+
+@pytest.mark.parametrize("status", [400, 403, 404])
+def test_rejected_request_statuses_require_switching_paths_instead_of_resending(status: int) -> None:
+    message = public_aliyun_error(
+        f"aliyun_target_http_error:{status}:InvalidParameter",
+        product="Ros",
+        action="ListStackEvents",
+    )
+
+    assert message == (
+        f"Alibaba Cloud API Ros/ListStackEvents rejected the request with HTTP {status} and error code "
+        "InvalidParameter. An equivalent request will be rejected again; fix the request or switch to an API path "
+        "that does not depend on the rejected input."
+    )
+
+
+@pytest.mark.parametrize("status", [408, 429, 500, 503])
+def test_timing_and_server_statuses_keep_the_retryable_guidance(status: int) -> None:
+    message = public_aliyun_error(
+        f"aliyun_target_http_error:{status}",
+        product="Ros",
+        action="ListStackEvents",
+    )
+
+    assert message == (
+        f"Alibaba Cloud API Ros/ListStackEvents returned HTTP {status}. "
+        "Check the request and cloud permissions before retrying."
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_failure_recovery.py
+++ b/tests/tools/test_failure_recovery.py
@@ -1,0 +1,65 @@
+"""Tests for the terminal tool-failure ledger."""
+
+from __future__ import annotations
+
+from iac_code.tools.base import ToolResult
+from iac_code.tools.failure_recovery import (
+    TERMINAL_FAILURE_METADATA_KEY,
+    TerminalFailureLedger,
+    mark_terminal_failure,
+    take_terminal_failure,
+    terminal_failure_signature,
+)
+
+
+def test_signature_includes_the_business_error_code_when_present():
+    assert terminal_failure_signature(status=400, code="ResourceTypeNotFound") == "http_400:ResourceTypeNotFound"
+    assert terminal_failure_signature(status=404) == "http_404"
+
+
+def test_marking_preserves_existing_metadata():
+    result = ToolResult.error("rejected")
+    result.metadata = {"aliyun_http": {"status": 400}}
+
+    mark_terminal_failure(result, "http_400")
+
+    assert result.metadata == {"aliyun_http": {"status": 400}, TERMINAL_FAILURE_METADATA_KEY: "http_400"}
+
+
+def test_taking_the_marker_removes_it_and_drops_empty_metadata():
+    result = mark_terminal_failure(ToolResult.error("rejected"), "http_400")
+
+    assert take_terminal_failure(result) == "http_400"
+    assert result.metadata is None
+    assert take_terminal_failure(result) is None
+
+
+def test_taking_the_marker_keeps_other_metadata():
+    result = ToolResult.error("rejected")
+    result.metadata = {"aliyun_http": {"status": 400}}
+    mark_terminal_failure(result, "http_400")
+
+    assert take_terminal_failure(result) == "http_400"
+    assert result.metadata == {"aliyun_http": {"status": 400}}
+
+
+def test_ledger_records_and_looks_up_per_tool_and_input():
+    ledger = TerminalFailureLedger()
+    ledger.record(tool_name="aliyun_api", canonical_input_sha256="a" * 64, signature="http_400")
+
+    assert ledger.lookup(tool_name="aliyun_api", canonical_input_sha256="a" * 64) == "http_400"
+    assert ledger.lookup(tool_name="aliyun_api", canonical_input_sha256="b" * 64) is None
+    assert ledger.lookup(tool_name="ros_stack", canonical_input_sha256="a" * 64) is None
+
+
+def test_ledger_evicts_the_least_recently_used_entry_when_full():
+    ledger = TerminalFailureLedger(max_entries=2)
+    ledger.record(tool_name="aliyun_api", canonical_input_sha256="a" * 64, signature="http_400")
+    ledger.record(tool_name="aliyun_api", canonical_input_sha256="b" * 64, signature="http_403")
+    assert ledger.lookup(tool_name="aliyun_api", canonical_input_sha256="a" * 64) == "http_400"
+
+    ledger.record(tool_name="aliyun_api", canonical_input_sha256="c" * 64, signature="http_404")
+
+    assert ledger.lookup(tool_name="aliyun_api", canonical_input_sha256="b" * 64) is None
+    assert ledger.lookup(tool_name="aliyun_api", canonical_input_sha256="a" * 64) == "http_400"
+    assert ledger.lookup(tool_name="aliyun_api", canonical_input_sha256="c" * 64) == "http_404"

--- a/tests/tools/test_tool_executor.py
+++ b/tests/tools/test_tool_executor.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from iac_code.tools.base import Tool, ToolContext, ToolResult
+from iac_code.tools.failure_recovery import mark_terminal_failure
 from iac_code.tools.tool_executor import ToolCallRequest, ToolExecutor
 from iac_code.types.permissions import InvocationBinding
 
@@ -628,3 +629,102 @@ class TestRosPreflightOutcomePropagation:
 
         summaries = [item.metadata["ros_validation"]["diagnostics"][0]["summary"] for item in results]
         assert summaries == ["warning-a", "warning-b"]
+
+
+class FakeTerminalFailureTool(FakeReadTool):
+    """Fails like an Alibaba Cloud 4xx: same request shape, same rejection."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def execute(self, *, tool_input, context):
+        self.calls.append(dict(tool_input))
+        result = ToolResult.error("rejected")
+        if tool_input.get("terminal", True):
+            mark_terminal_failure(result, "http_400:ResourceTypeNotFound")
+        return result
+
+
+def _binding(canonical_input_sha256: str) -> InvocationBinding:
+    return InvocationBinding("nonce", "session", "call", "read", canonical_input_sha256)
+
+
+@pytest.mark.asyncio
+class TestTerminalFailureRecovery:
+    async def test_equivalent_request_is_refused_without_calling_the_tool_again(self, monkeypatch):
+        monkeypatch.setattr("iac_code.tools.tool_executor._", lambda message: message)
+        tool = FakeTerminalFailureTool()
+        registry = MagicMock()
+        registry.get = lambda name: tool
+        executor = ToolExecutor(registry=registry)
+        call = ToolCallRequest(id="first", name="read", input={}, invocation_binding=_binding("a" * 64))
+
+        first = (await executor.execute_batch([call], ToolContext()))[0]
+        second = (await executor.execute_batch([call], ToolContext()))[0]
+
+        assert len(tool.calls) == 1
+        assert first.content == "rejected"
+        assert second.is_error is True
+        assert "already failed terminally (http_400:ResourceTypeNotFound)" in second.content
+        assert "switch" in second.content
+
+    async def test_internal_terminal_marker_never_reaches_the_returned_result(self):
+        tool = FakeTerminalFailureTool()
+        registry = MagicMock()
+        registry.get = lambda name: tool
+        executor = ToolExecutor(registry=registry)
+
+        result = (
+            await executor.execute_batch(
+                [ToolCallRequest(id="first", name="read", input={}, invocation_binding=_binding("b" * 64))],
+                ToolContext(),
+            )
+        )[0]
+
+        assert result.metadata is None
+
+    async def test_a_different_request_shape_is_still_executed(self):
+        tool = FakeTerminalFailureTool()
+        registry = MagicMock()
+        registry.get = lambda name: tool
+        executor = ToolExecutor(registry=registry)
+
+        await executor.execute_batch(
+            [ToolCallRequest(id="first", name="read", input={"stack": "a"}, invocation_binding=_binding("c" * 64))],
+            ToolContext(),
+        )
+        await executor.execute_batch(
+            [ToolCallRequest(id="second", name="read", input={"stack": "b"}, invocation_binding=_binding("d" * 64))],
+            ToolContext(),
+        )
+
+        assert [call["stack"] for call in tool.calls] == ["a", "b"]
+
+    async def test_non_terminal_failures_stay_repeatable(self):
+        tool = FakeTerminalFailureTool()
+        registry = MagicMock()
+        registry.get = lambda name: tool
+        executor = ToolExecutor(registry=registry)
+        call = ToolCallRequest(
+            id="first",
+            name="read",
+            input={"terminal": False},
+            invocation_binding=_binding("e" * 64),
+        )
+
+        await executor.execute_batch([call], ToolContext())
+        await executor.execute_batch([call], ToolContext())
+
+        assert len(tool.calls) == 2
+
+    async def test_calls_without_an_invocation_binding_are_not_tracked(self):
+        tool = FakeTerminalFailureTool()
+        registry = MagicMock()
+        registry.get = lambda name: tool
+        executor = ToolExecutor(registry=registry)
+        call = ToolCallRequest(id="first", name="read", input={})
+
+        await executor.execute_batch([call], ToolContext())
+        await executor.execute_batch([call], ToolContext())
+
+        assert len(tool.calls) == 2


### PR DESCRIPTION
## 背景

证据会话 `2916da860b314205badbbda2356834d9`（AnalysisId `sarpt-auto-2026072918`）中，ROS 的 ListStackEvents / ListStackResources / GetStack 三次调用都返回 HTTP 400（资源类型 `ALIYUN::Milvus::Instance` 无法识别）。Agent 把错误文本当成诊断结论，既没有切换查询路径，也反复重发等价请求。

传输层重试策略只覆盖 `{429, 502, 503, 504}`，400 从未被重试，所以重复请求来自 Agent 主循环：`ToolExecutor` 没有"等价请求已终态失败"的记忆，云侧 4xx 也没有和可重试错误区分，公共错误文案还在提示 "before retrying"。

## 改动

1. 新增 `src/iac_code/tools/failure_recovery.py`
   - `terminal_failure_signature(status, code)` 生成稳定签名（如 `http_400:ResourceTypeNotFound`）
   - `mark_terminal_failure` / `take_terminal_failure`：内部元数据标记 `_iac_code_terminal_failure`，仿照既有 `TOOL_RENDER_METADATA_KEY` 约定，在 executor 内被摘除，不会泄漏到事件流或前端
   - `TerminalFailureLedger`：以 `(tool_name, canonical_input_sha256)` 为键的有界 LRU 记忆（128 条）

2. `tools/tool_executor.py`：执行前查账本，命中则直接返回明确错误（提示先定位根因、再换路径或给出结论），不再真正调用工具；执行后消费并记录终态失败标记。等价性复用既有的 `canonical_input_sha256`。

3. `tools/cloud/aliyun/aliyun_api.py`：非 2xx 时计算终态签名。408/429 依赖时序而非请求形状，被显式排除，保持可重复。

4. `tools/cloud/aliyun/public_errors.py`：请求被拒绝的 4xx 文案改为"等价请求会再次被拒绝，请修正请求或切换不依赖该输入的 API 路径"，其余状态维持原有可重试提示。

5. `agent/system_prompt.py`：工具约定新增一条——错误文本是症状不是诊断，禁止重发等价请求，先定位根因，再换路径或给出显式结论。

6. 6 个 locale 的 `messages.po` 补齐 3 条新 msgid 的实际译文。

## 测试

- 新增 `tests/tools/test_failure_recovery.py`（7 例）：签名格式、元数据标记/摘除、账本按 (tool, input) 隔离、LRU 淘汰
- `tests/tools/test_tool_executor.py`：新增 `TestTerminalFailureRecovery`（5 例）——等价请求被拒且不再调用工具、内部标记不外泄、不同入参仍执行、非终态失败可重复、无 `invocation_binding` 时不记账
- `tests/tools/cloud/aliyun/test_public_errors.py`、`test_aliyun_api.py`、`tests/agent/test_system_prompt.py` 同步覆盖新文案与元数据
- 全量：14360 个测试，14346 通过，12 skipped，14 failed；14 个失败全部已核验与本次改动无关（zh 目录 `{s:.0}` msgfmt 问题在 baseline 即存在；3 个用 `git stash` 验证为 pre-existing；其余 10 个由全量跑自身删除仓库 symlink / 改写 `__release_date__` 导致，恢复后重跑 401 通过）
- `ruff check`、`ruff format --check`、`ty check` 全部通过
