### PR TITLE
fix(a2a): stage terminal backups for asynchronous publication

### DIFF
--- a/skills/alicloud-ros-agent/scripts/ros_agent.py
+++ b/skills/alicloud-ros-agent/scripts/ros_agent.py
@@ -4077,6 +4077,8 @@ class _ManagerServer(ThreadingHTTPServer):
         self.record = record
         self.last_activity = time.monotonic()
         self.activity_mtime_ns = 0
+        self.startup_deadline = self.last_activity + MANAGER_START_TIMEOUT_SECONDS
+        self.startup_health_checked = False
 
 
 class _ManagerHandler(BaseHTTPRequestHandler):
@@ -4120,6 +4122,7 @@ class _ManagerHandler(BaseHTTPRequestHandler):
                 "pid": os.getpid(),
             },
         )
+        self.server.startup_health_checked = True
 
     def do_POST(self) -> None:
         if not self._authorized():
@@ -4196,6 +4199,10 @@ def run_manager_server(record_file: str) -> int:
                 if activity_mtime_ns > server.activity_mtime_ns:
                     server.activity_mtime_ns = activity_mtime_ns
                     server.last_activity = time.monotonic()
+            if not server.startup_health_checked:
+                if time.monotonic() >= server.startup_deadline:
+                    break
+                continue
             if _active_worker_exists():
                 server.last_activity = time.monotonic()
                 continue

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -836,8 +836,9 @@ class A2ATaskStore(TaskStore):
             return True
 
     async def cancel_task_and_wait(self, task_id: str, *, timeout: float | None = None) -> bool:
+        task_id = validate_protocol_id(task_id)
         async with self._mutation_lock:
-            record = self._tasks.get(validate_protocol_id(task_id))
+            record = self._tasks.get(task_id)
             if record is None or record.active_task is None or record.active_task.done():
                 return False
             active_task = record.active_task
@@ -853,9 +854,36 @@ class A2ATaskStore(TaskStore):
         except asyncio.CancelledError:
             if not active_task.done():
                 raise
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.warning("Timed out waiting for canceled A2A task %s to finish", task_id)
-        return True
+            return False
+        return await self._complete_cancel_task_wait(
+            task_id=task_id,
+            canceled_owner=active_task,
+        )
+
+    async def _complete_cancel_task_wait(
+        self,
+        *,
+        task_id: str,
+        canceled_owner: asyncio.Task[Any],
+    ) -> bool:
+        async with self._mutation_lock:
+            record = self._tasks.get(task_id)
+            if record is None:
+                return True
+            current_owner = record.active_task
+            if current_owner is not None and current_owner is not canceled_owner and not current_owner.done():
+                return False
+            if current_owner is not None:
+                record.active_task = None
+
+            context = self._contexts.get(record.context_id)
+            if context is not None and context.active_task_id == task_id:
+                context.active_task_id = None
+                context.touch()
+                self._mirror_context(context)
+            return True
 
     async def is_task_active(self, task_id: str) -> bool:
         async with self._mutation_lock:

