### PR TITLE
fix(pipeline): 空意图解析不再静默跳过候选生成

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1731,9 +1731,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             raise ValueError("Invalid A2A workspace metadata.")
         logical_cwd = os.path.normpath(cwd)
         resolved_cwd = resolve_workspace_path(Path(logical_cwd))
-        if not trust_request_cwd() and not any(
-            _is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()
-        ):
+        if not trust_request_cwd() and not any(_is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()):
             raise ValueError("Invalid A2A workspace metadata.")
         if resolved_cwd.exists():
             if not resolved_cwd.is_dir():

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -178,35 +178,29 @@ def permission_display_fields(request: PermissionRequestEvent, *, language: str 
             command = safe_input.get("command") or safe_input.get("cmd")
         if isinstance(command, str) and command.strip():
             command_fallback = translate_message("shell command", language=language)
-            target = translate_message(
-                "the current local workspace; command: {command}", language=language
-            ).format(command=_display_text(command, fallback=command_fallback, maximum=240))
+            target = translate_message("the current local workspace; command: {command}", language=language).format(
+                command=_display_text(command, fallback=command_fallback, maximum=240)
+            )
         else:
             target = translate_message("the current local workspace", language=language)
         effect = "read" if is_read_only else ("local_execution" if read_only_known else "unknown")
     elif tool_name in {"write_file", "edit_file"}:
         title = translate_message("Change a workspace file", language=language)
-        purpose = translate_message(
-            "Write a file needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Write a file needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "a file in the current workspace", language=language
         )
         effect = "file_change"
     elif tool_name in {"read_file", "glob", "grep"} or is_read_only:
         title = translate_message("Read workspace data with {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Read local data needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Read local data needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current local workspace", language=language
         )
         effect = "read"
     else:
         title = translate_message("Run {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Run this operation for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Run this operation for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current task workspace or cloud account", language=language
         )
@@ -319,9 +313,7 @@ def _cloud_operation_title(product: str, action: str, *, is_read_only: bool, lan
     if action == "CreateStack":
         return translate_message("Create {product} stack", language=language).format(product=product_label)
     if action == "ContinueCreateStack":
-        return translate_message("Continue creating {product} stack", language=language).format(
-            product=product_label
-        )
+        return translate_message("Continue creating {product} stack", language=language).format(product=product_label)
     if action == "UpdateStack":
         return translate_message("Update {product} stack", language=language).format(product=product_label)
     if action == "DeleteStack":
@@ -344,9 +336,7 @@ def _safe_input_target(value: Any, *, language: str) -> str:
     for key in ("file_path", "filePath", "path", "region_id", "regionId", "resource_id", "resourceId"):
         candidate = value.get(key)
         if isinstance(candidate, str) and candidate.strip():
-            return _display_text(
-                candidate, fallback=translate_message("the current task scope", language=language)
-            )
+            return _display_text(candidate, fallback=translate_message("the current task scope", language=language))
     return ""
 
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -1235,11 +1235,7 @@ class IacCodeA2APipelineExecutor:
             def permission_context_getter() -> Any:
                 return getattr(agent_loop, "_permission_context", None)
 
-        surface = (
-            A2A_RICH_CANDIDATE_SURFACE
-            if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION
-            else "a2a"
-        )
+        surface = A2A_RICH_CANDIDATE_SURFACE if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION else "a2a"
         return create_pipeline(
             pipeline_name,
             provider_manager=runtime.provider_manager,

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -864,9 +864,7 @@ class A2ATaskStore(TaskStore):
                 any(record.active_task is not None and not record.active_task.done() for record in self._tasks.values())
                 or any(not task.done() for task in self._context_runtime_tasks.values())
                 or any(
-                    not task.done()
-                    for starts in self._context_execution_starts.values()
-                    for task in starts.values()
+                    not task.done() for starts in self._context_execution_starts.values() for task in starts.values()
                 )
                 or any(self._context_reconciliation_waiters.values())
                 or any(lock.locked() for lock in self._reconciliation_locks.values())

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4158,6 +4158,20 @@ msgid "complete_step validation failed."
 msgstr "Die Validierung von complete_step ist fehlgeschlagen."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"conclusion must be a non-empty object; an empty conclusion means the step"
+" produced no result. Fill in the fields required by the current step, or "
+"state the failure reason in the conclusion."
+msgstr "conclusion muss ein nicht leeres Objekt sein; eine leere conclusion bedeutet, dass der Schritt kein Ergebnis erzeugt hat. Füllen Sie die vom aktuellen Schritt geforderten Felder aus oder nennen Sie den Fehlergrund in der conclusion."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Step {step_id} submitted an empty conclusion {attempts} times; the step "
+"produced no usable result."
+msgstr "Schritt {step_id} hat {attempts} Mal eine leere conclusion übermittelt; der Schritt hat kein verwertbares Ergebnis erzeugt."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
 msgstr "Vor Abschluss des aktuellen Schritts ist eine Klärung erforderlich."
 

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4132,6 +4132,20 @@ msgid "complete_step validation failed."
 msgstr "La validación de complete_step falló."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"conclusion must be a non-empty object; an empty conclusion means the step"
+" produced no result. Fill in the fields required by the current step, or "
+"state the failure reason in the conclusion."
+msgstr "conclusion debe ser un objeto no vacío; una conclusion vacía significa que el paso no produjo ningún resultado. Rellena los campos que exige el paso actual o indica el motivo del fallo en la conclusion."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Step {step_id} submitted an empty conclusion {attempts} times; the step "
+"produced no usable result."
+msgstr "El paso {step_id} envió una conclusion vacía {attempts} veces; el paso no produjo ningún resultado utilizable."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
 msgstr "Se requiere una aclaración antes de completar el paso actual."
 

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4139,6 +4139,20 @@ msgid "complete_step validation failed."
 msgstr "La validation de complete_step a échoué."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"conclusion must be a non-empty object; an empty conclusion means the step"
+" produced no result. Fill in the fields required by the current step, or "
+"state the failure reason in the conclusion."
+msgstr "conclusion doit être un objet non vide ; une conclusion vide signifie que l'étape n'a produit aucun résultat. Renseignez les champs requis par l'étape actuelle ou indiquez la raison de l'échec dans la conclusion."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Step {step_id} submitted an empty conclusion {attempts} times; the step "
+"produced no usable result."
+msgstr "L'étape {step_id} a soumis une conclusion vide {attempts} fois ; l'étape n'a produit aucun résultat exploitable."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
 msgstr "Une clarification est requise avant de terminer l’étape actuelle."
 

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3937,6 +3937,20 @@ msgid "complete_step validation failed."
 msgstr "complete_step の検証に失敗しました。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"conclusion must be a non-empty object; an empty conclusion means the step"
+" produced no result. Fill in the fields required by the current step, or "
+"state the failure reason in the conclusion."
+msgstr "conclusion は空でないオブジェクトである必要があります。空の conclusion はステップが結果を生成しなかったことを意味します。現在のステップで必要なフィールドを入力するか、conclusion に失敗理由を記載してください。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Step {step_id} submitted an empty conclusion {attempts} times; the step "
+"produced no usable result."
+msgstr "ステップ {step_id} が空の conclusion を {attempts} 回送信しました。このステップは利用可能な結果を生成しませんでした。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
 msgstr "現在のステップを完了する前に確認が必要です。"
 

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4110,6 +4110,20 @@ msgid "complete_step validation failed."
 msgstr "A validação de complete_step falhou."
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"conclusion must be a non-empty object; an empty conclusion means the step"
+" produced no result. Fill in the fields required by the current step, or "
+"state the failure reason in the conclusion."
+msgstr "conclusion precisa ser um objeto não vazio; uma conclusion vazia significa que a etapa não produziu nenhum resultado. Preencha os campos exigidos pela etapa atual ou informe o motivo da falha na conclusion."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Step {step_id} submitted an empty conclusion {attempts} times; the step "
+"produced no usable result."
+msgstr "A etapa {step_id} enviou uma conclusion vazia {attempts} vezes; a etapa não produziu nenhum resultado utilizável."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
 msgstr "É necessário esclarecimento antes de concluir a etapa atual."
 

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3899,6 +3899,20 @@ msgid "complete_step validation failed."
 msgstr "complete_step 校验失败。"
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
+"conclusion must be a non-empty object; an empty conclusion means the step"
+" produced no result. Fill in the fields required by the current step, or "
+"state the failure reason in the conclusion."
+msgstr "conclusion 必须是非空对象；空 conclusion 表示该步骤没有产出结果。请填写当前步骤要求的字段，或在 conclusion 中说明失败原因。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+#, python-brace-format
+msgid ""
+"Step {step_id} submitted an empty conclusion {attempts} times; the step "
+"produced no usable result."
+msgstr "步骤 {step_id} 连续 {attempts} 次提交了空 conclusion，该步骤没有产出可用结果。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid "Clarification is required before completing the current step."
 msgstr "完成当前步骤前需要先澄清。"
 

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 MAX_PARALLEL_CANDIDATES = 5
 MAX_ROLLBACK_TARGETS = 5
+EMPTY_CONCLUSION_FAILURE_KIND = "empty_conclusion"
 _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
     "reviewing_rerun_after_validate_template_write": (
         "reviewing ran write_file/edit_file after ros_validate_template; "
@@ -297,6 +298,35 @@ class CompleteStepTool(Tool):
         if verbose:
             return output.strip()
         return _("complete_step validation failed.")
+
+    def _validate_non_empty_conclusion(self, conclusion: Any) -> str | None:
+        """Reject empty conclusions even when the step declares no ``conclusion_schema``.
+
+        A null/NoneType parse result degrades to ``{}`` after ``normalize_input``. Without this
+        check a schema-less step would accept it and report COMPLETED, silently skipping the
+        downstream stages that depend on the conclusion.
+        """
+        if isinstance(conclusion, dict) and conclusion:
+            return None
+        logger.warning(
+            "Empty conclusion rejected for step %s",
+            sanitize_strict_text(self._step_config.step_id),
+        )
+        return _(
+            "conclusion must be a non-empty object; an empty conclusion means the step produced no result. "
+            "Fill in the fields required by the current step, or state the failure reason in the conclusion."
+        )
+
+    def _empty_conclusion_failure(self, attempts: int) -> tuple[str, dict[str, Any]]:
+        reason = _(
+            "Step {step_id} submitted an empty conclusion {attempts} times; the step produced no usable result."
+        ).format(step_id=display_step_name(self._step_config.step_id), attempts=attempts)
+        return reason, {
+            "failed": True,
+            "failure_kind": EMPTY_CONCLUSION_FAILURE_KIND,
+            "step_id": self._step_config.step_id,
+            "reason": reason,
+        }
 
     def _validate_conclusion(self, conclusion: dict) -> str | None:
         """Validate conclusion against schema. Returns error message or None."""
@@ -952,7 +982,9 @@ class CompleteStepTool(Tool):
                 "Rollback count cannot exceed {max_rollbacks}. Complete the current step or ask the user for help."
             ).format(max_rollbacks=max_rollbacks)
 
-        validation_error = self._validate_conclusion(conclusion)
+        validation_error = self._validate_non_empty_conclusion(conclusion)
+        if validation_error is None:
+            validation_error = self._validate_conclusion(conclusion)
         if validation_error is None:
             validation_error = self._validate_completion_guards(conclusion)
         if validation_error is None:
@@ -1142,7 +1174,10 @@ class CompleteStepTool(Tool):
                 is_error=True,
             )
 
-        validation_error = self._validate_conclusion(conclusion)
+        empty_conclusion_error = self._validate_non_empty_conclusion(conclusion)
+        validation_error = empty_conclusion_error
+        if validation_error is None:
+            validation_error = self._validate_conclusion(conclusion)
         if validation_error is None:
             validation_error = self._validate_completion_guards(conclusion)
         if validation_error is None:
@@ -1150,14 +1185,24 @@ class CompleteStepTool(Tool):
         if validation_error:
             self._validation_attempts += 1
             if self._validation_attempts > self._step_config.max_conclusion_retries:
-                step_result = StepResult(
-                    step_id=self._step_config.step_id,
-                    status=StepStatus.FAILED,
-                    error=_("Schema validation failed after {attempts} attempts: {error}").format(
-                        attempts=self._validation_attempts,
-                        error=validation_error,
-                    ),
-                )
+                if empty_conclusion_error is not None:
+                    error, failure_conclusion = self._empty_conclusion_failure(self._validation_attempts)
+                    step_result = StepResult(
+                        step_id=self._step_config.step_id,
+                        status=StepStatus.FAILED,
+                        conclusion=failure_conclusion,
+                        error=error,
+                        failure_kind=EMPTY_CONCLUSION_FAILURE_KIND,
+                    )
+                else:
+                    step_result = StepResult(
+                        step_id=self._step_config.step_id,
+                        status=StepStatus.FAILED,
+                        error=_("Schema validation failed after {attempts} attempts: {error}").format(
+                            attempts=self._validation_attempts,
+                            error=validation_error,
+                        ),
+                    )
                 max_retries = self._step_config.max_conclusion_retries
                 return ToolResult(
                     content=_(

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -343,9 +343,7 @@ def _parse_surface_overrides(raw: object, step_id: str) -> dict[str, StepSurface
 
         conclusion_schema = override.get("conclusion_schema")
         if conclusion_schema is not None and not isinstance(conclusion_schema, dict):
-            raise ValueError(
-                f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping"
-            )
+            raise ValueError(f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping")
 
         overrides[surface] = StepSurfaceOverride(
             prompt_file=prompt,

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -93,6 +93,8 @@ _REAL_RESTORE_FAILURE_REASONS = {
 
 def _is_a2a_surface(surface: str) -> bool:
     return surface == "a2a" or surface.startswith("a2a_")
+
+
 _SIDECAR_ROOT_DIRS = {"a2a", "image-cache", "pipeline", "tool-results"}
 _SIDECAR_ROOT_FILES = {
     ".backup-state.json",
@@ -989,6 +991,8 @@ class PipelineRunner:
     def should_switch_to_normal(self, completed_event_data: dict) -> bool:
         policy = self.on_complete_policy
         if policy is None or policy.action != "switch_to_normal":
+            return False
+        if completed_event_data.get("handoff_blocked"):
             return False
         outcome = terminal_outcome_from_completed_event(completed_event_data)
         return outcome in policy.apply_on
@@ -4443,8 +4447,21 @@ class PipelineRunner:
                 type=PipelineEventType.PIPELINE_COMPLETED,
                 step_id=step.step_id,
                 timestamp=time.time(),
-                data={"total_steps": self.state_machine.total_steps, "failed": True},
+                data=self._terminal_failed_event_data(step_result),
             )
+
+    def _terminal_failed_event_data(self, step_result: StepResult | None) -> dict:
+        """Build PIPELINE_COMPLETED data for a failed step, blocking handoff on typed failures.
+
+        A typed failure (e.g. an empty conclusion) carries no usable result downstream, so the
+        normal-mode handoff must not be published as if the pipeline had succeeded.
+        """
+        data: dict = {"total_steps": self.state_machine.total_steps, "failed": True}
+        failure_kind = getattr(step_result, "failure_kind", None)
+        if failure_kind:
+            data["failure_kind"] = failure_kind
+            data["handoff_blocked"] = True
+        return data
 
     def clear_sidecar(self) -> None:
         """Mark the sidecar non-resumable while preserving files for debugging."""

--- a/src/iac_code/pipeline/engine/step_executor.py
+++ b/src/iac_code/pipeline/engine/step_executor.py
@@ -425,6 +425,8 @@ class StepExecutor:
 
         if terminal_failed_step_result is not None:
             step_result = terminal_failed_step_result
+            if step_result.conclusion:
+                context.set_conclusion(step.conclusion_field, step_result.conclusion)
         elif complete_step_input is not None:
             conclusion = complete_step_input.get("conclusion", {})
             conclusion = self._merge_preserved_candidate_selection(preserved_selection, conclusion)

--- a/src/iac_code/pipeline/engine/types.py
+++ b/src/iac_code/pipeline/engine/types.py
@@ -40,3 +40,4 @@ class StepResult:
     conclusion: dict | None = None
     rollback_request: tuple[str, str] | None = None
     error: str | None = None
+    failure_kind: str | None = None

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -298,9 +298,7 @@ class AliyunCredentials:
 
             owns_client = oauth_client is None
             client = (
-                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type))
-                if oauth_client is None
-                else oauth_client
+                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type)) if oauth_client is None else oauth_client
             )
 
             try:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -149,8 +149,7 @@ class StagedSessionBackupService(SessionBackupService):
                         existing = self._read_existing_snapshot_state(destination, session_id)
                         if existing is not None:
                             completed_next = (
-                                base_state.status == "succeeded"
-                                and existing.parent_generation == base_state.generation
+                                base_state.status == "succeeded" and existing.parent_generation == base_state.generation
                             )
                             if not completed_next and not existing.same_lineage(committed_state):
                                 raise SessionBackupConflict(

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -3788,12 +3788,10 @@ class TestResolveCandidatePresentation:
         executor = self._make_executor()
 
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}}) == "rich-v1"
         )
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}}) == "rich-v1"
         )
 
     def test_rejects_unknown_or_missing_presentation(self) -> None:

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -240,9 +240,7 @@ def test_ros_deployment_permission_is_localized_and_preserves_safe_plan_summary(
                         "stackName": "demo-stack",
                         "template": "templates/demo.yml",
                         "totalMonthlyCost": "¥88/月",
-                        "resources": [
-                            {"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}
-                        ],
+                        "resources": [{"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}],
                     },
                 },
             ),
@@ -388,9 +386,7 @@ async def test_pipeline_permission_uses_same_input_envelope_and_waits_serially(m
 async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(monkeypatch, tmp_path) -> None:
     registry = PermissionInputRegistry()
     store = A2ATaskStore()
-    await store.save(
-        Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING))
-    )
+    await store.save(Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)))
     queue = FakeEventQueue()
     publisher = PipelineA2AEventPublisher(
         event_queue=queue,
@@ -466,9 +462,7 @@ async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(m
     task = await store.get("task-1")
     assert task is not None
     task_metadata = MessageToDict(task.metadata, preserving_proto_field_name=False)
-    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [
-        requests[1]["inputId"]
-    ]
+    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [requests[1]["inputId"]]
     remaining = task_metadata["iac_code"]["pendingPermissions"][0]
     assert remaining["language"] == "zh"
     assert remaining["prompt"] == "是否允许本次操作：运行本地 Shell 命令？"

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from iac_code.pipeline.engine.complete_step_tool import CompleteStepTool
+from iac_code.pipeline.engine.complete_step_tool import EMPTY_CONCLUSION_FAILURE_KIND, CompleteStepTool
 from iac_code.pipeline.engine.types import StepConfig, StepStatus
 from iac_code.tools.base import ToolContext
 
@@ -1672,6 +1672,67 @@ class TestSchemaValidation:
             context=ToolContext(),
         )
         assert not result.is_error
+
+
+class TestEmptyConclusionFailure:
+    """An empty conclusion must fail the step instead of silently reporting COMPLETED."""
+
+    @staticmethod
+    def _schemaless_config(**overrides):
+        return StepConfig(
+            step_id="intent_parsing",
+            conclusion_field="intent",
+            forward="architecture_planning",
+            **overrides,
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_conclusion_retries_before_failing(self):
+        tool = CompleteStepTool(self._schemaless_config(max_conclusion_retries=1))
+
+        first = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
+        assert first.is_error
+        assert first.metadata is None
+
+        second = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
+        assert second.is_error
+        step_result = second.metadata["step_result"]
+        assert step_result.status == StepStatus.FAILED
+        assert step_result.failure_kind == EMPTY_CONCLUSION_FAILURE_KIND
+
+    @pytest.mark.asyncio
+    async def test_terminal_failure_carries_non_empty_conclusion(self):
+        tool = CompleteStepTool(self._schemaless_config(max_conclusion_retries=0))
+
+        result = await tool.execute(tool_input={"conclusion": {}}, context=ToolContext())
+
+        step_result = result.metadata["step_result"]
+        assert step_result.status == StepStatus.FAILED
+        assert step_result.conclusion
+        assert step_result.conclusion["failed"] is True
+        assert step_result.conclusion["failure_kind"] == EMPTY_CONCLUSION_FAILURE_KIND
+        assert step_result.conclusion["step_id"] == "intent_parsing"
+        assert step_result.conclusion["reason"]
+        assert step_result.error
+
+    @pytest.mark.asyncio
+    async def test_null_only_conclusion_is_rejected(self):
+        """A NoneType parse result degrades to {} after normalization and must not pass."""
+        tool = CompleteStepTool(self._schemaless_config(max_conclusion_retries=0))
+
+        result = await tool.execute(
+            tool_input={"conclusion": {"is_infra_intent": None, "confidence": None}},
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert result.metadata["step_result"].failure_kind == EMPTY_CONCLUSION_FAILURE_KIND
+
+    def test_validate_completion_input_rejects_empty_conclusion(self):
+        tool = CompleteStepTool(self._schemaless_config())
+
+        assert tool.validate_completion_input({"conclusion": {}}) is not None
+        assert tool.validate_completion_input({"conclusion": {"is_infra_intent": True}}) is None
 
 
 class TestNullNormalization:

--- a/tests/pipeline/engine/test_pipeline_handoff.py
+++ b/tests/pipeline/engine/test_pipeline_handoff.py
@@ -6,6 +6,7 @@ import yaml
 
 from iac_code.pipeline.engine.handoff import build_handoff_summary, terminal_outcome_from_completed_event
 from iac_code.pipeline.engine.pipeline_runner import PipelineRunner
+from iac_code.pipeline.engine.types import StepResult, StepStatus
 
 
 def _make_runner(tmp_path: Path, on_complete: dict | None = None) -> PipelineRunner:
@@ -169,6 +170,44 @@ def test_runner_should_switch_to_normal_for_configured_canceled_event(tmp_path):
     runner = _make_runner(tmp_path, _switch_policy("completed", "canceled"))
 
     assert runner.should_switch_to_normal({"canceled": True}) is True
+
+
+def test_runner_blocks_handoff_for_blocked_failure(tmp_path):
+    """A typed step failure must not hand off to normal mode even when 'failed' is in apply_on."""
+    runner = _make_runner(tmp_path, _switch_policy("completed", "failed"))
+
+    assert (
+        runner.should_switch_to_normal({"failed": True, "failure_kind": "empty_conclusion", "handoff_blocked": True})
+        is False
+    )
+
+
+def test_runner_terminal_failed_event_data_marks_handoff_blocked_for_typed_failure(tmp_path):
+    runner = _make_runner(tmp_path, _switch_policy("completed", "failed"))
+    step_result = StepResult(
+        step_id="step",
+        status=StepStatus.FAILED,
+        conclusion={"failed": True, "failure_kind": "empty_conclusion", "reason": "empty intent"},
+        error="empty conclusion",
+        failure_kind="empty_conclusion",
+    )
+
+    data = runner._terminal_failed_event_data(step_result)
+
+    assert data["failed"] is True
+    assert data["failure_kind"] == "empty_conclusion"
+    assert data["handoff_blocked"] is True
+    assert runner.should_switch_to_normal(data) is False
+
+
+def test_runner_terminal_failed_event_data_keeps_handoff_for_untyped_failure(tmp_path):
+    runner = _make_runner(tmp_path, _switch_policy("completed", "failed"))
+    step_result = StepResult(step_id="step", status=StepStatus.FAILED, error="No conclusion extracted")
+
+    data = runner._terminal_failed_event_data(step_result)
+
+    assert "handoff_blocked" not in data
+    assert runner.should_switch_to_normal(data) is True
 
 
 def test_runner_build_normal_handoff_summary_uses_configured_context_values(tmp_path):

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -2610,6 +2610,51 @@ class TestStepExecutorValidationRespect:
         assert results == [terminal_result]
 
     @pytest.mark.asyncio
+    async def test_terminal_failure_conclusion_is_written_to_context(self, tmp_path):
+        """An empty-conclusion failure must leave a non-empty reason in the pipeline context."""
+        failure_conclusion = {
+            "failed": True,
+            "failure_kind": "empty_conclusion",
+            "step_id": "intent_parsing",
+            "reason": "intent_parsing submitted an empty conclusion",
+        }
+        terminal_result = StepResult(
+            step_id="intent_parsing",
+            status=StepStatus.FAILED,
+            conclusion=failure_conclusion,
+            error="intent_parsing submitted an empty conclusion",
+            failure_kind="empty_conclusion",
+        )
+
+        class FakeAgentLoop:
+            def __init__(self, **kwargs):
+                pass
+
+            async def run_streaming(self, user_input):
+                yield ToolUseStartEvent(tool_use_id="tu_1", name="complete_step")
+                yield ToolUseEndEvent(tool_use_id="tu_1", name="complete_step", input={"conclusion": {}})
+                yield ToolResultEvent(
+                    tool_use_id="tu_1",
+                    tool_name="complete_step",
+                    result="conclusion validation failed",
+                    is_error=True,
+                    metadata={"step_result": terminal_result},
+                )
+
+        executor = _make_executor(tmp_path)
+        step = _make_step()
+        ctx = PipelineContext(SIMPLE_DEPS)
+
+        collected = []
+        with patch("iac_code.agent.agent_loop.AgentLoop", FakeAgentLoop):
+            async for event in executor.execute(step, ctx, "test_session"):
+                collected.append(event)
+
+        results = [e for e in collected if isinstance(e, StepResult)]
+        assert results == [terminal_result]
+        assert ctx.get_conclusion(step.conclusion_field) == failure_conclusion
+
+    @pytest.mark.asyncio
     async def test_accepts_conclusion_only_after_successful_validation(self, tmp_path):
         """When first call fails validation and second succeeds, only second conclusion is accepted."""
         call_count = [0]  # noqa: F841
@@ -2776,11 +2821,15 @@ class TestStepExecutorSchemaWiring:
             surface="a2a_rich",
         )
 
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=True,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=True,
+            )
+            .get("complete_step")
+            .input_schema
+        )
         conclusion_schema = tool_schema["properties"]["conclusion"]
         assert conclusion_schema["required"] == [
             "selected_candidate_name",
@@ -2863,11 +2912,15 @@ class TestStepExecutorSchemaWiring:
             context,
             resume_candidate_selection=True,
         )
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=preserved is not None,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=preserved is not None,
+            )
+            .get("complete_step")
+            .input_schema
+        )
 
         assert preserved is None
         conclusion_schema = tool_schema["properties"]["conclusion"]
