### PR TITLE
fix(pipeline): 诊断卡死的候选子步骤，禁止静默换新候选掩盖失败

### DIFF
--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -245,8 +245,26 @@ def _parse_sub_pipelines(
             max_rollbacks=sub_raw.get("max_rollbacks", 5),
             iterate_over=sub_raw.get("iterate_over", ""),
             context_fields_from_parent=sub_raw.get("context_fields_from_parent", []),
+            sub_step_stall_timeout_s=_parse_sub_step_stall_timeout(sub_name, sub_raw.get("sub_step_stall_timeout_s")),
+            sub_step_stall_retries=_parse_sub_step_stall_retries(sub_name, sub_raw.get("sub_step_stall_retries", 1)),
         )
     return result
+
+
+def _parse_sub_step_stall_timeout(sub_name: str, raw: object) -> float | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, (int, float)) or isinstance(raw, bool) or raw <= 0:
+        raise ValueError(
+            f"sub_pipelines.{sub_name}.sub_step_stall_timeout_s must be a positive number or omitted, got {raw!r}"
+        )
+    return float(raw)
+
+
+def _parse_sub_step_stall_retries(sub_name: str, raw: object) -> int:
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw < 0:
+        raise ValueError(f"sub_pipelines.{sub_name}.sub_step_stall_retries must be a non-negative integer, got {raw!r}")
+    return raw
 
 
 def _parse_steps(raw_steps: list[dict]) -> list[StepSpec]:

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -3197,6 +3197,11 @@ class PipelineRunner:
 
         parent_step_id = parent_step_id or self.state_machine.current_step.step_id
         candidate_name = state.get("name", "")