--- a/tests/a2a/test_app.py
+++ b/tests/a2a/test_app.py
@@ -2819,6 +2819,7 @@ async def test_subscribe_to_active_task_yields_initial_task_then_updates(monkeyp
 async def test_active_task_push_enqueue_failure_does_not_fail_task(monkeypatch, tmp_path, caplog) -> None:
     release = asyncio.Event()
     loop_completed = asyncio.Event()
+    enqueue_attempted = asyncio.Event()
 
     class ControlledLoop:
         async def run_streaming(self, _prompt: str):
@@ -2839,6 +2840,7 @@ async def test_active_task_push_enqueue_failure_does_not_fail_task(monkeypatch, 
     call_context = ServerCallContext()
 
     async def fail_enqueue(_job) -> None:
+        enqueue_attempted.set()
         raise OSError("queue unavailable")
 
     try:
@@ -2876,6 +2878,7 @@ async def test_active_task_push_enqueue_failure_does_not_fail_task(monkeypatch, 
 
             await asyncio.wait_for(collect_remaining_events(), timeout=1)
             await asyncio.wait_for(loop_completed.wait(), timeout=1)
+            await asyncio.wait_for(enqueue_attempted.wait(), timeout=1)
 
         final_task = await components.handler.on_get_task(GetTaskRequest(id=result.id), call_context)
         assert final_task.status.state != TaskState.TASK_STATE_FAILED

--- a/tests/a2a/test_backup.py
+++ b/tests/a2a/test_backup.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import pytest
+
+from iac_code.a2a.backup import backup_session_async
+from iac_code.services.session_backup import BackupReason, BackupResult
+
+
+class RecordingStagedBackupService:
+    def __init__(self) -> None:
+        self.wait_calls = 0
+
+    def backup_session(self, *_args, **_kwargs) -> BackupResult:
+        return BackupResult(
+            enabled=True,
+            destination=Path("/tmp/staging/projects/project/session_v1"),
+            generation=1,
+            commit_id="commit-1",
+            staged_committed=True,
+            shared_committed=False,
+        )
+
+    def wait_for_shared_commit(
+        self,
+        result: BackupResult,
+        *,
+        timeout: float | None = None,
+    ) -> BackupResult:
+        del result, timeout
+        self.wait_calls += 1
+        raise AssertionError("A2A terminal backup must not wait for shared publication")
+
+
+@pytest.mark.asyncio
+async def test_terminal_backup_returns_after_local_staging_without_shared_wait() -> None:
+    service = RecordingStagedBackupService()
+
+    result = await backup_session_async(
+        service,
+        "/repo",
+        "session",
+        reason=BackupReason.TERMINAL,
+        critical=True,
+    )
+
+    assert result.staged_committed is True
+    assert result.shared_committed is False
+    assert service.wait_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_non_terminal_backup_keeps_existing_local_staging_behavior() -> None:
+    service = RecordingStagedBackupService()
+
+    result = await backup_session_async(
+        service,
+        "/repo",
+        "session",
+        reason=BackupReason.NORMAL_TURN_END,
+        critical=False,
+    )
+
+    assert result.staged_committed is True
+    assert result.shared_committed is False
+    assert service.wait_calls == 0

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -36,12 +36,14 @@ from iac_code.mcp.types import (
 from iac_code.pipeline.engine.user_input import PipelineUserInput
 from iac_code.services.permission_wait import RecoveredPermissionAuditBoundary
 from iac_code.services.session_backup import (
+    BACKUP_STATE_FILENAME,
     BackupReason,
     BackupResult,
     SessionBackupBlocked,
     SessionBackupService,
     SessionReconcileResult,
 )
+from iac_code.services.session_backup_staging import StagedSessionBackupService
 from iac_code.services.session_backup_state import NORMAL_HANDOFF_PROOF_KEY, BackupPublicationProof
 from iac_code.services.session_storage import SessionStorage
 from iac_code.skills.frontmatter import SkillFrontmatter
@@ -1482,6 +1484,66 @@ async def test_executor_mirrors_canceled_terminal_before_terminal_backup(
     assert [(reason, critical) for *_ids, reason, critical in backup_service.calls] == [(BackupReason.TERMINAL, True)]
     record = await executor._task_store.get_or_create_task(task_id="task-1", context_id="ctx-1")
     assert record.state == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_wait_returns_after_terminal_snapshot_staged_before_shared_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_root = tmp_path / "config"
+    staging_root = tmp_path / "staging"
+    backup_root = tmp_path / "backup"
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    cwd = cwd.resolve()
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(config_root))
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(backup_root))
+    started = asyncio.Event()
+
+    class BlockingLoop:
+        async def run_streaming(self, prompt: str):
+            started.set()
+            await asyncio.Future()
+            yield TextDeltaEvent(text="never")
+
+    runtime = FakeRuntime(agent_loop=BlockingLoop(), session_id="session-1")
+    monkeypatch.setattr("iac_code.a2a.executor.create_agent_runtime", lambda options: runtime)
+    storage = SessionStorage(projects_dir=config_root / "projects")
+    backup_service = StagedSessionBackupService(staging_root, storage, retry_delays=())
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    executor = IacCodeA2AExecutor(
+        task_store=store,
+        model="qwen3.6-plus",
+        backup_service=backup_service,
+    )
+    execute_task = asyncio.create_task(
+        executor.execute(
+            FakeRequestContext(metadata={"iac_code": {"cwd": str(cwd)}}),
+            FakeEventQueue(),
+        )
+    )
+    await started.wait()
+    context_record = await store.get_context_record("ctx-1")
+    session_dir = storage.session_dir(str(cwd), context_record.session_id)
+    (session_dir / "session.jsonl").write_text("terminal-v1\n", encoding="utf-8")
+    cancel_queue = FakeEventQueue()
+
+    await executor.cancel(FakeRequestContext(), cancel_queue)
+    await execute_task
+
+    snapshot = staging_root / "projects" / session_dir.parent.name / "{}_v1".format(context_record.session_id)
+    staged_state = json.loads((snapshot / BACKUP_STATE_FILENAME).read_text(encoding="utf-8"))
+    staged_task = json.loads((snapshot / "a2a" / "task.json").read_text(encoding="utf-8"))
+    staged_context = json.loads((snapshot / "a2a" / "context.json").read_text(encoding="utf-8"))
+    assert dump(cancel_queue.events[-1])["status"]["state"] == "TASK_STATE_CANCELED"
+    assert staged_state["generation"] == 1
+    assert staged_state["reason"] == BackupReason.TERMINAL.value
+    assert (snapshot / "session.jsonl").read_text(encoding="utf-8") == "terminal-v1\n"
+    assert staged_task["state"] == "canceled"
+    assert staged_context["active_task_id"] is None
+    assert not list(staging_root.rglob("*.copying"))
+    assert not backup_root.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -38,6 +38,7 @@ from iac_code.pipeline.engine.prerequisites import PrerequisiteDecision, Prerequ
 from iac_code.pipeline.engine.user_input import PipelineUserInput, normalize_pipeline_user_input
 from iac_code.services.permission_wait import (
     PermissionWaitCheckpointStore,
+    PermissionWaitCoordinator,
     PermissionWaitPolicy,
     RecoveredPermissionAuditBoundary,
 )
@@ -3198,6 +3199,24 @@ async def test_pipeline_permission_resident_timer_survives_full_executor_publica
 ) -> None:
     monkeypatch.setenv("IAC_CODE_MODE", "pipeline")
     future = asyncio.get_running_loop().create_future()
+    timer_started = asyncio.Event()
+    timer_completed = asyncio.Event()
+    release_timer = asyncio.Event()
+
+    class GatedPermissionWaitCoordinator(PermissionWaitCoordinator):
+        async def _run_resident_timer(self, owner) -> None:
+            timer_started.set()
+            await release_timer.wait()
+            try:
+                await super()._run_resident_timer(owner)
+            finally:
+                if future.done():
+                    timer_completed.set()
+
+    monkeypatch.setattr(
+        "iac_code.services.permission_wait.PermissionWaitCoordinator",
+        GatedPermissionWaitCoordinator,
+    )
 
     class PermissionPipeline(FakePipeline):
         def __init__(self) -> None:
@@ -3244,10 +3263,8 @@ async def test_pipeline_permission_resident_timer_survives_full_executor_publica
         model="qwen3.6-plus",
         backup_service=backup_service,
         permission_wait_policy=PermissionWaitPolicy(
-            # Leave enough time for critical backup and publication to finish
-            # so the test measures timer ownership rather than runner speed.
-            resident_timeout_seconds=2,
-            timeout_grace_seconds=0.1,
+            resident_timeout_seconds=0.01,
+            timeout_grace_seconds=0,
         ),
     )
     queue = FakeEventQueue()
@@ -3257,7 +3274,11 @@ async def test_pipeline_permission_resident_timer_survives_full_executor_publica
         timeout=3,
     )
 
