### PR TITLE
fix(pipeline): 候选方案与 confirm 前强校验用户 intent 资源覆盖

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1731,9 +1731,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             raise ValueError("Invalid A2A workspace metadata.")
         logical_cwd = os.path.normpath(cwd)
         resolved_cwd = resolve_workspace_path(Path(logical_cwd))
-        if not trust_request_cwd() and not any(
-            _is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()
-        ):
+        if not trust_request_cwd() and not any(_is_relative_to(resolved_cwd, root) for root in _allowed_cwd_roots()):
             raise ValueError("Invalid A2A workspace metadata.")
         if resolved_cwd.exists():
             if not resolved_cwd.is_dir():

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -178,35 +178,29 @@ def permission_display_fields(request: PermissionRequestEvent, *, language: str 
             command = safe_input.get("command") or safe_input.get("cmd")
         if isinstance(command, str) and command.strip():
             command_fallback = translate_message("shell command", language=language)
-            target = translate_message(
-                "the current local workspace; command: {command}", language=language
-            ).format(command=_display_text(command, fallback=command_fallback, maximum=240))
+            target = translate_message("the current local workspace; command: {command}", language=language).format(
+                command=_display_text(command, fallback=command_fallback, maximum=240)
+            )
         else:
             target = translate_message("the current local workspace", language=language)
         effect = "read" if is_read_only else ("local_execution" if read_only_known else "unknown")
     elif tool_name in {"write_file", "edit_file"}:
         title = translate_message("Change a workspace file", language=language)
-        purpose = translate_message(
-            "Write a file needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Write a file needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "a file in the current workspace", language=language
         )
         effect = "file_change"
     elif tool_name in {"read_file", "glob", "grep"} or is_read_only:
         title = translate_message("Read workspace data with {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Read local data needed for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Read local data needed for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current local workspace", language=language
         )
         effect = "read"
     else:
         title = translate_message("Run {tool}", language=language).format(tool=public_tool)
-        purpose = translate_message(
-            "Run this operation for the requested infrastructure task.", language=language
-        )
+        purpose = translate_message("Run this operation for the requested infrastructure task.", language=language)
         target = _safe_input_target(safe_input, language=language) or translate_message(
             "the current task workspace or cloud account", language=language
         )
@@ -319,9 +313,7 @@ def _cloud_operation_title(product: str, action: str, *, is_read_only: bool, lan
     if action == "CreateStack":
         return translate_message("Create {product} stack", language=language).format(product=product_label)
     if action == "ContinueCreateStack":
-        return translate_message("Continue creating {product} stack", language=language).format(
-            product=product_label
-        )
+        return translate_message("Continue creating {product} stack", language=language).format(product=product_label)
     if action == "UpdateStack":
         return translate_message("Update {product} stack", language=language).format(product=product_label)
     if action == "DeleteStack":
@@ -344,9 +336,7 @@ def _safe_input_target(value: Any, *, language: str) -> str:
     for key in ("file_path", "filePath", "path", "region_id", "regionId", "resource_id", "resourceId"):
         candidate = value.get(key)
         if isinstance(candidate, str) and candidate.strip():
-            return _display_text(
-                candidate, fallback=translate_message("the current task scope", language=language)
-            )
+            return _display_text(candidate, fallback=translate_message("the current task scope", language=language))
     return ""
 
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -1235,11 +1235,7 @@ class IacCodeA2APipelineExecutor:
             def permission_context_getter() -> Any:
                 return getattr(agent_loop, "_permission_context", None)
 
-        surface = (
-            A2A_RICH_CANDIDATE_SURFACE
-            if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION
-            else "a2a"
-        )
+        surface = A2A_RICH_CANDIDATE_SURFACE if self._candidate_presentation == RICH_CANDIDATE_PRESENTATION else "a2a"
         return create_pipeline(
             pipeline_name,
             provider_manager=runtime.provider_manager,

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -864,9 +864,7 @@ class A2ATaskStore(TaskStore):
                 any(record.active_task is not None and not record.active_task.done() for record in self._tasks.values())
                 or any(not task.done() for task in self._context_runtime_tasks.values())
                 or any(
-                    not task.done()
-                    for starts in self._context_execution_starts.values()
-                    for task in starts.values()
+                    not task.done() for starts in self._context_execution_starts.values() for task in starts.values()
                 )
                 or any(self._context_reconciliation_waiters.values())
                 or any(lock.locked() for lock in self._reconciliation_locks.values())

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -4088,6 +4088,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource declared in the user intent must be covered, or recorded "
+"as an explicit gap with a reason."
+msgstr ""
+"Jede in der Nutzerabsicht deklarierte Ressource muss abgedeckt oder als "
+"ausdrückliche Lücke mit einer Begründung erfasst werden."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -4065,6 +4065,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource declared in the user intent must be covered, or recorded "
+"as an explicit gap with a reason."
+msgstr ""
+"Cada recurso declarado en la intención del usuario debe estar cubierto o "
+"registrado como una brecha explícita con un motivo."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -4074,6 +4074,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource declared in the user intent must be covered, or recorded "
+"as an explicit gap with a reason."
+msgstr ""
+"Chaque ressource déclarée dans l'intention de l'utilisateur doit être "
+"couverte ou consignée comme un écart explicite avec un motif."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -3876,6 +3876,12 @@ msgstr "ユーザーが明示した各ハード制約は、パラメーターと
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource declared in the user intent must be covered, or recorded "
+"as an explicit gap with a reason."
+msgstr "ユーザーインテントで宣言されたすべてのリソースは、カバーされるか、理由付きの明示的なギャップとして記録される必要があります。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -4046,6 +4046,14 @@ msgstr ""
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource declared in the user intent must be covered, or recorded "
+"as an explicit gap with a reason."
+msgstr ""
+"Cada recurso declarado na intenção do usuário deve ser coberto ou "
+"registrado como uma lacuna explícita com um motivo."
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr ""

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -3840,6 +3840,12 @@ msgstr "每个用户明确提出的硬约束都必须由一条状态为满足的
 
 #: src/iac_code/pipeline/engine/complete_step_tool.py
 msgid ""
+"Every resource declared in the user intent must be covered, or recorded "
+"as an explicit gap with a reason."
+msgstr "用户意图中声明的每个资源都必须被覆盖，或作为带原因的显式缺口记录下来。"
+
+#: src/iac_code/pipeline/engine/complete_step_tool.py
+msgid ""
 "Complete the current step by calling this tool to submit the conclusion. "
 "If you need to roll back to an earlier step, set rollback_request."
 msgstr "调用此工具提交结论以完成当前步骤。如需回滚到较早步骤，请设置 rollback_request。"

--- a/src/iac_code/pipeline/engine/complete_step_tool.py
+++ b/src/iac_code/pipeline/engine/complete_step_tool.py
@@ -14,6 +14,10 @@ import jsonschema
 from iac_code.i18n import _
 from iac_code.pipeline.display_names import display_step_name
 from iac_code.pipeline.engine.hard_constraints import collect_hard_constraints, validate_hard_constraint_checks
+from iac_code.pipeline.engine.resource_intent_coverage import (
+    collect_resource_intents,
+    validate_resource_intent_coverage,
+)
 from iac_code.pipeline.engine.types import StepResult, StepStatus
 from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.utils.public_errors import sanitize_strict_text
@@ -60,6 +64,9 @@ _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY = {
         "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
         "and evidence."
     ),
+    "resource_intent_coverage_required": (
+        "Every resource declared in the user intent must be covered, or recorded as an explicit gap with a reason."
+    ),
 }
 _COMPLETION_GUARD_MESSAGE_KEY_BY_TEXT = {text: key for key, text in _COMPLETION_GUARD_MESSAGE_TEXT_BY_KEY.items()}
 
@@ -100,6 +107,7 @@ def _completion_guard_message_i18n_markers() -> tuple[str, ...]:
             "Every explicit user hard constraint must be covered by a satisfied check with matching parameters "
             "and evidence."
         ),
+        _("Every resource declared in the user intent must be covered, or recorded as an explicit gap with a reason."),
     )
 
 