+        # A candidate that is about to restart in place keeps running; every other
+        # cancellation reason must leave a terminal, diagnosable state behind so a
+        # replacement candidate cannot mask why this one stopped.
+        if reason != "candidate_restart":
+            state["cancel_reason"] = reason
         if not state.get("_candidate_cancelled_observed", False):
             state["_candidate_cancelled_observed"] = True
             self._observability.candidate_cancelled(
@@ -4605,6 +4610,50 @@ class PipelineRunner:
             failed_by_index[i] = dict(entry)
             await self._save_running(step.step_id, reason="parallel candidate failed")
 
+        def save_candidate_cancelled_sync(i: int, state: dict[str, Any], reason: str) -> None:
+            """Persist a terminal entry for a cancelled candidate, preserving the reason.
+
+            Runs synchronously because the owning task is already cancelled. The
+            status stays ``failed`` so restore/replay keep routing on the three
+            known states; ``terminal_reason`` carries why it stopped.
+            """
+            active_attempt_id = state.get("active_attempt_id")
+            if active_attempt_id:
+                self._mark_attempt_status(active_attempt_id, "failed")
+            terminal_reason = "superseded" if reason == "hard_interrupt_parent_rollback" else "canceled"
+            failure = public_error(
+                message=_("Candidate {index} was {reason} before completing sub-step {sub_step}.").format(
+                    index=i + 1,
+                    reason=terminal_reason,
+                    sub_step=state.get("current_sub_step") or "?",
+                ),
+                error_type="CandidateCancelled",
+                extra_details={
+                    "cancel_reason": reason,
+                    "terminal_reason": terminal_reason,
+                    "sub_step_id": state.get("current_sub_step") or None,
+                },
+            )
+            entry = {
+                "status": "failed",
+                "terminal_reason": terminal_reason,
+                "candidate": candidates[i],
+                "sub_pipeline_id": state.get("sub_pipeline_id") or f"{sub_spec.name}_candidate_{i}",
+                "state_machine": state.get("state_machine"),
+                "context": state.get("context"),
+                "current_sub_step": state.get("current_sub_step", ""),
+                "current_index": state.get("current_index"),
+                "active_attempt_id": active_attempt_id,
+                "transcript_id": state.get("transcript_id"),
+                "conclusions": state.get("conclusions", {}),
+                "step_conclusions": state.get("step_conclusions", {}),
+                "error": state.get("error") or failure.summary,
+                "error_details": state.get("error_details") or failure.details,
+            }
+            self._execution.setdefault("candidates", {})[str(i)] = entry
+            failed_by_index[i] = dict(entry)
+            self._save_running_sync(step.step_id, reason="parallel candidate cancelled")
+
         async def put_candidate_event(candidate_index: int, event: Any) -> None:
             nonlocal event_sequence
             event_sequence += 1
@@ -4781,6 +4830,12 @@ class PipelineRunner:
                     await put_candidate_event(i, event)
             except asyncio.CancelledError:
                 logger.debug("Candidate %d cancelled", i)
+                cancel_reason = state.get("cancel_reason")
+                if isinstance(cancel_reason, str) and i not in conclusions_by_index and i not in failed_by_index:
+                    try:
+                        save_candidate_cancelled_sync(i, state, cancel_reason)
+                    except PipelineStatePersistenceError:
+                        logger.warning("Failed to persist cancelled candidate %d terminal state", i)
             except PipelineStatePersistenceError as exc:
                 await put_candidate_event(i, exc)
             except SessionBackupBlocked as exc:
@@ -4964,9 +5019,27 @@ class PipelineRunner:
                     result["error"] = restored["error"]
                 if restored.get("error_details") is not None:
                     result["error_details"] = restored["error_details"]
+                if restored.get("terminal_reason") is not None:
+                    result["terminal_reason"] = restored["terminal_reason"]
                 aggregated.append(result)
             else:
-                aggregated.append({"candidate": candidate, "failed": True})
+                # Never aggregate a reason-less failure: a replacement candidate must
+                # not be able to silently take over from an undiagnosed one.
+                failure = public_error(
+                    message=_("Candidate {index} ended without a result or a recorded failure reason.").format(
+                        index=i + 1
+                    ),
+                    error_type="CandidateOutcomeMissing",
+                    extra_details={"parent_step_id": step.step_id, "candidate_index": i},
+                )
+                aggregated.append(
+                    {
+                        "candidate": candidate,
+                        "failed": True,
+                        "error": failure.summary,
+                        "error_details": failure.details,
+                    }
+                )
 
         self.context.set_conclusion(step.conclusion_field, aggregated)
         candidate_success_count = sum(1 for item in aggregated if isinstance(item, dict) and not item.get("failed"))

--- a/src/iac_code/pipeline/engine/step_spec.py
+++ b/src/iac_code/pipeline/engine/step_spec.py
@@ -117,6 +117,13 @@ class SubPipelineSpec:
     max_rollbacks: int
     iterate_over: str
     context_fields_from_parent: list[str] = field(default_factory=list)
+    # Seconds a sub-step may go without emitting any event before it is treated
+    # as stalled. ``None`` disables stall detection.
+    sub_step_stall_timeout_s: float | None = None
+    # How many times a stalled sub-step is retried in place before the candidate
+    # is failed. Retrying the same sub-step is preferred over replacing the
+    # candidate so the original failure stays visible.
+    sub_step_stall_retries: int = 1
 
 
 @dataclass

--- a/src/iac_code/pipeline/engine/sub_pipeline_executor.py
+++ b/src/iac_code/pipeline/engine/sub_pipeline_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import logging
 import time
@@ -24,10 +25,25 @@ from iac_code.pipeline.engine.step_executor import StepExecutor
 from iac_code.pipeline.engine.step_spec import LoadedPipeline, SubPipelineSpec
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.services.session_backup import SessionBackupBlocked
-from iac_code.types.stream_events import SubPipelineStreamEvent
+from iac_code.types.stream_events import AskUserQuestionEvent, PermissionRequestEvent, SubPipelineStreamEvent
 from iac_code.utils.public_errors import sanitize_strict_text
 
 logger = logging.getLogger(__name__)
+
+SUB_STEP_STALLED_ERROR_TYPE = "SubStepStalled"
+
+
+class SubStepStalledError(Exception):
+    """A sub-step produced no event within its configured stall window.
+
+    Raised by the stall watchdog so a hanging sub-step becomes an explicit,
+    diagnosable failure instead of an indefinitely ``working`` candidate.
+    """
+
+    def __init__(self, *, step_id: str, stalled_seconds: float) -> None:
+        super().__init__("Sub-step {0} stalled for {1:.1f}s".format(step_id, stalled_seconds))
+        self.step_id = step_id
+        self.stalled_seconds = stalled_seconds
 
 
 @dataclass
@@ -367,6 +383,55 @@ class SubPipelineExecutor:
         self._apply_telemetry_correlation(executor)
         return executor
 
+    async def _iter_events_with_stall_watchdog(
+        self,
+        stream: Any,
+        *,
+        step_id: str,
+        timeout_s: float,
+    ) -> AsyncGenerator[Any, None]:
+        """Yield step-executor events, raising SubStepStalledError on prolonged silence.
+
+        The watchdog measures the gap between consecutive events rather than the
+        total step duration, so legitimately slow sub-steps keep running as long
+        as they make observable progress. Waiting for a user answer or a paused
+        pipeline is not progress-free work, so any window that overlaps such a
+        wait is discarded instead of being judged.
+        """
+        iterator = stream.__aiter__()
+        awaiting_user_response = False
+        while True:
+            next_event = asyncio.ensure_future(iterator.__anext__())
+            while True:
+                suspended_at_start = self._stall_watchdog_suspended(awaiting_user_response)
+                window_started = time.monotonic()
+                done, _pending = await asyncio.wait({next_event}, timeout=timeout_s)
+                if done:
+                    break
+                if suspended_at_start or self._stall_watchdog_suspended(awaiting_user_response):
+                    continue
+                stalled_seconds = time.monotonic() - window_started
+                next_event.cancel()
+                with contextlib.suppress(BaseException):
+                    await next_event
+                aclose = getattr(stream, "aclose", None)
+                if callable(aclose):
+                    with contextlib.suppress(Exception):
+                        await aclose()
+                raise SubStepStalledError(step_id=step_id, stalled_seconds=stalled_seconds)
+            try:
+                event = next_event.result()
+            except StopAsyncIteration:
+                return
+            awaiting_user_response = isinstance(event, (AskUserQuestionEvent, PermissionRequestEvent))
+            yield event
+
+    def _stall_watchdog_suspended(self, awaiting_user_response: bool) -> bool:
+        """Whether the sub-step is legitimately idle and must not be judged stalled."""
+        if awaiting_user_response:
+            return True
+        return self._pause_event is not None and not self._pause_event.is_set()
+
     async def execute_streaming(
         self,
         sub_spec: SubPipelineSpec,
@@ -487,6 +552,7 @@ class SubPipelineExecutor:
         sub_step_started_at: float | None = None
         current_sub_step_id: str | None = None
         attempt_info: dict[str, Any] | None = None
+        stall_attempts: dict[str, int] = {}
 
         async def publish_sub_step_state(
             *,
@@ -654,6 +720,7 @@ class SubPipelineExecutor:
                             step_msg = None
                         is_first_step = False
                         step_result: StepResult | None = None
+                        stalled: SubStepStalledError | None = None
                         with self._observability.sub_step_span(**current_step_attrs):
                             execute_kwargs: dict[str, Any] = {
                                 "user_message": step_msg,
@@ -675,23 +742,116 @@ class SubPipelineExecutor:
                                 execute_kwargs = {
                                     key: value for key, value in execute_kwargs.items() if key in parameters
                                 }
-                            async for event in step_executor.execute(
+                            event_stream: Any = step_executor.execute(
                                 step,
                                 sub_context,
                                 session_id,
                                 **execute_kwargs,
-                            ):
-                                if isinstance(event, StepResult):
-                                    step_result = event
-                                elif isinstance(event, PipelineEvent):
-                                    # Forward pipeline-level events from the step executor directly
-                                    yield event
-                                else:
-                                    yield SubPipelineStreamEvent(
-                                        sub_pipeline_id=sub_pipeline_id,
-                                        candidate_index=candidate_index,
-                                        inner=event,
-                                    )
+                            )
+                            if sub_spec.sub_step_stall_timeout_s is not None:
+                                event_stream = self._iter_events_with_stall_watchdog(
+                                    event_stream,
+                                    step_id=step.step_id,
+                                    timeout_s=sub_spec.sub_step_stall_timeout_s,
+                                )
+                            try:
+                                async for event in event_stream:
+                                    if isinstance(event, StepResult):
+                                        step_result = event
+                                    elif isinstance(event, PipelineEvent):
+                                        # Forward pipeline-level events from the step executor directly
+                                        yield event
+                                    else:
+                                        yield SubPipelineStreamEvent(
+                                            sub_pipeline_id=sub_pipeline_id,
+                                            candidate_index=candidate_index,
+                                            inner=event,
+                                        )
+                            except SubStepStalledError as stall:
+                                stalled = stall
+
+                        if stalled is not None:
+                            # A stalled sub-step must be diagnosed explicitly and retried in
+                            # place; replacing the candidate would hide the original failure
+                            # and silently change the delivered plan.
+                            stall_attempts[step.step_id] = stall_attempts.get(step.step_id, 0) + 1
+                            stall_attempt = stall_attempts[step.step_id]
+                            will_retry = stall_attempt <= sub_spec.sub_step_stall_retries
+                            failure = public_error(
+                                message=str(stalled),
+                                error_type=SUB_STEP_STALLED_ERROR_TYPE,
+                                extra_details={
+                                    "step_id": step.step_id,
+                                    "stalled_seconds": round(stalled.stalled_seconds, 3),
+                                    "stall_timeout_s": sub_spec.sub_step_stall_timeout_s,
+                                    "stall_attempt": stall_attempt,
+                                    "stall_retries_allowed": sub_spec.sub_step_stall_retries,
+                                    "will_retry": will_retry,
+                                },
+                            )
+                            error_summary = failure.summary
+                            self._observability.sub_step_completed(
+                                duration_ms=self._observability.duration_ms(sub_step_started_at),
+                                failed=True,
+                                error_summary=error_summary,
+                                error_type=SUB_STEP_STALLED_ERROR_TYPE,
+                                error_id=failure.error_id,
+                                **current_step_attrs,
+                            )
+                            await publish_sub_step_state(
+                                status="running" if will_retry else "failed",
+                                attempt_status="failed",
+                                current_sub_step=step.step_id,
+                                attempt_info=attempt_info,
+                            )
+                            yield PipelineEvent(
+                                type=PipelineEventType.SUB_STEP_FAILED,
+                                step_id=step.step_id,
+                                timestamp=time.time(),
+                                data=sub_step_event_data(
+                                    step.step_id,
+                                    {
+                                        "error": error_summary,
+                                        "error_summary": error_summary,
+                                        "error_details": failure.details,
+                                    },
+                                ),
+                            )
+                            if will_retry:
+                                logger.warning(
+                                    (
+                                        "Retrying stalled sub-step in place: pipeline=%s session_id=%s "
+                                        "sub_pipeline_id=%s candidate_index=%d sub_step_id=%s "
+                                        "stalled_seconds=%.1f stall_attempt=%d"
+                                    ),
+                                    sanitize_strict_text(self._pipeline.name),
+                                    sanitize_strict_text(session_id),
+                                    sanitize_strict_text(sub_pipeline_id),
+                                    candidate_index,
+                                    sanitize_strict_text(step.step_id),
+                                    stalled.stalled_seconds,
+                                    stall_attempt,
+                                )
+                                continue
+                            terminal_event = PipelineEvent(
+                                type=PipelineEventType.SUB_PIPELINE_COMPLETED,
+                                step_id=None,
+                                timestamp=time.time(),
+                                data=sub_pipeline_event_data(
+                                    {
+                                        "failed": True,
+                                        "error": error_summary,
+                                        "error_summary": error_summary,
+                                        "error_details": failure.details,
+                                    },
+                                ),
+                            )
+                            emit_sub_pipeline_failed(
+                                error_summary,
+                                SUB_STEP_STALLED_ERROR_TYPE,
+                                failure.error_id,
+                            )
+                            break
 
                         if step_result is None or step_result.status == StepStatus.FAILED:
                             # P-I22: surface structured error info (error_summary + error_details)

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -134,6 +134,11 @@ max_rollbacks: 3
 sub_pipelines:
   evaluate_candidate:
     max_rollbacks: 5
+    # 子步骤在这么久没有产出任何事件即判定卡死（等待用户输入/暂停期间不计时）。
+    # 卡死会记录显式失败原因并优先原地重试同一子步骤，重试用尽后候选进入终态，
+    # 不允许静默换成缩减模板的新候选。
+    sub_step_stall_timeout_s: 600
+    sub_step_stall_retries: 1
     context_fields_from_parent: [intent]
     iterate_over: architecture.candidates
     steps:

--- a/tests/pipeline/engine/test_loader.py
+++ b/tests/pipeline/engine/test_loader.py
@@ -374,6 +374,66 @@ class TestSubPipelineParsing:
         assert len(sub.steps) == 1
         assert sub.steps[0].skill == "iac_aliyun"
 
+    @staticmethod
+    def _stall_yaml(extra_keys: str) -> str:
+        return dedent("""\
+            name: test
+            context_dependencies:
+              result: []
+            max_rollbacks: 1
+            sub_pipelines:
+              sub1:
+                max_rollbacks: 1
+                iterate_over: result.items
+            {extra_keys}    steps:
+                  - id: inner
+                    conclusion_field: out
+                    forward: null
+                    prompt: prompts/inner.md
+            steps:
+              - id: outer
+                type: parallel_sub_pipeline
+                sub_pipeline: sub1
+                conclusion_field: result
+                forward: null
+                prompt: prompts/outer.md
+        """).format(extra_keys=extra_keys)
+
+    def test_stall_detection_keys_parsed(self, tmp_path):
+        yaml_content = self._stall_yaml("    sub_step_stall_timeout_s: 600\n    sub_step_stall_retries: 2\n")
+        _write_pipeline(tmp_path, yaml_content, {"outer.md": "O", "inner.md": "I"})
+
+        loaded = load_pipeline_dir(tmp_path)
+
+        sub = loaded.sub_pipelines["sub1"]
+        assert sub.sub_step_stall_timeout_s == 600.0
+        assert sub.sub_step_stall_retries == 2
+
+    def test_stall_detection_disabled_by_default(self, tmp_path):
+        _write_pipeline(tmp_path, self._stall_yaml(""), {"outer.md": "O", "inner.md": "I"})
+
+        loaded = load_pipeline_dir(tmp_path)
+
+        sub = loaded.sub_pipelines["sub1"]
+        assert sub.sub_step_stall_timeout_s is None
+        assert sub.sub_step_stall_retries == 1
+
+    @pytest.mark.parametrize("raw_timeout", ["0", "-5", "abc", "true"])
+    def test_rejects_invalid_stall_timeout(self, tmp_path, raw_timeout):
+        yaml_content = self._stall_yaml(f"    sub_step_stall_timeout_s: {raw_timeout}\n")
+        _write_pipeline(tmp_path, yaml_content, {"outer.md": "O", "inner.md": "I"})
+
+        with pytest.raises(ValueError, match="sub_step_stall_timeout_s"):
+            load_pipeline_dir(tmp_path)
+
+    @pytest.mark.parametrize("raw_retries", ["-1", "1.5", "abc", "true"])
+    def test_rejects_invalid_stall_retries(self, tmp_path, raw_retries):
+        yaml_content = self._stall_yaml(f"    sub_step_stall_retries: {raw_retries}\n")
+        _write_pipeline(tmp_path, yaml_content, {"outer.md": "O", "inner.md": "I"})
+
+        with pytest.raises(ValueError, match="sub_step_stall_retries"):
+            load_pipeline_dir(tmp_path)
+
     def test_step_type_parallel(self, tmp_path):
         yaml_content = dedent("""\
             name: test

--- a/tests/pipeline/engine/test_pipeline_runner.py
+++ b/tests/pipeline/engine/test_pipeline_runner.py
@@ -4704,3 +4704,175 @@ class TestResolveIterateField:
         runner.context.snapshot = MagicMock(return_value={"plan": {"options": [{"x": 1}]}})
         result = runner._resolve_iterate_field("plan.options")
         assert result == [{"x": 1}]
+
+
+class TestCandidateTerminalStateOnCancel:
+    """A candidate that stops without finishing must leave a terminal, diagnosable
+    entry behind. Otherwise a replacement candidate silently takes over and the
+    original failure (e.g. a hanging cost_estimating sub-step) is never surfaced."""
+
+    @staticmethod
+    def _build_runner(tmp_path):
+        (tmp_path / "prompts").mkdir(exist_ok=True)
+        (tmp_path / "prompts" / "arch.md").write_text("Arch", encoding="utf-8")
+        (tmp_path / "prompts" / "eval.md").write_text("Eval", encoding="utf-8")
+        (tmp_path / "prompts" / "template.md").write_text("T", encoding="utf-8")
+        (tmp_path / "pipeline.yaml").write_text(
+            dedent("""\
+            name: test
+            context_dependencies:
+              architecture: []
+              evaluated: [architecture]
+            max_rollbacks: 3
+            sub_pipelines:
+              evaluate_candidate:
+                max_rollbacks: 2
+                iterate_over: architecture.candidates
+                context_fields_from_parent: []
+                steps:
+                  - id: cost_estimating
+                    conclusion_field: template
+                    forward: null
+                    prompt: prompts/template.md
+                    context_fields: [candidate]
+            steps:
+              - id: arch
+                conclusion_field: architecture
+                forward: eval
+                prompt: prompts/arch.md
+              - id: eval
+                type: parallel_sub_pipeline
+                sub_pipeline: evaluate_candidate
+                conclusion_field: evaluated
+                forward: null
+                prompt: prompts/eval.md
+        """),
+            encoding="utf-8",
+        )
+        runner = PipelineRunner(
+            pipeline_dir=tmp_path,
+            provider_manager=MagicMock(),
+            base_tool_registry=MagicMock(),
+            session_storage=FakeSessionStorage(),
+            session_id="test123",
+        )
+        runner.context.set_conclusion("architecture", {"candidates": [{"name": "Plan A"}, {"name": "Plan B"}]})
+        runner.state_machine.advance()  # position at "eval"
+        return runner
+
+    @staticmethod
+    def _hanging_execute_streaming(released):
+        async def execute_streaming(sub_spec, candidate, candidate_index, parent_context, session_id, **kwargs):
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_PIPELINE_STARTED,
+                step_id=None,
+                timestamp=0,
+                data={
+                    "sub_pipeline_id": f"eval_{candidate_index}",
+                    "candidate_index": candidate_index,
+                    "candidate_name": candidate["name"],
+                    "total_steps": 1,
+                    "sub_pipeline_name": "evaluate_candidate",
+                },
+            )
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_STEP_STARTED,
+                step_id=None,
+                timestamp=0,
+                data={"step_id": "cost_estimating", "candidate_index": candidate_index},
+            )
+            await released.wait()  # never completes: mimics the stalled sub-step
+            yield  # pragma: no cover
+
+        return execute_streaming
+
+    async def _run_until_cancelled(self, runner, *, cancel_reason):
+        released = asyncio.Event()
+        with patch("iac_code.pipeline.engine.pipeline_runner.SubPipelineExecutor") as mock_sub_exec:
+            instance = MagicMock()
+            instance.execute_streaming = self._hanging_execute_streaming(released)
+            instance.current_step_executor_agent_loop = None
+            mock_sub_exec.return_value = instance
+
+            step = next(s for s in runner._loaded.steps if s.step_id == "eval")
+            gen = runner._execute_parallel_sub_pipeline(step)
+            for _ in range(4):  # both candidates: started + sub-step started
+                await gen.__anext__()
+            assert len(runner._active_candidates) == 2
+
+            runner._cancel_active_candidates(reason=cancel_reason)
+            await gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_parent_rollback_cancel_records_superseded_terminal_state(self, tmp_path):
+        runner = self._build_runner(tmp_path)
+
+        await self._run_until_cancelled(runner, cancel_reason="hard_interrupt_parent_rollback")
+
+        entries = runner._execution["candidates"]
+        assert set(entries) == {"0", "1"}
+        for index in ("0", "1"):
+            entry = entries[index]
+            assert entry["status"] == "failed", "terminal status must stay one of completed/failed/running"
+            assert entry["terminal_reason"] == "superseded"
+            assert entry["current_sub_step"] == "cost_estimating"
+            assert entry["error"]
+            assert entry["error_details"]["type"] == "CandidateCancelled"
+            assert entry["error_details"]["cancel_reason"] == "hard_interrupt_parent_rollback"
+            assert entry["error_details"]["sub_step_id"] == "cost_estimating"
+
+    @pytest.mark.asyncio
+    async def test_plain_cancel_records_canceled_terminal_state(self, tmp_path):
+        runner = self._build_runner(tmp_path)
+
+        await self._run_until_cancelled(runner, cancel_reason="parallel_cleanup")
+
+        for entry in runner._execution["candidates"].values():
+            assert entry["status"] == "failed"
+            assert entry["terminal_reason"] == "canceled"
+            assert entry["error_details"]["cancel_reason"] == "parallel_cleanup"
+
+    @pytest.mark.asyncio
+    async def test_candidate_restart_does_not_write_terminal_state(self, tmp_path):
+        """An in-place restart is not a terminal outcome, so nothing must be recorded."""
+        runner = self._build_runner(tmp_path)
+
+        await self._run_until_cancelled(runner, cancel_reason="candidate_restart")
+
+        assert runner._execution.get("candidates", {}) == {}
+
+    @pytest.mark.asyncio
+    async def test_candidate_without_outcome_aggregates_a_reason(self, tmp_path):
+        """A candidate stream that ends silently must not aggregate as a blank result."""
+        runner = self._build_runner(tmp_path)
+
+        async def silent_execute_streaming(sub_spec, candidate, candidate_index, parent_context, session_id, **kwargs):
+            yield PipelineEvent(
+                type=PipelineEventType.SUB_PIPELINE_STARTED,
+                step_id=None,
+                timestamp=0,
+                data={
+                    "sub_pipeline_id": f"eval_{candidate_index}",
+                    "candidate_index": candidate_index,
+                    "candidate_name": candidate["name"],
+                    "total_steps": 1,
+                    "sub_pipeline_name": "evaluate_candidate",
+                },
+            )
+
+        with patch("iac_code.pipeline.engine.pipeline_runner.SubPipelineExecutor") as mock_sub_exec:
+            instance = MagicMock()
+            instance.execute_streaming = silent_execute_streaming
+            instance.current_step_executor_agent_loop = None
+            mock_sub_exec.return_value = instance
+
+            step = next(s for s in runner._loaded.steps if s.step_id == "eval")
+            async for _event in runner._execute_parallel_sub_pipeline(step):
+                pass
+
+        aggregated = runner.context.get_conclusion("evaluated")
+        assert len(aggregated) == 2
+        for item in aggregated:
+            assert item["failed"] is True
+            assert item["error"]
+            assert item["error_details"]["type"] == "CandidateOutcomeMissing"

--- a/tests/pipeline/engine/test_sub_pipeline_executor.py
+++ b/tests/pipeline/engine/test_sub_pipeline_executor.py
@@ -1,5 +1,6 @@
 """Tests for SubPipelineExecutor."""
 
+import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1761,3 +1762,283 @@ class TestFailedCandidateErrorPropagated:
             conclusions={},
         )
         assert result.error_details is None
+
+
+def _stall_sub_spec(*, timeout_s: float, retries: int) -> SubPipelineSpec:
+    spec = _make_sub_spec()
+    spec.sub_step_stall_timeout_s = timeout_s
+    spec.sub_step_stall_retries = retries
+    return spec
+
+
+def _stall_pipeline() -> LoadedPipeline:
+    return LoadedPipeline(
+        name="test",
+        steps=[],
+        context_dependencies={"intent": []},
+        max_rollbacks=3,
+        skills={"iac_aliyun": "# Skill", "iac-aliyun-cost": "# Cost"},
+    )
+
+
+def _stall_parent_context() -> PipelineContext:
+    parent_ctx = PipelineContext({"intent": []})
+    parent_ctx.set_conclusion("intent", {"type": "test"})
+    return parent_ctx
+
+
+class TestSubStepStallWatchdog:
+    """A stalled sub-step must be diagnosed in place, never silently replaced."""
+
+    @pytest.mark.asyncio
+    async def test_stall_without_retries_fails_with_reason(self, tmp_path, monkeypatch):
+        class HangingStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                if step.step_id == "cost_estimating":
+                    await asyncio.Event().wait()
+                    return
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        executor = SubPipelineExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=_stall_pipeline(),
+            pipeline_dir=tmp_path,
+        )
+        monkeypatch.setattr(executor, "_make_step_executor", lambda: HangingStepExecutor())
+
+        events = [
+            event
+            async for event in executor.execute_streaming(
+                sub_spec=_stall_sub_spec(timeout_s=0.05, retries=0),
+                candidate={"name": "Plan A"},
+                candidate_index=0,
+                parent_context=_stall_parent_context(),
+                session_id="test_session",
+            )
+        ]
+
+        failed = [e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_STEP_FAILED]
+        assert len(failed) == 1
+        details = failed[0].data["error_details"]
+        assert details["type"] == "SubStepStalled"
+        assert details["step_id"] == "cost_estimating"
+        assert details["stalled_seconds"] > 0
+        assert details["will_retry"] is False
+
+        terminal = [
+            e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_PIPELINE_COMPLETED
+        ]
+        assert len(terminal) == 1
+        assert terminal[0].data["failed"] is True
+        assert terminal[0].data["error_details"]["type"] == "SubStepStalled"
+
+    @pytest.mark.asyncio
+    async def test_stall_retries_same_sub_step_in_place(self, tmp_path, monkeypatch):
+        attempts: list[str] = []
+
+        class StallOnceStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                attempts.append(step.step_id)
+                if step.step_id == "cost_estimating" and attempts.count("cost_estimating") == 1:
+                    await asyncio.Event().wait()
+                    return
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": step.step_id})
+
+        executor = SubPipelineExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=_stall_pipeline(),
+            pipeline_dir=tmp_path,
+        )
+        monkeypatch.setattr(executor, "_make_step_executor", lambda: StallOnceStepExecutor())
+
+        events = [
+            event
+            async for event in executor.execute_streaming(
+                sub_spec=_stall_sub_spec(timeout_s=0.05, retries=1),
+                candidate={"name": "Plan A"},
+                candidate_index=0,
+                parent_context=_stall_parent_context(),
+                session_id="test_session",
+            )
+        ]
+
+        # The same sub-step ran twice; the earlier sub-step was not re-run.
+        assert attempts == ["template_generating", "cost_estimating", "cost_estimating"]
+
+        failed = [e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_STEP_FAILED]
+        assert len(failed) == 1
+        assert failed[0].data["error_details"]["will_retry"] is True
+
+        terminal = [
+            e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_PIPELINE_COMPLETED
+        ]
+        assert len(terminal) == 1
+        assert terminal[0].data["failed"] is False
+        # Conclusions from the sub-step completed before the stall are preserved.
+        assert terminal[0].data["step_conclusions"]["template_generating"] == {"body": "template_generating"}
+        assert terminal[0].data["step_conclusions"]["cost_estimating"] == {"body": "cost_estimating"}
+
+    @pytest.mark.asyncio
+    async def test_stall_publishes_running_state_while_retrying(self, tmp_path, monkeypatch):
+        published: list[tuple[str, str]] = []
+
+        class StallOnceStepExecutor:
+            current_agent_loop = None
+            seen = 0
+
+            async def execute(self, step, context, session_id, **kwargs):
+                if step.step_id == "cost_estimating":
+                    StallOnceStepExecutor.seen += 1
+                    if StallOnceStepExecutor.seen == 1:
+                        await asyncio.Event().wait()
+                        return
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        def record(payload):
+            published.append((payload["current_sub_step"], payload["status"]))
+
+        executor = SubPipelineExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=_stall_pipeline(),
+            pipeline_dir=tmp_path,
+        )
+        monkeypatch.setattr(executor, "_make_step_executor", lambda: StallOnceStepExecutor())
+
+        async for _event in executor.execute_streaming(
+            sub_spec=_stall_sub_spec(timeout_s=0.05, retries=1),
+            candidate={"name": "Plan A"},
+            candidate_index=0,
+            parent_context=_stall_parent_context(),
+            session_id="test_session",
+            sub_step_state_callback=record,
+        ):
+            pass
+
+        # The stalled attempt keeps the candidate running so it can retry in place.
+        assert ("cost_estimating", "running") in published
+        assert ("cost_estimating", "failed") not in published
+
+    @pytest.mark.asyncio
+    async def test_waiting_for_user_answer_is_not_a_stall(self, tmp_path, monkeypatch):
+        from iac_code.types.stream_events import AskUserQuestionEvent
+
+        class AskThenIdleStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                if step.step_id == "cost_estimating":
+                    yield AskUserQuestionEvent(
+                        tool_use_id="tu_1",
+                        question="which region?",
+                        options=[{"id": "a", "label": "A"}],
+                    )
+                    await asyncio.sleep(0.3)  # 6 stall windows pass awaiting an answer; none may count
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        executor = SubPipelineExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=_stall_pipeline(),
+            pipeline_dir=tmp_path,
+        )
+        monkeypatch.setattr(executor, "_make_step_executor", lambda: AskThenIdleStepExecutor())
+
+        events = [
+            event
+            async for event in executor.execute_streaming(
+                sub_spec=_stall_sub_spec(timeout_s=0.05, retries=0),
+                candidate={"name": "Plan A"},
+                candidate_index=0,
+                parent_context=_stall_parent_context(),
+                session_id="test_session",
+            )
+        ]
+
+        assert not [e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_STEP_FAILED]
+        terminal = [
+            e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_PIPELINE_COMPLETED
+        ]
+        assert terminal[0].data["failed"] is False
+
+    @pytest.mark.asyncio
+    async def test_paused_pipeline_is_not_a_stall(self, tmp_path, monkeypatch):
+        pause_event = asyncio.Event()
+        reached_paused_step = asyncio.Event()
+
+        class PausedThenResumingStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                if step.step_id == "cost_estimating":
+                    reached_paused_step.set()
+                    await pause_event.wait()
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        executor = SubPipelineExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=_stall_pipeline(),
+            pipeline_dir=tmp_path,
+            pause_event=pause_event,
+        )
+        monkeypatch.setattr(executor, "_make_step_executor", lambda: PausedThenResumingStepExecutor())
+
+        async def resume_once_several_windows_elapsed():
+            await reached_paused_step.wait()
+            await asyncio.sleep(0.3)  # 6 stall windows pass while paused; none may count
+            pause_event.set()
+
+        resume_task = asyncio.ensure_future(resume_once_several_windows_elapsed())
+        events = [
+            event
+            async for event in executor.execute_streaming(
+                sub_spec=_stall_sub_spec(timeout_s=0.05, retries=0),
+                candidate={"name": "Plan A"},
+                candidate_index=0,
+                parent_context=_stall_parent_context(),
+                session_id="test_session",
+            )
+        ]
+        await resume_task
+
+        assert not [e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_STEP_FAILED]
+
+    @pytest.mark.asyncio
+    async def test_stall_detection_disabled_by_default(self, tmp_path, monkeypatch):
+        class SlowStepExecutor:
+            current_agent_loop = None
+
+            async def execute(self, step, context, session_id, **kwargs):
+                await asyncio.sleep(0.02)
+                yield StepResult(step_id=step.step_id, status=StepStatus.COMPLETED, conclusion={"body": "ok"})
+
+        sub_spec = _make_sub_spec()
+        assert sub_spec.sub_step_stall_timeout_s is None
+
+        executor = SubPipelineExecutor(
+            provider_manager=MagicMock(),
+            base_tool_registry=ToolRegistry(),
+            pipeline=_stall_pipeline(),
+            pipeline_dir=tmp_path,
+        )
+        monkeypatch.setattr(executor, "_make_step_executor", lambda: SlowStepExecutor())
+
+        events = [
+            event
+            async for event in executor.execute_streaming(
+                sub_spec=sub_spec,
+                candidate={"name": "Plan A"},
+                candidate_index=0,
+                parent_context=_stall_parent_context(),
+                session_id="test_session",
+            )
+        ]
+
+        assert not [e for e in events if isinstance(e, PipelineEvent) and e.type == PipelineEventType.SUB_STEP_FAILED]


### PR DESCRIPTION
## 背景

Session `7be8bcd32aa44fd399f3e5bf7ec7db7d`（UserId `1754580903499898`，AnalysisId `sarpt-auto-2026072900`，Aone 84817164）中，候选 `096430be` 的 `cost_estimating` 子步骤长时间 `conclusion: null` / `status: working`。流水线既没有诊断这个卡死，也没有让该候选收敛，而是直接开启新的 `evaluate_candidates` 步骤，由一个使用缩减模板的新候选顶替。结果是：原失败被完全掩盖，交付方案被静默改写。

## 根因与修复

### 1. 子步骤卡死不可观测

`SubPipelineSpec` 新增 `sub_step_stall_timeout_s` / `sub_step_stall_retries`；`SubPipelineExecutor` 用看门狗包装 `StepExecutor.execute` 的事件流，按**相邻事件间隔**（而非总时长）判定卡死，因此本身耗时长但持续产出事件的子步骤不受影响。卡死时以 `SubStepStalled` 记录显式失败原因，`error_details` 带上 `step_id` / `stalled_seconds` / `stall_attempt` / `will_retry`。

两类合法空窗被显式豁免，且只要窗口与豁免状态有重叠就整窗作废：

- `ask_user_question` / 权限请求等待用户回答；
- `_pause_event` 未置位（流水线被暂停）。

### 2. 卡死后不重试原子步骤

重试预算内**优先原地重试同一子步骤**：候选状态保持 `running`，已完成子步骤的结论保留，不回退到前序子步骤。预算耗尽才让候选进入终态。

### 3. 候选无终态、失败无原因

- `_cancel_candidate_task` 记录 `cancel_reason`；候选任务被取消时落一条终态条目，保留失败原因。`status` 仍为 `failed`（`display_replay.py`、`ui/pipeline_display_replay.py`、`pipeline_runner.py` 的 restore/replay 分支都只路由 `completed`/`failed`/`running` 三个字面量，新增第四态会破坏恢复），由独立的 `terminal_reason` 区分 `canceled` 与 `superseded`。
- 原地重启（`candidate_restart`）不是终态，不写终态条目。
- 聚合阶段不再产出无原因的 `{failed: True}`；缺失结果时补 `CandidateOutcomeMissing` 原因，杜绝"新候选静默顶替未诊断候选"。

selling 流水线 `evaluate_candidate` 启用 600s 阈值 + 1 次原地重试；阈值默认为 `None`（关闭），其他流水线行为不变。

## 验收

对应需求验收标准「重跑 7be8bcd32 会话，确认卡死的 `cost_estimating` 记录失败原因或原地重试，且原候选进入终态而非悬挂」，以单元测试等价覆盖：

- `TestSubStepStallWatchdog`（6 例）：卡死记录失败原因 / 原地重试同一子步骤 / 重试期间候选保持 running / 等待用户回答不算卡死 / 暂停不算卡死 / 默认关闭。
- `TestCandidateTerminalStateOnCancel`（4 例）：父级回滚取消 → `superseded` 终态、普通取消 → `canceled` 终态、原地重启不写终态、无结果候选聚合出原因。
- `TestSubPipelineParsing` 新增 5 例：两个新配置键的解析、默认值、非法值报错。

验证命令：

- `uv run pytest tests/pipeline -q` → **1628 passed**（1 例 deselect，见下）
- `uv run ruff check src tests` → 全部通过
- `uv run ty check src` → 本次改动文件 0 条诊断

`tests/pipeline/engine/test_prerequisites.py::test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token` 在**未修改的干净工作区**同样失败（沙箱无网络，urllib 抛 `HTTPError` 而非 `InvalidURL`），与本次改动无关。

Aone: 84817164