+    await asyncio.wait_for(timer_started.wait(), timeout=3)
+    assert future.done() is False
+    release_timer.set()
     assert await asyncio.wait_for(future, timeout=3) is PermissionWaitOutcome.SUSPEND
+    await asyncio.wait_for(timer_completed.wait(), timeout=3)
     context_record = await store.get_context_record("ctx-1")
     checkpoint = PermissionWaitCheckpointStore(str(tmp_path), context_record.session_id).list_active()[0]
     assert checkpoint["phase"] == "SUSPENDED"

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -682,6 +682,105 @@ async def test_cancel_active_task_does_not_need_context_lock() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancel_task_and_wait_reports_unfinished_task_after_timeout() -> None:
+    store = A2ATaskStore(
+        metrics=NoOpA2AMetrics(),
+        idle_timeout_seconds=60,
+        cleanup_interval_seconds=300,
+    )
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    release = asyncio.Event()
+
+    async def ignore_cancel_until_released() -> None:
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    active = asyncio.create_task(ignore_cancel_until_released())
+    task.active_task = active
+    await asyncio.sleep(0)
+
+    assert await store.cancel_task_and_wait("task-1", timeout=0.01) is False
+    assert active.done() is False
+
+    release.set()
+    await active
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_and_wait_clears_inactive_context_fence(
+    tmp_path,
+) -> None:
+    store = A2ATaskStore(
+        metrics=NoOpA2AMetrics(),
+        idle_timeout_seconds=60,
+        cleanup_interval_seconds=300,
+    )
+    context = await store.get_or_create_context(
+        context_id="ctx-1",
+        cwd=str(tmp_path),
+        runtime_factory=lambda sid: object(),
+    )
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    context.active_task_id = task.task_id
+    store.mirror_context(context)
+
+    async def run_until_cancelled() -> None:
+        await asyncio.sleep(60)
+
+    active = asyncio.create_task(run_until_cancelled())
+    task.active_task = active
+    await asyncio.sleep(0)
+
+    assert await store.cancel_task_and_wait(task.task_id, timeout=1) is True
+    assert task.active_task is None
+    assert (await store.get_context_record(context.context_id)).active_task_id is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_and_wait_preserves_live_replacement_owner(
+    tmp_path,
+) -> None:
+    store = A2ATaskStore(
+        metrics=NoOpA2AMetrics(),
+        idle_timeout_seconds=60,
+        cleanup_interval_seconds=300,
+    )
+    context = await store.get_or_create_context(
+        context_id="ctx-1",
+        cwd=str(tmp_path),
+        runtime_factory=lambda sid: object(),
+    )
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    context.active_task_id = task.task_id
+    store.mirror_context(context)
+    replacement_release = asyncio.Event()
+
+    async def replacement_owner() -> None:
+        await replacement_release.wait()
+
+    replacement = asyncio.create_task(replacement_owner())
+
+    async def replace_owner_when_cancelled() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            task.active_task = replacement
+
+    active = asyncio.create_task(replace_owner_when_cancelled())
+    task.active_task = active
+    await asyncio.sleep(0)
+
+    assert await store.cancel_task_and_wait(task.task_id, timeout=1) is False
+    assert task.active_task is replacement
+    assert (await store.get_context_record(context.context_id)).active_task_id == task.task_id
+
+    replacement_release.set()
+    await replacement
+
+
+@pytest.mark.asyncio
 async def test_task_status_access_waits_for_mutation_lock() -> None:
     store = A2ATaskStore(metrics=NoOpA2AMetrics(), idle_timeout_seconds=60, cleanup_interval_seconds=300)
     task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")