@@ -3143,12 +3196,26 @@ async def test_resumed_step_returns_reconstructed_complete_step(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
-async def test_resumed_completed_step_sets_empty_conclusion_and_calls_on_exit(monkeypatch, tmp_path):
-    class FailIfAgentLoopIsCreated:
-        def __init__(self, *args, **kwargs):
-            raise AssertionError("AgentLoop should not be created for already-completed transcript")
+async def test_resumed_completed_step_rejects_empty_conclusion_and_reruns(monkeypatch, tmp_path):
+    """An empty conclusion in the transcript is not a completed step — the step must be re-driven."""
 
-    monkeypatch.setattr("iac_code.agent.agent_loop.AgentLoop", FailIfAgentLoopIsCreated)
+    class FakeAgentLoop:
+        def __init__(self, *args, **kwargs):
+            self.resume_messages = kwargs.get("resume_messages")
+
+        async def continue_streaming(self):
+            yield ToolUseStartEvent(tool_use_id="tu_retry", name="complete_step")
+            yield ToolUseEndEvent(
+                tool_use_id="tu_retry",
+                name="complete_step",
+                input={"conclusion": {"is_infra_intent": True}},
+            )
+            yield ToolResultEvent(tool_use_id="tu_retry", tool_name="complete_step", result="ok")
+
+        async def run_streaming(self, user_input):
+            raise AssertionError("resumed step should continue, not start a fresh prompt")
+
+    monkeypatch.setattr("iac_code.agent.agent_loop.AgentLoop", FakeAgentLoop)
 
     executor = _make_executor(tmp_path)
     step = _make_step()
@@ -3176,9 +3243,9 @@ async def test_resumed_completed_step_sets_empty_conclusion_and_calls_on_exit(mo
 
     assert len(results) == 1
     assert results[0].status == StepStatus.COMPLETED
-    assert results[0].conclusion == {}
-    assert ctx.get_conclusion(step.conclusion_field) == {}
-    step.on_exit.assert_called_once_with(ctx, {})
+    assert results[0].conclusion == {"is_infra_intent": True}
+    assert ctx.get_conclusion(step.conclusion_field) == {"is_infra_intent": True}
+    step.on_exit.assert_called_once_with(ctx, {"is_infra_intent": True})
 
 
 @pytest.mark.asyncio

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -133,9 +133,7 @@ def test_confirm_prompt_tells_model_to_preserve_parameter_overrides():
 def test_confirm_prompts_share_selection_contract_structure():
     repl_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.md").read_text(encoding="utf-8")
     a2a_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.md").read_text(encoding="utf-8")
-    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(
-        encoding="utf-8"
-    )
+    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(encoding="utf-8")
 
     shared_fragments = [
         "## 首次执行",

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -1676,9 +1676,7 @@ class TestProviderManagerCompleteRetry:
 
     async def test_complete_attributes_bailian_openai_endpoint_to_dashscope_on_all_signals(self):
         mock_provider = AsyncMock()
-        mock_provider._base_url = (
-            "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
-        )
+        mock_provider._base_url = "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
         mock_provider.complete = AsyncMock(
             return_value=NonStreamingResponse(
                 message_id="complete-response",

--- a/tests/skill_bridge/test_iac_code_bridge.py
+++ b/tests/skill_bridge/test_iac_code_bridge.py
@@ -542,12 +542,10 @@ def test_bridge_automatically_runs_cleanup_only_task_and_restores_pipeline_resul
 
     assert len(captured_payloads) == 2
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True for payload in captured_payloads
     )
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host"
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host" for payload in captured_payloads
     )
     assert captured_payloads[0]["params"]["message"]["contextId"] == "ctx-pipeline-1"
     assert result["state"] == "completed"
@@ -1138,9 +1136,7 @@ def test_candidate_presentation_survives_bounded_bridge_projection() -> None:
                                     "summary": "单 ECS 低成本方案。",
                                     "architectureDiagram": "flowchart LR\nU[用户] --> E[ECS]",
                                     "totalMonthlyCost": "¥88/月",
-                                    "costItems": [
-                                        {"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}
-                                    ],
+                                    "costItems": [{"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}],
                                 }
                             ],
                             "required": True,

--- a/tests/skill_bridge/test_runtime_release.py
+++ b/tests/skill_bridge/test_runtime_release.py
@@ -104,9 +104,7 @@ def test_runtime_archive_and_version_marker_are_rooted_consistently(tmp_path: Pa
     assert "artifactRevision" not in marker
 
 
-def test_runtime_a2a_smoke_checks_health_and_agent_card(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_runtime_a2a_smoke_checks_health_and_agent_card(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module("skill_runtime_smoke", BUILD_SCRIPT)
     server = tmp_path / "server.py"
     server.write_text(

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -2547,7 +2547,7 @@ def test_completed_turn_collapses_process_into_summary() -> None:
     # 「已处理」组的展开态必须跨重建保留:openKey 让 toggle 记录器登记用户操作、
     # applyDetailsOpenOverrides 在重建后恢复;键取 turnId,缺 turnId 时回退首条消息 id。
     assert 'const turnKey = turnId || text(agentMessages[0]?.messageId || agentMessages[0]?.id || "");' in app_source
-    assert 'details.dataset.openKey = `turnproc:${turnKey}`;' in app_source
+    assert "details.dataset.openKey = `turnproc:${turnKey}`;" in app_source
 
     # 只有最后一次工具调用之后的文本才是「最终回答」;此前每个步骤的文本旁白
     # (夹在工具调用之间的 text delta)连同思考、工具一起折进「已处理」,不平铺成答案。


### PR DESCRIPTION
## 问题

`intent_parsing` 步骤未声明 `conclusion_schema`，`CompleteStepTool._validate_conclusion()` 因此短路返回；
`normalize_input()` 又会剥离 None 值，于是 NoneType 意图被压平成 `{}` 并被当作成功结果接受：

- 步骤上报 `COMPLETED`，空 conclusion 被写入 pipeline context
- `pipeline_runner.py` 的 `if step.exit_condition and step_result.conclusion:` 守卫使 exit_condition 判定被跳过，但状态机仍然推进
- 正常模式下仍然发布 `pipeline_handoff_ready`
- 结果：候选生成被静默跳过，`failed_statuses=0`，问题不可观测

## 修复

- `CompleteStepTool` 无论是否声明 `conclusion_schema`，一律拒绝空 conclusion；复用既有 `max_conclusion_retries` 预算给模型自我纠正的机会
- 重试耗尽后返回 `StepStatus.FAILED`，携带 `failure_kind="empty_conclusion"` 以及**非空**失败 conclusion（`failed` / `failure_kind` / `step_id` / `reason`），由 `StepExecutor` 写入 pipeline context
- 终态 `PIPELINE_COMPLETED` 事件带上 `failure_kind` 与 `handoff_blocked`，`should_switch_to_normal()` 据此拒绝切换，typed failure 不再发布 `pipeline_handoff_ready`
- 6 个 locale 补齐新增 msgid 翻译并重新编译

## 验证

- `tests/pipeline` + `tests/test_i18n.py`：1646 passed
- 定向用例（`test_complete_step_tool.py` / `test_pipeline_handoff.py` / `test_step_executor.py`）：145 passed
- `make lint`：ruff check + ty check 全部通过

已知 2 个失败为存量/环境问题，已通过 stash 基线复现确认与本次改动无关：
`test_prepare_direct_binary_installer_reports_invalid_http_url_without_leaking_token`、
`test_message_catalogs_pass_gnu_msgfmt_checks`（存量 zh 2505-2525 行 `{s:.0}` python-brace-format）。

## 说明

本 commit 同时包含 `ruff format` 对存量格式漂移的输出：仓库 pre-commit 钩子以
`pass_filenames: false` 全树运行 `make format`，而 `pyproject.toml` 仅约束
`ruff>=0.4.0`，实际解析到的 ruff 版本比产出当前提交格式的版本更新。该副作用由钩子强制产生，
禁用钩子不在允许范围内。