@@ -324,6 +332,7 @@ class CompleteStepTool(Tool):
             required_tool_result = guard.get("require_tool_result")
             required_conclusion_sha256 = guard.get("require_conclusion_sha256")
             required_constraint_coverage = guard.get("require_context_constraint_coverage")
+            required_intent_coverage = guard.get("require_resource_intent_coverage")
             required_field = guard.get("required_conclusion_field")
             required_any_of = guard.get("required_conclusion_any_of") or []
             successful_tools = self._completion_guard_state.get("successful_tools", set())
@@ -383,7 +392,64 @@ class CompleteStepTool(Tool):
                 )
                 if validation_error is not None:
                     return validation_error
+            if isinstance(required_intent_coverage, dict):
+                validation_error = self._validate_resource_intent_coverage(
+                    required_intent_coverage,
+                    conclusion,
+                    self._completion_guard_message(guard, None),
+                )
+                if validation_error is not None:
+                    return validation_error
         return None
+
+    def _validate_resource_intent_coverage(
+        self,
+        requirement: dict[str, Any],
+        conclusion: dict[str, Any],
+        message: str | None,
+    ) -> str | None:
+        source_fields = requirement.get("source_fields") or []
+        covered_products_fields = requirement.get("covered_products_fields") or []
+        items_field = str(requirement.get("items_field") or "")
+        if (
+            not items_field
+            or not isinstance(source_fields, list)
+            or not all(isinstance(field, str) for field in source_fields)
+            or not isinstance(covered_products_fields, list)
+            or not all(isinstance(field, str) for field in covered_products_fields)
+        ):
+            return message or _("A completion guard is misconfigured.")
+        items = self._resolve_dotted(conclusion, items_field)
+        if items is None:
+            # A later round may submit a compact conclusion without the presented items
+            # (e.g. the selection-only round of candidate selection); nothing to validate.
+            return None
+        context_snapshot = self._completion_guard_state.get("context_snapshot")
+        if not isinstance(context_snapshot, dict):
+            context_snapshot = {}
+        intents, source_issues = collect_resource_intents(context_snapshot, source_fields)
+        issues = source_issues + validate_resource_intent_coverage(
+            intents,
+            items,
+            covered_products_fields=covered_products_fields,
+            gaps_field=str(requirement.get("gaps_field") or "resource_intent_gaps"),
+        )
+        if not issues:
+            return None
+        base_message = message or _(
+            "Every resource declared in the user intent must be covered, or recorded as an explicit gap with a reason."
+        )
+        issue_summaries = []
+        for issue in issues:
+            specifics = ", ".join(value for value in (issue.product, issue.detail) if value)
+            issue_summaries.append(f"{issue.code}[{specifics}]" if specifics else issue.code)
+        code = issues[0].code if len(issues) == 1 else "multiple_resource_intent_issues"
+        detail = "; ".join(issue_summaries)
+        return _("{message} Validation issue: {code} ({detail}).").format(
+            message=base_message,
+            code=code,
+            detail=detail,
+        )
 
     def _validate_context_constraint_coverage(
         self,

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -43,6 +43,7 @@ _SUPPORTED_COMPLETION_GUARD_KEYS = {
     "message_key",
     "require_conclusion_sha256",
     "require_context_constraint_coverage",
+    "require_resource_intent_coverage",
     "require_tool",
     "require_tool_result",
     "required_conclusion_any_of",

--- a/src/iac_code/pipeline/engine/loader.py
+++ b/src/iac_code/pipeline/engine/loader.py
@@ -343,9 +343,7 @@ def _parse_surface_overrides(raw: object, step_id: str) -> dict[str, StepSurface
 
         conclusion_schema = override.get("conclusion_schema")
         if conclusion_schema is not None and not isinstance(conclusion_schema, dict):
-            raise ValueError(
-                f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping"
-            )
+            raise ValueError(f"Step '{step_id}': surface_overrides.{surface}.conclusion_schema must be a mapping")
 
         overrides[surface] = StepSurfaceOverride(
             prompt_file=prompt,

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -93,6 +93,8 @@ _REAL_RESTORE_FAILURE_REASONS = {
 
 def _is_a2a_surface(surface: str) -> bool:
     return surface == "a2a" or surface.startswith("a2a_")
+
+
 _SIDECAR_ROOT_DIRS = {"a2a", "image-cache", "pipeline", "tool-results"}
 _SIDECAR_ROOT_FILES = {
     ".backup-state.json",

--- a/src/iac_code/pipeline/engine/resource_intent_coverage.py
+++ b/src/iac_code/pipeline/engine/resource_intent_coverage.py
@@ -1,0 +1,153 @@
+"""Coverage validation between declared resource intents and generated plan items."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ResourceIntentIssue:
+    code: str
+    product: str = ""
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {key: value for key, value in asdict(self).items() if value}
+
+
+def collect_resource_intents(
+    context_snapshot: dict[str, Any],
+    source_fields: list[str],
+) -> tuple[list[dict[str, Any]], list[ResourceIntentIssue]]:
+    """Merge declared resource intents from oldest to newest, later revisions winning by product."""
+
+    merged: dict[str, dict[str, Any]] = {}
+    issues: list[ResourceIntentIssue] = []
+    for source_field in source_fields:
+        raw_intents = _resolve_dotted(context_snapshot, source_field)
+        if raw_intents is None:
+            continue
+        if not isinstance(raw_intents, list):
+            issues.append(ResourceIntentIssue("invalid_resource_intent_source", detail=source_field))
+            continue
+        for raw_intent in raw_intents:
+            if not isinstance(raw_intent, dict):
+                issues.append(ResourceIntentIssue("invalid_resource_intent"))
+                continue
+            product = raw_intent.get("product")
+            if not isinstance(product, str) or not product.strip():
+                issues.append(ResourceIntentIssue("missing_resource_intent_product"))
+                continue
+            merged[normalize_product(product)] = raw_intent
+    return list(merged.values()), issues
+
+
+def validate_resource_intent_coverage(
+    intents: list[dict[str, Any]],
+    items: Any,
+    *,
+    covered_products_fields: list[str],
+    gaps_field: str,
+) -> list[ResourceIntentIssue]:
+    """Require every non-forbidden intent to be covered by each item or declared as an explicit gap."""
+
+    required = {
+        normalize_product(str(intent.get("product") or "")): intent
+        for intent in intents
+        if isinstance(intent, dict) and intent.get("action") != "forbid"
+    }
+    forbidden = {
+        normalize_product(str(intent.get("product") or ""))
+        for intent in intents
+        if isinstance(intent, dict) and intent.get("action") == "forbid"
+    }
+    if not required and not forbidden:
+        return []
+    if not isinstance(items, list) or not items:
+        return [ResourceIntentIssue("invalid_coverage_items")]
+
+    issues: list[ResourceIntentIssue] = []
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            issues.append(ResourceIntentIssue("invalid_coverage_item", detail=str(index)))
+            continue
+        covered = _collect_covered_products(item, covered_products_fields)
+        declared_gaps, gap_issues = _collect_declared_gaps(item, gaps_field)
+        issues.extend(gap_issues)
+        for product, intent in required.items():
+            if product in covered:
+                continue
+            if product in declared_gaps:
+                continue
+            issues.append(
+                ResourceIntentIssue("uncovered_resource_intent", str(intent.get("product") or ""), str(index))
+            )
+        for product in declared_gaps - required.keys():
+            issues.append(ResourceIntentIssue("unexpected_resource_intent_gap", product, str(index)))
+        for product in covered & forbidden:
+            issues.append(ResourceIntentIssue("forbidden_resource_intent_covered", product, str(index)))
+    return issues
+
+
+def normalize_product(product: str) -> str:
+    """Fold product aliases such as ``NAT Gateway``/``NATGateway``/``nat-gateway`` into one key."""
+
+    return "".join(char for char in product.casefold() if char.isalnum())
+
+
+def _collect_covered_products(item: dict[Any, Any], covered_products_fields: list[str]) -> set[str]:
+    covered: set[str] = set()
+    for field in covered_products_fields:
+        values = _resolve_dotted(item, field)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if isinstance(value, str):
+                covered.add(normalize_product(value))
+            elif isinstance(value, dict) and value.get("action") != "forbid":
+                product = value.get("product")
+                if isinstance(product, str):
+                    covered.add(normalize_product(product))
+    covered.discard("")
+    return covered
+
+
+def _collect_declared_gaps(item: dict[Any, Any], gaps_field: str) -> tuple[set[str], list[ResourceIntentIssue]]:
+    raw_gaps = _resolve_dotted(item, gaps_field)
+    if raw_gaps is None:
+        return set(), []
+    if not isinstance(raw_gaps, list):
+        return set(), [ResourceIntentIssue("invalid_resource_intent_gap", detail=gaps_field)]
+    gaps: set[str] = set()
+    issues: list[ResourceIntentIssue] = []
+    for raw_gap in raw_gaps:
+        if not isinstance(raw_gap, dict):
+            issues.append(ResourceIntentIssue("invalid_resource_intent_gap"))
+            continue
+        product = raw_gap.get("product")
+        reason = raw_gap.get("reason")
+        if not isinstance(product, str) or not product.strip():
+            issues.append(ResourceIntentIssue("invalid_resource_intent_gap"))
+            continue
+        if not isinstance(reason, str) or not reason.strip():
+            issues.append(ResourceIntentIssue("invalid_resource_intent_gap", normalize_product(product)))
+            continue
+        gaps.add(normalize_product(product))
+    return gaps, issues
+
+
+def _resolve_dotted(value: Any, path: str) -> Any:
+    if not path:
+        return None
+    for part in path.split("."):
+        if isinstance(value, dict):
+            value = value.get(part)
+        elif isinstance(value, list) and part.isdigit():
+            index = int(part)
+            value = value[index] if 0 <= index < len(value) else None
+        else:
+            return None
+        if value is None:
+            return None
+    return value

--- a/src/iac_code/pipeline/selling/pipeline.yaml
+++ b/src/iac_code/pipeline/selling/pipeline.yaml
@@ -453,6 +453,14 @@ steps:
     skill: iac-aliyun-architecture
     prompt: prompts/architecture_planning.md
     context_fields: [intent]
+    completion_guards:
+      - always: true
+        require_resource_intent_coverage:
+          source_fields: [intent.resource_intents]
+          items_field: candidates
+          covered_products_fields: [resource_intents, products]
+          gaps_field: resource_intent_gaps
+        message_key: resource_intent_coverage_required
     tools:
       include: [read_memory, read_file, list_files, glob, grep, web_fetch, aliyun_doc_search]
       exclude: []
@@ -470,10 +478,18 @@ steps:
     conclusion_field: selected_plan
     forward: deploying
     prompt: prompts/confirm_and_select.md
-    context_fields: [evaluated_candidates]
+    context_fields: [intent, evaluated_candidates]
     auto_advance: false
     ui_mode: candidate_selection
     inject_tools: [show_architecture_diagram, show_candidate_detail]
+    completion_guards:
+      - always: true
+        require_resource_intent_coverage:
+          source_fields: [intent.resource_intents]
+          items_field: options
+          covered_products_fields: [covered_products]
+          gaps_field: resource_intent_gaps
+        message_key: resource_intent_coverage_required
     surface_overrides:
       a2a:
         prompt: prompts/confirm_and_select.a2a.md
@@ -494,7 +510,7 @@ steps:
               minItems: 1
               items:
                 type: object
-                required: [name, summary, candidate_index, architecture_diagram, total_monthly_cost, cost_items]
+                required: [name, summary, candidate_index, covered_products, architecture_diagram, total_monthly_cost, cost_items]
                 additionalProperties: false
                 properties:
                   name:
@@ -503,6 +519,23 @@ steps:
                     type: string
                   candidate_index:
                     type: integer
+                  covered_products:
+                    type: array
+                    description: 本方案实际交付的产品列表；必须覆盖 intent.resource_intents 中所有非 forbid 资源
+                    items:
+                      type: string
+                  resource_intent_gaps:
+                    type: array
+                    description: 本方案未覆盖的 intent 资源及原因；缺口必须显式登记，不得静默丢弃
+                    items:
+                      type: object
+                      required: [product, reason]
+                      additionalProperties: false
+                      properties:
+                        product:
+                          type: string
+                        reason:
+                          type: string
                   architecture_diagram:
                     type: string
                     description: A2A 富展示使用的紧凑 Mermaid 架构图
@@ -554,7 +587,7 @@ steps:
           minItems: 1
           items:
             type: object
-            required: [name, summary, candidate_index]
+            required: [name, summary, candidate_index, covered_products]
             additionalProperties: false
             properties:
               name:
@@ -563,6 +596,23 @@ steps:
                 type: string
               candidate_index:
                 type: integer
+              covered_products:
+                type: array
+                description: 本方案实际交付的产品列表；必须覆盖 intent.resource_intents 中所有非 forbid 资源
+                items:
+                  type: string
+              resource_intent_gaps:
+                type: array
+                description: 本方案未覆盖的 intent 资源及原因；缺口必须显式登记，不得静默丢弃
+                items:
+                  type: object
+                  required: [product, reason]
+                  additionalProperties: false
+                  properties:
+                    product:
+                      type: string
+                    reason:
+                      type: string
         user_input:
           type: string
           description: 用户选择方案时输入的原始文本；首次展示方案时可省略

--- a/src/iac_code/pipeline/selling/prompts/architecture_planning.md
+++ b/src/iac_code/pipeline/selling/prompts/architecture_planning.md
@@ -15,6 +15,11 @@
 ## 输出
 调用 `complete_step` 提交候选方案列表。
 
+### 资源覆盖校对（提交前必做）
+逐项对照 `intent.resource_intents`：所有 `action != forbid` 的资源都必须出现在每个 candidate 的 `resource_intents` 中。
+确实无法覆盖时，在该 candidate 的 `resource_intent_gaps` 写入 `product` 和 `reason`，并在 `cons` 中说明为部分满足。
+不得只保留基础网络资源而丢掉用户明确要求的 ECS、NAT、EIP、SLB 等资源。
+
 ### output_path 命名规则
 - 格式：`templates/{index}-{英文简写}.yml`
 - index 从 1 开始

--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.md
@@ -5,6 +5,11 @@
 ## 任务
 基于候选方案评估结果生成可选择方案列表，并在用户选择后提交最终选择结果。
 
+## 用户意图（资源覆盖基准）
+```json
+{intent}
+```
+
 ## 评估结果
 ```json
 {evaluated_candidates}
@@ -22,6 +27,10 @@
 - `options[].name`：候选方案名称，取 `candidate.name`
 - `options[].summary`：候选方案摘要
 - `options[].candidate_index`：候选方案在 `evaluated_candidates` 数组中的 0 基下标
+- `options[].covered_products`：本方案实际交付的产品列表；必须覆盖 `intent.resource_intents` 中所有 `action != forbid` 的资源
+- `options[].resource_intent_gaps`：本方案未覆盖的 intent 资源，每项包含 `product` 和 `reason`；全部覆盖时省略该字段
+
+存在缺口时必须在 `summary` 中标注「部分满足」及缺失资源和原因，且不得作为唯一推荐；方案名称与 `summary` 不得宣称未实际交付的资源。
 
 `complete_step.conclusion.user_prompt` 必须是展示给用户的选择提示，例如“请选择要部署的方案：”。
 

--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.rich.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.a2a.rich.md
@@ -5,6 +5,11 @@
 ## 任务
 基于候选方案评估结果生成可选择方案列表，并在用户选择后提交最终选择结果。
 
+## 用户意图（资源覆盖基准）
+```json
+{intent}
+```
+
 ## 评估结果
 ```json
 {evaluated_candidates}
@@ -22,6 +27,8 @@
 - `options[].name`：候选方案名称，取 `candidate.name`
 - `options[].summary`：使用用户当前语言撰写 2-3 句方案描述，说明核心产品组合、架构特点和主要取舍
 - `options[].candidate_index`：候选方案在 `evaluated_candidates` 数组中的 0 基下标
+- `options[].covered_products`：本方案实际交付的产品列表；必须覆盖 `intent.resource_intents` 中所有 `action != forbid` 的资源
+- `options[].resource_intent_gaps`：本方案未覆盖的 intent 资源，每项包含 `product` 和 `reason`；全部覆盖时省略该字段。存在缺口时必须在 `summary` 中标注「部分满足」及缺失资源和原因，且不得作为唯一推荐
 - `options[].architecture_diagram`：紧凑 Mermaid `flowchart` 源码，只使用当前 `candidate`、`template` 和拓扑中已有的事实；最多 12 个节点，不要添加 Markdown 代码围栏
 - `options[].total_monthly_cost`：原样取 `evaluated_candidates[i].cost.monthly_estimate`
 - `options[].cost_items`：逐项取 `evaluated_candidates[i].cost.resources`，每项包含 `name`、可选 `spec` 和 `monthly_cost`；`monthly_cost` 原样取资源的 `cost`

--- a/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
+++ b/src/iac_code/pipeline/selling/prompts/confirm_and_select.md
@@ -5,6 +5,11 @@
 ## 任务
 基于候选方案评估结果生成可选择方案列表，并在用户选择后提交最终选择结果。
 
+## 用户意图（资源覆盖基准）
+```json
+{intent}
+```
+
 ## 评估结果
 ```json
 {evaluated_candidates}
@@ -60,6 +65,15 @@
 - `options[].name`：候选方案名称，取 `candidate.name`
 - `options[].summary`：候选方案摘要
 - `options[].candidate_index`：候选方案在 `evaluated_candidates` 数组中的 0 基下标
+- `options[].covered_products`：本方案实际交付的产品列表，取自 `candidate.resource_intents` 和模板中真实存在的资源；必须覆盖 `intent.resource_intents` 中所有 `action != forbid` 的资源
+- `options[].resource_intent_gaps`：本方案未覆盖的 intent 资源，每项包含 `product` 和 `reason`；全部覆盖时省略该字段
+
+### 资源一致性校验（提交前必做）
+逐个 option 对照 `intent.resource_intents`：
+
+- 缺失资源必须写入 `resource_intent_gaps`，并在 `summary` 中明确标注「部分满足」及缺失的资源和原因（例如分期交付范围）。
+- 存在缺口的方案不得作为唯一推荐；若所有方案都缺同一资源，在 `user_prompt` 中说明当前没有完整覆盖意图的方案，让用户决定是否调整范围。
+- 方案名称与 `summary` 不得宣称未实际交付的资源。
 
 `complete_step.conclusion.user_prompt` 必须是展示给用户的选择提示，例如“请选择要部署的方案：”。
 

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-architecture/SKILL.md
@@ -11,7 +11,7 @@ conclusion_schema:
       minItems: 1
       items:
         type: object
-        required: [name, output_path, products, hard_constraints, topology, monthly_estimate, pros, cons]
+        required: [name, output_path, products, resource_intents, hard_constraints, topology, monthly_estimate, pros, cons]
         properties:
           name:
             type: string
@@ -42,6 +42,19 @@ conclusion_schema:
                 notes:
                   type: string
             description: 本方案中每个资源的新建、复用、引用或禁止语义；从 intent.resource_intents 继承或收窄
+          resource_intent_gaps:
+            type: array
+            description: 本方案未覆盖的 intent 资源及原因；缺口必须显式登记，不得静默丢弃
+            items:
+              type: object
+              required: [product, reason]
+              additionalProperties: false
+              properties:
+                product:
+                  type: string
+                reason:
+                  type: string
+                  description: 未覆盖原因，例如分期交付范围或与其他资源互斥
           hard_constraints:
             type: array
             description: 当前候选采用的用户硬约束完整快照；以进入本步骤后的最新用户要求为准，不得加入推断规格或方案推荐值
@@ -129,7 +142,7 @@ conclusion_schema:
 
 - 方案名称（体现核心差异，如"Serverless 轻量方案"而非泛泛的"方案一"）
 - 核心阿里云产品组合（只列必要的产品）
-- 资源生命周期：`resource_intents`
+- 资源生命周期：`resource_intents`（必须覆盖 intent 中所有非 forbid 资源）
 - 拓扑描述（简述部署架构）
 - 月度费用估算范围
 - 优势和局限
@@ -138,12 +151,17 @@ conclusion_schema:
 
 如果 intent 中存在 `resource_intents`，它是架构设计的硬约束：
 
+- `resource_intents` 是**覆盖清单**：intent 中所有 `action != forbid` 的资源都必须出现在每个 candidate 的 `resource_intents` 中，并保留原 `action`。方案名称、`products` 和 `topology` 只能描述实际覆盖的资源，不得宣称未覆盖的资源。
+- 确有理由无法覆盖某个资源（例如用户要求的分期交付范围、与本方案其他取舍互斥）时，必须在该 candidate 的 `resource_intent_gaps` 中登记 `product` 和 `reason`，并在 `cons` 中说明这是部分满足；不得静默丢弃资源。
+- 所有方案都存在同一缺口时，说明当前意图无法被完整满足：优先重新设计方案以覆盖全部资源，只有确实不可覆盖才逐个方案登记缺口。
 - 只有 `action=create` 的资源可以作为本方案要新建的资源。不要把 `action=use_existing` 或 `action=reference` 的资源设计成新建资源。
 - `action=use_existing/reference` 必须作为已有资源引用，后续模板中应通过参数（如 `VpcId`）或用户提供 ID 引用，不得生成对应的新建资源。换句话说，use_existing/reference 必须作为已有资源引用。
 - `action=forbid` 的资源不得出现在候选方案的新增资源里，也不得作为“顺手补齐”的依赖加入。
 - 将 `resource_intents` 原样或按方案收窄后写入每个 candidate，供模板生成步骤继续执行同一约束。
 
 示例：intent 表示“已有 VPC 中创建安全组”时，candidate 应包含 `resource_intents: [{"product": "VPC", "action": "use_existing"}, {"product": "SecurityGroup", "action": "create"}]`。不得生成 VSwitch，也不得设计成“创建 VPC + VSwitch + SecurityGroup”。
+
+示例：intent 声明 `ECS(create)` + `NATGateway(create)` + `EIP(create)` 时，每个 candidate 的 `resource_intents` 必须同时包含这三个产品；只保留 VPC/VSwitch 而丢掉 ECS/NAT/EIP 是错误输出，即使方案名叫「ECS+NAT 公网方案」也不成立。
 
 ## 用户硬约束
 

--- a/src/iac_code/services/providers/aliyun.py
+++ b/src/iac_code/services/providers/aliyun.py
@@ -298,9 +298,7 @@ class AliyunCredentials:
 
             owns_client = oauth_client is None
             client = (
-                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type))
-                if oauth_client is None
-                else oauth_client
+                AliyunOAuthClient(get_oauth_site(credential.oauth_site_type)) if oauth_client is None else oauth_client
             )
 
             try:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -149,8 +149,7 @@ class StagedSessionBackupService(SessionBackupService):
                         existing = self._read_existing_snapshot_state(destination, session_id)
                         if existing is not None:
                             completed_next = (
-                                base_state.status == "succeeded"
-                                and existing.parent_generation == base_state.generation
+                                base_state.status == "succeeded" and existing.parent_generation == base_state.generation
                             )
                             if not completed_next and not existing.same_lineage(committed_state):
                                 raise SessionBackupConflict(

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -3788,12 +3788,10 @@ class TestResolveCandidatePresentation:
         executor = self._make_executor()
 
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidatePresentation": " rich-v1 "}}) == "rich-v1"
         )
         assert (
-            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}})
-            == "rich-v1"
+            executor._resolve_candidate_presentation({"iac_code": {"candidate_presentation": "RICH-V1"}}) == "rich-v1"
         )
 
     def test_rejects_unknown_or_missing_presentation(self) -> None:

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -240,9 +240,7 @@ def test_ros_deployment_permission_is_localized_and_preserves_safe_plan_summary(
                         "stackName": "demo-stack",
                         "template": "templates/demo.yml",
                         "totalMonthlyCost": "¥88/月",
-                        "resources": [
-                            {"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}
-                        ],
+                        "resources": [{"name": "ECS", "spec": "2 vCPU / 4 GiB", "monthlyCost": "¥88/月"}],
                     },
                 },
             ),
@@ -388,9 +386,7 @@ async def test_pipeline_permission_uses_same_input_envelope_and_waits_serially(m
 async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(monkeypatch, tmp_path) -> None:
     registry = PermissionInputRegistry()
     store = A2ATaskStore()
-    await store.save(
-        Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING))
-    )
+    await store.save(Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)))
     queue = FakeEventQueue()
     publisher = PipelineA2AEventPublisher(
         event_queue=queue,
@@ -466,9 +462,7 @@ async def test_sub_pipeline_permissions_stay_working_and_resolve_independently(m
     task = await store.get("task-1")
     assert task is not None
     task_metadata = MessageToDict(task.metadata, preserving_proto_field_name=False)
-    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [
-        requests[1]["inputId"]
-    ]
+    assert [item["inputId"] for item in task_metadata["iac_code"]["pendingPermissions"]] == [requests[1]["inputId"]]
     remaining = task_metadata["iac_code"]["pendingPermissions"][0]
     assert remaining["language"] == "zh"
     assert remaining["prompt"] == "是否允许本次操作：运行本地 Shell 命令？"

--- a/tests/pipeline/engine/test_complete_step_tool.py
+++ b/tests/pipeline/engine/test_complete_step_tool.py
@@ -466,6 +466,145 @@ class TestCompletionGuards:
         assert "missing_constraint_check" in terminal.metadata["step_result"].error
 
     @staticmethod
+    def _resource_intent_guard(items_field: str, covered_products_fields: list[str]) -> dict:
+        return {
+            "always": True,
+            "require_resource_intent_coverage": {
+                "source_fields": ["intent.resource_intents"],
+                "items_field": items_field,
+                "covered_products_fields": covered_products_fields,
+                "gaps_field": "resource_intent_gaps",
+            },
+            "message_key": "resource_intent_coverage_required",
+        }
+
+    @staticmethod
+    def _intent_snapshot() -> dict:
+        return {
+            "intent": {
+                "resource_intents": [
+                    {"product": "ECS", "action": "create"},
+                    {"product": "NATGateway", "action": "create"},
+                    {"product": "EIP", "action": "create"},
+                ]
+            }
+        }
+
+    def _architecture_tool(self) -> CompleteStepTool:
+        return CompleteStepTool(
+            StepConfig(step_id="architecture_planning", conclusion_field="architecture", forward=None),
+            completion_guards=[self._resource_intent_guard("candidates", ["resource_intents", "products"])],
+            completion_guard_state={"context_snapshot": self._intent_snapshot()},
+        )
+
+    def _confirm_tool(self) -> CompleteStepTool:
+        return CompleteStepTool(
+            StepConfig(step_id="confirm_and_select", conclusion_field="selected_plan", forward=None),
+            completion_guards=[self._resource_intent_guard("options", ["covered_products"])],
+            completion_guard_state={"context_snapshot": self._intent_snapshot()},
+        )
+
+    @pytest.mark.asyncio
+    async def test_resource_intent_guard_rejects_candidate_dropping_declared_resources(self):
+        result = await self._architecture_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "candidates": [
+                        {
+                            "name": "ECS+NAT 公网方案",
+                            "products": ["VPC", "VSwitch"],
+                            "resource_intents": [
+                                {"product": "VPC", "action": "create"},
+                                {"product": "VSwitch", "action": "create"},
+                            ],
+                        }
+                    ]
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "declared in the user intent" in result.content
+        assert "uncovered_resource_intent[ECS, 0]" in result.content
+        assert "uncovered_resource_intent[NATGateway, 0]" in result.content
+        assert "uncovered_resource_intent[EIP, 0]" in result.content
+
+    @pytest.mark.asyncio
+    async def test_resource_intent_guard_accepts_candidate_covering_all_declared_resources(self):
+        result = await self._architecture_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "candidates": [
+                        {
+                            "name": "ECS+NAT 公网方案",
+                            "products": ["VPC", "VSwitch", "ECS", "NAT Gateway", "EIP"],
+                        }
+                    ]
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_resource_intent_guard_accepts_candidate_with_annotated_gap(self):
+        result = await self._architecture_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "candidates": [
+                        {
+                            "name": "先建网络（部分满足）",
+                            "products": ["ECS", "NATGateway"],
+                            "resource_intent_gaps": [{"product": "EIP", "reason": "第二期随 NAT 带宽包一起交付"}],
+                        }
+                    ]
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_resource_intent_guard_rejects_options_missing_declared_resources(self):
+        result = await self._confirm_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "user_prompt": "请选择要部署的方案：",
+                    "options": [
+                        {
+                            "name": "ECS+NAT 公网方案",
+                            "summary": "VPC 与交换机",
+                            "candidate_index": 0,
+                            "covered_products": ["VPC", "VSwitch"],
+                        }
+                    ],
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert result.is_error
+        assert "uncovered_resource_intent[ECS, 0]" in result.content
+
+    @pytest.mark.asyncio
+    async def test_resource_intent_guard_skips_selection_only_round(self):
+        result = await self._confirm_tool().execute(
+            tool_input={
+                "conclusion": {
+                    "selected_candidate_name": "ECS+NAT 公网方案",
+                    "selected_candidate_index": 0,
+                    "selected_evaluated_candidate_index": 0,
+                }
+            },
+            context=ToolContext(),
+        )
+
+        assert not result.is_error
+
+    @staticmethod
     def _deploying_success_guard() -> dict:
         return {
             "when_conclusion_field_equals": {"status": "success"},

--- a/tests/pipeline/engine/test_resource_intent_coverage.py
+++ b/tests/pipeline/engine/test_resource_intent_coverage.py
@@ -1,0 +1,174 @@
+from iac_code.pipeline.engine.resource_intent_coverage import (
+    collect_resource_intents,
+    normalize_product,
+    validate_resource_intent_coverage,
+)
+
+
+def _intents():
+    return [
+        {"product": "ECS", "action": "create"},
+        {"product": "NATGateway", "action": "create"},
+        {"product": "EIP", "action": "create"},
+    ]
+
+
+def _codes(issues):
+    return [issue.code for issue in issues]
+
+
+def test_collect_resource_intents_merges_by_normalized_product():
+    intents, issues = collect_resource_intents(
+        {
+            "intent": {"resource_intents": [{"product": "NAT Gateway", "action": "create"}]},
+            "candidate": {"resource_intents": [{"product": "natgateway", "action": "use_existing"}]},
+        },
+        ["intent.resource_intents", "candidate.resource_intents"],
+    )
+    assert intents == [{"product": "natgateway", "action": "use_existing"}]
+    assert issues == []
+
+
+def test_collect_resource_intents_reports_invalid_sources():
+    intents, issues = collect_resource_intents(
+        {"intent": {"resource_intents": "ECS"}, "candidate": {"resource_intents": ["ECS", {"action": "create"}]}},
+        ["intent.resource_intents", "candidate.resource_intents", "missing.field"],
+    )
+    assert intents == []
+    assert _codes(issues) == [
+        "invalid_resource_intent_source",
+        "invalid_resource_intent",
+        "missing_resource_intent_product",
+    ]
+
+
+def test_full_coverage_passes_with_alias_product_names():
+    items = [{"covered_products": ["ecs", "nat-gateway", "Elastic IP"]}]
+    issues = validate_resource_intent_coverage(
+        [{"product": "ECS", "action": "create"}, {"product": "NATGateway", "action": "create"}],
+        items,
+        covered_products_fields=["covered_products"],
+        gaps_field="resource_intent_gaps",
+    )
+    assert issues == []
+
+
+def test_missing_intent_resource_is_reported_per_item():
+    items = [{"covered_products": ["VPC", "VSwitch"]}]
+    issues = validate_resource_intent_coverage(
+        _intents(),
+        items,
+        covered_products_fields=["covered_products"],
+        gaps_field="resource_intent_gaps",
+    )
+    assert _codes(issues) == ["uncovered_resource_intent"] * 3
+    assert [issue.product for issue in issues] == ["ECS", "NATGateway", "EIP"]
+
+
+def test_declared_gap_with_reason_is_accepted():
+    items = [
+        {
+            "covered_products": ["ECS", "NATGateway"],
+            "resource_intent_gaps": [{"product": "EIP", "reason": "第二期交付"}],
+        }
+    ]
+    assert (
+        validate_resource_intent_coverage(
+            _intents(),
+            items,
+            covered_products_fields=["covered_products"],
+            gaps_field="resource_intent_gaps",
+        )
+        == []
+    )
+
+
+def test_gap_without_reason_is_rejected():
+    items = [{"covered_products": ["ECS", "NATGateway"], "resource_intent_gaps": [{"product": "EIP"}]}]
+    issues = validate_resource_intent_coverage(
+        _intents(),
+        items,
+        covered_products_fields=["covered_products"],
+        gaps_field="resource_intent_gaps",
+    )
+    assert _codes(issues) == ["invalid_resource_intent_gap", "uncovered_resource_intent"]
+
+
+def test_gap_for_undeclared_product_is_reported():
+    items = [
+        {
+            "covered_products": ["ECS", "NATGateway", "EIP"],
+            "resource_intent_gaps": [{"product": "RDS", "reason": "不在范围内"}],
+        }
+    ]
+    issues = validate_resource_intent_coverage(
+        _intents(),
+        items,
+        covered_products_fields=["covered_products"],
+        gaps_field="resource_intent_gaps",
+    )
+    assert _codes(issues) == ["unexpected_resource_intent_gap"]
+
+
+def test_forbidden_product_must_not_be_covered():
+    issues = validate_resource_intent_coverage(
+        [{"product": "ECS", "action": "create"}, {"product": "VSwitch", "action": "forbid"}],
+        [{"covered_products": ["ECS", "VSwitch"]}],
+        covered_products_fields=["covered_products"],
+        gaps_field="resource_intent_gaps",
+    )
+    assert _codes(issues) == ["forbidden_resource_intent_covered"]
+
+
+def test_resource_intent_objects_are_accepted_as_coverage_source():
+    issues = validate_resource_intent_coverage(
+        [{"product": "VPC", "action": "use_existing"}, {"product": "SecurityGroup", "action": "create"}],
+        [
+            {
+                "resource_intents": [
+                    {"product": "VPC", "action": "use_existing"},
+                    {"product": "SecurityGroup", "action": "create"},
+                ]
+            }
+        ],
+        covered_products_fields=["resource_intents", "products"],
+        gaps_field="resource_intent_gaps",
+    )
+    assert issues == []
+
+
+def test_forbid_marked_coverage_entry_does_not_count_as_covered():
+    issues = validate_resource_intent_coverage(
+        [{"product": "ECS", "action": "create"}],
+        [{"resource_intents": [{"product": "ECS", "action": "forbid"}]}],
+        covered_products_fields=["resource_intents"],
+        gaps_field="resource_intent_gaps",
+    )
+    assert _codes(issues) == ["uncovered_resource_intent"]
+
+
+def test_empty_or_invalid_items_are_reported():
+    for items in ([], "options", None):
+        issues = validate_resource_intent_coverage(
+            _intents(),
+            items,
+            covered_products_fields=["covered_products"],
+            gaps_field="resource_intent_gaps",
+        )
+        assert _codes(issues) == ["invalid_coverage_items"]
+
+
+def test_no_declared_intents_skips_validation():
+    assert (
+        validate_resource_intent_coverage(
+            [],
+            [],
+            covered_products_fields=["covered_products"],
+            gaps_field="resource_intent_gaps",
+        )
+        == []
+    )
+
+
+def test_normalize_product_folds_case_and_separators():
+    assert normalize_product("NAT Gateway") == normalize_product("nat-gateway") == "natgateway"

--- a/tests/pipeline/engine/test_step_executor.py
+++ b/tests/pipeline/engine/test_step_executor.py
@@ -2776,11 +2776,15 @@ class TestStepExecutorSchemaWiring:
             surface="a2a_rich",
         )
 
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=True,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=True,
+            )
+            .get("complete_step")
+            .input_schema
+        )
         conclusion_schema = tool_schema["properties"]["conclusion"]
         assert conclusion_schema["required"] == [
             "selected_candidate_name",
@@ -2863,11 +2867,15 @@ class TestStepExecutorSchemaWiring:
             context,
             resume_candidate_selection=True,
         )
-        tool_schema = executor._build_step_tools(
-            step,
-            context,
-            compact_candidate_selection=preserved is not None,
-        ).get("complete_step").input_schema
+        tool_schema = (
+            executor._build_step_tools(
+                step,
+                context,
+                compact_candidate_selection=preserved is not None,
+            )
+            .get("complete_step")
+            .input_schema
+        )
 
         assert preserved is None
         conclusion_schema = tool_schema["properties"]["conclusion"]

--- a/tests/pipeline/selling/test_resource_intent_coverage_guards.py
+++ b/tests/pipeline/selling/test_resource_intent_coverage_guards.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from iac_code.pipeline.engine.loader import load_pipeline_dir
+
+
+def _selling_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "src" / "iac_code" / "pipeline" / "selling"
+
+
+def _step(step_id: str):
+    loaded = load_pipeline_dir(_selling_dir())
+    return next(step for step in loaded.steps if step.step_id == step_id)
+
+
+def _coverage_guard(step):
+    return next(guard["require_resource_intent_coverage"] for guard in step.completion_guards)
+
+
+def test_architecture_planning_guards_full_resource_intent_coverage():
+    guard = _coverage_guard(_step("architecture_planning"))
+
+    assert guard["source_fields"] == ["intent.resource_intents"]
+    assert guard["items_field"] == "candidates"
+    assert guard["covered_products_fields"] == ["resource_intents", "products"]
+    assert guard["gaps_field"] == "resource_intent_gaps"
+
+
+def test_confirm_and_select_guards_options_against_intent():
+    step = _step("confirm_and_select")
+    guard = _coverage_guard(step)
+
+    assert guard["source_fields"] == ["intent.resource_intents"]
+    assert guard["items_field"] == "options"
+    assert guard["covered_products_fields"] == ["covered_products"]
+    assert "intent" in step.context_fields
+
+
+def test_confirm_and_select_options_expose_coverage_fields_on_every_surface():
+    step = _step("confirm_and_select")
+    schemas = [step.conclusion_schema] + [
+        override.conclusion_schema
+        for override in step.surface_overrides.values()
+        if override.conclusion_schema is not None
+    ]
+
+    for schema in schemas:
+        option_schema = schema["properties"]["options"]["items"]
+        assert "covered_products" in option_schema["required"]
+        gaps_schema = option_schema["properties"]["resource_intent_gaps"]
+        assert gaps_schema["items"]["required"] == ["product", "reason"]

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -41,6 +41,7 @@ def test_confirm_rich_a2a_schema_requires_skill_presentation_fields():
         "name",
         "summary",
         "candidate_index",
+        "covered_products",
         "architecture_diagram",
         "total_monthly_cost",
         "cost_items",

--- a/tests/pipeline/selling/test_terminal_ui_contract.py
+++ b/tests/pipeline/selling/test_terminal_ui_contract.py
@@ -133,9 +133,7 @@ def test_confirm_prompt_tells_model_to_preserve_parameter_overrides():
 def test_confirm_prompts_share_selection_contract_structure():
     repl_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.md").read_text(encoding="utf-8")
     a2a_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.md").read_text(encoding="utf-8")
-    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(
-        encoding="utf-8"
-    )
+    rich_prompt = (_selling_pipeline_dir() / "prompts" / "confirm_and_select.a2a.rich.md").read_text(encoding="utf-8")
 
     shared_fragments = [
         "## 首次执行",

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -1676,9 +1676,7 @@ class TestProviderManagerCompleteRetry:
 
     async def test_complete_attributes_bailian_openai_endpoint_to_dashscope_on_all_signals(self):
         mock_provider = AsyncMock()
-        mock_provider._base_url = (
-            "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
-        )
+        mock_provider._base_url = "https://llm-testworkspace000000.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
         mock_provider.complete = AsyncMock(
             return_value=NonStreamingResponse(
                 message_id="complete-response",

--- a/tests/skill_bridge/test_iac_code_bridge.py
+++ b/tests/skill_bridge/test_iac_code_bridge.py
@@ -542,12 +542,10 @@ def test_bridge_automatically_runs_cleanup_only_task_and_restores_pipeline_resul
 
     assert len(captured_payloads) == 2
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["cleanupOnly"] is True for payload in captured_payloads
     )
     assert all(
-        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host"
-        for payload in captured_payloads
+        payload["params"]["message"]["metadata"]["iac_code"]["channel"] == "skill/host" for payload in captured_payloads
     )
     assert captured_payloads[0]["params"]["message"]["contextId"] == "ctx-pipeline-1"
     assert result["state"] == "completed"
@@ -1138,9 +1136,7 @@ def test_candidate_presentation_survives_bounded_bridge_projection() -> None:
                                     "summary": "单 ECS 低成本方案。",
                                     "architectureDiagram": "flowchart LR\nU[用户] --> E[ECS]",
                                     "totalMonthlyCost": "¥88/月",
-                                    "costItems": [
-                                        {"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}
-                                    ],
+                                    "costItems": [{"name": "ECS", "spec": "2核4G", "monthlyCost": "¥88/月"}],
                                 }
                             ],
                             "required": True,

--- a/tests/skill_bridge/test_runtime_release.py
+++ b/tests/skill_bridge/test_runtime_release.py
@@ -104,9 +104,7 @@ def test_runtime_archive_and_version_marker_are_rooted_consistently(tmp_path: Pa
     assert "artifactRevision" not in marker
 
 
-def test_runtime_a2a_smoke_checks_health_and_agent_card(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_runtime_a2a_smoke_checks_health_and_agent_card(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module("skill_runtime_smoke", BUILD_SCRIPT)
     server = tmp_path / "server.py"
     server.write_text(

--- a/tests/web/test_frontend_static.py
+++ b/tests/web/test_frontend_static.py
@@ -2547,7 +2547,7 @@ def test_completed_turn_collapses_process_into_summary() -> None:
     # 「已处理」组的展开态必须跨重建保留:openKey 让 toggle 记录器登记用户操作、
     # applyDetailsOpenOverrides 在重建后恢复;键取 turnId,缺 turnId 时回退首条消息 id。
     assert 'const turnKey = turnId || text(agentMessages[0]?.messageId || agentMessages[0]?.id || "");' in app_source
-    assert 'details.dataset.openKey = `turnproc:${turnKey}`;' in app_source
+    assert "details.dataset.openKey = `turnproc:${turnKey}`;" in app_source
 
     # 只有最后一次工具调用之后的文本才是「最终回答」;此前每个步骤的文本旁白
     # (夹在工具调用之间的 text delta)连同思考、工具一起折进「已处理」,不平铺成答案。


### PR DESCRIPTION
## 背景

Session `7be8bcd32aa44fd399f3e5bf7ec7db7d` 等三个会话（UserId 1754580903499898）暴露同一个问题：`intent_parsing` 已经正确解析出用户声明的全部资源（ECS/NATGateway/EIP；VPC/VSwitch/ECS；NatGateway/SnatEntry/EIP），但最终候选模板与 `confirm_and_select` 选项只保留了 VPC/VSwitch，ECS/SLB/NAT/EIP 被静默丢弃，而候选名称仍然声称包含这些资源（例如「ECS+NAT公网方案」）。用户因此在不知情的情况下确认了不完整的方案。

AnalysisId: `sarpt-auto-2026072900`

## 根因

两处都缺少把 `resource_intents` 当作"必须交付清单"的机制：

1. `architecture_planning` 没有任何 `completion_guards`，且 `iac-aliyun-architecture` SKILL 中 `resource_intents` 只是**可选**字段，「资源生命周期约束」章节只有禁止性规则（不要把 use_existing 设计成新建、不要引入 forbid 资源），没有"必须覆盖"这一条。模型少写资源时没有任何拦截。
2. `confirm_and_select`（`repl` / `a2a` / `a2a_rich` 三种 surface）同样没有 guard，选项 schema 里也没有任何资源字段，唯一的过滤条件是 `failed == false`。只要候选评估成功，缺资源的方案就会原样呈现给用户。

## 改动

### 1. 新增引擎级 completion guard `require_resource_intent_coverage`

`src/iac_code/pipeline/engine/resource_intent_coverage.py`（新增）：

- `collect_resource_intents(context_snapshot, source_fields)`：从 context 快照按 `normalize_product`（casefold + 仅保留字母数字）归并 `resource_intents`，使 `NAT Gateway` / `NATGateway` / `natgateway` 视为同一产品。
- `validate_resource_intent_coverage(...)`：以 intent 中所有 `action != forbid` 的资源为必覆盖基准，逐个 candidate / option 校验。覆盖来源同时支持 `list[str]`（`products` / `covered_products`）与 `list[dict]`（`resource_intents`，其中 `action == forbid` 的条目不计入覆盖）。
- 错误码：`uncovered_resource_intent`（未覆盖且未登记缺口）、`unexpected_resource_intent_gap`（登记了 intent 中不存在的缺口）、`invalid_resource_intent_gap`（缺口条目缺 `product`/`reason`）、`forbidden_resource_intent_covered`（forbid 资源被覆盖）、以及 `invalid_*` 系列配置/结构错误。

`loader.py` 把 guard key 加入 `_SUPPORTED_COMPLETION_GUARD_KEYS`；`complete_step_tool.py` 增加 `_validate_resource_intent_coverage` 分派、`resource_intent_coverage_required` 用户可见文案及其 i18n marker。

**surface 兼容**：`items_field` 在 conclusion 中缺失时 guard 返回 `None` 跳过校验。这样 `a2a_rich` 的第二轮（`_candidate_selection_response_schema` 会剥离 `options`，只提交 `selected_candidate_*`）不会被误判失败。

### 2. `pipeline.yaml` 两处挂载 guard

- `architecture_planning`：`source_fields: [intent.resource_intents]`、`items_field: candidates`、`covered_products_fields: [resource_intents, products]`、`gaps_field: resource_intent_gaps`。
- `confirm_and_select`：`context_fields` 补入 `intent`（原先没有 intent，无从校验）；`items_field: options`、`covered_products_fields: [covered_products]`。
- 三种 surface 的 option schema 均新增 `covered_products`（required）与 `resource_intent_gaps`（`required: [product, reason]`）。

### 3. prompt / SKILL 正向规则

- `iac-aliyun-architecture/SKILL.md`：`resource_intents` 改为 candidate 的 required 字段；新增 `resource_intent_gaps` schema；给「资源生命周期约束」补上覆盖清单、缺口登记、以及"所有方案同缺口应先重新设计"三条正向规则；新增本次 badcase 反例（intent 为 `ECS(create)+NATGateway(create)+EIP(create)` 时只保留 VPC/VSwitch 属错误输出，方案名叫「ECS+NAT 公网方案」不构成覆盖证明）。
- `architecture_planning.md` 增加「资源覆盖校对（提交前必做）」。
- `confirm_and_select.md` / `.a2a.md` / `.a2a.rich.md` 增加「用户意图（资源覆盖基准）」`{intent}` 区块、`covered_products` / `resource_intent_gaps` 字段说明，以及部分满足需标注、不得把有缺口方案作为唯一推荐、全部方案同缺口需在 `user_prompt` 中如实披露。

### 4. i18n

新增用户可见文案 `resource_intent_coverage_required`，`make translate` 后为 zh/es/fr/de/ja/pt 六种语言补齐译文并编译。

## 测试

`pytest tests/pipeline/engine/test_resource_intent_coverage.py tests/pipeline/engine/test_complete_step_tool.py tests/pipeline/selling/` → **458 passed**

- `test_resource_intent_coverage.py`（新增 13 例）：别名归一、非法来源、完整覆盖、逐项缺资源、缺口登记通过、缺口缺 reason 拒绝、未声明缺口、forbid 被覆盖、`resource_intents` 作覆盖来源、forbid 条目不计覆盖、items 非法/为空、无 intent 时跳过。
- `test_complete_step_tool.py`（新增 6 例）：badcase 复现（candidate 丢弃 ECS/NAT/EIP 时报 `uncovered_resource_intent[ECS, 0]`）、别名 `NAT Gateway` 视为覆盖、已登记缺口放行、options 缺资源被拒、a2a_rich 仅提交选择结果时跳过校验。
- `test_resource_intent_coverage_guards.py`（新增 3 例）：两步 guard 字段值、`intent` 在 `confirm_and_select.context_fields`、各 surface option schema 字段契约。
- `test_terminal_ui_contract.py`：更新 a2a_rich option required 集合。

全量分批串行执行合计约 14350 passed / 4 skipped。静态检查 `ruff check`、`ruff format --check`（1082 files already formatted）、`ty check src/` 均通过。

## 已知限制

- 3 个存量失败点与本次改动无关：`test_i18n.py::test_message_catalogs_pass_gnu_msgfmt_checks`（zh 目录 `{n} day{s} ago` 等 5 条存量译文用 `{s:.0}`，在改动前的 HEAD 上复现同样 5 处 msgfmt 错误）、`test_prerequisites.py` 中 infraguard 下载错误类型断言（依赖沙箱网络）、`test_run_pipeline_contract_scenario.py::test_latest_pipeline_sidecar_reads_nested_session_layout`（`max(st_mtime_ns)` 在本环境 mtime 粒度过粗时 tie-break 不确定）。
- `41f73c6` 是前置的纯格式化提交：仓库 HEAD 在锁定的 ruff 0.15.10 下有 14 个文件存量格式漂移，导致 pre-commit 的 format 钩子每次都改文件并回滚，必须先单独落地格式化，业务提交才能通过钩子。该提交不含任何逻辑改动。


Aone: https://project.aone.alibaba-inc.com/v2/project/2169409/req/84817160