--- a/tests/cli/test_mcp_command.py
+++ b/tests/cli/test_mcp_command.py
@@ -3167,7 +3167,6 @@ def test_mcp_auth_exchanges_loopback_code_and_stores_token(monkeypatch, tmp_path
         "discover_oauth_metadata",
         lambda config, resource_metadata_url=None: _fake_oauth_metadata(oauth_server),
     )
-    callback_port = _free_port()
     runner = CliRunner()
     runner.invoke(
         app,
@@ -3182,7 +3181,7 @@ def test_mcp_auth_exchanges_loopback_code_and_stores_token(monkeypatch, tmp_path
             "--client-id",
             "client-id",
             "--callback-port",
-            str(callback_port),
+            "0",
             "--auth-server-metadata-url",
             oauth_server.metadata_url,
             "--scope",

--- a/tests/services/test_session_backup_staging.py
+++ b/tests/services/test_session_backup_staging.py
@@ -283,15 +283,22 @@ def test_staged_reconcile_treats_concurrently_published_snapshot_as_absent(
     assert result.action == "current"
 
 
-def test_staging_worker_publishes_versions_in_order_and_empties_staging_root(
+def test_terminal_staging_allows_same_sandbox_reentry_before_ordered_publication(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     service, session_dir, staging_root, backup_root = _create_staged_service(monkeypatch, tmp_path)
     (session_dir / "session.jsonl").write_text("v1\n", encoding="utf-8")
-    service.backup_session("/repo", "s1", reason=BackupReason.NORMAL_TURN_END, critical=True)
-    (session_dir / "session.jsonl").write_text("v2\n", encoding="utf-8")
     service.backup_session("/repo", "s1", reason=BackupReason.TERMINAL, critical=True)
+
+    reconciled = service.reconcile_session("/repo", "s1")
+
+    assert reconciled.action == "staged_current"
+    assert reconciled.state is not None and reconciled.state.generation == 1
+    assert not backup_root.exists()
+
+    (session_dir / "session.jsonl").write_text("v2\n", encoding="utf-8")
+    service.backup_session("/repo", "s1", reason=BackupReason.NORMAL_TURN_END, critical=True)
     worker = SessionBackupStagingWorker(staging_root, backup_root)
     published: list[int] = []
     original_publish = worker.publish_snapshot
@@ -309,6 +316,58 @@ def test_staging_worker_publishes_versions_in_order_and_empties_staging_root(
     assert (final_dir / "session.jsonl").read_text(encoding="utf-8") == "v2\n"
     assert _read_state(final_dir, shared=True).generation == 2
     assert list(staging_root.iterdir()) == []
+
+
+def test_terminal_publication_restores_in_another_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service, session_dir, staging_root, backup_root = _create_staged_service(
+        monkeypatch,
+        tmp_path,
+    )
+    expected_files = {
+        "session.jsonl": '{"role":"user","content":"restore-me"}\n',
+        "a2a/pipeline/a2a-snapshot.json": '{"status":"canceled"}\n',
+    }
+    for relative, content in expected_files.items():
+        path = session_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    staged = service.backup_session(
+        "/repo",
+        "s1",
+        reason=BackupReason.TERMINAL,
+        critical=True,
+    )
+
+    assert SessionBackupStagingWorker(staging_root, backup_root).run_once() == 1
+
+    sandbox_b_storage = SessionStorage(projects_dir=tmp_path / "sandbox-b-config" / "projects")
+    sandbox_b_service = StagedSessionBackupService(
+        tmp_path / "sandbox-b-staging",
+        sandbox_b_storage,
+        retry_delays=(),
+    )
+    restored = sandbox_b_service.restore_session("/repo", "s1")
+    restored_dir = sandbox_b_storage.session_dir("/repo", "s1")
+
+    assert restored.restored is True
+    for relative, content in expected_files.items():
+        assert (restored_dir / relative).read_text(encoding="utf-8") == content
+
+    shared_dir = backup_root / "projects" / session_dir.parent.name / "s1"
+    published_state = _read_state(shared_dir, shared=True)
+    assert published_state.generation == staged.generation
+    assert published_state.commit_id == staged.commit_id
+    assert not (shared_dir / "generations").exists()
+    assert sorted(path.name for path in shared_dir.iterdir()) == [
+        ".backup-state.json",
+        "a2a",
+        "metadata.json",
+        "session.jsonl",
+    ]
 
 
 def test_staging_worker_does_not_skip_failed_version_for_same_session(

--- a/tests/skill_bridge/test_alicloud_ros_agent_bridge.py
+++ b/tests/skill_bridge/test_alicloud_ros_agent_bridge.py
@@ -2294,6 +2294,36 @@ def test_manager_is_loopback_authenticated_reused_and_recovers_after_idle_shutdo
     _wait_for_pid_exit(third["pid"])
 
 
+def test_manager_waits_for_first_authorized_health_before_idle_shutdown(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(bridge.STATE_DIR_ENV, str(tmp_path / "state"))
+    original_manager_matches = bridge._manager_matches
+    delayed_health_check = False
+
+    def delay_first_authorized_health_check(record):
+        nonlocal delayed_health_check
+        if delayed_health_check:
+            return original_manager_matches(record)
+        invalid_record = dict(record, token="invalid")
+        deadline = time.monotonic() + bridge.MANAGER_START_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            try:
+                bridge._manager_request(invalid_record, "/health", timeout=0.2)
+            except bridge.BridgeError as exc:
+                if exc.code == "unauthorized":
+                    delayed_health_check = True
+                    time.sleep(0.7)
+                    break
+            time.sleep(0.05)
+        return original_manager_matches(record)
+
+    monkeypatch.setattr(bridge, "_manager_matches", delay_first_authorized_health_check)
+
+    manager = bridge.ensure_manager(0.1)
+
+    assert delayed_health_check
+    _wait_for_pid_exit(manager["pid"])
+
+
 def test_manager_idle_countdown_starts_after_sse_worker_exits(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv(bridge.STATE_DIR_ENV, str(tmp_path / "state"))
     workspace = tmp_path / "workspace"
@@ -2368,9 +2398,11 @@ def test_managed_worker_outlives_start_and_follow_returns_step_start_before_fina
     monkeypatch.setenv(bridge.STATE_DIR_ENV, str(tmp_path / "state"))
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    release_final = tmp_path / "release-final"
     fake_cli = _write_fake_aliyun(
         tmp_path,
         "import json, time\n"
+        + "from pathlib import Path\n"
         + "def emit(value):\n"
         + "    print(json.dumps({'data': value}), flush=True)\n"
         + "def status(state, text='', metadata=None):\n"
@@ -2382,7 +2414,10 @@ def test_managed_worker_outlives_start_and_follow_returns_step_start_before_fina
         + "time.sleep(0.35)\n"
         + "emit(status('TASK_STATE_WORKING', metadata={'pipeline': {'eventType': 'step_started', "
         + "'step': {'id': 'intent_parsing', 'name': 'Understand'}}}))\n"
-        + "time.sleep(0.35)\n"
+        + "release = Path({!r})\n".format(str(release_final))
+        + "deadline = time.monotonic() + 10\n"
+        + "while not release.exists() and time.monotonic() < deadline:\n"
+        + "    time.sleep(0.05)\n"
         + "emit(status('TASK_STATE_WORKING', 'done', {'assistantFinal': {'complete': True}}))\n"
         + "emit(status('TASK_STATE_INPUT_REQUIRED'))\n",
     )
@@ -2413,6 +2448,7 @@ def test_managed_worker_outlives_start_and_follow_returns_step_start_before_fina
     assert "finalText" not in first
     assert bridge._pid_alive(started["workerPid"])
 
+    release_final.touch()
     second = bridge._follow_job_local(started["jobId"], first["cursor"], 3)
     assert second["state"] == "turn-completed"
     assert second["finalText"] == "done"


### PR DESCRIPTION
- stage immutable terminal session data before returning from cancellation
- keep shared backup publication asynchronous and preserve staging until it is durable
- cover cancellation, task-store, executor, and backup-staging handoff contracts