### PR TITLE
feat: add Qwen-specific DashScope provider

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,2 +1,2 @@
 [python: src/iac_code/**.py]
-keywords = translate_message CompletionEnrichmentError CompletionValidationError
+keywords = translate_message CompletionEnrichmentError CompletionValidationError ToolCallProtocolError UnsafeStreamProtocolError ProviderRequestLeaseError _localizable_message_id

--- a/src/iac_code/a2a/events.py
+++ b/src/iac_code/a2a/events.py
@@ -22,7 +22,8 @@ from google.protobuf.json_format import ParseDict
 
 from iac_code.a2a.artifacts import sanitize_public_artifact_text
 from iac_code.a2a.exposure import A2AExposureType, normalize_a2a_exposure_types
-from iac_code.i18n import _
+from iac_code.a2a.runtime_overrides import get_a2a_preferred_language
+from iac_code.i18n import _, translate_message
 from iac_code.mcp.progress import mcp_progress_metadata, mcp_progress_public_name
 from iac_code.services.permissions.audit import (
     build_input_summary,
@@ -528,11 +529,17 @@ async def publish_stream_event(
         error_metadata: dict[str, Any] = {"retryable": event.is_retryable}
         if event.error_id:
             error_metadata["errorId"] = event.error_id
+        language = get_a2a_preferred_language() or "en"
         if event.is_retryable:
-            text = _("A temporary error occurred. Please retry.")
+            text = translate_message("A temporary error occurred. Please retry.", language=language)
             state = TaskState.TASK_STATE_INPUT_REQUIRED
         else:
-            raw = event.error or "Unknown error"
+            if event.i18n_message_id:
+                raw = translate_message(event.i18n_message_id, language=language).format(
+                    **(event.i18n_message_args or {})
+                )
+            else:
+                raw = event.error or translate_message("Unknown error", language=language)
             # Provider ErrorEvent is an explicitly retained compatibility
             # exception; ordinary A2A payloads are projected at the wire edge.
             text = sanitize_public_artifact_text(raw)[:_ERROR_TEXT_MAX_CHARS]

--- a/src/iac_code/agent/agent_loop.py
+++ b/src/iac_code/agent/agent_loop.py
@@ -76,6 +76,7 @@ from iac_code.types.stream_events import (
     ToolUseStartEvent,
     Usage,
 )
+from iac_code.types.usage_attribution import UsageAttribution
 from iac_code.utils.public_paths import build_public_path_roots
 
 
@@ -371,7 +372,11 @@ class AgentLoop:
         self._memory_recall_generation = 0
         self._memory_recall_active_turns = 0
         self._last_provider_request_snapshot: dict[str, Any] | None = None
+        self._last_effective_system_prompt = system_prompt
         self._system_prompt_refresher = system_prompt_refresher
+        self._active_streaming_runs = 0
+        self._provider_requests_in_flight = 0
+        self._pending_provider_context_sync = False
 
         model_name = ""
         if hasattr(provider_manager, "get_model_name"):
@@ -463,17 +468,36 @@ class AgentLoop:
     def set_provider(self, provider_manager: Any, system_prompt: str | None = None) -> None:
         """Swap the provider manager in place, preserving conversation history.
 
-        Updates the tokenizer/context-window config when the model name changes.
-        Optionally refreshes the system prompt — useful when memory or skill
-        listing has changed since the loop was constructed.
+        Idle loops update context accounting immediately.  An active turn keeps
+        the model, effective prompt, and tools bound by its existing request
+        lease; the new provider is synchronized at the next safe boundary.
         """
         self._provider_manager = provider_manager
-        new_model = provider_manager.get_model_name() if hasattr(provider_manager, "get_model_name") else ""
-        self.context_manager.set_model(new_model)
         if system_prompt is not None:
             self.system_prompt = system_prompt
-            self.context_manager.set_system_prompt(system_prompt)
-        self._sync_tool_definitions(system_prompt=self.system_prompt if system_prompt is not None else None)
+        if self._active_streaming_runs or self._provider_requests_in_flight:
+            self._pending_provider_context_sync = True
+            return
+        self._sync_current_provider_context()
+
+    def _sync_current_provider_context(self) -> None:
+        """Synchronize idle ContextManager accounting with the selected provider."""
+        get_model_name = getattr(self._provider_manager, "get_model_name", None)
+        model_name = get_model_name() if callable(get_model_name) else None
+        if isinstance(model_name, str) and model_name:
+            self.context_manager.set_model(model_name)
+        self.context_manager.set_system_prompt(self.system_prompt)
+        self._sync_tool_definitions(system_prompt=self.system_prompt)
+        self._last_effective_system_prompt = self.system_prompt
+        self._pending_provider_context_sync = False
+
+    def _sync_pending_provider_context_if_idle(self) -> None:
+        if (
+            self._pending_provider_context_sync
+            and self._active_streaming_runs == 0
+            and self._provider_requests_in_flight == 0
+        ):
+            self._sync_current_provider_context()
 
     def set_auto_trigger_skills(self, skill_commands: list[Any] | None) -> None:
         """Refresh skills considered for automatic trigger injection."""
@@ -977,6 +1001,7 @@ class AgentLoop:
             memory_prefetch = None
             turn_cancelled = False
             self._memory_recall_active_turns += 1
+            self._active_streaming_runs += 1
             try:
                 # Refresh the git branch once per turn — branch may change
                 # between turns (user runs git checkout via Bash tool), but
@@ -1009,7 +1034,7 @@ class AgentLoop:
                             final_text_chunks.append(event.text)
                         if isinstance(event, MessageEndEvent):
                             final_stop_reason = event.stop_reason
-                            self._record_session_usage(event.usage)
+                            self._record_session_usage(event.usage, event.usage_attribution)
                         yield event
                 except asyncio.CancelledError:
                     turn_cancelled = True
@@ -1023,7 +1048,9 @@ class AgentLoop:
                     # Recall prefetches are turn-scoped: ready results are consumed only at in-turn poll points.
                     self._discard_memory_prefetch_for_turn(memory_prefetch)
                 self._memory_recall_active_turns = max(0, self._memory_recall_active_turns - 1)
-                self.context_manager.set_system_prompt(self.system_prompt)
+                self.context_manager.set_system_prompt(self._last_effective_system_prompt)
+                self._active_streaming_runs = max(0, self._active_streaming_runs - 1)
+                self._sync_pending_provider_context_if_idle()
                 elapsed = time.monotonic() - interaction_started
                 add_metric(Metrics.ACTIVE_TIME_TOTAL, int(elapsed), {})
                 if should_capture_content_on_span() and final_text_chunks:
@@ -1066,6 +1093,7 @@ class AgentLoop:
             first_token_received = False
             final_text_chunks: list[str] = []
             final_stop_reason = "stop"
+            self._active_streaming_runs += 1
             try:
                 self._refresh_git_branch()
                 try:
@@ -1079,7 +1107,7 @@ class AgentLoop:
                             final_text_chunks.append(event.text)
                         if isinstance(event, MessageEndEvent):
                             final_stop_reason = event.stop_reason
-                            self._record_session_usage(event.usage)
+                            self._record_session_usage(event.usage, event.usage_attribution)
                         yield event
                 except asyncio.CancelledError:
                     log_event(Events.SESSION_CANCELLED, {"stage": "in_query"})
@@ -1087,7 +1115,9 @@ class AgentLoop:
             finally:
                 self._accepting_injected_user_messages = False
                 self._cancel_owned_contract_snapshots()
-                self.context_manager.set_system_prompt(self.system_prompt)
+                self.context_manager.set_system_prompt(self._last_effective_system_prompt)
+                self._active_streaming_runs = max(0, self._active_streaming_runs - 1)
+                self._sync_pending_provider_context_if_idle()
                 elapsed = time.monotonic() - interaction_started
                 add_metric(Metrics.ACTIVE_TIME_TOTAL, int(elapsed), {})
                 if should_capture_content_on_span() and final_text_chunks:
@@ -1699,23 +1729,33 @@ class AgentLoop:
     async def _stream_provider(
         self,
         *,
+        request_manager: Any = None,
+        lease: Any = None,
         messages: list[Any],
         system: str,
         tools: list[Any] | None,
         telemetry_messages: list[Any] | None = None,
     ) -> AsyncGenerator[StreamEvent, None]:
-        with use_span_attributes(self._telemetry_attributes):
-            stream_method = self._provider_manager.stream
-            stream_parameters = inspect.signature(stream_method).parameters.values()
-            supports_telemetry_sidecar = any(
-                parameter.name == "telemetry_messages" or parameter.kind is inspect.Parameter.VAR_KEYWORD
-                for parameter in stream_parameters
-            )
-            stream_kwargs = {"messages": messages, "system": system, "tools": tools}
-            if supports_telemetry_sidecar:
-                stream_kwargs["telemetry_messages"] = telemetry_messages
-            provider_stream = stream_method(**stream_kwargs)
+        request_manager = request_manager or self._provider_manager
+        self._provider_requests_in_flight += 1
         try:
+            with use_span_attributes(self._telemetry_attributes):
+                stream_method = request_manager.stream
+                stream_parameters = inspect.signature(stream_method).parameters.values()
+                supports_telemetry_sidecar = any(
+                    parameter.name == "telemetry_messages" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in stream_parameters
+                )
+                stream_kwargs = {"messages": messages, "system": system, "tools": tools}
+                if supports_telemetry_sidecar:
+                    stream_kwargs["telemetry_messages"] = telemetry_messages
+                supports_lease = any(
+                    parameter.name == "lease" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in stream_parameters
+                )
+                if lease is not None and supports_lease:
+                    stream_kwargs["lease"] = lease
+                provider_stream = stream_method(**stream_kwargs)
             while True:
                 with use_span_attributes(self._telemetry_attributes):
                     try:
@@ -1724,8 +1764,63 @@ class AgentLoop:
                         return
                 yield event
         finally:
-            with use_span_attributes(self._telemetry_attributes):
-                await provider_stream.aclose()
+            try:
+                if "provider_stream" in locals():
+                    with use_span_attributes(self._telemetry_attributes):
+                        await provider_stream.aclose()
+            finally:
+                try:
+                    self._release_request_lease(request_manager, lease)
+                finally:
+                    self._provider_requests_in_flight = max(0, self._provider_requests_in_flight - 1)
+                    self._sync_pending_provider_context_if_idle()
+
+    def _prepare_request_lease(
+        self,
+        request_manager: Any,
+        *,
+        base_system_prompt: str | None = None,
+    ) -> tuple[Any, str, list[Any]]:
+        if base_system_prompt is None:
+            self._refresh_system_prompt()
+            base_system_prompt = self._system_prompt_for_current_turn()
+        tools = list(self.tool_registry.list_tools())
+        tool_definitions = self._get_tool_definitions(tools)
+        begin_request = (
+            getattr(request_manager, "begin_request", None)
+            if hasattr(type(request_manager), "begin_request")
+            else None
+        )
+        lease = begin_request(base_system_prompt, tool_definitions or None) if callable(begin_request) else None
+        try:
+            effective_system = getattr(lease, "system_prompt", base_system_prompt)
+            effective_model = getattr(lease, "context_window_model", None)
+            if not isinstance(effective_model, str) or not effective_model:
+                get_model_name = getattr(request_manager, "get_model_name", None)
+                effective_model = get_model_name() if callable(get_model_name) else None
+            if isinstance(effective_model, str) and effective_model:
+                self.context_manager.set_model(effective_model)
+            self.context_manager.set_system_prompt(effective_system)
+            self.context_manager.set_tool_definitions(tool_definitions)
+            self._sync_tool_system_prompt(effective_system, tools=tools)
+            self._last_effective_system_prompt = effective_system
+            if request_manager is self._provider_manager:
+                self._pending_provider_context_sync = False
+            return lease, effective_system, tool_definitions
+        except BaseException:
+            self._release_request_lease(request_manager, lease)
+            raise
+
+    @staticmethod
+    def _release_request_lease(request_manager: Any, lease: Any) -> None:
+        if lease is None:
+            return
+        token = getattr(lease, "_lease_token", None)
+        if getattr(token, "state", None) == "released":
+            return
+        release = getattr(request_manager, "release_request", None)
+        if callable(release):
+            release(lease)
 
     async def _run_streaming_inner(
         self,
@@ -1752,21 +1847,37 @@ class AgentLoop:
             self._drain_pending_injections()
             self._current_turn_text = ""
 
-            system_prompt = self._prepare_provider_system_prompt()
-            tool_definitions = self._sync_tool_definitions(system_prompt=system_prompt)
+            request_manager = self._provider_manager
             await self._consume_ready_memory_prefetches(memory_prefetch)
+            self._refresh_system_prompt()
+            request_base_system_prompt = self._system_prompt_for_current_turn()
+            lease, system_prompt, tool_definitions = self._prepare_request_lease(
+                request_manager,
+                base_system_prompt=request_base_system_prompt,
+            )
 
             # Auto-compact if needed
-            if self.context_manager.needs_compaction():
+            try:
+                needs_compaction = self.context_manager.needs_compaction()
+            except BaseException:
+                self._release_request_lease(request_manager, lease)
+                raise
+            if needs_compaction:
                 # Emit a "started" marker first so the web UI can render the
                 # "正在自动压缩上下文" running indicator while the (blocking)
                 # summarization LLM call is in flight, then always emit a
                 # terminal event so the indicator never sticks. A no-op or
                 # failure is explicit instead of looking like a successful
                 # 0 -> 0 compaction.
+                self._release_request_lease(request_manager, lease)
+                lease = None
                 yield CompactionEvent(phase="started")
-                compact_event = await self._auto_compact()
+                compact_event = await self._auto_compact(request_manager)
                 yield compact_event if compact_event else CompactionEvent(phase="failed", reason="no_result")
+                lease, system_prompt, tool_definitions = self._prepare_request_lease(
+                    request_manager,
+                    base_system_prompt=request_base_system_prompt,
+                )
 
             step_attrs = {
                 GenAiAttr.SPAN_KIND: GenAiSpanKind.STEP,
@@ -1783,7 +1894,11 @@ class AgentLoop:
                 message_ended = False
                 turn_stop_reason = "stop"
 
-                provider_messages, telemetry_messages = self._get_provider_messages_with_telemetry()
+                try:
+                    provider_messages, telemetry_messages = self._get_provider_messages_with_telemetry()
+                except BaseException:
+                    self._release_request_lease(request_manager, lease)
+                    raise
                 provider_tools = tool_definitions or None
                 self._last_provider_request_snapshot = {
                     "system_prompt": system_prompt,
@@ -1793,6 +1908,8 @@ class AgentLoop:
 
                 # Stream from provider
                 async for event in self._stream_provider(
+                    request_manager=request_manager,
+                    lease=lease,
                     messages=provider_messages,
                     system=system_prompt,
                     tools=provider_tools,
@@ -2692,7 +2809,44 @@ class AgentLoop:
             ),
         )
 
-    async def _auto_compact(self) -> CompactionEvent | None:
+    async def _complete_provider_with_lease(
+        self,
+        request_manager: Any,
+        *,
+        messages: list[Any],
+        system: str,
+        tools: list[Any] | None = None,
+        max_tokens: int | None = None,
+        cache_policy: str | None = None,
+    ) -> Any:
+        begin_request = (
+            getattr(request_manager, "begin_request", None)
+            if hasattr(type(request_manager), "begin_request")
+            else None
+        )
+        lease = begin_request(system, tools) if callable(begin_request) else None
+        effective_system = getattr(lease, "system_prompt", system)
+        self._provider_requests_in_flight += 1
+        try:
+            complete_method = request_manager.complete
+            kwargs: dict[str, Any] = {"messages": messages, "system": effective_system}
+            if tools is not None:
+                kwargs["tools"] = tools
+            if max_tokens is not None:
+                kwargs["max_tokens"] = max_tokens
+            if cache_policy is not None:
+                kwargs["cache_policy"] = cache_policy
+            if lease is not None:
+                kwargs["lease"] = lease
+            return await complete_method(**kwargs)
+        finally:
+            try:
+                self._release_request_lease(request_manager, lease)
+            finally:
+                self._provider_requests_in_flight = max(0, self._provider_requests_in_flight - 1)
+                self._sync_pending_provider_context_if_idle()
+
+    async def _auto_compact(self, request_manager: Any | None = None) -> CompactionEvent | None:
         """Perform automatic context compaction via provider."""
         from iac_code.services.telemetry import log_event
         from iac_code.services.telemetry.names import Events
@@ -2701,10 +2855,12 @@ class AgentLoop:
         if not compaction_prompt:
             return None
         started = time.monotonic()
+        request_manager = request_manager or self._provider_manager
         try:
             from iac_code.providers.base import Message as ProviderMessage
 
-            response = await self._provider_manager.complete(
+            response = await self._complete_provider_with_lease(
+                request_manager,
                 messages=[ProviderMessage.user(compaction_prompt)],
                 system="You are a helpful assistant that summarizes conversations concisely.",
             )
@@ -2748,7 +2904,9 @@ class AgentLoop:
         try:
             from iac_code.providers.base import Message as ProviderMessage
 
-            response = await self._provider_manager.complete(
+            request_manager = self._provider_manager
+            response = await self._complete_provider_with_lease(
+                request_manager,
                 messages=[ProviderMessage.user(compaction_prompt)],
                 system="You are a helpful assistant that summarizes conversations concisely.",
             )
@@ -2883,12 +3041,31 @@ class AgentLoop:
     def refresh_session_usage(self) -> None:
         self._session_usage_totals = self._session_usage_store.load(self._cwd, self._session_id)
 
-    def _record_session_usage(self, usage: Usage) -> None:
+    def _record_session_usage(
+        self,
+        usage: Usage,
+        attribution: UsageAttribution | None = None,
+    ) -> None:
         if not self._session_usage_totals.add(usage):
             return
 
-        provider = self._get_runtime_provider_key()
-        model = self._provider_manager.get_model_name() if hasattr(self._provider_manager, "get_model_name") else ""
+        if attribution is not None:
+            provider = attribution.logical_provider_key
+            model = attribution.actual_model
+        else:
+            from iac_code.providers.manager import ProviderManager
+
+            if isinstance(self._provider_manager, ProviderManager):
+                logger.warning("Provider usage was reported without terminal attribution; persistence skipped")
+                return
+            # Compatibility for lightweight third-party/test managers that do
+            # not implement ProviderManager's internal attribution contract.
+            provider = self._get_runtime_provider_key()
+            model = (
+                self._provider_manager.get_model_name()
+                if hasattr(self._provider_manager, "get_model_name")
+                else ""
+            )
         try:
             self._session_usage_store.append(
                 self._cwd,
@@ -2903,7 +3080,11 @@ class AgentLoop:
     def _record_response_usage(self, response: Any) -> None:
         usage = getattr(response, "usage", None)
         if isinstance(usage, Usage):
-            self._record_session_usage(usage)
+            attribution = getattr(response, "usage_attribution", None)
+            self._record_session_usage(
+                usage,
+                attribution if isinstance(attribution, UsageAttribution) else None,
+            )
 
     def _get_runtime_provider_key(self) -> str:
         if hasattr(self._provider_manager, "get_provider_key"):

--- a/src/iac_code/cli/output_formats.py
+++ b/src/iac_code/cli/output_formats.py
@@ -128,6 +128,11 @@ def stream_json_event_data(event: StreamEvent) -> dict[str, Any]:
         return data
 
     data = dataclasses.asdict(event)
+    if isinstance(event, MessageEndEvent):
+        data.pop("usage_attribution", None)
+    if isinstance(event, ErrorEvent):
+        data.pop("i18n_message_id", None)
+        data.pop("i18n_message_args", None)
     if isinstance(event, ToolResultEvent):
         data.pop("public_path_roots", None)
         if data.get("metadata") is None:

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -45,7 +45,8 @@ msgstr "afterSequence muss eine nicht negative Ganzzahl sein"
 msgid "Unsafe artifact filename"
 msgstr "Unsicherer Artefaktdateiname"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/a2a/events.py
+#: src/iac_code/pipeline/engine/public_errors.py
 #: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
@@ -6350,6 +6351,37 @@ msgstr ""
 "Kein API-Schlüssel für Anbieter '{provider}' konfiguriert (Modell: "
 "{model}). Führen Sie /auth aus, um die Konfiguration vorzunehmen."
 
+#: src/iac_code/providers/manager.py
+#, python-brace-format
+msgid "Provider request lease cannot be consumed from state {state}."
+msgstr ""
+"Die Lease der Provider-Anfrage kann im Zustand {state} nicht verwendet "
+"werden."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease was already released."
+msgstr "Die Lease der Provider-Anfrage wurde bereits freigegeben."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease belongs to a different manager."
+msgstr "Die Lease der Provider-Anfrage gehört zu einem anderen Manager."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the streamed prompt."
+msgstr ""
+"Der System-Prompt der expliziten Anforderungs-Lease stimmt nicht mit dem "
+"Streaming-Prompt überein."
+
+#: src/iac_code/providers/manager.py
+msgid "Qwen replay ended before message completion."
+msgstr "Die Qwen-Wiederholung endete, bevor die Nachricht vollständig war."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the completion prompt."
+msgstr ""
+"Der System-Prompt der expliziten Anforderungs-Lease stimmt nicht mit dem "
+"Completion-Prompt überein."
+
 #: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
@@ -6371,6 +6403,74 @@ msgstr ""
 "Die API hat eine ungültige Antwort zurückgegeben. Prüfen Sie, ob Ihre API"
 " Base URL korrekt ist (aktuell: {base_url}). Viele OpenAI-kompatible "
 "Endpunkte erfordern ein /v1-Suffix (z. B. {base_url}/v1)."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must be a non-empty JSON object."
+msgstr "Qwen-Werkzeugargumente müssen ein nicht leeres JSON-Objekt sein."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments are malformed JSON."
+msgstr "Qwen-Werkzeugargumente enthalten fehlerhaftes JSON."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must decode to an object."
+msgstr "Qwen-Werkzeugargumente müssen als Objekt dekodiert werden."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen native tool call is missing its ID or name."
+msgstr "Dem nativen Qwen-Werkzeugaufruf fehlt die ID oder der Name."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call index."
+msgstr "Ungültiger Index für einen Qwen-Werkzeugaufruf."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call identity."
+msgstr "Widersprüchliche Identität des Qwen-Werkzeugaufrufs."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call name."
+msgstr "Widersprüchlicher Name des Qwen-Werkzeugaufrufs."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments must be a string."
+msgstr "Die Argumente des Qwen-Werkzeugaufrufs müssen eine Zeichenfolge sein."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call identity."
+msgstr "Doppelte Identität des Qwen-Werkzeugaufrufs."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call identity."
+msgstr "Mehrdeutige Identität eines anonymen Qwen-Werkzeugaufrufs."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call fragment."
+msgstr "Mehrdeutiges Fragment eines anonymen Qwen-Werkzeugaufrufs."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call JSON structure."
+msgstr "Ungültige JSON-Struktur des Qwen-Werkzeugaufrufs."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen response ended with tool_calls but no complete tool call."
+msgstr ""
+"Die Qwen-Antwort endete mit tool_calls, enthält aber keinen vollständigen"
+" Werkzeugaufruf."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool call is anonymous or nameless."
+msgstr "Der Qwen-Werkzeugaufruf ist anonym oder hat keinen Namen."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call ID."
+msgstr "Doppelte ID des Qwen-Werkzeugaufrufs."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments ended before JSON was complete."
+msgstr ""
+"Die Argumente des Qwen-Werkzeugaufrufs endeten, bevor das JSON "
+"vollständig war."
 
 #: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
@@ -6447,6 +6547,28 @@ msgstr "Volcengine CodingPlan"
 #: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Anthropic-kompatibel"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen thinking-tag candidate exceeded the safety limit."
+msgstr ""
+"Der Qwen-Kandidat für ein thinking-Tag hat das Sicherheitslimit "
+"überschritten."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted an unsafe or conflicting thinking-tag block."
+msgstr ""
+"Qwen hat einen unsicheren oder widersprüchlichen thinking-Tag-Block "
+"ausgegeben."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a stray thinking closing tag."
+msgstr "Qwen hat ein einzelnes schließendes thinking-Tag ausgegeben."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a closing thinking tag without a valid native tool call."
+msgstr ""
+"Qwen hat ein schließendes thinking-Tag ohne gültigen nativen "
+"Werkzeugaufruf ausgegeben."
 
 #: src/iac_code/services/agent_factory.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -46,7 +46,8 @@ msgstr "afterSequence debe ser un entero no negativo"
 msgid "Unsafe artifact filename"
 msgstr "Nombre de archivo de artefacto no seguro"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/a2a/events.py
+#: src/iac_code/pipeline/engine/public_errors.py
 #: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Error desconocido"
@@ -6300,6 +6301,37 @@ msgstr ""
 "No se ha configurado una clave API para el proveedor '{provider}' "
 "(modelo: {model}). Ejecute /auth para configurar."
 
+#: src/iac_code/providers/manager.py
+#, python-brace-format
+msgid "Provider request lease cannot be consumed from state {state}."
+msgstr ""
+"La reserva de la solicitud al proveedor no se puede consumir desde el "
+"estado {state}."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease was already released."
+msgstr "La reserva de la solicitud al proveedor ya se liberó."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease belongs to a different manager."
+msgstr "La reserva de la solicitud al proveedor pertenece a otro gestor."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the streamed prompt."
+msgstr ""
+"El prompt del sistema de la reserva de solicitud explícita no coincide "
+"con el prompt de streaming."
+
+#: src/iac_code/providers/manager.py
+msgid "Qwen replay ended before message completion."
+msgstr "La repetición de Qwen terminó antes de completarse el mensaje."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the completion prompt."
+msgstr ""
+"El prompt del sistema de la reserva de solicitud explícita no coincide "
+"con el prompt de finalización."
+
 #: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
@@ -6321,6 +6353,74 @@ msgstr ""
 "La API devolvió una respuesta no válida. Compruebe que la API Base URL es"
 " correcta (actual: {base_url}). Muchos endpoints compatibles con OpenAI "
 "requieren el sufijo /v1 (p. ej., {base_url}/v1)."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must be a non-empty JSON object."
+msgstr "Los argumentos de herramienta de Qwen deben ser un objeto JSON no vacío."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments are malformed JSON."
+msgstr "Los argumentos de herramienta de Qwen contienen JSON no válido."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must decode to an object."
+msgstr "Los argumentos de herramienta de Qwen deben decodificarse como un objeto."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen native tool call is missing its ID or name."
+msgstr "A la llamada nativa a herramienta de Qwen le falta el ID o el nombre."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call index."
+msgstr "El índice de la llamada a herramienta de Qwen no es válido."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call identity."
+msgstr "La identidad de la llamada a herramienta de Qwen está en conflicto."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call name."
+msgstr "El nombre de la llamada a herramienta de Qwen está en conflicto."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments must be a string."
+msgstr "Los argumentos de la llamada a herramienta de Qwen deben ser una cadena."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call identity."
+msgstr "La identidad de la llamada a herramienta de Qwen está duplicada."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call identity."
+msgstr "La identidad de una llamada anónima a herramienta de Qwen es ambigua."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call fragment."
+msgstr "El fragmento de una llamada anónima a herramienta de Qwen es ambiguo."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call JSON structure."
+msgstr "La estructura JSON de la llamada a herramienta de Qwen no es válida."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen response ended with tool_calls but no complete tool call."
+msgstr ""
+"La respuesta de Qwen terminó con tool_calls, pero no contiene ninguna "
+"llamada a herramienta completa."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool call is anonymous or nameless."
+msgstr "La llamada a herramienta de Qwen es anónima o no tiene nombre."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call ID."
+msgstr "El ID de la llamada a herramienta de Qwen está duplicado."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments ended before JSON was complete."
+msgstr ""
+"Los argumentos de la llamada a herramienta de Qwen terminaron antes de "
+"que se completara el JSON."
 
 #: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
@@ -6397,6 +6497,24 @@ msgstr "Volcengine CodingPlan"
 #: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Compatible con Anthropic"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen thinking-tag candidate exceeded the safety limit."
+msgstr "El candidato a etiqueta thinking de Qwen superó el límite de seguridad."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted an unsafe or conflicting thinking-tag block."
+msgstr "Qwen generó un bloque de etiquetas thinking no seguro o en conflicto."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a stray thinking closing tag."
+msgstr "Qwen generó una etiqueta de cierre thinking aislada."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a closing thinking tag without a valid native tool call."
+msgstr ""
+"Qwen generó una etiqueta de cierre thinking sin una llamada nativa a "
+"herramienta válida."
 
 #: src/iac_code/services/agent_factory.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -46,7 +46,8 @@ msgstr "afterSequence doit être un entier non négatif"
 msgid "Unsafe artifact filename"
 msgstr "Nom de fichier d’artefact non sûr"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/a2a/events.py
+#: src/iac_code/pipeline/engine/public_errors.py
 #: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Erreur inconnue"
@@ -6314,6 +6315,37 @@ msgstr ""
 "Aucune clé API configurée pour le fournisseur '{provider}' (modèle : "
 "{model}). Exécutez /auth pour configurer."
 
+#: src/iac_code/providers/manager.py
+#, python-brace-format
+msgid "Provider request lease cannot be consumed from state {state}."
+msgstr ""
+"Le bail de requête du fournisseur ne peut pas être consommé depuis l'état"
+" {state}."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease was already released."
+msgstr "Le bail de requête du fournisseur a déjà été libéré."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease belongs to a different manager."
+msgstr "Le bail de requête du fournisseur appartient à un autre gestionnaire."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the streamed prompt."
+msgstr ""
+"L'invite système du bail de requête explicite ne correspond pas à "
+"l'invite diffusée en continu."
+
+#: src/iac_code/providers/manager.py
+msgid "Qwen replay ended before message completion."
+msgstr "Le rejeu Qwen s'est terminé avant la fin du message."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the completion prompt."
+msgstr ""
+"L'invite système du bail de requête explicite ne correspond pas à "
+"l'invite de complétion."
+
 #: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
@@ -6335,6 +6367,74 @@ msgstr ""
 "L’API a renvoyé une réponse invalide. Vérifiez que votre API Base URL est"
 " correcte (actuelle : {base_url}). De nombreux points de terminaison "
 "compatibles OpenAI exigent le suffixe /v1 (p. ex. {base_url}/v1)."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must be a non-empty JSON object."
+msgstr "Les arguments de l'outil Qwen doivent être un objet JSON non vide."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments are malformed JSON."
+msgstr "Les arguments de l'outil Qwen contiennent un JSON mal formé."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must decode to an object."
+msgstr "Les arguments de l'outil Qwen doivent être décodés en objet."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen native tool call is missing its ID or name."
+msgstr "Il manque l'ID ou le nom dans l'appel d'outil natif Qwen."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call index."
+msgstr "L'index de l'appel d'outil Qwen n'est pas valide."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call identity."
+msgstr "L'identité de l'appel d'outil Qwen est conflictuelle."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call name."
+msgstr "Le nom de l'appel d'outil Qwen est conflictuel."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments must be a string."
+msgstr "Les arguments de l'appel d'outil Qwen doivent être une chaîne."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call identity."
+msgstr "L'identité de l'appel d'outil Qwen est dupliquée."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call identity."
+msgstr "L'identité d'un appel d'outil Qwen anonyme est ambiguë."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call fragment."
+msgstr "Le fragment d'un appel d'outil Qwen anonyme est ambigu."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call JSON structure."
+msgstr "La structure JSON de l'appel d'outil Qwen n'est pas valide."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen response ended with tool_calls but no complete tool call."
+msgstr ""
+"La réponse Qwen s'est terminée avec tool_calls, mais sans appel d'outil "
+"complet."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool call is anonymous or nameless."
+msgstr "L'appel d'outil Qwen est anonyme ou sans nom."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call ID."
+msgstr "L'ID de l'appel d'outil Qwen est dupliqué."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments ended before JSON was complete."
+msgstr ""
+"Les arguments de l'appel d'outil Qwen se sont terminés avant la fin du "
+"JSON."
 
 #: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
@@ -6411,6 +6511,24 @@ msgstr "Volcengine CodingPlan"
 #: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Compatible Anthropic"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen thinking-tag candidate exceeded the safety limit."
+msgstr "Le candidat de balise thinking Qwen a dépassé la limite de sécurité."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted an unsafe or conflicting thinking-tag block."
+msgstr "Qwen a émis un bloc de balises thinking dangereux ou conflictuel."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a stray thinking closing tag."
+msgstr "Qwen a émis une balise de fermeture thinking isolée."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a closing thinking tag without a valid native tool call."
+msgstr ""
+"Qwen a émis une balise de fermeture thinking sans appel d'outil natif "
+"valide."
 
 #: src/iac_code/services/agent_factory.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -41,7 +41,8 @@ msgstr "afterSequence は非負整数である必要があります"
 msgid "Unsafe artifact filename"
 msgstr "安全でないアーティファクトファイル名"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/a2a/events.py
+#: src/iac_code/pipeline/engine/public_errors.py
 #: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "不明なエラー"
@@ -5925,6 +5926,31 @@ msgid ""
 "/auth to configure."
 msgstr "プロバイダー '{provider}' の API キーが設定されていません（モデル: {model}）。/auth を実行して設定してください。"
 
+#: src/iac_code/providers/manager.py
+#, python-brace-format
+msgid "Provider request lease cannot be consumed from state {state}."
+msgstr "Provider リクエストリースは状態 {state} では使用できません。"
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease was already released."
+msgstr "Provider リクエストリースはすでに解放されています。"
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease belongs to a different manager."
+msgstr "Provider リクエストリースは別のマネージャーに属しています。"
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the streamed prompt."
+msgstr "明示的なリクエストリースのシステムプロンプトがストリーミング用プロンプトと一致しません。"
+
+#: src/iac_code/providers/manager.py
+msgid "Qwen replay ended before message completion."
+msgstr "Qwen の再実行はメッセージが完了する前に終了しました。"
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the completion prompt."
+msgstr "明示的なリクエストリースのシステムプロンプトが補完用プロンプトと一致しません。"
+
 #: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
@@ -5944,6 +5970,70 @@ msgid ""
 msgstr ""
 "API から無効な応答が返りました。API Base URL が正しいか確認してください（現在：{base_url}）。 多くの OpenAI "
 "互換エンドポイントでは /v1 接尾辞が必要です（例：{base_url}/v1）。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must be a non-empty JSON object."
+msgstr "Qwen のツール引数は空でない JSON オブジェクトである必要があります。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments are malformed JSON."
+msgstr "Qwen のツール引数に不正な JSON が含まれています。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must decode to an object."
+msgstr "Qwen のツール引数はオブジェクトとしてデコードされる必要があります。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen native tool call is missing its ID or name."
+msgstr "Qwen のネイティブツール呼び出しに ID または名前がありません。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call index."
+msgstr "Qwen ツール呼び出しのインデックスが無効です。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call identity."
+msgstr "Qwen ツール呼び出しの識別情報が競合しています。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call name."
+msgstr "Qwen ツール呼び出しの名前が競合しています。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments must be a string."
+msgstr "Qwen ツール呼び出しの引数は文字列である必要があります。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call identity."
+msgstr "Qwen ツール呼び出しの識別情報が重複しています。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call identity."
+msgstr "匿名の Qwen ツール呼び出しの識別情報が曖昧です。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call fragment."
+msgstr "匿名の Qwen ツール呼び出しのフラグメントが曖昧です。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call JSON structure."
+msgstr "Qwen ツール呼び出しの JSON 構造が無効です。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen response ended with tool_calls but no complete tool call."
+msgstr "Qwen の応答は tool_calls で終了しましたが、完全なツール呼び出しがありません。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool call is anonymous or nameless."
+msgstr "Qwen ツール呼び出しが匿名、または名前なしです。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call ID."
+msgstr "Qwen ツール呼び出しの ID が重複しています。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments ended before JSON was complete."
+msgstr "Qwen ツール呼び出しの引数が JSON の完成前に終了しました。"
 
 #: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
@@ -6020,6 +6110,22 @@ msgstr "Volcengine CodingPlan"
 #: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Anthropic 互換"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen thinking-tag candidate exceeded the safety limit."
+msgstr "Qwen の thinking タグ候補が安全上限を超えました。"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted an unsafe or conflicting thinking-tag block."
+msgstr "Qwen が安全でない、または競合する thinking タグブロックを出力しました。"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a stray thinking closing tag."
+msgstr "Qwen が単独の thinking 終了タグを出力しました。"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a closing thinking tag without a valid native tool call."
+msgstr "Qwen が有効なネイティブツール呼び出しなしで thinking 終了タグを出力しました。"
 
 #: src/iac_code/services/agent_factory.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -45,7 +45,8 @@ msgstr "afterSequence deve ser um inteiro não negativo"
 msgid "Unsafe artifact filename"
 msgstr "Nome de arquivo de artefato inseguro"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/a2a/events.py
+#: src/iac_code/pipeline/engine/public_errors.py
 #: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "Erro desconhecido"
@@ -6250,6 +6251,37 @@ msgstr ""
 "Nenhuma chave API configurada para o provedor '{provider}' (modelo: "
 "{model}). Execute /auth para configurar."
 
+#: src/iac_code/providers/manager.py
+#, python-brace-format
+msgid "Provider request lease cannot be consumed from state {state}."
+msgstr ""
+"A reserva da solicitação ao provedor não pode ser consumida a partir do "
+"estado {state}."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease was already released."
+msgstr "A reserva da solicitação ao provedor já foi liberada."
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease belongs to a different manager."
+msgstr "A reserva da solicitação ao provedor pertence a outro gerenciador."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the streamed prompt."
+msgstr ""
+"O prompt de sistema da reserva de solicitação explícita não corresponde "
+"ao prompt de streaming."
+
+#: src/iac_code/providers/manager.py
+msgid "Qwen replay ended before message completion."
+msgstr "A repetição do Qwen terminou antes da conclusão da mensagem."
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the completion prompt."
+msgstr ""
+"O prompt de sistema da reserva de solicitação explícita não corresponde "
+"ao prompt de conclusão."
+
 #: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
@@ -6271,6 +6303,76 @@ msgstr ""
 "A API retornou uma resposta inválida. Verifique se a API Base URL está "
 "correta (atual: {base_url}). Muitos endpoints compatíveis com OpenAI "
 "exigem o sufixo /v1 (por exemplo, {base_url}/v1)."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must be a non-empty JSON object."
+msgstr "Os argumentos da ferramenta do Qwen devem ser um objeto JSON não vazio."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments are malformed JSON."
+msgstr "Os argumentos da ferramenta do Qwen contêm JSON malformado."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must decode to an object."
+msgstr ""
+"Os argumentos da ferramenta do Qwen devem ser decodificados como um "
+"objeto."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen native tool call is missing its ID or name."
+msgstr "A chamada de ferramenta nativa do Qwen não tem ID ou nome."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call index."
+msgstr "O índice da chamada de ferramenta do Qwen é inválido."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call identity."
+msgstr "A identidade da chamada de ferramenta do Qwen está em conflito."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call name."
+msgstr "O nome da chamada de ferramenta do Qwen está em conflito."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments must be a string."
+msgstr "Os argumentos da chamada de ferramenta do Qwen devem ser uma string."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call identity."
+msgstr "A identidade da chamada de ferramenta do Qwen está duplicada."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call identity."
+msgstr "A identidade de uma chamada de ferramenta anônima do Qwen é ambígua."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call fragment."
+msgstr "O fragmento de uma chamada de ferramenta anônima do Qwen é ambíguo."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call JSON structure."
+msgstr "A estrutura JSON da chamada de ferramenta do Qwen é inválida."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen response ended with tool_calls but no complete tool call."
+msgstr ""
+"A resposta do Qwen terminou com tool_calls, mas sem uma chamada de "
+"ferramenta completa."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool call is anonymous or nameless."
+msgstr "A chamada de ferramenta do Qwen é anônima ou não tem nome."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call ID."
+msgstr "O ID da chamada de ferramenta do Qwen está duplicado."
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments ended before JSON was complete."
+msgstr ""
+"Os argumentos da chamada de ferramenta do Qwen terminaram antes da "
+"conclusão do JSON."
 
 #: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
@@ -6347,6 +6449,24 @@ msgstr "Volcengine CodingPlan"
 #: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Compatível com Anthropic"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen thinking-tag candidate exceeded the safety limit."
+msgstr "O candidato à tag thinking do Qwen excedeu o limite de segurança."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted an unsafe or conflicting thinking-tag block."
+msgstr "O Qwen emitiu um bloco de tags thinking inseguro ou conflitante."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a stray thinking closing tag."
+msgstr "O Qwen emitiu uma tag de fechamento thinking isolada."
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a closing thinking tag without a valid native tool call."
+msgstr ""
+"O Qwen emitiu uma tag de fechamento thinking sem uma chamada de "
+"ferramenta nativa válida."
 
 #: src/iac_code/services/agent_factory.py
 #, python-brace-format

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -41,7 +41,8 @@ msgstr "afterSequence 必须是非负整数"
 msgid "Unsafe artifact filename"
 msgstr "不安全的工件文件名"
 
-#: src/iac_code/a2a/artifacts.py src/iac_code/pipeline/engine/public_errors.py
+#: src/iac_code/a2a/artifacts.py src/iac_code/a2a/events.py
+#: src/iac_code/pipeline/engine/public_errors.py
 #: src/iac_code/utils/public_errors.py
 msgid "Unknown error"
 msgstr "未知错误"
@@ -5851,6 +5852,31 @@ msgid ""
 "/auth to configure."
 msgstr "提供商 '{provider}' 未配置 API 密钥（模型: {model}）。请运行 /auth 进行配置。"
 
+#: src/iac_code/providers/manager.py
+#, python-brace-format
+msgid "Provider request lease cannot be consumed from state {state}."
+msgstr "无法使用状态为 {state} 的 Provider 请求租约。"
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease was already released."
+msgstr "Provider 请求租约已被释放。"
+
+#: src/iac_code/providers/manager.py
+msgid "Provider request lease belongs to a different manager."
+msgstr "Provider 请求租约属于其他管理器。"
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the streamed prompt."
+msgstr "显式请求租约的系统提示词与流式请求提示词不匹配。"
+
+#: src/iac_code/providers/manager.py
+msgid "Qwen replay ended before message completion."
+msgstr "Qwen 重放在消息完成前结束。"
+
+#: src/iac_code/providers/manager.py
+msgid "Explicit request lease system prompt does not match the completion prompt."
+msgstr "显式请求租约的系统提示词与补全请求提示词不匹配。"
+
 #: src/iac_code/providers/openai_provider.py
 #, python-brace-format
 msgid ""
@@ -5870,6 +5896,70 @@ msgid ""
 msgstr ""
 "API 返回了无效响应。请检查您的 API Base URL 是否正确（当前：{base_url}）。许多 OpenAI 兼容端点需要 /v1 "
 "后缀（如 {base_url}/v1）。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must be a non-empty JSON object."
+msgstr "Qwen 工具参数必须是非空 JSON 对象。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments are malformed JSON."
+msgstr "Qwen 工具参数包含格式错误的 JSON。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool arguments must decode to an object."
+msgstr "Qwen 工具参数解析后必须是对象。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen native tool call is missing its ID or name."
+msgstr "Qwen 原生工具调用缺少 ID 或名称。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call index."
+msgstr "Qwen 工具调用索引无效。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call identity."
+msgstr "Qwen 工具调用标识冲突。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Conflicting Qwen tool-call name."
+msgstr "Qwen 工具调用名称冲突。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments must be a string."
+msgstr "Qwen 工具调用参数必须是字符串。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call identity."
+msgstr "Qwen 工具调用标识重复。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call identity."
+msgstr "匿名 Qwen 工具调用标识存在歧义。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Ambiguous anonymous Qwen tool-call fragment."
+msgstr "匿名 Qwen 工具调用片段存在歧义。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Invalid Qwen tool-call JSON structure."
+msgstr "Qwen 工具调用 JSON 结构无效。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen response ended with tool_calls but no complete tool call."
+msgstr "Qwen 响应以 tool_calls 结束，但没有完整的工具调用。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool call is anonymous or nameless."
+msgstr "Qwen 工具调用缺少标识或名称。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Duplicate Qwen tool-call ID."
+msgstr "Qwen 工具调用 ID 重复。"
+
+#: src/iac_code/providers/qwen_tool_call_parser.py
+msgid "Qwen tool-call arguments ended before JSON was complete."
+msgstr "Qwen 工具调用参数在 JSON 完成前结束。"
 
 #: src/iac_code/providers/registry.py
 msgid "Alibaba Cloud Bailian"
@@ -5946,6 +6036,22 @@ msgstr "火山引擎编程计划"
 #: src/iac_code/providers/registry.py
 msgid "Anthropic Compatible"
 msgstr "Anthropic 兼容"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen thinking-tag candidate exceeded the safety limit."
+msgstr "Qwen thinking 标签候选内容超过安全限制。"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted an unsafe or conflicting thinking-tag block."
+msgstr "Qwen 输出了不安全或相互冲突的 thinking 标签块。"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a stray thinking closing tag."
+msgstr "Qwen 输出了多余的 thinking 结束标签。"
+
+#: src/iac_code/providers/streaming.py
+msgid "Qwen emitted a closing thinking tag without a valid native tool call."
+msgstr "Qwen 输出了 thinking 结束标签，但没有有效的原生工具调用。"
 
 #: src/iac_code/services/agent_factory.py
 #, python-brace-format

--- a/src/iac_code/memory/recall.py
+++ b/src/iac_code/memory/recall.py
@@ -14,6 +14,7 @@ from iac_code.memory.memory_manager import MemoryManager
 from iac_code.memory.project_memory import is_auto_memory_enabled
 from iac_code.providers.base import Message
 from iac_code.types.stream_events import Usage
+from iac_code.types.usage_attribution import UsageAttribution
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,7 @@ class MemoryRecallResult:
     selected_files: list[str] = field(default_factory=list)
     status: str = "skipped"
     usage: Usage | None = None
+    usage_attribution: UsageAttribution | None = None
 
 
 class MemoryRecallPrefetch:
@@ -200,6 +202,7 @@ class MemoryRecallService:
         self._stats.total_side_queries += 1
         self._stats.in_flight_side_queries += 1
         response_usage: Usage | None = None
+        response_attribution: UsageAttribution | None = None
         prompt = self._build_user_prompt(user_input, manifest)
         response_text = ""
         self._stats.last_usage = MemoryRecallUsageStats()
@@ -220,6 +223,9 @@ class MemoryRecallService:
             if isinstance(usage, Usage):
                 response_usage = usage
                 self._stats.record_usage(usage)
+            attribution = getattr(response, "usage_attribution", None)
+            if isinstance(attribution, UsageAttribution):
+                response_attribution = attribution
             response_text = str(getattr(response, "text", ""))
             selected_files = self._parse_selected_files(response_text, manifest)
             selected_files = self._filter_unsuppressed_files(selected_files)
@@ -230,7 +236,11 @@ class MemoryRecallService:
         except Exception:
             self._stats.failed_side_queries += 1
             self._record("failed", started, selected_files=[], prompt=prompt, response=response_text, side_query=True)
-            return MemoryRecallResult(status="failed", usage=response_usage)
+            return MemoryRecallResult(
+                status="failed",
+                usage=response_usage,
+                usage_attribution=response_attribution,
+            )
         finally:
             self._stats.in_flight_side_queries = max(0, self._stats.in_flight_side_queries - 1)
 
@@ -250,6 +260,7 @@ class MemoryRecallService:
             selected_files=selected_files,
             status="success",
             usage=response_usage,
+            usage_attribution=response_attribution,
         )
 
     def get_stats_snapshot(self) -> dict[str, Any]:

--- a/src/iac_code/providers/base.py
+++ b/src/iac_code/providers/base.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from iac_code.types.stream_events import StreamEvent, Usage
+from iac_code.types.usage_attribution import UsageAttribution
 
 
 @dataclass
@@ -90,6 +91,7 @@ class NonStreamingResponse:
     usage: Usage
     thinking: str = ""
     thinking_blocks: list[dict[str, Any]] = field(default_factory=list)
+    usage_attribution: UsageAttribution | None = field(default=None, kw_only=True, compare=False)
 
 
 class Provider(ABC):

--- a/src/iac_code/providers/dashscope_endpoints.py
+++ b/src/iac_code/providers/dashscope_endpoints.py
@@ -1,0 +1,97 @@
+"""Precise DashScope endpoint classification shared by routing and cache gates."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+DASHSCOPE_WIRE_PROVIDER_KEYS = frozenset(
+    {"dashscope", "dashscope_token_plan", "aliyun_codingplan", "aliyun_codingplan_intl"}
+)
+
+_STANDARD_HOSTS = frozenset(
+    {
+        "dashscope.aliyuncs.com",
+        "dashscope-intl.aliyuncs.com",
+        "dashscope-us.aliyuncs.com",
+        "cn-hongkong.dashscope.aliyuncs.com",
+    }
+)
+_CODING_HOST_TO_KEY = {
+    "coding.dashscope.aliyuncs.com": "aliyun_codingplan",
+    "coding-intl.dashscope.aliyuncs.com": "aliyun_codingplan_intl",
+}
+_TOKEN_PLAN_REGIONS = frozenset(
+    {"cn-beijing", "ap-southeast-1", "ap-northeast-1", "eu-central-1", "us-east-1"}
+)
+
+
+def _parsed_https_endpoint(base_url: str | None) -> tuple[str, str] | None:
+    if not isinstance(base_url, str) or not base_url.strip():
+        return None
+    try:
+        parsed = urlsplit(base_url.strip())
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme.lower() != "https" or not hostname or port not in (None, 443):
+        return None
+    return hostname.lower().rstrip("."), parsed.path.rstrip("/")
+
+
+def _path_matches(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def official_dashscope_wire_provider_key(base_url: str | None) -> str | None:
+    """Classify official OpenAI-compatible endpoints without substring matches."""
+    parsed = _parsed_https_endpoint(base_url)
+    if parsed is None:
+        return None
+    host, path = parsed
+    if host in _STANDARD_HOSTS and _path_matches(path, "/compatible-mode"):
+        return "dashscope"
+    coding_key = _CODING_HOST_TO_KEY.get(host)
+    if coding_key is not None and _path_matches(path, "/v1"):
+        return coding_key
+    labels = host.split(".")
+    if (
+        len(labels) == 5
+        and labels[0] == "token-plan"
+        and labels[1] in _TOKEN_PLAN_REGIONS
+        and labels[2:] == ["maas", "aliyuncs", "com"]
+        and _path_matches(path, "/compatible-mode")
+    ):
+        return "dashscope_token_plan"
+    return None
+
+
+def is_bailian_compatible_endpoint(base_url: str | None) -> bool:
+    """Broad telemetry predicate for official Bailian-compatible endpoints."""
+    parsed = _parsed_https_endpoint(base_url)
+    if parsed is None:
+        return False
+    host, path = parsed
+    if host in _CODING_HOST_TO_KEY:
+        return _path_matches(path, "/v1") or _path_matches(path, "/apps/anthropic")
+    if host in _STANDARD_HOSTS:
+        return _path_matches(path, "/compatible-mode") or _path_matches(path, "/apps/anthropic")
+    labels = host.split(".")
+    is_maas = (
+        len(labels) == 5
+        and labels[2:] == ["maas", "aliyuncs", "com"]
+        and _is_dns_label(labels[0])
+        and labels[1] in _TOKEN_PLAN_REGIONS
+    )
+    return is_maas and (
+        _path_matches(path, "/compatible-mode") or _path_matches(path, "/apps/anthropic")
+    )
+
+
+def _is_dns_label(value: str) -> bool:
+    return (
+        1 <= len(value) <= 63
+        and value[0] != "-"
+        and value[-1] != "-"
+        and all(character == "-" or "a" <= character <= "z" or "0" <= character <= "9" for character in value)
+    )

--- a/src/iac_code/providers/dashscope_provider.py
+++ b/src/iac_code/providers/dashscope_provider.py
@@ -75,6 +75,7 @@ class DashScopeProvider(OpenAIProvider):
         thinking_enabled: bool | None = None,
         thinking_budget: int | None = None,
         max_completion_tokens: int | None = None,
+        client: Any = None,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -86,6 +87,7 @@ class DashScopeProvider(OpenAIProvider):
             thinking_budget=thinking_budget,
             max_completion_tokens=max_completion_tokens,
             provider_key=provider_key,
+            client=client,
         )
 
     # -- Explicit context cache ------------------------------------------------

--- a/src/iac_code/providers/manager.py
+++ b/src/iac_code/providers/manager.py
@@ -6,11 +6,11 @@ import asyncio
 import copy
 import sys
 import time
+import uuid
 from collections.abc import AsyncGenerator, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
-from urllib.parse import urlsplit
 
 from anthropic import APIConnectionError as AnthropicAPIConnectionError
 from loguru import logger
@@ -19,9 +19,17 @@ from opentelemetry.trace import Status, StatusCode
 
 from iac_code.i18n import _
 from iac_code.providers.base import Message, NonStreamingResponse, Provider, ToolDefinition
+from iac_code.providers.dashscope_endpoints import (
+    DASHSCOPE_WIRE_PROVIDER_KEYS,
+    is_bailian_compatible_endpoint,
+    official_dashscope_wire_provider_key,
+)
+from iac_code.providers.model_family import is_qwen_model
+from iac_code.providers.request_lease import LeaseToken, ProviderRequestLease
 from iac_code.providers.request_policy import ProviderRequestPolicy, bool_or_none, positive_int_or_none
 from iac_code.providers.retry import RetryableError, RetryConfig, with_retry
 from iac_code.providers.stream_watchdog import StreamWatchdog
+from iac_code.providers.streaming import UnsafeStreamProtocolError
 from iac_code.services.session_logging import is_custom_endpoint, sanitize_endpoint_origin
 from iac_code.services.telemetry import (
     add_metric,
@@ -64,6 +72,7 @@ from iac_code.types.stream_events import (
     ToolUseStartEvent,
     Usage,
 )
+from iac_code.types.usage_attribution import UsageAttribution
 from iac_code.utils.public_errors import public_error, public_exception_summary
 
 
@@ -73,6 +82,15 @@ class ProviderNotConfiguredError(ValueError):
 
 class ProviderConfigurationError(RuntimeError):
     """Raised when provider configuration cannot be loaded during a request."""
+
+
+class ProviderRequestLeaseError(ValueError):
+    """A request lease invariant failed with a localizable public message."""
+
+    def __init__(self, message_id: str, **message_args: Any) -> None:
+        self.i18n_message_id = message_id
+        self.i18n_message_args = message_args or None
+        super().__init__(_(message_id).format(**message_args))
 
 
 class _ModelRefusalError(RuntimeError):
@@ -116,34 +134,6 @@ _TOKEN_METRIC_SCOPE_KEYS = frozenset(
         PipelineAttr.CANDIDATE_INDEX,
     }
 )
-
-# Keep these telemetry-only allowlists aligned with the official Model Studio
-# Base URL overview: https://help.aliyun.com/zh/model-studio/base-url
-_BAILIAN_SHARED_HOSTS = frozenset(
-    {
-        "dashscope.aliyuncs.com",
-        "dashscope-intl.aliyuncs.com",
-        "dashscope-us.aliyuncs.com",
-    }
-)
-_BAILIAN_CODING_HOSTS = frozenset(
-    {
-        "coding.dashscope.aliyuncs.com",
-        "coding-intl.dashscope.aliyuncs.com",
-    }
-)
-_BAILIAN_MAAS_REGIONS = frozenset(
-    {
-        "cn-beijing",
-        "ap-southeast-1",
-        "ap-northeast-1",
-        "eu-central-1",
-        "us-east-1",
-    }
-)
-_BAILIAN_COMPATIBLE_PATHS = ("/compatible-mode", "/apps/anthropic")
-_BAILIAN_CODING_PATHS = ("/v1", "/apps/anthropic")
-
 
 class _BestEffortSpan:
     def __init__(self, span: Any | None = None) -> None:
@@ -344,6 +334,7 @@ class _StreamAttemptOutcome:
     refusal_detected: bool = False
     buffer_until_accepted: bool = False
     retryable_stream_error: BaseException | None = None
+    stream_failure_exception: BaseException | None = None
     provider_name: str = ""
     sanitized_model: str = ""
     orphaned_message_ids: list[str] = field(default_factory=list)
@@ -361,7 +352,15 @@ class _CompletionResult:
 def _error_event_from_exception(exc: BaseException) -> ErrorEvent:
     summary = public_exception_summary(exc, max_chars=1000)
     failure = public_error(message=summary, error_type=type(exc).__name__)
-    return ErrorEvent(error=summary, is_retryable=False, error_id=failure.error_id)
+    message_id = getattr(exc, "i18n_message_id", None)
+    message_args = getattr(exc, "i18n_message_args", None)
+    return ErrorEvent(
+        error=summary,
+        is_retryable=False,
+        error_id=failure.error_id,
+        i18n_message_id=message_id if isinstance(message_id, str) else None,
+        i18n_message_args=dict(message_args) if isinstance(message_args, dict) else None,
+    )
 
 
 MODEL_FALLBACK_MAP = {
@@ -512,6 +511,13 @@ def create_provider(
     wire_provider_key = _wire_provider_key_for_openai_compatible_base(
         provider_key,
         effective_base_url,
+        model=model,
+    )
+    thinking_intent = _resolve_thinking_intent(
+        provider_cfg,
+        model,
+        request_policy_override,
+        provider_key=wire_provider_key,
     )
     if _legacy_effort_disables_thinking(effort_override):
         effort = None
@@ -538,6 +544,10 @@ def create_provider(
         if wire_desc is not None:
             provider_class_path = wire_desc.provider_class
     provider_cls = _import_provider_class(provider_class_path)
+    if _should_use_qwen_provider(provider_cls, model):
+        from iac_code.providers.qwen_provider import QwenProvider
+
+        provider_cls = QwenProvider
     request_policy_kwargs: dict[str, Any] = {}
     if thinking_enabled is not None:
         request_policy_kwargs["thinking_enabled"] = thinking_enabled
@@ -548,6 +558,10 @@ def create_provider(
             request_policy_kwargs["thinking_budget"] = thinking_budget
         if max_completion_tokens is not None:
             request_policy_kwargs["max_completion_tokens"] = max_completion_tokens
+        from iac_code.providers.qwen_provider import QwenProvider
+
+        if issubclass(provider_cls, QwenProvider):
+            request_policy_kwargs["thinking_intent"] = thinking_intent
     else:
         from iac_code.providers.anthropic_provider import AnthropicProvider
 
@@ -581,6 +595,13 @@ def _import_provider_class(dotted_path: str):
 
     module = importlib.import_module(module_path)
     return getattr(module, class_name)
+
+
+def _should_use_qwen_provider(provider_cls: type, model: str) -> bool:
+    """Select the Qwen adapter only on an existing DashScope transport."""
+    from iac_code.providers.dashscope_provider import DashScopeProvider
+
+    return issubclass(provider_cls, DashScopeProvider) and is_qwen_model(model)
 
 
 def _get_model_provider_config(provider_cfg: dict[str, Any], model: str) -> dict[str, Any]:
@@ -619,15 +640,83 @@ def _get_bool_provider_config_value(provider_cfg: dict[str, Any], model: str, ke
 def _wire_provider_key_for_openai_compatible_base(
     provider_key: str,
     base_url: str | None,
+    *,
+    model: str = "",
 ) -> str:
     if provider_key != "openai_compatible" or not isinstance(base_url, str):
         return provider_key
-    lower_base_url = base_url.lower()
-    if "token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode" in lower_base_url:
-        return "dashscope_token_plan"
-    if "dashscope.aliyuncs.com/compatible-mode" in lower_base_url:
-        return "dashscope"
+    wire_key = official_dashscope_wire_provider_key(base_url)
+    if wire_key is None:
+        return provider_key
+    # Preserve the feature's pre-existing non-Qwen route set. New regional and
+    # Coding Plan recognition is enabled only for Qwen requests.
+    if wire_key == "dashscope" and _is_legacy_standard_dashscope_url(base_url):
+        return wire_key
+    if wire_key == "dashscope_token_plan" and _is_legacy_token_plan_url(base_url):
+        return wire_key
+    if is_qwen_model(model):
+        return wire_key
     return provider_key
+
+
+def _is_legacy_standard_dashscope_url(base_url: str) -> bool:
+    try:
+        from urllib.parse import urlsplit
+
+        host = (urlsplit(base_url.strip()).hostname or "").lower().rstrip(".")
+    except ValueError:
+        return False
+    return host in {"dashscope.aliyuncs.com", "cn-hongkong.dashscope.aliyuncs.com"}
+
+
+def _is_legacy_token_plan_url(base_url: str) -> bool:
+    try:
+        from urllib.parse import urlsplit
+
+        host = (urlsplit(base_url.strip()).hostname or "").lower().rstrip(".")
+    except ValueError:
+        return False
+    return host == "token-plan.cn-beijing.maas.aliyuncs.com"
+
+
+def _resolve_thinking_intent(
+    provider_cfg: dict[str, Any],
+    model: str,
+    request_policy: ProviderRequestPolicy | None,
+    *,
+    provider_key: str,
+):
+    from iac_code.providers.thinking_intent import ResolvedThinkingIntent, SourcedValue
+
+    model_cfg = _get_model_provider_config(provider_cfg, model)
+
+    def configured(key: str, converter):
+        model_value = converter(model_cfg.get(key)) if key in model_cfg else None
+        if model_value is not None:
+            return SourcedValue(model_value, "model")
+        provider_value = converter(provider_cfg.get(key))
+        if provider_value is not None:
+            return SourcedValue(provider_value, "provider")
+        return SourcedValue()
+
+    def effort_value(value: Any) -> str | None:
+        return value.strip() if isinstance(value, str) and value.strip() else None
+
+    enabled = configured("thinkingEnabled", bool_or_none)
+    effort = configured("effort", effort_value)
+    budget = configured("thinkingBudget", positive_int_or_none)
+    if request_policy is not None:
+        if request_policy.thinking_enabled is not None:
+            enabled = SourcedValue(request_policy.thinking_enabled, "request")
+        if request_policy.effort is not None:
+            effort = SourcedValue(request_policy.effort, "request")
+        if request_policy.thinking_budget is not None:
+            budget = SourcedValue(request_policy.thinking_budget, "request")
+    if _legacy_effort_disables_thinking(effort.value):
+        if enabled.priority <= effort.priority:
+            enabled = SourcedValue(False, effort.source)
+        effort = SourcedValue()
+    return ResolvedThinkingIntent(enabled=enabled, effort=effort, budget=budget)
 
 
 def _positive_int_or_none(value: Any) -> int | None:
@@ -710,50 +799,30 @@ def _provider_endpoint_url(provider: Any) -> str | None:
 
 def _is_bailian_compatible_endpoint(base_url: str | None) -> bool:
     """Return whether a compatible API URL is an official Bailian endpoint."""
-    if not isinstance(base_url, str) or not base_url.strip():
-        return False
-    try:
-        parsed = urlsplit(base_url.strip())
-        hostname = parsed.hostname
-        port = parsed.port
-    except ValueError:
-        return False
-    if parsed.scheme.lower() != "https" or not hostname or port not in (None, 443):
-        return False
-    normalized_host = hostname.lower().rstrip(".")
-    path = parsed.path.rstrip("/")
-    if normalized_host in _BAILIAN_CODING_HOSTS:
-        return _path_matches_any_prefix(path, _BAILIAN_CODING_PATHS)
-    if normalized_host in _BAILIAN_SHARED_HOSTS:
-        return _path_matches_any_prefix(path, _BAILIAN_COMPATIBLE_PATHS)
-    labels = normalized_host.split(".")
-    is_maas_host = (
-        len(labels) == 5
-        and labels[-3:] == ["maas", "aliyuncs", "com"]
-        and _is_dns_label(labels[0])
-        and labels[1] in _BAILIAN_MAAS_REGIONS
-    )
-    return is_maas_host and _path_matches_any_prefix(path, _BAILIAN_COMPATIBLE_PATHS)
-
-
-def _path_matches_any_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
-    return any(path == prefix or path.startswith(f"{prefix}/") for prefix in prefixes)
-
-
-def _is_dns_label(value: str) -> bool:
-    return (
-        1 <= len(value) <= 63
-        and value[0] != "-"
-        and value[-1] != "-"
-        and all(character == "-" or "a" <= character <= "z" or "0" <= character <= "9" for character in value)
-    )
+    return is_bailian_compatible_endpoint(base_url)
 
 
 def _telemetry_provider_name(provider: Any) -> str:
     """Resolve the service provider reported by telemetry without changing the request adapter."""
+    wire_provider_key = _string_provider_attr(provider, "_PROVIDER_KEY")
+    if wire_provider_key in DASHSCOPE_WIRE_PROVIDER_KEYS:
+        return "dashscope"
     if _is_bailian_compatible_endpoint(_provider_endpoint_url(provider)):
         return "dashscope"
     return type(provider).__name__.replace("Provider", "").lower()
+
+
+def _provider_telemetry_attrs(provider: Any) -> dict[str, str | bool]:
+    attrs: dict[str, str | bool] = {
+        IacCodeAttr.OFFICIAL_ENDPOINT: official_dashscope_wire_provider_key(
+            _provider_endpoint_url(provider)
+        )
+        is not None,
+    }
+    adapter_name = _string_provider_attr(provider, "_ADAPTER_NAME")
+    if adapter_name is not None:
+        attrs[IacCodeAttr.PROVIDER_ADAPTER] = adapter_name
+    return attrs
 
 
 class ProviderManager:
@@ -785,6 +854,7 @@ class ProviderManager:
         self._base_url_override = base_url_override
         self._effort_override = effort_override
         self._provider_config_override = copy.deepcopy(provider_config_override)
+        self._lease_owner_identity = object()
         self._request_policy_override = _request_policy_with_effort_override(request_policy_override, effort_override)
         # 会话级显式 provider 覆盖时,忽略全局合作方源 llm_source(当前唯一实现为 QwenPaw)的每轮热切换:
         # 否则每次请求开头的 _check_qwenpaw_config_change 都会因全局 llm_source 仍指向合作方而把本会话
@@ -841,6 +911,71 @@ class ProviderManager:
         if self._pinned_provider is not None and self._pinned_model is not None:
             return self._pinned_provider, self._pinned_model
         return self._ensure_provider(), self._model
+
+    def begin_request(
+        self,
+        system: str,
+        tools: list[ToolDefinition] | None = None,
+    ) -> ProviderRequestLease:
+        """Atomically bind one request to its provider, model, and prompt."""
+        self._check_qwenpaw_config_change()
+        provider, actual_model = self._active_provider_and_model()
+        prompt_preparer = getattr(type(provider), "prepare_system_prompt", None)
+        effective_system = prompt_preparer(provider, system, tools) if callable(prompt_preparer) else system
+        logical_key = _string_provider_attr(provider, "_logical_provider_key") or self.get_provider_key()
+        wire_key = _string_provider_attr(provider, "_PROVIDER_KEY") or logical_key
+        adapter_name = _string_provider_attr(provider, "_ADAPTER_NAME")
+        return ProviderRequestLease(
+            request_id=f"req_{uuid.uuid4().hex}",
+            provider=provider,
+            system_prompt=effective_system,
+            requested_model=self._model,
+            logical_provider_key=logical_key,
+            wire_provider_key=wire_key,
+            telemetry_provider_name=_telemetry_provider_name(provider),
+            adapter_name=adapter_name,
+            context_window_model=actual_model,
+            _owner_identity=self._lease_owner_identity,
+            _lease_token=LeaseToken(),
+        )
+
+    def _consume_request_lease(self, lease: ProviderRequestLease) -> None:
+        self._validate_request_lease(lease)
+        token = lease._lease_token
+        if token.state != "active":
+            raise ProviderRequestLeaseError(
+                "Provider request lease cannot be consumed from state {state}.",
+                state=repr(token.state),
+            )
+        token.state = "consumed"
+
+    def release_request(self, lease: ProviderRequestLease) -> None:
+        self._validate_request_lease(lease)
+        token = lease._lease_token
+        if token.state == "released":
+            raise ProviderRequestLeaseError("Provider request lease was already released.")
+        token.state = "released"
+
+    def _validate_request_lease(self, lease: ProviderRequestLease) -> None:
+        if not isinstance(lease, ProviderRequestLease) or lease._owner_identity is not self._lease_owner_identity:
+            raise ProviderRequestLeaseError("Provider request lease belongs to a different manager.")
+
+    def _usage_attribution(
+        self,
+        lease: ProviderRequestLease,
+        *,
+        provider: Provider,
+        actual_model: str,
+        telemetry_provider_name: str | None = None,
+    ) -> UsageAttribution:
+        return UsageAttribution(
+            logical_provider_key=lease.logical_provider_key,
+            wire_provider_key=_string_provider_attr(provider, "_PROVIDER_KEY") or lease.wire_provider_key,
+            telemetry_provider_name=telemetry_provider_name or _telemetry_provider_name(provider),
+            adapter_name=_string_provider_attr(provider, "_ADAPTER_NAME"),
+            requested_model=lease.requested_model,
+            actual_model=actual_model,
+        )
 
     def _provider_create_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {
@@ -993,18 +1128,69 @@ class ProviderManager:
         tools: list[ToolDefinition] | None = None,
         max_tokens: int = 8192,
         telemetry_messages: list[Any] | None = None,
+        *,
+        lease: ProviderRequestLease | None = None,
     ) -> AsyncGenerator[StreamEvent, None]:
         captured_scope = _safe_span_scope_attributes()
         captured_parent = _safe_current_context()
-        return self._stream_impl(
+        return self._stream_with_request_lease(
             messages,
             system,
             tools,
             max_tokens,
+            lease=lease,
             telemetry_messages=telemetry_messages,
             captured_scope=captured_scope,
             captured_parent=captured_parent,
         )
+
+    async def _stream_with_request_lease(
+        self,
+        messages: list[Message],
+        system: str,
+        tools: list[ToolDefinition] | None,
+        max_tokens: int,
+        *,
+        lease: ProviderRequestLease | None,
+        telemetry_messages: list[Any] | None,
+        captured_scope: dict[str, str | int],
+        captured_parent: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        implicit_lease = lease is None
+        try:
+            active_lease = lease or self.begin_request(system, tools)
+            self._consume_request_lease(active_lease)
+            if system != active_lease.system_prompt:
+                if implicit_lease:
+                    system = active_lease.system_prompt
+                else:
+                    raise ProviderRequestLeaseError(
+                        "Explicit request lease system prompt does not match the streamed prompt."
+                    )
+            request_stream = self._stream_impl(
+                messages,
+                system,
+                tools,
+                max_tokens,
+                lease=active_lease,
+                telemetry_messages=telemetry_messages,
+                captured_scope=captured_scope,
+                captured_parent=captured_parent,
+            )
+            try:
+                while True:
+                    try:
+                        event = await anext(request_stream)
+                    except StopAsyncIteration:
+                        break
+                    yield event
+            finally:
+                await request_stream.aclose()
+        except ProviderConfigurationError as exc:
+            yield _error_event_from_exception(exc)
+        finally:
+            if implicit_lease and "active_lease" in locals() and active_lease._lease_token.state != "released":
+                self.release_request(active_lease)
 
     async def _stream_attempt(
         self,
@@ -1013,6 +1199,7 @@ class ProviderManager:
         tools: list[ToolDefinition] | None,
         max_tokens: int,
         *,
+        lease: ProviderRequestLease,
         telemetry_messages: list[Any] | None,
         captured_scope: dict[str, str | int],
         captured_parent: Any,
@@ -1024,13 +1211,10 @@ class ProviderManager:
         attempt is retried or downgraded to a non-streaming request belongs to
         ``_stream_impl``.
         """
-        try:
-            self._check_qwenpaw_config_change()
-        except ProviderConfigurationError as exc:
-            yield _error_event_from_exception(exc)
-            return
-        provider, model = self._active_provider_and_model()
+        provider = lease.provider
+        model = lease.context_window_model
         provider_name = _telemetry_provider_name(provider)
+        provider_identity_attrs = _provider_telemetry_attrs(provider)
         sanitized_model = sanitize_model_name(model)
         outcome.provider_name = provider_name
         outcome.sanitized_model = sanitized_model
@@ -1048,6 +1232,7 @@ class ProviderManager:
             GenAiAttr.SESSION_ID: session_id,
             GenAiAttr.CONVERSATION_ID: session_id,
             GenAiAttr.OUTPUT_TYPE: "text",
+            **provider_identity_attrs,
         }
         span_attrs.update(captured_scope)
         _capture_request_content(span_attrs, messages, system, tools, telemetry_messages)
@@ -1058,6 +1243,7 @@ class ProviderManager:
         buffer_until_accepted = model in _MODEL_REFUSAL_FALLBACK_MAP
         buffered_events: list[StreamEvent] = []
         streaming_failed = False
+        stream_failure_exception: BaseException | None = None
         refusal_detected = False
         first_token_received = False
         watchdog: StreamWatchdog | None = None
@@ -1066,7 +1252,6 @@ class ProviderManager:
         close_attempted = False
         close_completed = False
         end_attempted = False
-        stream_exception: BaseException | None = None
         idle_timeout_hit = False
 
         with replace_span_attributes(captured_scope):
@@ -1139,6 +1324,7 @@ class ProviderManager:
                     started,
                     event.usage,
                     status=status,
+                    identity_attrs=provider_identity_attrs,
                 )
             return True
 
@@ -1168,6 +1354,7 @@ class ProviderManager:
                     status=status,
                     record_duration=True,
                     scope_attrs=captured_scope,
+                    identity_attrs=provider_identity_attrs,
                 )
             return True
 
@@ -1179,6 +1366,7 @@ class ProviderManager:
                         "provider": provider_name,
                         "model": sanitized_model,
                         "message_count": len(messages),
+                        **provider_identity_attrs,
                     },
                 )
             watchdog = StreamWatchdog(idle_timeout=self._stream_idle_timeout)
@@ -1213,6 +1401,7 @@ class ProviderManager:
                                     "model": sanitized_model,
                                     GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN: ttft_ns,
                                     "first_token_source": event.type,
+                                    **provider_identity_attrs,
                                     **captured_scope,
                                 },
                             )
@@ -1249,6 +1438,15 @@ class ProviderManager:
                     raise
 
                 if isinstance(event, MessageEndEvent):
+                    event = replace(
+                        event,
+                        usage_attribution=self._usage_attribution(
+                            lease,
+                            provider=provider,
+                            actual_model=model,
+                            telemetry_provider_name=provider_name,
+                        ),
+                    )
                     watchdog.stop()
                     if event.stop_reason == "refusal":
                         commit_success(event, status="refusal")
@@ -1314,6 +1512,7 @@ class ProviderManager:
                 end_span_once()
             raise
         except Exception as exc:
+            stream_failure_exception = exc
             already_terminal = terminal_status is not None
             commit_failure(
                 exc,
@@ -1328,8 +1527,10 @@ class ProviderManager:
             if already_terminal:
                 raise
             streaming_failed = True
-            stream_exception = exc
-            logger.warning(f"Streaming failed: {exc}")
+            if isinstance(exc, UnsafeStreamProtocolError):
+                logger.warning("Unsafe Qwen stream detected; replaying with streaming protocol validation")
+            else:
+                logger.warning(f"Streaming failed, falling back to non-streaming: {exc}")
         except BaseException as exc:
             commit_failure(
                 exc,
@@ -1351,13 +1552,14 @@ class ProviderManager:
         outcome.buffer_until_accepted = buffer_until_accepted
         outcome.orphaned_message_ids = orphaned_message_ids
         outcome.orphaned_tool_use_ids = orphaned_tool_use_ids
+        outcome.stream_failure_exception = stream_failure_exception
         if (
             streaming_failed
-            and stream_exception is not None
+            and stream_failure_exception is not None
             and not idle_timeout_hit
-            and _is_retryable_provider_error(stream_exception)
+            and _is_retryable_provider_error(stream_failure_exception)
         ):
-            outcome.retryable_stream_error = stream_exception
+            outcome.retryable_stream_error = stream_failure_exception
 
     async def _stream_impl(
         self,
@@ -1366,6 +1568,7 @@ class ProviderManager:
         tools: list[ToolDefinition] | None,
         max_tokens: int,
         *,
+        lease: ProviderRequestLease,
         telemetry_messages: list[Any] | None,
         captured_scope: dict[str, str | int],
         captured_parent: Any,
@@ -1382,6 +1585,11 @@ class ProviderManager:
         reached the caller: once events are out, a second attempt would
         duplicate them, so that case still downgrades (behind a tombstone).
         """
+        provider = lease.provider
+        model = lease.context_window_model
+        provider_name = _telemetry_provider_name(provider)
+        provider_identity_attrs = _provider_telemetry_attrs(provider)
+        sanitized_model = sanitize_model_name(model)
         attempt = 0
         # Bound before the loop as well so the post-loop read is unambiguous.
         outcome = _StreamAttemptOutcome()
@@ -1393,6 +1601,7 @@ class ProviderManager:
                 system,
                 tools,
                 max_tokens,
+                lease=lease,
                 telemetry_messages=telemetry_messages,
                 captured_scope=captured_scope,
                 captured_parent=captured_parent,
@@ -1425,10 +1634,12 @@ class ProviderManager:
                     "attempt": attempt,
                     "error_type": type(retryable_error).__name__,
                     "streaming": True,
+                    **provider_identity_attrs,
                 },
             )
             await asyncio.sleep(delay)
 
+        stream_failure_exception = outcome.stream_failure_exception
         if outcome.streaming_failed:
             logger.warning("Falling back to non-streaming after the stream failed")
             if not outcome.buffer_until_accepted:
@@ -1437,6 +1648,196 @@ class ProviderManager:
                         message_id=msg_id,
                         affected_tool_use_ids=outcome.orphaned_tool_use_ids.get(msg_id, []),
                     )
+            if isinstance(stream_failure_exception, UnsafeStreamProtocolError):
+                span_name = f"{Spans.LLM_CHAT} {model}"
+                session_id = _safe_session_id()
+                span_attrs = {
+                    GenAiAttr.SPAN_KIND: GenAiSpanKind.LLM,
+                    GenAiAttr.OPERATION_NAME: GenAiOperationName.CHAT,
+                    GenAiAttr.PROVIDER_NAME: provider_name,
+                    GenAiAttr.REQUEST_MODEL: model,
+                    GenAiAttr.REQUEST_MAX_TOKENS: max_tokens,
+                    GenAiAttr.SESSION_ID: session_id,
+                    GenAiAttr.CONVERSATION_ID: session_id,
+                    GenAiAttr.OUTPUT_TYPE: "text",
+                    **provider_identity_attrs,
+                    **captured_scope,
+                }
+                _capture_request_content(span_attrs, messages, system, tools, telemetry_messages)
+                last_unsafe_error: BaseException = stream_failure_exception
+                for _replay_attempt in range(2):
+                    replay_message_ids: list[str] = []
+                    replay_tool_ids: dict[str, list[str]] = {}
+                    replay_current_message: str | None = None
+                    replay_iter: AsyncGenerator[StreamEvent, None] | None = None
+                    replay_started = time.monotonic()
+                    replay_span = _safe_start_detached_span(span_name, span_attrs, captured_parent)
+                    replay_span_ended = False
+
+                    @contextmanager
+                    def activate_replay_span() -> Iterator[None]:
+                        with replace_span_attributes(captured_scope), _safe_use_span(replay_span):
+                            yield
+
+                    def end_replay_span_once() -> None:
+                        nonlocal replay_span_ended
+                        if replay_span_ended:
+                            return
+                        replay_span_ended = True
+                        try:
+                            with replace_span_attributes(captured_scope):
+                                replay_span.end()
+                        except Exception:
+                            logger.opt(exception=True).warning(
+                                "Provider replay telemetry span failed to end: span={}", span_name
+                            )
+
+                    def commit_replay_failure(
+                        exc: BaseException,
+                        *,
+                        status: str = "error",
+                        mark_span_error: bool = True,
+                        record_exception: bool = True,
+                    ) -> None:
+                        with activate_replay_span():
+                            description = public_exception_summary(exc, max_chars=1000)
+                            if record_exception:
+                                replay_span.record_exception_once(exc)
+                            if mark_span_error:
+                                replay_span.set_error_status_once(description)
+                            self._emit_failure_telemetry(
+                                provider_name,
+                                sanitized_model,
+                                replay_started,
+                                exc,
+                                status=status,
+                                record_duration=True,
+                                scope_attrs=captured_scope,
+                                identity_attrs=provider_identity_attrs,
+                            )
+                        end_replay_span_once()
+
+                    with activate_replay_span():
+                        _safe_log_event(
+                            Events.API_REQUEST_STARTED,
+                            {
+                                "provider": provider_name,
+                                "model": sanitized_model,
+                                "message_count": len(messages),
+                                "replay_attempt": _replay_attempt + 1,
+                                **provider_identity_attrs,
+                            },
+                        )
+                    replay_first_token_received = False
+                    try:
+                        replay_iter = provider.stream(messages, system, tools, max_tokens)
+                        async for replay_event in replay_iter:
+                            if isinstance(replay_event, MessageStartEvent):
+                                replay_message_ids.append(replay_event.message_id)
+                                replay_current_message = replay_event.message_id
+                                replay_tool_ids.setdefault(replay_event.message_id, [])
+                                replay_span.set_attribute(GenAiAttr.RESPONSE_ID, replay_event.message_id)
+                            elif (
+                                isinstance(replay_event, (ToolUseStartEvent, ToolUseEndEvent))
+                                and replay_current_message is not None
+                            ):
+                                ids = replay_tool_ids.setdefault(replay_current_message, [])
+                                if replay_event.tool_use_id not in ids:
+                                    ids.append(replay_event.tool_use_id)
+                            elif (
+                                isinstance(replay_event, (TextDeltaEvent, ThinkingDeltaEvent))
+                                and replay_event.text
+                                and not replay_first_token_received
+                            ):
+                                replay_first_token_received = True
+                                ttft_ns = int((time.monotonic() - replay_started) * 1_000_000_000)
+                                replay_span.set_attribute(GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN, ttft_ns)
+                                with activate_replay_span():
+                                    _safe_log_event(
+                                        Events.API_RESPONSE_FIRST_TOKEN,
+                                        {
+                                            "provider": provider_name,
+                                            "model": sanitized_model,
+                                            GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN: ttft_ns,
+                                            "first_token_source": replay_event.type,
+                                            "replay_attempt": _replay_attempt + 1,
+                                            **provider_identity_attrs,
+                                            **captured_scope,
+                                        },
+                                    )
+                            if isinstance(replay_event, MessageEndEvent):
+                                replay_event.usage.provider = provider_name
+                                replay_event.usage.model = sanitized_model
+                                terminal_event = replace(
+                                    replay_event,
+                                    usage_attribution=self._usage_attribution(
+                                        lease,
+                                        provider=provider,
+                                        actual_model=model,
+                                        telemetry_provider_name=provider_name,
+                                    ),
+                                )
+                                with activate_replay_span():
+                                    self._set_llm_response_span_attrs(replay_span, terminal_event, model)
+                                    self._emit_success_telemetry(
+                                        provider_name,
+                                        sanitized_model,
+                                        replay_started,
+                                        terminal_event.usage,
+                                        identity_attrs=provider_identity_attrs,
+                                    )
+                                end_replay_span_once()
+                                yield terminal_event
+                                return
+                            yield replay_event
+                        raise UnsafeStreamProtocolError(
+                            "Qwen replay ended before message completion."
+                        )
+                    except UnsafeStreamProtocolError as exc:
+                        last_unsafe_error = exc
+                        commit_replay_failure(exc)
+                    except asyncio.CancelledError as exc:
+                        commit_replay_failure(
+                            exc,
+                            status="cancelled",
+                            mark_span_error=False,
+                            record_exception=False,
+                        )
+                        raise
+                    except GeneratorExit as exc:
+                        commit_replay_failure(
+                            exc,
+                            status="cancelled",
+                            mark_span_error=False,
+                            record_exception=False,
+                        )
+                        raise
+                    except Exception as exc:
+                        commit_replay_failure(exc)
+                        for msg_id in replay_message_ids:
+                            yield TombstoneEvent(
+                                message_id=msg_id,
+                                affected_tool_use_ids=replay_tool_ids.get(msg_id, []),
+                            )
+                        yield _error_event_from_exception(exc)
+                        return
+                    except BaseException as exc:
+                        commit_replay_failure(exc)
+                        raise
+                    finally:
+                        if replay_iter is not None:
+                            try:
+                                await replay_iter.aclose()
+                            except Exception:
+                                logger.opt(exception=True).warning("Qwen replay stream close failed")
+                        end_replay_span_once()
+                    for msg_id in replay_message_ids:
+                        yield TombstoneEvent(
+                            message_id=msg_id,
+                            affected_tool_use_ids=replay_tool_ids.get(msg_id, []),
+                        )
+                yield _error_event_from_exception(last_unsafe_error)
+                return
             try:
                 with replace_span_attributes(captured_scope), _safe_attach_parent_context(captured_parent):
                     completion = await self._complete_with_retry_result(
@@ -1444,6 +1845,8 @@ class ProviderManager:
                         system,
                         tools,
                         max_tokens,
+                        provider_override=provider,
+                        model_override=model,
                         telemetry_messages=telemetry_messages,
                         refusal_detected=outcome.refusal_detected,
                     )
@@ -1453,6 +1856,16 @@ class ProviderManager:
             response = completion.response
             response.usage.provider = completion.provider_name
             response.usage.model = sanitize_model_name(completion.model)
+            completion_provider = getattr(completion, "provider", provider)
+            completion_model = getattr(completion, "model", model)
+            completion_provider_name = getattr(completion, "provider_name", provider_name)
+            attribution = self._usage_attribution(
+                lease,
+                provider=completion_provider,
+                actual_model=completion_model,
+                telemetry_provider_name=completion_provider_name,
+            )
+            response = replace(response, usage_attribution=attribution)
             yield MessageStartEvent(message_id=response.message_id)
             if response.thinking_blocks:
                 for block_index, block in enumerate(response.thinking_blocks):
@@ -1484,7 +1897,11 @@ class ProviderManager:
                     provider_metadata=provider_metadata,
                     input_error=tu.get("input_error"),
                 )
-            yield MessageEndEvent(stop_reason=response.stop_reason, usage=response.usage)
+            yield MessageEndEvent(
+                stop_reason=response.stop_reason,
+                usage=response.usage,
+                usage_attribution=attribution,
+            )
 
     @staticmethod
     def _set_llm_response_span_attrs(span, end_event: MessageEndEvent, model: str) -> None:
@@ -1522,6 +1939,7 @@ class ProviderManager:
         usage: Usage,
         *,
         status: str = "ok",
+        identity_attrs: dict[str, str | bool] | None = None,
     ) -> None:
         duration_ms = int((time.monotonic() - started) * 1000)
         scope_attrs = _safe_span_scope_attributes()
@@ -1547,10 +1965,15 @@ class ProviderManager:
                 "status": status,
                 "duration_ms": duration_ms,
                 **usage_attrs,
+                **(identity_attrs or {}),
                 **scope_attrs,
             },
         )
-        request_metric_attrs = {"provider": provider_name, "model": model}
+        request_metric_attrs = {
+            "provider": provider_name,
+            "model": model,
+            **(identity_attrs or {}),
+        }
         _safe_add_metric(
             Metrics.API_REQUEST_COUNT,
             1,
@@ -1589,6 +2012,7 @@ class ProviderManager:
         status: str = "error",
         record_duration: bool = False,
         scope_attrs: dict[str, str | int] | None = None,
+        identity_attrs: dict[str, str | bool] | None = None,
     ) -> None:
         duration_ms = int((time.monotonic() - started) * 1000)
         summary = public_exception_summary(exc, max_chars=1000)
@@ -1601,13 +2025,18 @@ class ProviderManager:
             "error_message": sanitize_error_message(failure.summary),
             "error_id": failure.error_id,
             "status": status,
+            **(identity_attrs or {}),
             **(scope_attrs or {}),
         }
         _safe_log_event(
             Events.API_REQUEST_FAILED,
             event_attrs,
         )
-        request_metric_attrs = {"provider": provider_name, "model": model}
+        request_metric_attrs = {
+            "provider": provider_name,
+            "model": model,
+            **(identity_attrs or {}),
+        }
         _safe_add_metric(
             Metrics.API_REQUEST_COUNT,
             1,
@@ -1624,15 +2053,40 @@ class ProviderManager:
         max_tokens: int = 8192,
         cache_policy: str = "default",
         telemetry_messages: list[Any] | None = None,
+        *,
+        lease: ProviderRequestLease | None = None,
     ) -> NonStreamingResponse:
-        return await self._complete_with_retry(
-            messages,
-            system,
-            tools,
-            max_tokens,
-            cache_policy=cache_policy,
-            telemetry_messages=telemetry_messages,
-        )
+        implicit_lease = lease is None
+        try:
+            active_lease = lease or self.begin_request(system, tools)
+            self._consume_request_lease(active_lease)
+            if system != active_lease.system_prompt:
+                if implicit_lease:
+                    system = active_lease.system_prompt
+                else:
+                    raise ProviderRequestLeaseError(
+                        "Explicit request lease system prompt does not match the completion prompt."
+                    )
+            result = await self._complete_with_retry_result(
+                messages,
+                system,
+                tools,
+                max_tokens,
+                provider_override=active_lease.provider,
+                model_override=active_lease.context_window_model,
+                cache_policy=cache_policy,
+                telemetry_messages=telemetry_messages,
+            )
+            attribution = self._usage_attribution(
+                active_lease,
+                provider=result.provider,
+                actual_model=result.model,
+                telemetry_provider_name=result.provider_name,
+            )
+            return replace(result.response, usage_attribution=attribution)
+        finally:
+            if implicit_lease and "active_lease" in locals() and active_lease._lease_token.state != "released":
+                self.release_request(active_lease)
 
     async def _complete_with_retry(
         self,
@@ -1679,6 +2133,7 @@ class ProviderManager:
         visited = set(fallback_visited or ())
         visited.add(model)
         provider_name = _telemetry_provider_name(provider)
+        provider_identity_attrs = _provider_telemetry_attrs(provider)
         sanitized_model = sanitize_model_name(model)
 
         async def _on_retry(attempt, exc, delay):
@@ -1689,6 +2144,7 @@ class ProviderManager:
                     "model": sanitized_model,
                     "attempt": attempt,
                     "error_type": type(exc).__name__,
+                    **provider_identity_attrs,
                 },
             )
 
@@ -1706,6 +2162,7 @@ class ProviderManager:
                 GenAiAttr.SESSION_ID: session_id,
                 GenAiAttr.CONVERSATION_ID: session_id,
                 GenAiAttr.OUTPUT_TYPE: "text",
+                **provider_identity_attrs,
                 **_safe_span_scope_attributes(),
             }
             _capture_request_content(span_attrs, messages, system, tools, telemetry_messages)
@@ -1721,6 +2178,7 @@ class ProviderManager:
                                 "provider": provider_name,
                                 "model": sanitized_model,
                                 "message_count": len(messages),
+                                **provider_identity_attrs,
                             },
                         )
                         request_started = time.monotonic()
@@ -1733,10 +2191,17 @@ class ProviderManager:
                             exc,
                             status="cancelled",
                             record_duration=True,
+                            identity_attrs=provider_identity_attrs,
                         )
                         raise
                     except Exception as exc:
-                        self._emit_failure_telemetry(provider_name, sanitized_model, request_started, exc)
+                        self._emit_failure_telemetry(
+                            provider_name,
+                            sanitized_model,
+                            request_started,
+                            exc,
+                            identity_attrs=provider_identity_attrs,
+                        )
                         raise
                     except BaseException as exc:
                         self._emit_failure_telemetry(
@@ -1747,6 +2212,7 @@ class ProviderManager:
                             status="error",
                             record_duration=True,
                             scope_attrs=_safe_span_scope_attributes(),
+                            identity_attrs=provider_identity_attrs,
                         )
                         raise
 
@@ -1759,6 +2225,7 @@ class ProviderManager:
                         request_started,
                         response.usage,
                         status=response_status,
+                        identity_attrs=provider_identity_attrs,
                     )
 
                 if response.stop_reason == "refusal":
@@ -1812,6 +2279,7 @@ class ProviderManager:
                         "from_model": sanitized_model,
                         "to_model": sanitize_model_name(fallback),
                         "reason": fallback_reason,
+                        **provider_identity_attrs,
                     },
                 )
                 try:
@@ -1828,9 +2296,15 @@ class ProviderManager:
                         self._credentials,
                         **fallback_kwargs,
                     )
+                    fallback_prompt_preparer = getattr(type(fallback_provider), "prepare_system_prompt", None)
+                    fallback_system = (
+                        fallback_prompt_preparer(fallback_provider, system, tools)
+                        if callable(fallback_prompt_preparer)
+                        else system
+                    )
                     result = await self._complete_with_retry_result(
                         messages,
-                        system,
+                        fallback_system,
                         tools,
                         max_tokens,
                         provider_override=fallback_provider,

--- a/src/iac_code/providers/model_family.py
+++ b/src/iac_code/providers/model_family.py
@@ -1,0 +1,18 @@
+"""Model-family predicates used by provider selection and adapters."""
+
+from __future__ import annotations
+
+
+def normalized_model_name(model: str) -> str:
+    """Return the provider-independent leaf model identifier."""
+    return model.strip().lower().rsplit("/", 1)[-1]
+
+
+def is_qwen_model(model: str) -> bool:
+    """Whether *model* uses the Qwen wire behaviour implemented here.
+
+    ``qwq`` intentionally remains outside this family until an observed wire
+    fixture proves that it needs the Qwen-specific parser and prompt adapter.
+    """
+    normalized = normalized_model_name(model)
+    return normalized.startswith("qwen") or normalized == "coder-model"

--- a/src/iac_code/providers/openai_provider.py
+++ b/src/iac_code/providers/openai_provider.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 import uuid
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from typing import Any
 
 from openai import AsyncOpenAI
@@ -20,16 +22,13 @@ from iac_code.providers.base import (
 )
 from iac_code.providers.request_logging import log_provider_request_policy
 from iac_code.providers.request_policy import bool_or_none, positive_int_or_none
+from iac_code.providers.streaming import OpenAIStreamResponseAdapter
 from iac_code.providers.thinking import ThinkingFamily, get_thinking_spec, normalize_effort
 from iac_code.types.stream_events import (
     MessageEndEvent,
     MessageStartEvent,
     StreamEvent,
-    TextDeltaEvent,
-    ThinkingDeltaEvent,
-    ToolInputDeltaEvent,
     ToolUseEndEvent,
-    ToolUseStartEvent,
     Usage,
 )
 from iac_code.utils.tool_input_parser import parse_tool_input_events
@@ -46,6 +45,15 @@ def _plain_mapping(value: Any) -> dict[str, Any]:
             if isinstance(dumped, dict):
                 return dumped
     return {}
+
+
+@dataclass
+class ChatRequestContext:
+    streaming: bool
+    cache_policy: str = "default"
+    mandatory_thinking_retry: bool = False
+    retry_attempted: bool = False
+    mandatory_thinking: bool | None = None
 
 
 class OpenAIProvider(Provider):
@@ -181,6 +189,19 @@ class OpenAIProvider(Provider):
     def get_model_name(self) -> str:
         return self._model
 
+    def prepare_system_prompt(self, system: str, tools: list[ToolDefinition] | None) -> str:
+        """Prepare the request-local system prompt without mutating provider state."""
+        return system
+
+    def _extract_reasoning_text(self, message_or_delta: Any) -> str:
+        reasoning = getattr(message_or_delta, "reasoning_content", None)
+        return reasoning if isinstance(reasoning, str) else ""
+
+    def _create_stream_response_adapter(
+        self, tools: list[ToolDefinition] | None
+    ) -> OpenAIStreamResponseAdapter:
+        return OpenAIStreamResponseAdapter(self, tools)
+
     # -- Message conversion ----------------------------------------------------
 
     def _convert_messages(self, messages: list[Message]) -> list[dict[str, Any]]:
@@ -290,6 +311,113 @@ class OpenAIProvider(Provider):
             for t in tools
         ]
 
+    def _prepare_tool_schema_for_wire(self, schema: dict[str, Any]) -> dict[str, Any]:
+        return schema
+
+    def _build_api_tools(
+        self,
+        tools: list[ToolDefinition],
+        *,
+        streaming: bool,
+        cache_policy: str = "default",
+    ) -> list[dict[str, Any]]:
+        prepared = [
+            ToolDefinition(
+                name=tool.name,
+                description=tool.description,
+                input_schema=self._prepare_tool_schema_for_wire(tool.input_schema),
+            )
+            for tool in tools
+        ]
+        return self._convert_tools(prepared)
+
+    def _request_headers(self, *, cache_policy: str = "default") -> dict[str, str]:
+        return {}
+
+    def _thinking_kwargs_for_context(self, context: ChatRequestContext) -> dict[str, Any]:
+        return self._effort_request_kwargs()
+
+    def _create_chat_request_context(
+        self,
+        *,
+        streaming: bool,
+        cache_policy: str = "default",
+    ) -> ChatRequestContext:
+        return ChatRequestContext(streaming=streaming, cache_policy=cache_policy)
+
+    def _build_chat_completion_kwargs(
+        self,
+        messages: list[Message],
+        system: str,
+        tools: list[ToolDefinition] | None,
+        max_tokens: int,
+        context: ChatRequestContext,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": self._build_api_messages(messages, system, cache_policy=context.cache_policy),
+        }
+        if context.streaming:
+            kwargs["stream"] = True
+        kwargs.update(self._token_limit_kwargs(max_tokens))
+        if context.streaming and self.supports_stream_options:
+            kwargs["stream_options"] = {"include_usage": True}
+        if tools:
+            kwargs["tools"] = self._build_api_tools(
+                tools,
+                streaming=context.streaming,
+                cache_policy=context.cache_policy,
+            )
+        headers = self._request_headers(cache_policy=context.cache_policy)
+        if headers:
+            kwargs["extra_headers"] = headers
+        kwargs.update(self._thinking_kwargs_for_context(context))
+        kwargs.update(self._extra_request_kwargs)
+        return kwargs
+
+    async def _create_chat_completion(
+        self,
+        build_kwargs: Any,
+        context: ChatRequestContext,
+        operation_name: str,
+    ) -> Any:
+        kwargs = build_kwargs()
+        log_provider_request_policy(self._PROVIDER_KEY, self._model, operation_name, kwargs)
+        request_started = time.monotonic()
+        try:
+            return await self._client.chat.completions.create(**kwargs)
+        except Exception as error:
+            if context.retry_attempted or not self._retry_request_context_after_error(error, kwargs, context):
+                raise
+            context.retry_attempted = True
+            self._record_request_compatibility_retry(
+                error,
+                context,
+                operation_name=operation_name,
+                duration_ms=int((time.monotonic() - request_started) * 1000),
+            )
+            retry_kwargs = build_kwargs()
+            log_provider_request_policy(self._PROVIDER_KEY, self._model, operation_name, retry_kwargs)
+            return await self._client.chat.completions.create(**retry_kwargs)
+
+    def _record_request_compatibility_retry(
+        self,
+        error: Exception,
+        context: ChatRequestContext,
+        *,
+        operation_name: str,
+        duration_ms: int,
+    ) -> None:
+        """Let provider adapters observe a consumed compatibility attempt."""
+
+    def _retry_request_context_after_error(
+        self,
+        error: Exception,
+        sent_kwargs: dict[str, Any],
+        context: ChatRequestContext,
+    ) -> bool:
+        return False
+
     # -- API message assembly ---------------------------------------------------
 
     def _build_api_messages(
@@ -318,40 +446,21 @@ class OpenAIProvider(Provider):
         tools: list[ToolDefinition] | None = None,
         max_tokens: int = 8192,
     ) -> AsyncGenerator[StreamEvent, None]:
-        api_messages = self._build_api_messages(messages, system)
+        context = self._create_chat_request_context(streaming=True)
 
-        kwargs: dict[str, Any] = {
-            "model": self._model,
-            "messages": api_messages,
-            "stream": True,
-        }
-        kwargs.update(self._token_limit_kwargs(max_tokens))
-        if self.supports_stream_options:
-            kwargs["stream_options"] = {"include_usage": True}
-        if tools:
-            kwargs["tools"] = self._convert_tools(tools)
-        for k, v in self._effort_request_kwargs().items():
-            kwargs[k] = v
-        for k, v in self._extra_request_kwargs.items():
-            kwargs[k] = v
+        def build_kwargs() -> dict[str, Any]:
+            return self._build_chat_completion_kwargs(messages, system, tools, max_tokens, context)
 
         message_id = f"msg_{uuid.uuid4().hex[:24]}"
         yield MessageStartEvent(message_id=message_id)
 
-        # Accumulators for tool calls (index-based)
-        tool_calls_acc: dict[int, dict[str, Any]] = {}
+        adapter = self._create_stream_response_adapter(tools)
         stop_reason = "end_turn"
+        raw_finish_reason: str | None = None
         usage = Usage()
         has_content = False
-        message_provider_metadata: dict[str, Any] = {}
 
-        log_provider_request_policy(
-            self._PROVIDER_KEY,
-            self._model,
-            "chat.completions.stream",
-            kwargs,
-        )
-        response = await self._client.chat.completions.create(**kwargs)
+        response = await self._create_chat_completion(build_kwargs, context, "chat.completions.stream")
         async for chunk in response:
             has_content = True
             # Usage info (final chunk)
@@ -377,6 +486,7 @@ class OpenAIProvider(Provider):
 
             # Finish reason
             if choice.finish_reason:
+                raw_finish_reason = choice.finish_reason
                 if choice.finish_reason == "tool_calls":
                     stop_reason = "tool_use"
                 elif choice.finish_reason == "length":
@@ -388,87 +498,8 @@ class OpenAIProvider(Provider):
             if delta is None:
                 continue
 
-            provider_metadata = self._message_provider_metadata(delta)
-            if provider_metadata and provider_metadata != message_provider_metadata:
-                message_provider_metadata = provider_metadata
-                yield ThinkingDeltaEvent(text="", provider_metadata=provider_metadata)
-
-            # Reasoning content (DeepSeek V4, Qwen thinking mode via OpenAI-compat)
-            reasoning = getattr(delta, "reasoning_content", None)
-            if reasoning:
-                yield ThinkingDeltaEvent(text=reasoning)
-
-            # Text content
-            if delta.content:
-                yield TextDeltaEvent(text=delta.content)
-
-            # Tool calls (streamed with index-based accumulation)
-            if delta.tool_calls:
-                for tc_delta in delta.tool_calls:
-                    idx = tc_delta.index
-                    if idx not in tool_calls_acc:
-                        tool_calls_acc[idx] = {
-                            "id": tc_delta.id or "",
-                            "name": "",
-                            "arguments": "",
-                            "argument_deltas": [],
-                            "arguments_waited_for_id": False,
-                            "ready_to_start": False,
-                            "started": False,
-                            "provider_metadata": {},
-                        }
-                    current = tool_calls_acc[idx]
-                    if tc_delta.id and not current["id"]:
-                        current["id"] = tc_delta.id
-                    provider_metadata = self._tool_provider_metadata(tc_delta)
-                    if provider_metadata:
-                        current["provider_metadata"].update(provider_metadata)
-                    has_name_delta = bool(tc_delta.function and tc_delta.function.name)
-                    if has_name_delta:
-                        current["name"] += tc_delta.function.name
-                    if tc_delta.function and tc_delta.function.arguments:
-                        if not current["id"]:
-                            current["arguments_waited_for_id"] = True
-                        current["arguments"] += tc_delta.function.arguments
-                        current["argument_deltas"].append(tc_delta.function.arguments)
-                    if (
-                        current["id"]
-                        and current["name"]
-                        and current["arguments"]
-                        and not current["started"]
-                        and not has_name_delta
-                    ):
-                        current["ready_to_start"] = True
-
-                # Tool arguments may arrive out of order. Start calls in API index
-                # order so downstream execution remains deterministic.
-                for start_idx in sorted(tool_calls_acc):
-                    pending_start = tool_calls_acc[start_idx]
-                    if pending_start["started"]:
-                        continue
-                    if not pending_start["ready_to_start"]:
-                        break
-                    pending_start["started"] = True
-                    yield ToolUseStartEvent(
-                        tool_use_id=pending_start["id"],
-                        name=pending_start["name"],
-                        provider_metadata=pending_start["provider_metadata"] or None,
-                    )
-
-                for flush_idx in sorted(tool_calls_acc):
-                    pending_flush = tool_calls_acc[flush_idx]
-                    if not pending_flush["started"]:
-                        continue
-                    pending_argument_deltas = pending_flush["argument_deltas"]
-                    pending_flush["argument_deltas"] = []
-                    if pending_flush["arguments_waited_for_id"]:
-                        pending_argument_deltas = ["".join(pending_argument_deltas)]
-                        pending_flush["arguments_waited_for_id"] = False
-                    for pending_arguments in pending_argument_deltas:
-                        yield ToolInputDeltaEvent(
-                            tool_use_id=pending_flush["id"],
-                            partial_json=pending_arguments,
-                        )
+            for event in adapter.feed(delta, raw_finish_reason):
+                yield event
 
         if not has_content:
             base_url = str(self._base_url or self._client.base_url).rstrip("/")
@@ -479,30 +510,10 @@ class OpenAIProvider(Provider):
                 ).format(base_url=base_url)
             )
 
-        # Emit ToolUseEndEvent for each accumulated tool call
-        for idx in sorted(tool_calls_acc):
-            tc = tool_calls_acc[idx]
-            if not tc["id"]:
-                tc["id"] = f"call_{uuid.uuid4().hex[:24]}"
-            if not tc["started"]:
-                tc["started"] = True
-                yield ToolUseStartEvent(
-                    tool_use_id=tc["id"],
-                    name=tc["name"],
-                    provider_metadata=tc["provider_metadata"] or None,
-                )
-            pending_argument_deltas = tc["argument_deltas"]
-            if tc["arguments_waited_for_id"]:
-                pending_argument_deltas = ["".join(pending_argument_deltas)]
-            for pending_arguments in pending_argument_deltas:
-                yield ToolInputDeltaEvent(
-                    tool_use_id=tc["id"],
-                    partial_json=pending_arguments,
-                )
-            for ev in parse_tool_input_events(tc["id"], tc["name"], tc["arguments"]):
-                if isinstance(ev, ToolUseEndEvent) and ev.tool_use_id == tc["id"]:
-                    ev.provider_metadata = tc["provider_metadata"] or None
-                yield ev
+        for event in adapter.finalize(raw_finish_reason):
+            yield event
+        if adapter.terminal_stop_reason_override is not None:
+            stop_reason = adapter.terminal_stop_reason_override
 
         yield MessageEndEvent(stop_reason=stop_reason, usage=usage)
 
@@ -516,27 +527,12 @@ class OpenAIProvider(Provider):
         max_tokens: int = 8192,
         cache_policy: str = "default",
     ) -> NonStreamingResponse:
-        api_messages = self._build_api_messages(messages, system, cache_policy=cache_policy)
+        context = self._create_chat_request_context(streaming=False, cache_policy=cache_policy)
 
-        kwargs: dict[str, Any] = {
-            "model": self._model,
-            "messages": api_messages,
-        }
-        kwargs.update(self._token_limit_kwargs(max_tokens))
-        if tools:
-            kwargs["tools"] = self._convert_tools(tools)
-        for k, v in self._effort_request_kwargs().items():
-            kwargs[k] = v
-        for k, v in self._extra_request_kwargs.items():
-            kwargs[k] = v
+        def build_kwargs() -> dict[str, Any]:
+            return self._build_chat_completion_kwargs(messages, system, tools, max_tokens, context)
 
-        log_provider_request_policy(
-            self._PROVIDER_KEY,
-            self._model,
-            "chat.completions.create",
-            kwargs,
-        )
-        response = await self._client.chat.completions.create(**kwargs)
+        response = await self._create_chat_completion(build_kwargs, context, "chat.completions.create")
         if not hasattr(response, "choices"):
             base_url = str(self._base_url or self._client.base_url).rstrip("/")
             raise RuntimeError(
@@ -560,7 +556,7 @@ class OpenAIProvider(Provider):
         message = choice.message
 
         text = message.content or ""
-        thinking = getattr(message, "reasoning_content", None) or ""
+        thinking = self._extract_reasoning_text(message)
         message_provider_metadata = self._message_provider_metadata(message)
         thinking_blocks: list[dict[str, Any]] = []
         if message_provider_metadata:
@@ -571,22 +567,7 @@ class OpenAIProvider(Provider):
                     "provider_metadata": message_provider_metadata,
                 }
             )
-        tool_uses: list[dict[str, Any]] = []
-        if message.tool_calls:
-            for tc in message.tool_calls:
-                raw_args = tc.function.arguments or ""
-                provider_metadata = self._tool_provider_metadata(tc)
-                for ev in parse_tool_input_events(tc.id, tc.function.name, raw_args):
-                    if isinstance(ev, ToolUseEndEvent):
-                        tool_use = {"id": ev.tool_use_id, "name": tc.function.name, "input": ev.input}
-                        if ev.input_error:
-                            # Non-streaming path: the agent loop still has to see the parse
-                            # failure, otherwise the tool runs on {} and answers with a schema
-                            # error about arguments the model did send.
-                            tool_use["input_error"] = ev.input_error
-                        if ev.tool_use_id == tc.id and provider_metadata:
-                            tool_use["provider_metadata"] = provider_metadata
-                        tool_uses.append(tool_use)
+        tool_uses = self._parse_non_streaming_tool_calls(message.tool_calls)
 
         stop_reason = "end_turn"
         if choice.finish_reason == "tool_calls":
@@ -609,7 +590,7 @@ class OpenAIProvider(Provider):
             reported=response.usage is not None,
         )
 
-        return NonStreamingResponse(
+        unified_response = NonStreamingResponse(
             message_id=response.id,
             text=text,
             tool_uses=tool_uses,
@@ -618,6 +599,32 @@ class OpenAIProvider(Provider):
             thinking=thinking,
             thinking_blocks=thinking_blocks,
         )
+        return self._postprocess_non_streaming_response(message, unified_response, tools)
+
+    def _parse_non_streaming_tool_calls(self, tool_calls: Any) -> list[dict[str, Any]]:
+        tool_uses: list[dict[str, Any]] = []
+        for tc in tool_calls or []:
+            raw_args = tc.function.arguments or ""
+            provider_metadata = self._tool_provider_metadata(tc)
+            for event in parse_tool_input_events(tc.id, tc.function.name, raw_args):
+                if isinstance(event, ToolUseEndEvent):
+                    tool_use = {"id": event.tool_use_id, "name": tc.function.name, "input": event.input}
+                    if event.input_error:
+                        # Preserve malformed-input diagnostics so the agent loop does not
+                        # execute an accidental empty object on the non-streaming path.
+                        tool_use["input_error"] = event.input_error
+                    if event.tool_use_id == tc.id and provider_metadata:
+                        tool_use["provider_metadata"] = provider_metadata
+                    tool_uses.append(tool_use)
+        return tool_uses
+
+    def _postprocess_non_streaming_response(
+        self,
+        raw_message: Any,
+        response: NonStreamingResponse,
+        tools: list[ToolDefinition] | None,
+    ) -> NonStreamingResponse:
+        return response
 
     def _message_provider_metadata(self, message: Any) -> dict[str, Any]:
         """Extract opaque metadata attached to an assistant message or delta."""

--- a/src/iac_code/providers/qwen_prompts.py
+++ b/src/iac_code/providers/qwen_prompts.py
@@ -1,0 +1,58 @@
+"""Small Qwen tool-use hints generated only from tools available this turn."""
+
+from __future__ import annotations
+
+import json
+
+from iac_code.agent.system_prompt import DYNAMIC_BOUNDARY
+from iac_code.providers.base import ToolDefinition
+from iac_code.providers.model_family import normalized_model_name
+
+_START = "<!-- iac-code:qwen-tools:start -->"
+_END = "<!-- iac-code:qwen-tools:end -->"
+_MAX_HINT_CHARS = 900
+
+
+def prepare_qwen_system_prompt(system: str, model: str, tools: list[ToolDefinition] | None) -> str:
+    if not tools or _START in system:
+        return system
+    names = [tool.name for tool in tools if tool.name]
+    if not names:
+        return system
+    example_tool = next(tool for tool in tools if tool.name)
+    example_name = example_tool.name
+    properties = example_tool.input_schema.get("properties")
+    parameter_name = next(iter(properties), None) if isinstance(properties, dict) else None
+    normalized = normalized_model_name(model)
+    if "coder" in normalized:
+        parameter = (
+            f"\n<parameter={parameter_name}>VALUE</parameter>" if isinstance(parameter_name, str) else ""
+        )
+        example = f"<tool_call><function={example_name}>{parameter}</function></tool_call>"
+    elif "-vl" in normalized or normalized.endswith("vl") or "qwen-vl" in normalized:
+        arguments = {parameter_name: "VALUE"} if isinstance(parameter_name, str) else {}
+        example = (
+            "<tool_call>"
+            + json.dumps({"name": example_name, "arguments": arguments}, ensure_ascii=False, separators=(",", ":"))
+            + "</tool_call>"
+        )
+    else:
+        example = json.dumps(
+            {
+                "name": example_name,
+                "arguments": {parameter_name: "VALUE"} if isinstance(parameter_name, str) else {},
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    hint = (
+        f"{_START}\nWhen a tool is needed, use the native function-calling channel and only supplied schemas. "
+        f"Model-style format illustration: {example}\n{_END}"
+    )
+    if len(hint) > _MAX_HINT_CHARS:
+        hint = f"{_START}\nUse only supplied native tools; for example, {example_name!r}.\n{_END}"
+    if DYNAMIC_BOUNDARY in system:
+        static, dynamic = system.split(DYNAMIC_BOUNDARY, 1)
+        return f"{static}{DYNAMIC_BOUNDARY}\n\n{hint}{dynamic}"
+    separator = "\n\n" if system else ""
+    return f"{system}{separator}{hint}"

--- a/src/iac_code/providers/qwen_provider.py
+++ b/src/iac_code/providers/qwen_provider.py
@@ -1,0 +1,424 @@
+"""Qwen model adapter for DashScope OpenAI-compatible endpoints."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from typing import Any
+
+from iac_code.providers.base import NonStreamingResponse, ToolDefinition
+from iac_code.providers.dashscope_endpoints import official_dashscope_wire_provider_key
+from iac_code.providers.dashscope_provider import _EXPLICIT_CACHE_MODEL_PREFIXES, DashScopeProvider
+from iac_code.providers.model_family import normalized_model_name
+from iac_code.providers.openai_provider import ChatRequestContext
+from iac_code.providers.qwen_prompts import prepare_qwen_system_prompt
+from iac_code.providers.qwen_tool_call_parser import parse_non_streaming_tool_calls, recover_xml_tool_calls
+from iac_code.providers.schema_compat import relax_qwen_tool_schema
+from iac_code.providers.streaming import QwenStreamResponseAdapter
+from iac_code.providers.thinking import ThinkingFamily, get_thinking_spec, normalize_effort
+from iac_code.providers.thinking_intent import ResolvedThinkingIntent
+from iac_code.services.telemetry import add_metric, log_event
+from iac_code.services.telemetry.names import Events, IacCodeAttr, Metrics
+from iac_code.services.telemetry.sanitize import sanitize_error_message, sanitize_model_name
+from iac_code.services.telemetry.scope import get_span_attributes
+from iac_code.utils.public_errors import public_error, public_exception_summary
+
+
+class QwenProvider(DashScopeProvider):
+    """DashScope transport with Qwen-only request and response adaptation."""
+
+    _ADAPTER_NAME = "qwen"
+
+    def __init__(self, *args: Any, thinking_intent: ResolvedThinkingIntent | None = None, **kwargs: Any) -> None:
+        self._thinking_intent = thinking_intent or ResolvedThinkingIntent()
+        self._learned_mandatory_thinking = False
+        super().__init__(*args, **kwargs)
+
+    def prepare_system_prompt(self, system: str, tools: list[ToolDefinition] | None) -> str:
+        return prepare_qwen_system_prompt(system, self._model, tools)
+
+    def _supports_explicit_cache(self) -> bool:
+        model = normalized_model_name(self._model)
+        model_supported = model.startswith(_EXPLICIT_CACHE_MODEL_PREFIXES)
+        return official_dashscope_wire_provider_key(str(self._base_url or "")) is not None and model_supported
+
+    def _create_stream_response_adapter(self, tools: list[ToolDefinition] | None) -> QwenStreamResponseAdapter:
+        return QwenStreamResponseAdapter(self, tools)
+
+    def _parse_non_streaming_tool_calls(self, tool_calls: Any) -> list[dict[str, Any]]:
+        return parse_non_streaming_tool_calls(tool_calls)
+
+    def _postprocess_non_streaming_response(
+        self,
+        raw_message: Any,
+        response: NonStreamingResponse,
+        tools: list[ToolDefinition] | None,
+    ) -> NonStreamingResponse:
+        if response.tool_uses:
+            return response
+        recovered = recover_xml_tool_calls(response.text, tools)
+        if recovered is None:
+            return response
+        return replace(
+            response,
+            text=recovered.remaining_text,
+            tool_uses=recovered.calls,
+            stop_reason="tool_use",
+        )
+
+    def _prepare_tool_schema_for_wire(self, schema: dict[str, Any]) -> dict[str, Any]:
+        return relax_qwen_tool_schema(schema)
+
+    def _request_headers(self, *, cache_policy: str = "default") -> dict[str, str]:
+        if cache_policy == "no_explicit_cache" or not self._supports_explicit_cache():
+            return {}
+        return {"X-DashScope-CacheControl": "enable"}
+
+    def _build_api_tools(
+        self,
+        tools: list[ToolDefinition],
+        *,
+        streaming: bool,
+        cache_policy: str = "default",
+    ) -> list[dict[str, Any]]:
+        api_tools = super()._build_api_tools(tools, streaming=streaming, cache_policy=cache_policy)
+        if streaming and cache_policy != "no_explicit_cache" and self._supports_explicit_cache() and api_tools:
+            api_tools[-1]["cache_control"] = {"type": "ephemeral"}
+        return api_tools
+
+    def _build_thinking_kwargs(self) -> dict[str, Any]:
+        return self._build_thinking_kwargs_with_mandatory(self._known_mandatory_thinking())
+
+    def _known_mandatory_thinking(self) -> bool:
+        normalized_model = normalized_model_name(self._model)
+        token_plan_mandatory = self._PROVIDER_KEY == "dashscope_token_plan" and (
+            normalized_model == "qwen3.8-max" or normalized_model.startswith("qwen3.8-max-preview")
+        )
+        return self._learned_mandatory_thinking or token_plan_mandatory
+
+    def _build_thinking_kwargs_with_mandatory(self, mandatory: bool) -> dict[str, Any]:
+        spec = get_thinking_spec(self._PROVIDER_KEY, self._model)
+        if spec.family is not ThinkingFamily.DASHSCOPE:
+            return {}
+        normalized_model = normalized_model_name(self._model)
+        is_qwen38 = normalized_model.startswith("qwen3.8-max")
+        if not is_qwen38:
+            return self._build_legacy_qwen_thinking_kwargs(spec, mandatory=mandatory)
+
+        effort = normalize_effort(self._effort)
+        if effort == "max":
+            effort = "xhigh"
+        allowed = {item.value for item in spec.allowed_efforts}
+        extra_body: dict[str, Any] = {}
+        if self._supports_preserve_thinking():
+            extra_body["preserve_thinking"] = True
+
+        dominant = self._thinking_intent.dominant_concrete_field()
+        resolved_enabled = self._thinking_intent.enabled.value
+        disabled = (
+            not resolved_enabled
+            if resolved_enabled is not None
+            else self._thinking_disabled()
+            or effort in {"none", "off", "disable", "disabled", "false", "0"}
+        )
+        effort_is_disable = effort in {"none", "off", "disable", "disabled", "false", "0"}
+        concrete_priority = (
+            self._thinking_intent.effort.priority
+            if dominant == "effort"
+            else self._thinking_intent.budget.priority
+        )
+        if (
+            dominant in {"effort", "budget"}
+            and not effort_is_disable
+            and concrete_priority > self._thinking_intent.enabled.priority
+        ):
+            disabled = False
+        elif dominant == "disabled":
+            disabled = True
+        if disabled and not mandatory and spec.supports_disable:
+            kwargs: dict[str, Any] = {"reasoning_effort": "none"}
+            if extra_body:
+                kwargs["extra_body"] = extra_body
+            return kwargs
+
+        selected_budget = self._selected_thinking_budget(dominant, effort)
+        if selected_budget is not None:
+            budget_body = dict(extra_body)
+            budget_body["enable_thinking"] = True
+            budget_body["thinking_budget"] = selected_budget
+            return {"extra_body": budget_body}
+
+        if effort in allowed:
+            resolved_effort = effort
+        elif effort not in {None, "auto"} and spec.default_effort is not None:
+            resolved_effort = spec.default_effort.value
+        elif (
+            resolved_enabled is True
+            or self._thinking_forced()
+            or (not disabled and dominant is None and spec.thinking_enabled_by_default)
+        ) and spec.default_effort is not None:
+            resolved_effort = spec.default_effort.value
+        else:
+            resolved_effort = None
+        kwargs = {}
+        if resolved_effort is not None:
+            kwargs["reasoning_effort"] = resolved_effort
+        if extra_body:
+            kwargs["extra_body"] = extra_body
+        if mandatory and resolved_effort is None:
+            mandatory_body = dict(kwargs.get("extra_body") or {})
+            mandatory_body["enable_thinking"] = True
+            kwargs["extra_body"] = mandatory_body
+        return kwargs
+
+    def _build_legacy_qwen_thinking_kwargs(self, spec: Any, *, mandatory: bool) -> dict[str, Any]:
+        effort = normalize_effort(self._effort)
+        effort_is_disable = effort in {"none", "off", "disable", "disabled", "false", "0"}
+        resolved_enabled = self._thinking_intent.enabled.value
+        disabled = (
+            not resolved_enabled
+            if resolved_enabled is not None
+            else self._thinking_disabled() or effort_is_disable
+        )
+        dominant = self._thinking_intent.dominant_concrete_field()
+        concrete_priority = (
+            self._thinking_intent.effort.priority
+            if dominant == "effort"
+            else self._thinking_intent.budget.priority
+        )
+        if (
+            dominant in {"effort", "budget"}
+            and not effort_is_disable
+            and concrete_priority > self._thinking_intent.enabled.priority
+        ):
+            disabled = False
+        elif dominant == "disabled":
+            disabled = True
+        if disabled and not mandatory:
+            if not spec.supports_disable:
+                return self._preserve_thinking_kwargs()
+            return {"extra_body": {"enable_thinking": False}}
+        extra_body: dict[str, Any] = {"enable_thinking": True}
+        if self._supports_preserve_thinking():
+            extra_body["preserve_thinking"] = True
+        thinking_budget = self._selected_thinking_budget(dominant, effort)
+        if thinking_budget is not None:
+            extra_body["thinking_budget"] = thinking_budget
+        return {"extra_body": extra_body}
+
+    def _selected_thinking_budget(self, dominant: str | None, effort: str | None) -> int | None:
+        budget = self._thinking_intent.budget.value
+        if budget is None:
+            budget = self._thinking_budget
+        if budget is None:
+            return None
+        if dominant == "budget":
+            return budget
+        if dominant is None and effort in {None, "auto"}:
+            return budget
+        return None
+
+    def _thinking_kwargs_for_context(self, context: ChatRequestContext) -> dict[str, Any]:
+        if context.mandatory_thinking is None:
+            context.mandatory_thinking = self._known_mandatory_thinking()
+        kwargs = self._build_thinking_kwargs_with_mandatory(context.mandatory_thinking)
+        if not context.mandatory_thinking_retry:
+            return kwargs
+        retry_kwargs = dict(kwargs)
+        if retry_kwargs.get("reasoning_effort") == "none":
+            retry_kwargs.pop("reasoning_effort", None)
+        extra_body = dict(retry_kwargs.get("extra_body") or {})
+        if extra_body.get("enable_thinking") is False:
+            extra_body.pop("enable_thinking", None)
+        has_positive_shape = bool(retry_kwargs.get("reasoning_effort")) or extra_body.get("enable_thinking") is True
+        if not has_positive_shape:
+            extra_body["enable_thinking"] = True
+        if extra_body:
+            retry_kwargs["extra_body"] = extra_body
+        else:
+            retry_kwargs.pop("extra_body", None)
+        return retry_kwargs
+
+    def _create_chat_request_context(
+        self,
+        *,
+        streaming: bool,
+        cache_policy: str = "default",
+    ) -> ChatRequestContext:
+        context = super()._create_chat_request_context(streaming=streaming, cache_policy=cache_policy)
+        context.mandatory_thinking = self._known_mandatory_thinking()
+        return context
+
+    def _build_chat_completion_kwargs(
+        self,
+        messages,
+        system,
+        tools,
+        max_tokens,
+        context: ChatRequestContext,
+    ) -> dict[str, Any]:
+        kwargs = super()._build_chat_completion_kwargs(messages, system, tools, max_tokens, context)
+        if kwargs.get("tool_choice") == "required" and _request_enables_thinking(kwargs):
+            kwargs.pop("tool_choice", None)
+        if not context.streaming:
+            _remove_non_system_cache_markers(kwargs.get("messages"))
+        return kwargs
+
+    def _retry_request_context_after_error(
+        self,
+        error: Exception,
+        sent_kwargs: dict[str, Any],
+        context: ChatRequestContext,
+    ) -> bool:
+        if not _request_explicitly_disabled_thinking(sent_kwargs) or not _is_required_thinking_error(error):
+            return False
+        context.mandatory_thinking_retry = True
+        context.mandatory_thinking = True
+        self._learned_mandatory_thinking = True
+        return True
+
+    def _record_request_compatibility_retry(
+        self,
+        error: Exception,
+        context: ChatRequestContext,
+        *,
+        operation_name: str,
+        duration_ms: int,
+    ) -> None:
+        """Expose the consumed mandatory-thinking attempt to telemetry."""
+        endpoint = getattr(self, "_base_url", None) or getattr(getattr(self, "_client", None), "base_url", None)
+        identity_attrs: dict[str, str | bool] = {
+            IacCodeAttr.PROVIDER_ADAPTER: self._ADAPTER_NAME,
+            IacCodeAttr.OFFICIAL_ENDPOINT: official_dashscope_wire_provider_key(str(endpoint or "")) is not None,
+        }
+        model = sanitize_model_name(self._model)
+        summary = public_exception_summary(error, max_chars=1000)
+        failure = public_error(message=summary, error_type=type(error).__name__)
+        scope_attrs = get_span_attributes()
+        failure_attrs = {
+            "provider": "dashscope",
+            "model": model,
+            "error_type": type(error).__name__,
+            "duration_ms": duration_ms,
+            "error_message": sanitize_error_message(failure.summary),
+            "error_id": failure.error_id,
+            "status": "compatibility_retry",
+            "operation": operation_name,
+            **identity_attrs,
+            **scope_attrs,
+        }
+        retry_attrs = {
+            "provider": "dashscope",
+            "model": model,
+            "attempt": 1,
+            "error_type": type(error).__name__,
+            "streaming": context.streaming,
+            "reason": "mandatory_thinking_compatibility",
+            "operation": operation_name,
+            **identity_attrs,
+            **scope_attrs,
+        }
+        metric_attrs = {
+            "provider": "dashscope",
+            "model": model,
+            "status": "compatibility_retry",
+            "error_type": type(error).__name__,
+            **identity_attrs,
+        }
+        try:
+            log_event(Events.API_REQUEST_FAILED, failure_attrs)
+        except Exception:
+            pass
+        try:
+            log_event(Events.API_REQUEST_RETRIED, retry_attrs)
+        except Exception:
+            pass
+        try:
+            add_metric(Metrics.API_REQUEST_COUNT, 1, metric_attrs)
+        except Exception:
+            pass
+
+    def _extract_reasoning_text(self, message_or_delta: Any) -> str:
+        value = message_or_delta
+        sentinel = object()
+        reasoning_content = getattr(value, "reasoning_content", sentinel)
+        reasoning = getattr(value, "reasoning", sentinel)
+        extra = getattr(value, "model_extra", None)
+        if isinstance(extra, dict):
+            if reasoning_content is sentinel:
+                reasoning_content = extra.get("reasoning_content", sentinel)
+            if reasoning is sentinel:
+                reasoning = extra.get("reasoning", sentinel)
+        if reasoning_content is sentinel or reasoning is sentinel:
+            model_dump = getattr(value, "model_dump", None)
+            if callable(model_dump):
+                try:
+                    dumped = model_dump(exclude_none=False)
+                except TypeError:
+                    dumped = model_dump()
+                if isinstance(dumped, dict):
+                    if reasoning_content is sentinel:
+                        reasoning_content = dumped.get("reasoning_content", sentinel)
+                    if reasoning is sentinel:
+                        reasoning = dumped.get("reasoning", sentinel)
+        if reasoning_content is sentinel or reasoning_content is None:
+            selected = "" if reasoning is sentinel or reasoning is None else reasoning
+        else:
+            selected = reasoning_content
+        return selected if isinstance(selected, str) else str(selected)
+
+
+def _request_explicitly_disabled_thinking(kwargs: dict[str, Any]) -> bool:
+    if kwargs.get("reasoning_effort") == "none":
+        return True
+    extra_body = kwargs.get("extra_body")
+    return isinstance(extra_body, dict) and extra_body.get("enable_thinking") is False
+
+
+def _request_enables_thinking(kwargs: dict[str, Any]) -> bool:
+    effort = kwargs.get("reasoning_effort")
+    if isinstance(effort, str) and effort not in {"", "none"}:
+        return True
+    extra_body = kwargs.get("extra_body")
+    return isinstance(extra_body, dict) and extra_body.get("enable_thinking") is True
+
+
+def _remove_non_system_cache_markers(messages: Any) -> None:
+    if not isinstance(messages, list):
+        return
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") == "system":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, dict):
+                part.pop("cache_control", None)
+
+
+def _is_required_thinking_error(error: Exception) -> bool:
+    status = getattr(error, "status_code", None) or getattr(error, "status", None)
+    if status != 400:
+        return False
+    code = str(getattr(error, "code", "") or "").strip().lower()
+    body = getattr(error, "body", None)
+    if isinstance(body, dict):
+        code = str(body.get("code") or code).strip().lower()
+    body_message = str(body.get("message") or "") if isinstance(body, dict) else ""
+    message = f"{error} {body_message}".strip().lower()
+    stable_code = code in {"invalidparameter", "invalid_parameter", "invalid_request_error"}
+    stable_message = any(
+        marker in message
+        for marker in (
+            "thinking must be enabled",
+            "enable_thinking must be true",
+            "does not support disabling thinking",
+            "reasoning_effort cannot be none",
+        )
+    )
+    stable_message = stable_message or (
+        "enable_thinking" in message
+        and re.search(r"(?:restricted to|must be)\s+true\b", message, re.IGNORECASE) is not None
+    )
+    return stable_message and (stable_code or not code)

--- a/src/iac_code/providers/qwen_tool_call_parser.py
+++ b/src/iac_code/providers/qwen_tool_call_parser.py
@@ -1,0 +1,484 @@
+"""Strict native and conservative XML tool-call parsing for Qwen responses."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Any
+
+from iac_code.i18n import _
+from iac_code.providers.base import ToolDefinition
+
+_MAX_XML_CHARS = 128 * 1024
+_MAX_PARAMETER_CHARS = 32 * 1024
+
+
+class ToolCallProtocolError(ValueError):
+    """A structured Qwen tool call cannot be safely assembled."""
+
+    def __init__(self, message_id: str) -> None:
+        self.i18n_message_id = message_id
+        self.i18n_message_args: dict[str, Any] | None = None
+        super().__init__(_(message_id))
+
+
+def _localizable_message_id(message_id: str) -> str:
+    """Mark a deferred protocol error for catalog extraction without translating it early."""
+    return message_id
+
+
+def strict_tool_arguments(raw: Any, *, present: bool = True) -> dict[str, Any]:
+    """Parse one native call's arguments without the legacy ``{}`` fallback."""
+    if not present or raw is None or raw == "":
+        return {}
+    if not isinstance(raw, str) or not raw.strip():
+        raise ToolCallProtocolError("Qwen tool arguments must be a non-empty JSON object.")
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise ToolCallProtocolError("Qwen tool arguments are malformed JSON.") from exc
+    if not isinstance(parsed, dict):
+        raise ToolCallProtocolError("Qwen tool arguments must decode to an object.")
+    return parsed
+
+
+def parse_non_streaming_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    parsed: list[dict[str, Any]] = []
+    for call in tool_calls or []:
+        call_id = _field(call, "id")
+        function = _field(call, "function")
+        name = _field(function, "name")
+        if not isinstance(call_id, str) or not call_id or not isinstance(name, str) or not name:
+            raise ToolCallProtocolError("Qwen native tool call is missing its ID or name.")
+        arguments = _field(function, "arguments", _MISSING)
+        parsed.append(
+            {
+                "id": call_id,
+                "name": name,
+                "input": strict_tool_arguments(arguments, present=arguments is not _MISSING),
+            }
+        )
+    return parsed
+
+
+@dataclass
+class _Slot:
+    order: int
+    index: int
+    call_id: str = ""
+    name: str = ""
+    arguments: str = ""
+    arguments_present: bool = False
+    depth: int = 0
+    in_string: bool = False
+    escape: bool = False
+
+    def has_complete_object(self) -> bool:
+        if not self.arguments_present or self.arguments == "":
+            return True
+        if self.depth != 0 or self.in_string:
+            return False
+        try:
+            return isinstance(json.loads(self.arguments), dict)
+        except (TypeError, ValueError):
+            return False
+
+    def can_accept_anonymous_arguments(self) -> bool:
+        return not self.arguments_present or self.arguments == "" or not self.has_complete_object()
+
+
+class StrictToolCallAssembler:
+    """Request-local assembler that refuses ambiguous or malformed calls."""
+
+    def __init__(self) -> None:
+        self._slots: list[_Slot] = []
+        self._invalid_reason: str | None = None
+
+    @property
+    def has_fragments(self) -> bool:
+        return bool(self._slots) or self._invalid_reason is not None
+
+    def feed(self, fragments: Any) -> None:
+        for fragment in fragments or []:
+            index = _field(fragment, "index")
+            if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+                self._invalid_reason = _localizable_message_id("Invalid Qwen tool-call index.")
+                continue
+            function = _field(fragment, "function")
+            call_id = _string_or_empty(_field(fragment, "id"))
+            name = _string_or_empty(_field(function, "name"))
+            arguments = _field(function, "arguments", _MISSING)
+            if not call_id and not name and (arguments is _MISSING or arguments is None or arguments == ""):
+                # DashScope emits identity-free empty delimiter chunks before
+                # and after real argument deltas. They carry no protocol state;
+                # treating the trailing delimiter as a new slot creates a
+                # spurious anonymous call after the actual call is complete.
+                continue
+            slot = self._select_slot(index, call_id, name, arguments)
+            if slot is None:
+                continue
+            if call_id:
+                if slot.call_id and slot.call_id != call_id:
+                    self._invalid_reason = _localizable_message_id("Conflicting Qwen tool-call identity.")
+                    continue
+                slot.call_id = call_id
+            if name:
+                if slot.name and slot.name != name:
+                    self._invalid_reason = _localizable_message_id("Conflicting Qwen tool-call name.")
+                    continue
+                slot.name = name
+            if arguments is not _MISSING and arguments is not None:
+                if not isinstance(arguments, str):
+                    self._invalid_reason = _localizable_message_id("Qwen tool-call arguments must be a string.")
+                    continue
+                if call_id and slot.call_id == call_id and slot.arguments and slot.has_complete_object():
+                    # Some compatible endpoints replay a completed chunk with
+                    # the same stable id. It is not a second invocation.
+                    continue
+                slot.arguments_present = True
+                slot.arguments += arguments
+                self._scan_argument_fragment(slot, arguments)
+
+    def _select_slot(self, index: int, call_id: str, name: str, arguments: Any) -> _Slot | None:
+        if call_id:
+            known = [slot for slot in self._slots if slot.call_id == call_id]
+            if len(known) == 1:
+                return known[0]
+            if len(known) > 1:
+                self._invalid_reason = _localizable_message_id("Duplicate Qwen tool-call identity.")
+                return None
+        same_index = [slot for slot in self._slots if slot.index == index]
+        if call_id:
+            compatible = [
+                slot for slot in same_index if not slot.call_id and (not name or not slot.name or slot.name == name)
+            ]
+            if len(compatible) == 1:
+                return compatible[0]
+            if len(compatible) > 1:
+                self._invalid_reason = _localizable_message_id("Ambiguous anonymous Qwen tool-call identity.")
+                return None
+            global_compatible = []
+            if not _is_complete_argument_object(arguments):
+                global_compatible = [
+                    slot
+                    for slot in self._slots
+                    if not slot.call_id
+                    and slot.can_accept_anonymous_arguments()
+                    and (not name or not slot.name or slot.name == name)
+                ]
+            if len(global_compatible) == 1:
+                return global_compatible[0]
+            if len(global_compatible) > 1:
+                self._invalid_reason = _localizable_message_id("Ambiguous anonymous Qwen tool-call identity.")
+                return None
+            conflicting = [slot for slot in same_index if slot.call_id and slot.call_id != call_id]
+            if conflicting and any(not slot.has_complete_object() for slot in conflicting):
+                self._invalid_reason = _localizable_message_id("Conflicting Qwen tool-call identity.")
+        else:
+            if name:
+                named = [slot for slot in same_index if slot.name == name]
+                if len(named) == 1:
+                    return named[0]
+                unnamed = [slot for slot in same_index if not slot.name]
+                if len(unnamed) == 1:
+                    return unnamed[0]
+                if len(named) > 1 or len(unnamed) > 1:
+                    self._invalid_reason = _localizable_message_id("Ambiguous anonymous Qwen tool-call identity.")
+                    return None
+                if same_index and any(not slot.has_complete_object() for slot in same_index):
+                    self._invalid_reason = _localizable_message_id("Conflicting Qwen tool-call name.")
+                    return None
+            compatible = [slot for slot in same_index if slot.can_accept_anonymous_arguments()]
+            if len(compatible) == 1:
+                return compatible[0]
+            if len(compatible) > 1:
+                self._invalid_reason = _localizable_message_id("Ambiguous anonymous Qwen tool-call fragment.")
+                return None
+            incomplete = [slot for slot in self._slots if slot.can_accept_anonymous_arguments()]
+            if len(incomplete) == 1:
+                return incomplete[0]
+            if len(incomplete) > 1:
+                self._invalid_reason = _localizable_message_id("Ambiguous anonymous Qwen tool-call fragment.")
+                return None
+        slot = _Slot(order=len(self._slots), index=index)
+        self._slots.append(slot)
+        return slot
+
+    def _scan_argument_fragment(self, slot: _Slot, fragment: str) -> None:
+        for character in fragment:
+            if not slot.in_string:
+                if character in "[{":
+                    slot.depth += 1
+                elif character in "]}":
+                    slot.depth -= 1
+                    if slot.depth < 0:
+                        self._invalid_reason = _localizable_message_id("Invalid Qwen tool-call JSON structure.")
+            if character == '"' and not slot.escape:
+                slot.in_string = not slot.in_string
+            slot.escape = character == "\\" and not slot.escape
+
+    def finalize(self, finish_reason: str | None) -> list[dict[str, Any]]:
+        if self._invalid_reason is not None:
+            raise ToolCallProtocolError(self._invalid_reason)
+        if finish_reason == "tool_calls" and not self._slots:
+            raise ToolCallProtocolError("Qwen response ended with tool_calls but no complete tool call.")
+        result: list[dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        for slot in sorted(self._slots, key=lambda item: item.order):
+            if not slot.call_id or not slot.name:
+                raise ToolCallProtocolError("Qwen tool call is anonymous or nameless.")
+            if slot.call_id in seen_ids:
+                raise ToolCallProtocolError("Duplicate Qwen tool-call ID.")
+            if slot.depth != 0 or slot.in_string:
+                raise ToolCallProtocolError("Qwen tool-call arguments ended before JSON was complete.")
+            seen_ids.add(slot.call_id)
+            result.append(
+                {
+                    "id": slot.call_id,
+                    "name": slot.name,
+                    "raw_arguments": slot.arguments,
+                    "input": strict_tool_arguments(slot.arguments, present=slot.arguments_present),
+                }
+            )
+        return result
+
+
+@dataclass(frozen=True)
+class XmlToolCallRecovery:
+    calls: list[dict[str, Any]]
+    remaining_text: str
+
+
+_INVOKE_PATTERN = re.compile(
+    r"<invoke\s+name=(?P<quote>[\"'])(?P<name>[^\"']+)(?P=quote)>(?P<body>[\s\S]*?)</invoke>",
+)
+_FUNCTION_CALLS_PATTERN = re.compile(r"<function_calls>(?P<body>[\s\S]*?)</function_calls>")
+_FUNCTION_CALLS_TOKEN_PATTERN = re.compile(r"</?function_calls>")
+_FUNCTION_CALLS_HINT_PATTERN = re.compile(r"<\s*/?\s*function_calls\b", re.IGNORECASE)
+_FENCE_PATTERN = re.compile(r"^ {0,3}((`{3,})|(~{3,}))")
+_ENTITY_PATTERN = re.compile(r"&(?:#(?:x[0-9a-fA-F]+|[0-9]+)|[A-Za-z][A-Za-z0-9]+);")
+_SUPPORTED_ENTITIES = {"&amp;", "&lt;", "&gt;", "&quot;", "&apos;"}
+
+
+def recover_xml_tool_calls(text: str, tools: list[ToolDefinition] | None) -> XmlToolCallRecovery | None:
+    """Recover only the observed parameterized ``<invoke>`` dialect."""
+    if not tools or not text or len(text) > _MAX_XML_CHARS or "<invoke" not in text:
+        return None
+    matches = list(_INVOKE_PATTERN.finditer(text))
+    if not matches:
+        return None
+    invoke_ranges = [(match.start(), match.end()) for match in matches]
+    allowed_names = {tool.name for tool in tools}
+    recovered: list[dict[str, Any]] = []
+    recovered_ranges: list[tuple[int, int]] = []
+    for match in matches:
+        if _position_inside_markdown_fence(text, match.start(), invoke_ranges) or _position_inside_markdown_quote(
+            text, match.start()
+        ):
+            continue
+        parsed = _parse_invoke_block(match.group(0), allowed_names)
+        if parsed is None:
+            return None
+        recovered.append(parsed)
+        recovered_ranges.append((match.start(), match.end()))
+    if not recovered:
+        return None
+    if _has_unmatched_invoke_start(text, invoke_ranges):
+        return None
+
+    wrapper_ranges = _complete_function_calls_wrapper_ranges(text)
+    if wrapper_ranges is None:
+        return None
+    for wrapper_start, wrapper_end in wrapper_ranges:
+        wrapper = _FUNCTION_CALLS_PATTERN.fullmatch(text[wrapper_start:wrapper_end])
+        if wrapper is None:
+            return None
+        contained = [
+            item
+            for item in recovered_ranges
+            if wrapper_start + wrapper.start("body") <= item[0]
+            and item[1] <= wrapper_start + wrapper.end("body")
+        ]
+        if not contained:
+            return None
+        body_without_invokes = _remove_ranges(
+            text,
+            contained,
+            start=wrapper_start + wrapper.start("body"),
+            end=wrapper_start + wrapper.end("body"),
+        )
+        if body_without_invokes.strip():
+            return None
+
+    removal_ranges = list(wrapper_ranges)
+    removal_ranges.extend(
+        item
+        for item in recovered_ranges
+        if not any(wrapper_start <= item[0] and item[1] <= wrapper_end for wrapper_start, wrapper_end in wrapper_ranges)
+    )
+    remaining = _remove_ranges(text, removal_ranges).strip()
+    prose = re.sub(r"\n{3,}", "\n\n", remaining).strip()
+    if len(prose) / len(text) > 0.8:
+        return None
+    return XmlToolCallRecovery(
+        calls=recovered,
+        remaining_text=re.sub(r"\n{3,}", "\n\n", remaining),
+    )
+
+
+def _parse_invoke_block(block: str, allowed_names: set[str]) -> dict[str, Any] | None:
+    if any(entity.group(0) not in _SUPPORTED_ENTITIES for entity in _ENTITY_PATTERN.finditer(block)):
+        return None
+    try:
+        invoke = ET.fromstring(block)
+    except ET.ParseError:
+        return None
+    if invoke.tag != "invoke" or set(invoke.attrib) != {"name"} or (invoke.text or "").strip():
+        return None
+    name = invoke.attrib.get("name", "")
+    if name not in allowed_names:
+        return None
+    arguments: dict[str, Any] = {}
+    parameters = list(invoke)
+    if not parameters:
+        return None
+    for parameter in parameters:
+        if parameter.tag != "parameter" or set(parameter.attrib) != {"name"} or list(parameter):
+            return None
+        key = parameter.attrib.get("name", "")
+        if not key or key in arguments or (parameter.tail or "").strip():
+            return None
+        value = parameter.text or ""
+        if len(value) > _MAX_PARAMETER_CHARS:
+            return None
+        value = _trim_one_boundary_newline(value)
+        parsed_value: Any = value
+        if value.lstrip().startswith(("{", "[")):
+            try:
+                parsed_value = json.loads(value)
+            except ValueError:
+                parsed_value = value
+        arguments[key] = parsed_value
+    return {"id": f"call_{uuid.uuid4().hex[:24]}", "name": name, "input": arguments}
+
+
+def _position_inside_markdown_fence(
+    text: str,
+    index: int,
+    invoke_ranges: list[tuple[int, int]],
+) -> bool:
+    open_fence: tuple[str, int] | None = None
+    line_start = 0
+    for line in text[:index].split("\n"):
+        line_end = line_start + len(line)
+        inside_invoke = any(start <= line_start and line_end <= end for start, end in invoke_ranges)
+        line_start = line_end + 1
+        if inside_invoke:
+            continue
+        match = _FENCE_PATTERN.match(line)
+        if match is None:
+            continue
+        delimiter = "`" if match.group(2) else "~"
+        length = len(match.group(1))
+        if open_fence is None:
+            open_fence = (delimiter, length)
+        elif (
+            open_fence[0] == delimiter
+            and length >= open_fence[1]
+            and not line[match.end() :].strip()
+        ):
+            open_fence = None
+    return open_fence is not None
+
+
+def _position_inside_markdown_quote(text: str, index: int) -> bool:
+    """Return whether the invoke starts on a Markdown blockquote line."""
+    line_start = text.rfind("\n", 0, index) + 1
+    return re.match(r" {0,3}>", text[line_start:index]) is not None
+
+
+def _has_unmatched_invoke_start(text: str, matched_ranges: list[tuple[int, int]]) -> bool:
+    for match in re.finditer(r"<invoke(?:\s|>)", text):
+        if not any(start <= match.start() < end for start, end in matched_ranges):
+            return True
+    return False
+
+
+def _complete_function_calls_wrapper_ranges(text: str) -> list[tuple[int, int]] | None:
+    hints = list(_FUNCTION_CALLS_HINT_PATTERN.finditer(text))
+    tokens = list(_FUNCTION_CALLS_TOKEN_PATTERN.finditer(text))
+    if not hints:
+        return []
+    if len(hints) != len(tokens) or any(hint.start() != token.start() for hint, token in zip(hints, tokens)):
+        return None
+    ranges: list[tuple[int, int]] = []
+    opening: int | None = None
+    for token in tokens:
+        if token.group(0).startswith("</"):
+            if opening is None:
+                return None
+            ranges.append((opening, token.end()))
+            opening = None
+        else:
+            if opening is not None:
+                return None
+            opening = token.start()
+    return ranges if opening is None else None
+
+
+def _remove_ranges(
+    text: str,
+    ranges: list[tuple[int, int]],
+    *,
+    start: int = 0,
+    end: int | None = None,
+) -> str:
+    limit = len(text) if end is None else end
+    cursor = start
+    chunks: list[str] = []
+    for range_start, range_end in sorted(ranges):
+        if range_end <= start or range_start >= limit:
+            continue
+        clipped_start = max(range_start, start)
+        clipped_end = min(range_end, limit)
+        chunks.append(text[cursor:clipped_start])
+        cursor = clipped_end
+    chunks.append(text[cursor:limit])
+    return "".join(chunks)
+
+
+def _trim_one_boundary_newline(value: str) -> str:
+    if value.startswith("\r\n"):
+        value = value[2:]
+    elif value.startswith("\n"):
+        value = value[1:]
+    if value.endswith("\r\n"):
+        value = value[:-2]
+    elif value.endswith("\n"):
+        value = value[:-1]
+    return value
+
+
+_MISSING = object()
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _string_or_empty(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _is_complete_argument_object(value: Any) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        return isinstance(json.loads(value), dict)
+    except ValueError:
+        return False

--- a/src/iac_code/providers/request_lease.py
+++ b/src/iac_code/providers/request_lease.py
@@ -1,0 +1,28 @@
+"""Request-scoped immutable provider ownership snapshot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from iac_code.providers.base import Provider
+
+
+@dataclass
+class LeaseToken:
+    state: str = "active"
+
+
+@dataclass(frozen=True)
+class ProviderRequestLease:
+    request_id: str
+    provider: Provider
+    system_prompt: str
+    requested_model: str
+    logical_provider_key: str
+    wire_provider_key: str
+    telemetry_provider_name: str
+    adapter_name: str | None
+    context_window_model: str
+    _owner_identity: Any = field(repr=False, compare=False)
+    _lease_token: Any = field(repr=False, compare=False)

--- a/src/iac_code/providers/schema_compat.py
+++ b/src/iac_code/providers/schema_compat.py
@@ -1,0 +1,56 @@
+"""Minimal JSON Schema relaxation used only for Qwen wire copies."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+_SCHEMA_MAP_KEYS = frozenset(
+    {
+        "properties",
+        "$defs",
+        "definitions",
+        "patternProperties",
+        "dependencies",
+        "dependentSchemas",
+        "dependentRequired",
+    }
+)
+_SCHEMA_CHILD_KEYS = frozenset(
+    {"items", "contains", "additionalProperties", "propertyNames", "if", "then", "else", "not"}
+)
+_SCHEMA_LIST_KEYS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+
+
+def relax_qwen_tool_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    return _relax_schema_node(copy.deepcopy(schema))
+
+
+def _relax_schema_node(node: Any) -> Any:
+    if not isinstance(node, dict):
+        return node
+    result = dict(node)
+    result.pop("$schema", None)
+    result.pop("$id", None)
+    result.pop("uniqueItems", None)
+    properties = result.get("properties")
+    required = result.get("required")
+    if (
+        result.get("additionalProperties") is False
+        and isinstance(properties, dict)
+        and set(properties) - set(required if isinstance(required, list) else [])
+    ):
+        result.pop("additionalProperties", None)
+    for key in _SCHEMA_MAP_KEYS:
+        value = result.get(key)
+        if isinstance(value, dict):
+            result[key] = {name: _relax_schema_node(child) for name, child in value.items()}
+    for key in _SCHEMA_CHILD_KEYS:
+        value = result.get(key)
+        if isinstance(value, dict):
+            result[key] = _relax_schema_node(value)
+    for key in _SCHEMA_LIST_KEYS:
+        value = result.get(key)
+        if isinstance(value, list):
+            result[key] = [_relax_schema_node(child) for child in value]
+    return result

--- a/src/iac_code/providers/streaming.py
+++ b/src/iac_code/providers/streaming.py
@@ -1,0 +1,515 @@
+"""Request-local OpenAI-compatible stream response adapters."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+from iac_code.i18n import _
+from iac_code.providers.base import ToolDefinition
+from iac_code.providers.qwen_tool_call_parser import (
+    StrictToolCallAssembler,
+    ToolCallProtocolError,
+    recover_xml_tool_calls,
+)
+from iac_code.types.stream_events import (
+    StreamEvent,
+    TextDeltaEvent,
+    ThinkingDeltaEvent,
+    ToolInputDeltaEvent,
+    ToolUseEndEvent,
+    ToolUseStartEvent,
+)
+from iac_code.utils.tool_input_parser import parse_tool_input_events
+
+
+class UnsafeStreamProtocolError(RuntimeError):
+    """A stream contains Qwen content that must never use non-stream fallback."""
+
+    def __init__(self, message_id: str) -> None:
+        self.i18n_message_id = message_id
+        self.i18n_message_args: dict[str, Any] | None = None
+        super().__init__(_(message_id))
+
+
+class CumulativeDeltaNormalizer:
+    """Normalize a channel that may transition from incremental to cumulative."""
+
+    EXACT_REPEAT_THRESHOLD = 64
+    DETECTION_WINDOW = 1024
+
+    def __init__(self) -> None:
+        self._mode = "incremental"
+        self._emitted_text = ""
+        self._emitted_length = 0
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def feed(self, chunk: str) -> str:
+        if not chunk:
+            return ""
+        if not self._emitted_text:
+            self._emitted_text = chunk
+            self._emitted_length = len(chunk)
+            return chunk
+        if self._mode == "cumulative":
+            if chunk.startswith(self._emitted_text):
+                suffix = chunk[len(self._emitted_text) :]
+                self._emitted_text = chunk
+                self._emitted_length = len(chunk)
+                return suffix
+            if self._emitted_text.startswith(chunk):
+                return ""
+            self._mode = "incremental"
+            self._emitted_text = chunk
+            self._emitted_length += len(chunk)
+            return chunk
+        if len(chunk) > len(self._emitted_text) and chunk.startswith(self._emitted_text):
+            baseline_length = len(self._emitted_text)
+            baseline_frozen = baseline_length >= self.DETECTION_WINDOW and self._emitted_length > baseline_length
+            slice_from = self._emitted_length if baseline_frozen else baseline_length
+            if len(chunk) > slice_from:
+                suffix = chunk[slice_from:]
+                self._emitted_text = chunk
+                self._emitted_length = len(chunk)
+                self._mode = "cumulative"
+                return suffix
+        if chunk == self._emitted_text:
+            if len(chunk) >= self.EXACT_REPEAT_THRESHOLD:
+                self._mode = "cumulative"
+                return ""
+            self._emitted_length += len(chunk)
+            return chunk
+        if len(self._emitted_text) < self.DETECTION_WINDOW:
+            self._emitted_text += chunk
+        self._emitted_length += len(chunk)
+        return chunk
+
+
+class OpenAIStreamResponseAdapter:
+    """Default adapter preserving the existing OpenAI event contract."""
+
+    def __init__(self, provider: Any, tools: list[ToolDefinition] | None) -> None:
+        self._provider = provider
+        self._tools = tools
+        self._tool_calls: dict[int, dict[str, Any]] = {}
+        self._message_provider_metadata: dict[str, Any] = {}
+        self._terminal_stop_reason_override: str | None = None
+
+    @property
+    def terminal_stop_reason_override(self) -> str | None:
+        return self._terminal_stop_reason_override
+
+    def feed(self, delta: Any, finish_reason: str | None) -> list[StreamEvent]:
+        events: list[StreamEvent] = []
+        provider_metadata = self._provider._message_provider_metadata(delta)
+        if provider_metadata and provider_metadata != self._message_provider_metadata:
+            self._message_provider_metadata = provider_metadata
+            events.append(ThinkingDeltaEvent(text="", provider_metadata=provider_metadata))
+        reasoning = self._provider._extract_reasoning_text(delta)
+        if reasoning:
+            events.append(ThinkingDeltaEvent(text=reasoning))
+        content = getattr(delta, "content", None)
+        if content:
+            events.append(TextDeltaEvent(text=content))
+        tool_calls = getattr(delta, "tool_calls", None)
+        if tool_calls:
+            events.extend(self._feed_legacy_tool_calls(tool_calls))
+        return events
+
+    def _feed_legacy_tool_calls(self, tool_calls: Any) -> list[StreamEvent]:
+        events: list[StreamEvent] = []
+        for tc_delta in tool_calls:
+            idx = tc_delta.index
+            if idx not in self._tool_calls:
+                self._tool_calls[idx] = {
+                    "id": tc_delta.id or "",
+                    "name": "",
+                    "arguments": "",
+                    "argument_deltas": [],
+                    "arguments_waited_for_id": False,
+                    "ready_to_start": False,
+                    "started": False,
+                    "provider_metadata": {},
+                }
+            current = self._tool_calls[idx]
+            if tc_delta.id and not current["id"]:
+                current["id"] = tc_delta.id
+            provider_metadata = self._provider._tool_provider_metadata(tc_delta)
+            if provider_metadata:
+                current["provider_metadata"].update(provider_metadata)
+            has_name_delta = bool(tc_delta.function and tc_delta.function.name)
+            if has_name_delta:
+                current["name"] += tc_delta.function.name
+            if tc_delta.function and tc_delta.function.arguments:
+                if not current["id"]:
+                    current["arguments_waited_for_id"] = True
+                current["arguments"] += tc_delta.function.arguments
+                current["argument_deltas"].append(tc_delta.function.arguments)
+            if (
+                current["id"]
+                and current["name"]
+                and current["arguments"]
+                and not current["started"]
+                and not has_name_delta
+            ):
+                current["ready_to_start"] = True
+        for start_idx in sorted(self._tool_calls):
+            pending = self._tool_calls[start_idx]
+            if pending["started"]:
+                continue
+            if not pending["ready_to_start"]:
+                break
+            pending["started"] = True
+            events.append(
+                ToolUseStartEvent(
+                    tool_use_id=pending["id"],
+                    name=pending["name"],
+                    provider_metadata=pending["provider_metadata"] or None,
+                )
+            )
+        for flush_idx in sorted(self._tool_calls):
+            pending = self._tool_calls[flush_idx]
+            if not pending["started"]:
+                continue
+            deltas = pending["argument_deltas"]
+            pending["argument_deltas"] = []
+            if pending["arguments_waited_for_id"]:
+                deltas = ["".join(deltas)]
+                pending["arguments_waited_for_id"] = False
+            events.extend(ToolInputDeltaEvent(tool_use_id=pending["id"], partial_json=item) for item in deltas)
+        return events
+
+    def finalize(self, finish_reason: str | None) -> list[StreamEvent]:
+        events: list[StreamEvent] = []
+        for idx in sorted(self._tool_calls):
+            call = self._tool_calls[idx]
+            if not call["id"]:
+                call["id"] = f"call_{uuid.uuid4().hex[:24]}"
+            if not call["started"]:
+                events.append(
+                    ToolUseStartEvent(
+                        tool_use_id=call["id"],
+                        name=call["name"],
+                        provider_metadata=call["provider_metadata"] or None,
+                    )
+                )
+            deltas = call["argument_deltas"]
+            if call["arguments_waited_for_id"]:
+                deltas = ["".join(deltas)]
+            events.extend(ToolInputDeltaEvent(tool_use_id=call["id"], partial_json=item) for item in deltas)
+            for event in parse_tool_input_events(call["id"], call["name"], call["arguments"]):
+                if isinstance(event, ToolUseEndEvent) and event.tool_use_id == call["id"]:
+                    event.provider_metadata = call["provider_metadata"] or None
+                events.append(event)
+        return events
+
+
+class _QwenContentGuard:
+    _XML_STARTS = ("<invoke", "<function_calls")
+    _MAX_CANDIDATE = 128 * 1024
+    _LEADING_TAG = re.compile(r"^\s*</?think(?:ing)?\s*>", re.IGNORECASE)
+    _ANY_TAG = re.compile(r"</?think(?:ing)?\s*>", re.IGNORECASE)
+    _STANDALONE_CLOSING = re.compile(r"^\s*</(think|thinking)\s*>\s*$", re.IGNORECASE)
+    _FENCE = re.compile(r"^ {0,3}((`{3,})|(~{3,}))")
+    _BLOCKQUOTE = re.compile(r"^ {0,3}>")
+
+    def __init__(self) -> None:
+        self._thinking_state = "probe"
+        self._thinking_buffer = ""
+        self._tag_name: str | None = None
+        self._tag_closing = False
+        self._xml_pending = ""
+        self._xml_candidate: str | None = None
+        self._fence_delimiter: str | None = None
+        self._fence_length = 0
+        self._fence_line = ""
+
+    def feed_tags(self, text: str) -> list[str]:
+        if not text:
+            return []
+        if self._thinking_state == "tag":
+            self._thinking_buffer += text
+            if len(self._thinking_buffer) > self._MAX_CANDIDATE:
+                raise UnsafeStreamProtocolError("Qwen thinking-tag candidate exceeded the safety limit.")
+            return []
+        if self._thinking_state == "probe":
+            self._thinking_buffer += text
+            stripped = self._thinking_buffer.lstrip()
+            complete = self._LEADING_TAG.match(self._thinking_buffer)
+            if complete is not None:
+                self._thinking_state = "tag"
+                literal = complete.group(0).strip().lower()
+                self._tag_closing = literal.startswith("</")
+                self._tag_name = "thinking" if "thinking" in literal else "think"
+                return []
+            if self._is_possible_tag_prefix(stripped):
+                return []
+            self._thinking_state = "pass"
+            released = self._thinking_buffer
+            self._thinking_buffer = ""
+            return [released]
+        return [text]
+
+    @staticmethod
+    def _is_possible_tag_prefix(text: str) -> bool:
+        candidate = text.lower()
+        if not candidate:
+            return True
+        for tag in ("<think", "<thinking", "</think", "</thinking"):
+            if tag.startswith(candidate):
+                return True
+            if candidate.startswith(tag) and re.fullmatch(r"\s*(?:>\s*)?", candidate[len(tag) :]):
+                return True
+        return False
+
+    def feed_xml(self, text: str) -> list[str]:
+        if self._xml_candidate is not None:
+            self._xml_candidate += text
+            if len(self._xml_candidate) > self._MAX_CANDIDATE:
+                candidate = self._xml_candidate
+                self._xml_candidate = None
+                self._update_fence(candidate)
+                return [candidate]
+            return []
+        combined = self._xml_pending + text
+        self._xml_pending = ""
+        output: list[str] = []
+        while combined:
+            positions = [(combined.find(start), start) for start in self._XML_STARTS]
+            positions = [(position, start) for position, start in positions if position >= 0]
+            if positions:
+                position, _ = min(positions)
+                prefix = combined[:position]
+                self._update_fence(prefix)
+                if self._inside_fence() or self._inside_blockquote():
+                    emitted = prefix + combined[position]
+                    output.append(emitted)
+                    self._update_fence(combined[position])
+                    combined = combined[position + 1 :]
+                    continue
+                if prefix:
+                    output.append(prefix)
+                self._xml_candidate = combined[position:]
+                return output
+            suffix_length = self._longest_candidate_prefix_suffix(combined)
+            if suffix_length:
+                released = combined[:-suffix_length]
+                if released:
+                    output.append(released)
+                    self._update_fence(released)
+                self._xml_pending = combined[-suffix_length:]
+            else:
+                output.append(combined)
+                self._update_fence(combined)
+            return output
+        return output
+
+    @classmethod
+    def _longest_candidate_prefix_suffix(cls, text: str) -> int:
+        return max(
+            (size for start in cls._XML_STARTS for size in range(1, len(start)) if text.endswith(start[:size])),
+            default=0,
+        )
+
+    def _update_fence(self, text: str) -> None:
+        for character in text:
+            if character == "\n":
+                self._process_fence_line(self._fence_line)
+                self._fence_line = ""
+            else:
+                self._fence_line += character
+
+    def _process_fence_line(self, line: str) -> None:
+        match = self._FENCE.match(line)
+        if match is None:
+            return
+        delimiter = "`" if match.group(2) else "~"
+        length = len(match.group(1))
+        if self._fence_delimiter is None:
+            self._fence_delimiter = delimiter
+            self._fence_length = length
+        elif (
+            self._fence_delimiter == delimiter
+            and length >= self._fence_length
+            and not line[match.end() :].strip()
+        ):
+            self._fence_delimiter = None
+            self._fence_length = 0
+
+    def _inside_fence(self) -> bool:
+        if self._fence_delimiter is not None:
+            return True
+        return self._FENCE.match(self._fence_line) is not None
+
+    def _inside_blockquote(self) -> bool:
+        return self._BLOCKQUOTE.match(self._fence_line) is not None
+
+    def validate_pre_tools(self, *, has_reasoning: bool) -> None:
+        if self._thinking_state != "tag" or self._tag_closing:
+            return
+        if has_reasoning or not self._is_balanced_content_tag_block(self._thinking_buffer):
+            raise UnsafeStreamProtocolError("Qwen emitted an unsafe or conflicting thinking-tag block.")
+
+    @property
+    def has_closing_tag_candidate(self) -> bool:
+        return self._thinking_state == "tag" and self._tag_closing
+
+    @classmethod
+    def _is_balanced_content_tag_block(cls, text: str) -> bool:
+        leading = cls._LEADING_TAG.match(text)
+        if leading is None or leading.group(0).lstrip().startswith("</"):
+            return False
+        depth = 0
+        for match in cls._ANY_TAG.finditer(text):
+            depth += -1 if match.group(0).lstrip().startswith("</") else 1
+            if depth < 0:
+                return False
+        return depth == 0
+
+    def finalize_tags(
+        self,
+        *,
+        finish_reason: str | None,
+        native_calls: list[dict[str, Any]],
+        has_reasoning: bool,
+        reasoning_has_tag: bool = False,
+    ) -> tuple[list[str], bool]:
+        if self._thinking_state == "probe":
+            pending = self._thinking_buffer
+            self._thinking_buffer = ""
+            self._thinking_state = "pass"
+            released = [pending] if pending else []
+        else:
+            released = []
+        if self._thinking_state == "tag":
+            literal = self._thinking_buffer
+            if not self._tag_closing:
+                if not has_reasoning and self._is_balanced_content_tag_block(literal):
+                    return [literal], False
+                raise UnsafeStreamProtocolError("Qwen emitted an unsafe or conflicting thinking-tag block.")
+            closing = self._STANDALONE_CLOSING.fullmatch(literal)
+            safe_closing = (
+                finish_reason == "tool_calls"
+                and bool(native_calls)
+                and not reasoning_has_tag
+                and closing is not None
+            )
+            if safe_closing:
+                return [], True
+            raise UnsafeStreamProtocolError("Qwen emitted a stray thinking closing tag.")
+        return released, False
+
+    def finalize_xml(self, *, native_calls: list[dict[str, Any]]) -> tuple[list[str], str | None]:
+        released: list[str] = []
+        if self._xml_candidate is not None:
+            candidate = self._xml_candidate
+            self._xml_candidate = None
+            if native_calls:
+                released.append(candidate)
+                return released, None
+            return released, candidate
+        if self._xml_pending:
+            released.append(self._xml_pending)
+            self._xml_pending = ""
+        return released, None
+
+
+class QwenStreamResponseAdapter(OpenAIStreamResponseAdapter):
+    """Qwen-only ordered normalizer, guards, strict tools, and XML recovery."""
+
+    def __init__(self, provider: Any, tools: list[ToolDefinition] | None) -> None:
+        super().__init__(provider, tools)
+        self._content_normalizer = CumulativeDeltaNormalizer()
+        self._reasoning_normalizer = CumulativeDeltaNormalizer()
+        self._guard = _QwenContentGuard()
+        self._strict_tools = StrictToolCallAssembler()
+        self._has_reasoning = False
+        self._reasoning_has_tag = False
+        self._reasoning_tag_probe = ""
+
+    def feed(self, delta: Any, finish_reason: str | None) -> list[StreamEvent]:
+        events: list[StreamEvent] = []
+        provider_metadata = self._provider._message_provider_metadata(delta)
+        if provider_metadata and provider_metadata != self._message_provider_metadata:
+            self._message_provider_metadata = provider_metadata
+            events.append(ThinkingDeltaEvent(text="", provider_metadata=provider_metadata))
+        reasoning = self._provider._extract_reasoning_text(delta)
+        normalized_reasoning = self._reasoning_normalizer.feed(reasoning) if reasoning else ""
+        if normalized_reasoning:
+            self._has_reasoning = True
+            if not self._reasoning_has_tag:
+                tag_probe = self._reasoning_tag_probe + normalized_reasoning
+                self._reasoning_has_tag = self._guard._ANY_TAG.search(tag_probe) is not None
+                if self._reasoning_has_tag:
+                    self._reasoning_tag_probe = ""
+                else:
+                    last_open = tag_probe.rfind("<")
+                    possible = tag_probe[last_open:] if last_open >= 0 else ""
+                    self._reasoning_tag_probe = (
+                        possible if self._guard._is_possible_tag_prefix(possible) else ""
+                    )
+            events.append(ThinkingDeltaEvent(text=normalized_reasoning))
+        content = getattr(delta, "content", None)
+        normalized_content = self._content_normalizer.feed(content) if isinstance(content, str) and content else ""
+        tag_released = self._guard.feed_tags(normalized_content)
+        tool_calls = getattr(delta, "tool_calls", None)
+        if tool_calls:
+            self._strict_tools.feed(tool_calls)
+        for tagged_text in tag_released:
+            for released in self._guard.feed_xml(tagged_text):
+                if released:
+                    events.append(TextDeltaEvent(text=released))
+        return events
+
+    def finalize(self, finish_reason: str | None) -> list[StreamEvent]:
+        # Tag validation runs first so a malformed native call cannot downgrade
+        # a confirmed tag leak into the generic non-streaming fallback path.
+        self._guard.validate_pre_tools(has_reasoning=self._has_reasoning)
+        try:
+            native_calls = self._strict_tools.finalize(finish_reason)
+        except ToolCallProtocolError as exc:
+            if self._guard.has_closing_tag_candidate:
+                raise UnsafeStreamProtocolError(
+                    "Qwen emitted a closing thinking tag without a valid native tool call."
+                ) from exc
+            raise
+        tag_released, _sanitized = self._guard.finalize_tags(
+            finish_reason=finish_reason,
+            native_calls=native_calls,
+            has_reasoning=self._has_reasoning,
+            reasoning_has_tag=self._reasoning_has_tag,
+        )
+        events: list[StreamEvent] = []
+        for tagged_text in tag_released:
+            events.extend(TextDeltaEvent(text=text) for text in self._guard.feed_xml(tagged_text) if text)
+        released, xml_candidate = self._guard.finalize_xml(native_calls=native_calls)
+        events.extend(TextDeltaEvent(text=text) for text in released if text)
+        if native_calls:
+            events.extend(_tool_use_events(native_calls))
+            return events
+        if xml_candidate is not None:
+            recovered = recover_xml_tool_calls(xml_candidate, self._tools) if finish_reason is not None else None
+            if recovered is None:
+                events.append(TextDeltaEvent(text=xml_candidate))
+            else:
+                if recovered.remaining_text:
+                    events.append(TextDeltaEvent(text=recovered.remaining_text))
+                if recovered.calls:
+                    self._terminal_stop_reason_override = "tool_use"
+                events.extend(_tool_use_events(recovered.calls))
+        return events
+
+
+def _tool_use_events(calls: list[dict[str, Any]]) -> list[StreamEvent]:
+    events: list[StreamEvent] = []
+    for call in calls:
+        events.append(ToolUseStartEvent(tool_use_id=call["id"], name=call["name"]))
+        raw_arguments = call.get("raw_arguments")
+        if isinstance(raw_arguments, str) and raw_arguments:
+            events.append(ToolInputDeltaEvent(tool_use_id=call["id"], partial_json=raw_arguments))
+        events.append(ToolUseEndEvent(tool_use_id=call["id"], name=call["name"], input=call["input"]))
+    return events

--- a/src/iac_code/providers/thinking.py
+++ b/src/iac_code/providers/thinking.py
@@ -244,7 +244,7 @@ _DASHSCOPE_GLM51_SPEC = ThinkingSpec(
 
 _DASHSCOPE_QWEN38_SPEC = ThinkingSpec(
     ThinkingFamily.DASHSCOPE,
-    (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.XHIGH),
+    (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.HIGH, EffortLevel.XHIGH),
     EffortLevel.XHIGH,
     uses_reasoning_effort_param=True,
     thinking_enabled_by_default=True,
@@ -258,7 +258,7 @@ _DASHSCOPE_QWEN_HYBRID_SPEC = ThinkingSpec(
 
 _DASHSCOPE_QWEN38_PREVIEW_SPEC = ThinkingSpec(
     ThinkingFamily.DASHSCOPE,
-    (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.XHIGH),
+    (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.HIGH, EffortLevel.XHIGH),
     EffortLevel.XHIGH,
     uses_reasoning_effort_param=True,
     supports_disable=False,
@@ -598,6 +598,11 @@ def get_thinking_spec(provider_key: str, model: str) -> ThinkingSpec:
         spec = MODEL_THINKING.get(current_key, {}).get(model)
         if spec is not None:
             return spec
+        normalized_model = model.strip().lower().rsplit("/", 1)[-1]
+        if current_key in {"dashscope", "dashscope_token_plan"} and normalized_model.startswith("qwen3.8-max"):
+            if current_key == "dashscope_token_plan" and "preview" in normalized_model:
+                return _DASHSCOPE_QWEN38_PREVIEW_SPEC
+            return _DASHSCOPE_QWEN38_SPEC
         current_key = _THINKING_FALLBACK.get(current_key)
     return _NONE_SPEC
 

--- a/src/iac_code/providers/thinking_intent.py
+++ b/src/iac_code/providers/thinking_intent.py
@@ -1,0 +1,42 @@
+"""Resolved Qwen thinking values with their configuration provenance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar
+
+T = TypeVar("T")
+ThinkingSource = Literal["default", "provider", "model", "request"]
+
+
+@dataclass(frozen=True)
+class SourcedValue(Generic[T]):
+    value: T | None = None
+    source: ThinkingSource = "default"
+
+    @property
+    def priority(self) -> int:
+        return {"default": 0, "provider": 1, "model": 2, "request": 3}[self.source]
+
+
+@dataclass(frozen=True)
+class ResolvedThinkingIntent:
+    enabled: SourcedValue[bool] = SourcedValue()
+    effort: SourcedValue[str] = SourcedValue()
+    budget: SourcedValue[int] = SourcedValue()
+
+    def dominant_concrete_field(self) -> str | None:
+        """Return the closest explicit disable/effort/budget instruction.
+
+        An explicit enable only permits thinking and does not erase a more
+        distant concrete effort or budget. At one source level, disable wins,
+        followed by effort and budget.
+        """
+        candidates: list[tuple[int, int, str]] = []
+        if self.enabled.value is False:
+            candidates.append((self.enabled.priority, 3, "disabled"))
+        if self.effort.value is not None:
+            candidates.append((self.effort.priority, 2, "effort"))
+        if self.budget.value is not None:
+            candidates.append((self.budget.priority, 1, "budget"))
+        return max(candidates)[2] if candidates else None

--- a/src/iac_code/services/telemetry/names.py
+++ b/src/iac_code/services/telemetry/names.py
@@ -134,6 +134,8 @@ class IacCodeAttr:
 
     CHANNEL = "iac_code.channel"
     MODE = "iac_code.mode"
+    PROVIDER_ADAPTER = "iac_code.provider_adapter"
+    OFFICIAL_ENDPOINT = "iac_code.official_endpoint"
 
 
 class PipelineAttr:

--- a/src/iac_code/types/stream_events.py
+++ b/src/iac_code/types/stream_events.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Literal, Union
 
+from iac_code.types.usage_attribution import UsageAttribution
+
 TOOL_RENDER_METADATA_KEY = "_iac_code_tool_render"
 TOOL_RENDER_DISPLAY_NAME_KEY = "display_name"
 TOOL_RENDER_RESULT_COMPACT_KEY = "result_compact"
@@ -149,6 +151,7 @@ class MessageEndEvent:
     stop_reason: str
     usage: Usage
     type: Literal["message_end"] = "message_end"
+    usage_attribution: UsageAttribution | None = field(default=None, kw_only=True, compare=False)
 
 
 @dataclass
@@ -179,6 +182,8 @@ class ErrorEvent:
     is_retryable: bool
     error_id: str | None = None
     type: Literal["error"] = "error"
+    i18n_message_id: str | None = field(default=None, kw_only=True, compare=False)
+    i18n_message_args: dict[str, Any] | None = field(default=None, kw_only=True, compare=False)
 
 
 # -- AgentLoop-originated events (consumed by Renderer) ------------------------

--- a/src/iac_code/types/usage_attribution.py
+++ b/src/iac_code/types/usage_attribution.py
@@ -1,0 +1,15 @@
+"""Internal identity attached to the terminal outcome of one provider request."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class UsageAttribution:
+    logical_provider_key: str
+    wire_provider_key: str
+    telemetry_provider_name: str
+    adapter_name: str | None
+    requested_model: str
+    actual_model: str

--- a/tests/a2a/test_events.py
+++ b/tests/a2a/test_events.py
@@ -20,6 +20,7 @@ from iac_code.a2a.input_required import (
     PermissionResponse,
 )
 from iac_code.a2a.projection import project_a2a_data
+from iac_code.a2a.runtime_overrides import a2a_request_context
 from iac_code.services.permission_wait import (
     PermissionExecutionIdentity,
     PermissionWaitCheckpointStore,
@@ -1048,6 +1049,53 @@ async def test_error_event_passes_through_error_field() -> None:
     assert dumped["status"]["state"] == "TASK_STATE_FAILED"
     assert dumped["status"]["message"]["parts"][0]["text"] == "boom with /secret/path"
     assert dumped["metadata"]["iac_code"]["error"] == {"retryable": False, "errorId": "err-123"}
+
+
+@pytest.mark.asyncio
+async def test_error_event_uses_request_language_for_localizable_message(monkeypatch) -> None:
+    queue = FakeEventQueue()
+    monkeypatch.setattr(
+        "iac_code.a2a.events.translate_message",
+        lambda message, *, language: f"{language}:{message}",
+    )
+
+    with a2a_request_context(preferred_language="fr"):
+        await publish_stream_event(
+            queue,
+            task_id="task-1",
+            context_id="ctx-1",
+            event=ErrorEvent(
+                error="process-locale text must not win",
+                is_retryable=False,
+                i18n_message_id="Provider request lease cannot be consumed from state {state}.",
+                i18n_message_args={"state": "'released'"},
+            ),
+        )
+
+    dumped = dump(queue.events[0])
+    assert dumped["status"]["message"]["parts"][0]["text"] == (
+        "fr:Provider request lease cannot be consumed from state 'released'."
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_error_event_localizes_unknown_error_for_request(monkeypatch) -> None:
+    queue = FakeEventQueue()
+    monkeypatch.setattr(
+        "iac_code.a2a.events.translate_message",
+        lambda message, *, language: f"{language}:{message}",
+    )
+
+    with a2a_request_context(preferred_language="ja"):
+        await publish_stream_event(
+            queue,
+            task_id="task-1",
+            context_id="ctx-1",
+            event=ErrorEvent(error="", is_retryable=False),
+        )
+
+    dumped = dump(queue.events[0])
+    assert dumped["status"]["message"]["parts"][0]["text"] == "ja:Unknown error"
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_agent_loop_new.py
+++ b/tests/agent/test_agent_loop_new.py
@@ -2932,6 +2932,21 @@ class TestAgentLoopCompaction:
         assert call_kwargs["messages"][0].content == "compact me"
         assert "telemetry_messages" not in call_kwargs
 
+    async def test_compact_does_not_inspect_complete_without_request_lease(self, mock_provider, mock_registry):
+        mock_provider.complete = AsyncMock(return_value=SimpleNamespace(text="summary"))
+        loop = AgentLoop(provider_manager=mock_provider, system_prompt="test", tool_registry=mock_registry)
+        loop.context_manager = MagicMock()
+        loop.context_manager.get_messages.return_value = [object()]
+        loop.context_manager.build_compaction_prompt.return_value = "compact me"
+        loop.context_manager.apply_compaction.return_value = (900, 300)
+
+        with patch("iac_code.agent.agent_loop.inspect.signature") as signature_mock:
+            result = await loop.compact()
+
+        assert result.status == "success"
+        signature_mock.assert_not_called()
+        mock_provider.complete.assert_awaited_once()
+
     async def test_compact_persists_compacted_session(self, mock_provider, mock_registry):
         from iac_code.agent.message import Message
 
@@ -3093,6 +3108,113 @@ class TestAgentLoopHelpers:
 
 
 class TestAgentLoopSetProvider:
+    @pytest.mark.asyncio
+    async def test_auto_compact_keeps_captured_manager_and_base_prompt(self, mock_registry):
+        class LeaseManager:
+            def __init__(self, model, effective_prefix):
+                self.model = model
+                self.effective_prefix = effective_prefix
+                self.begin_systems = []
+                self.stream_systems = []
+
+            def get_model_name(self):
+                return self.model
+
+            def begin_request(self, system, tools=None):
+                self.begin_systems.append(system)
+                return SimpleNamespace(
+                    system_prompt=f"{self.effective_prefix}:{system}",
+                    context_window_model=self.model,
+                    _lease_token=SimpleNamespace(state="active"),
+                )
+
+            def release_request(self, lease):
+                lease._lease_token.state = "released"
+
+            def stream(self, messages, system, tools=None, lease=None):
+                self.stream_systems.append(system)
+
+                async def events():
+                    yield MessageStartEvent(message_id="m1")
+                    yield TextDeltaEvent(text="ok")
+                    yield MessageEndEvent(stop_reason="stop", usage=Usage())
+
+                return events()
+
+        old_manager = LeaseManager("qwen3.8-max", "old-effective")
+        next_manager = LeaseManager("claude-opus-4-7", "new-effective")
+        loop = AgentLoop(provider_manager=old_manager, system_prompt="old-base", tool_registry=mock_registry)
+        loop.context_manager.needs_compaction = MagicMock(return_value=True)
+
+        async def compact_with_switch(request_manager):
+            assert request_manager is old_manager
+            loop.set_provider(next_manager, system_prompt="new-base")
+            return CompactionEvent(original_tokens=1200, compacted_tokens=400)
+
+        loop._auto_compact = compact_with_switch
+        await loop.run("hello")
+
+        assert old_manager.begin_systems == ["old-base", "old-base"]
+        assert old_manager.stream_systems == ["old-effective:old-base"]
+        assert next_manager.begin_systems == []
+        assert loop.context_manager._model == "claude-opus-4-7"
+        assert loop.context_manager.system_prompt == "new-base"
+
+        loop._prepare_request_lease(next_manager)
+        assert next_manager.begin_systems == ["new-base"]
+        assert loop.context_manager._model == "claude-opus-4-7"
+        assert loop.context_manager.system_prompt == "new-effective:new-base"
+
+    @pytest.mark.asyncio
+    async def test_in_flight_request_keeps_old_manager_model_and_prompt(self, mock_registry):
+        loop_ref = None
+
+        class NextManager:
+            def get_model_name(self):
+                return "claude-opus-4-7"
+
+        next_manager = NextManager()
+
+        class OldManager:
+            def __init__(self):
+                self.released = False
+
+            def get_model_name(self):
+                return "qwen3.8-max"
+
+            def begin_request(self, system, tools=None):
+                return SimpleNamespace(
+                    system_prompt="old effective prompt",
+                    context_window_model="qwen3.8-max",
+                    _lease_token=SimpleNamespace(state="active"),
+                )
+
+            def release_request(self, lease):
+                lease._lease_token.state = "released"
+                self.released = True
+
+            def stream(self, messages, system, tools=None, lease=None):
+                assert system == "old effective prompt"
+                assert lease.context_window_model == "qwen3.8-max"
+                loop_ref.set_provider(next_manager, system_prompt="new base prompt")
+
+                async def events():
+                    yield MessageStartEvent(message_id="m1")
+                    yield TextDeltaEvent(text="ok")
+                    yield MessageEndEvent(stop_reason="stop", usage=Usage())
+
+                return events()
+
+        old_manager = OldManager()
+        loop_ref = AgentLoop(provider_manager=old_manager, system_prompt="old base prompt", tool_registry=mock_registry)
+
+        await loop_ref.run("hello")
+
+        assert loop_ref._provider_manager is next_manager
+        assert loop_ref.context_manager._model == "claude-opus-4-7"
+        assert loop_ref.context_manager.system_prompt == "new base prompt"
+        assert old_manager.released is True
+
     def test_set_provider_preserves_messages(self, mock_provider, mock_registry):
         loop = AgentLoop(provider_manager=mock_provider, system_prompt="test", tool_registry=mock_registry)
         loop.context_manager.add_user_message("Hello")
@@ -3108,7 +3230,7 @@ class TestAgentLoopSetProvider:
         assert messages[0].get_text() == "Hello"
         assert messages[1].get_text() == "World"
 
-    def test_set_provider_updates_context_window_for_new_model(self, mock_provider, mock_registry):
+    def test_set_provider_updates_context_window_immediately_when_idle(self, mock_provider, mock_registry):
         loop = AgentLoop(provider_manager=mock_provider, system_prompt="test", tool_registry=mock_registry)
         # mock_provider returns "test-model" → falls back to default config (128_000)
         assert loop.context_manager._config.context_window == 128_000

--- a/tests/cli/test_output_formats.py
+++ b/tests/cli/test_output_formats.py
@@ -35,6 +35,7 @@ from iac_code.types.stream_events import (
     ToolUseStartEvent,
     Usage,
 )
+from iac_code.types.usage_attribution import UsageAttribution
 
 # ---------------------------------------------------------------------------
 # TestTextWriter
@@ -229,6 +230,35 @@ class TestJsonWriter:
 
 
 class TestStreamJsonWriter:
+    def test_terminal_usage_attribution_is_internal_for_direct_and_subpipeline_events(self) -> None:
+        attribution = UsageAttribution(
+            logical_provider_key="openai_compatible",
+            wire_provider_key="dashscope_token_plan",
+            telemetry_provider_name="dashscope",
+            adapter_name="qwen",
+            requested_model="qwen3.8-max",
+            actual_model="qwen3.7-plus",
+        )
+        terminal = MessageEndEvent(
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=1, output_tokens=2),
+            usage_attribution=attribution,
+        )
+        stream = io.StringIO()
+        writer = StreamJsonWriter(stream)
+        writer.handle(terminal)
+        writer.handle(
+            SubPipelineStreamEvent(
+                sub_pipeline_id="sub-1",
+                candidate_index=0,
+                inner=terminal,
+            )
+        )
+        direct, nested = [json.loads(line) for line in stream.getvalue().splitlines()]
+        assert "usage_attribution" not in direct
+        assert "usage_attribution" not in nested["inner"]
+        assert "qwen3.7-plus" not in stream.getvalue()
+
     def test_text_delta_emitted(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
@@ -668,11 +698,21 @@ class TestStreamJsonWriter:
     def test_error_event_preserves_error_id(self) -> None:
         stream = io.StringIO()
         writer = StreamJsonWriter(stream)
-        writer.handle(ErrorEvent(error="boom", is_retryable=False, error_id="err-abc123"))
+        writer.handle(
+            ErrorEvent(
+                error="boom",
+                is_retryable=False,
+                error_id="err-abc123",
+                i18n_message_id="internal message id",
+                i18n_message_args={"state": "internal argument"},
+            )
+        )
 
         data = json.loads(stream.getvalue())
         assert data["type"] == "error"
         assert data["error_id"] == "err-abc123"
+        assert "i18n_message_id" not in data
+        assert "i18n_message_args" not in data
 
     def test_permission_request_omits_internal_audit_context(self) -> None:
         stream = io.StringIO()

--- a/tests/mcp/test_runtime_integration.py
+++ b/tests/mcp/test_runtime_integration.py
@@ -6,6 +6,7 @@ import sys
 import threading
 from collections.abc import Mapping
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -253,7 +254,21 @@ async def test_runtime_starts_failed_mcp_reconnect_on_agent_loop(monkeypatch, tm
     async def fake_stream(*args, **kwargs):
         yield MessageEndEvent(stop_reason="stop", usage=Usage())
 
-    runtime.agent_loop._provider_manager.stream = fake_stream
+    provider_manager = runtime.agent_loop._provider_manager
+
+    def fake_begin_request(system, tools=None):
+        return SimpleNamespace(
+            system_prompt=system,
+            context_window_model="qwen3.7-max",
+            _lease_token=SimpleNamespace(state="active"),
+        )
+
+    def fake_release_request(lease):
+        lease._lease_token.state = "released"
+
+    provider_manager.stream = fake_stream
+    provider_manager.begin_request = fake_begin_request
+    provider_manager.release_request = fake_release_request
 
     async for _event in runtime.agent_loop.run_streaming("hello"):
         pass

--- a/tests/memory/test_recall.py
+++ b/tests/memory/test_recall.py
@@ -9,6 +9,7 @@ import pytest
 
 from iac_code.memory.memory_manager import MemoryManager
 from iac_code.types.stream_events import Usage
+from iac_code.types.usage_attribution import UsageAttribution
 
 
 class FakeRecallProvider:
@@ -19,11 +20,13 @@ class FakeRecallProvider:
         delay: float = 0.0,
         error: Exception | None = None,
         usage: Usage | None = None,
+        usage_attribution: UsageAttribution | None = None,
     ):
         self.text = text
         self.delay = delay
         self.error = error
         self.usage = usage
+        self.usage_attribution = usage_attribution
         self.calls: list[dict[str, object]] = []
 
     async def complete(
@@ -47,7 +50,11 @@ class FakeRecallProvider:
             await asyncio.sleep(self.delay)
         if self.error is not None:
             raise self.error
-        return SimpleNamespace(text=self.text, usage=self.usage)
+        return SimpleNamespace(
+            text=self.text,
+            usage=self.usage,
+            usage_attribution=self.usage_attribution,
+        )
 
 
 class FailingMemoryManager:
@@ -205,6 +212,30 @@ async def test_recall_stats_record_side_call_token_usage(memory_manager):
         "recorded_events": 1,
         "has_recorded_usage": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_recall_result_preserves_terminal_usage_attribution(memory_manager):
+    from iac_code.memory.recall import MemoryRecallService
+
+    attribution = UsageAttribution(
+        logical_provider_key="openai_compatible",
+        wire_provider_key="dashscope",
+        telemetry_provider_name="dashscope",
+        adapter_name="qwen",
+        requested_model="qwen3.8-max",
+        actual_model="qwen3.7-plus",
+    )
+    service = MemoryRecallService(
+        memory_manager=memory_manager,
+        provider_manager=FakeRecallProvider(
+            json.dumps({"files": ["project-deadline.md"]}),
+            usage=Usage(input_tokens=3, output_tokens=1),
+            usage_attribution=attribution,
+        ),
+    )
+    result = await service.recall("deadline")
+    assert result.usage_attribution is attribution
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_manager.py
+++ b/tests/providers/test_manager.py
@@ -14,7 +14,9 @@ from iac_code.providers.manager import (
     _PROVIDER_MODEL_FALLBACK_MAP,
     MODEL_FALLBACK_MAP,
     ProviderManager,
+    ProviderRequestLeaseError,
     _detect_provider_name,
+    _error_event_from_exception,
     _is_bailian_compatible_endpoint,
     _telemetry_provider_name,
     create_provider,
@@ -37,6 +39,19 @@ STREAM_IDLE_TEST_TIMEOUT = 0.2
 
 async def _collect_stream_events(stream):
     return [event async for event in stream]
+
+
+def test_localizable_provider_error_metadata_reaches_error_event() -> None:
+    event = _error_event_from_exception(
+        ProviderRequestLeaseError(
+            "Provider request lease cannot be consumed from state {state}.",
+            state="'released'",
+        )
+    )
+
+    assert event.i18n_message_id == "Provider request lease cannot be consumed from state {state}."
+    assert event.i18n_message_args == {"state": "'released'"}
+    assert "'released'" in event.error
 
 
 class TestCreateProvider:
@@ -1040,6 +1055,7 @@ class TestProviderManagerStreaming:
             "model": "claude-sonnet-4-6",
             GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN: ttft_calls[0].args[1],
             "first_token_source": "thinking_delta",
+            IacCodeAttr.OFFICIAL_ENDPOINT: False,
             **scope,
         }
 
@@ -1632,6 +1648,11 @@ class TestProviderManagerStreaming:
             status_code = 429
 
         class FlakyStreamProvider:
+            _PROVIDER_KEY = "dashscope_token_plan"
+            _logical_provider_key = "dashscope_token_plan"
+            _ADAPTER_NAME = "qwen"
+            _base_url = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+
             def __init__(self):
                 self.stream_calls = 0
                 self.complete_calls = 0
@@ -1676,6 +1697,8 @@ class TestProviderManagerStreaming:
         assert retried[0]["attempt"] == 1
         assert retried[0]["error_type"] == "Status429Error"
         assert retried[0]["streaming"] is True
+        assert retried[0][IacCodeAttr.PROVIDER_ADAPTER] == "qwen"
+        assert retried[0][IacCodeAttr.OFFICIAL_ENDPOINT] is True
 
     async def test_stream_does_not_retry_streaming_once_events_reached_caller(self):
         from iac_code.providers.retry import RetryConfig
@@ -1900,7 +1923,15 @@ class TestProviderManagerCompleteRetry:
         assert success[0]["status"] == "ok"
         total_metrics = [(value, attrs) for name, value, attrs in metrics if name == Metrics.TOKEN_TOTAL]
         assert total_metrics == [
-            (120, {"provider": "asyncmock", "model": "claude-sonnet-4-6", "iac_code.mode": "normal"})
+            (
+                120,
+                {
+                    "provider": "asyncmock",
+                    "model": "claude-sonnet-4-6",
+                    IacCodeAttr.OFFICIAL_ENDPOINT: False,
+                    "iac_code.mode": "normal",
+                },
+            )
         ]
 
     async def test_complete_attributes_bailian_openai_endpoint_to_dashscope_on_all_signals(self):
@@ -2475,6 +2506,56 @@ class TestProviderManagerCompleteRetry:
         assert created_models == ["claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
         assert mgr.get_model_name() == "claude-sonnet-4-6"
         assert mgr._provider is original_provider
+
+    async def test_cross_family_qwen_fallback_prepares_qwen_prompt(self, monkeypatch):
+        from iac_code.providers.retry import RetryConfig
+
+        class Status503Error(Exception):
+            status_code = 503
+
+        class PrimaryProvider:
+            _PROVIDER_KEY = "dashscope"
+            _logical_provider_key = "dashscope"
+
+            async def complete(self, messages, system, tools=None, max_tokens=8192):
+                raise Status503Error("temporary outage")
+
+        class FallbackQwenProvider:
+            _PROVIDER_KEY = "dashscope"
+            _logical_provider_key = "dashscope"
+            _ADAPTER_NAME = "qwen"
+
+            def prepare_system_prompt(self, system, tools):
+                return f"{system}\nqwen-fallback-prompt"
+
+            async def complete(self, messages, system, tools=None, max_tokens=8192):
+                assert system == "base\nqwen-fallback-prompt"
+                return NonStreamingResponse(
+                    message_id="fallback-response",
+                    text="fallback ok",
+                    tool_uses=[],
+                    stop_reason="end_turn",
+                    usage=Usage(),
+                )
+
+        def fake_create_provider(model, credentials, **kwargs):
+            if model == "xiaomi/mimo-v2.5-pro":
+                return PrimaryProvider()
+            assert model == "qwen3.8-flash"
+            return FallbackQwenProvider()
+
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", fake_create_provider)
+        manager = ProviderManager(
+            model="xiaomi/mimo-v2.5-pro",
+            credentials={"dashscope": "key"},
+            retry_config=RetryConfig(max_retries=0, base_delay=0, jitter_factor=0),
+        )
+
+        response = await manager.complete(messages=[Message.user("hi")], system="base")
+
+        assert response.text == "fallback ok"
+        assert response.usage_attribution.actual_model == "qwen3.8-flash"
+        assert response.usage_attribution.adapter_name == "qwen"
 
     async def test_fallback_preserves_runtime_provider_identity(self, monkeypatch):
         from iac_code.providers.retry import RetryConfig

--- a/tests/providers/test_provider_model_research_updates.py
+++ b/tests/providers/test_provider_model_research_updates.py
@@ -396,7 +396,12 @@ def test_dashscope_new_model_protocols_are_not_flattened() -> None:
     assert deepseek.uses_reasoning_effort_param is True
 
     qwen = get_thinking_spec("dashscope", "qwen3.8-max")
-    assert qwen.allowed_efforts == (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.XHIGH)
+    assert qwen.allowed_efforts == (
+        EffortLevel.LOW,
+        EffortLevel.MEDIUM,
+        EffortLevel.HIGH,
+        EffortLevel.XHIGH,
+    )
     assert qwen.default_effort is EffortLevel.XHIGH
     assert qwen.supports_disable is True
     assert DashScopeProvider(
@@ -460,7 +465,12 @@ def test_dashscope_new_model_protocols_are_not_flattened() -> None:
     )._build_thinking_kwargs() == {"extra_body": {"enable_thinking": False}}
 
     preview = get_thinking_spec("dashscope_token_plan", "qwen3.8-max-preview")
-    assert preview.allowed_efforts == (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.XHIGH)
+    assert preview.allowed_efforts == (
+        EffortLevel.LOW,
+        EffortLevel.MEDIUM,
+        EffortLevel.HIGH,
+        EffortLevel.XHIGH,
+    )
     assert preview.default_effort is EffortLevel.XHIGH
     assert preview.supports_disable is False
     assert DashScopeProvider(

--- a/tests/providers/test_qwen_provider.py
+++ b/tests/providers/test_qwen_provider.py
@@ -1,0 +1,1406 @@
+from __future__ import annotations
+
+import copy
+import json
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from iac_code.agent.agent_loop import AgentLoop
+from iac_code.agent.system_prompt import DYNAMIC_BOUNDARY
+from iac_code.cli.output_formats import stream_json_event_data
+from iac_code.providers.base import ContentBlock, Message, NonStreamingResponse, ToolDefinition
+from iac_code.providers.dashscope_provider import DashScopeProvider
+from iac_code.providers.manager import ProviderManager, create_provider
+from iac_code.providers.model_family import is_qwen_model
+from iac_code.providers.openai_provider import OpenAIProvider
+from iac_code.providers.qwen_provider import QwenProvider
+from iac_code.providers.request_policy import ProviderRequestPolicy
+from iac_code.providers.retry import RetryConfig
+from iac_code.providers.schema_compat import relax_qwen_tool_schema
+from iac_code.providers.streaming import CumulativeDeltaNormalizer, UnsafeStreamProtocolError
+from iac_code.providers.thinking import EffortLevel, get_thinking_spec
+from iac_code.services.session_usage import SessionUsageStore
+from iac_code.services.telemetry.names import Events, GenAiAttr, IacCodeAttr, Metrics
+from iac_code.types.stream_events import (
+    ErrorEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    TextDeltaEvent,
+    ThinkingDeltaEvent,
+    TombstoneEvent,
+    ToolUseEndEvent,
+    Usage,
+)
+from tests.providers._fakes import FakeOpenAIClient, ns
+
+
+def _tool(name: str = "read_file") -> ToolDefinition:
+    return ToolDefinition(
+        name=name,
+        description="Read a file",
+        input_schema={
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def _chunk(*, content=None, reasoning_content=None, reasoning=None, tool_calls=None, finish_reason=None, usage=None):
+    delta = ns(content=content, tool_calls=tool_calls)
+    if reasoning_content is not None:
+        delta.reasoning_content = reasoning_content
+    if reasoning is not None:
+        delta.reasoning = reasoning
+    return ns(usage=usage, choices=[ns(finish_reason=finish_reason, delta=delta)])
+
+
+def _response(*, content="", reasoning_content=None, reasoning=None, tool_calls=None, finish_reason="stop"):
+    message = ns(content=content, tool_calls=tool_calls)
+    if reasoning_content is not None:
+        message.reasoning_content = reasoning_content
+    if reasoning is not None:
+        message.reasoning = reasoning
+    return ns(id="response-1", choices=[ns(finish_reason=finish_reason, message=message)], usage=None)
+
+
+class _RequiredThinkingError(RuntimeError):
+    status_code = 400
+    code = "InvalidParameter"
+
+
+class _AsyncChunks:
+    def __init__(self, chunks):
+        self._chunks = iter(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._chunks)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _SequentialCompletions:
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return _AsyncChunks(result) if kwargs.get("stream") else result
+
+
+def _sequential_client(*results):
+    completions = _SequentialCompletions(results)
+    return ns(chat=ns(completions=completions), base_url="https://fake.local"), completions
+
+
+class _ManagerFakeProvider:
+    _PROVIDER_KEY = "dashscope_token_plan"
+    _logical_provider_key = "openai_compatible"
+    _ADAPTER_NAME = "qwen"
+
+    def __init__(
+        self,
+        model,
+        *,
+        streams=None,
+        completion=None,
+        base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    ):
+        self.model = model
+        self._base_url = base_url
+        self.streams = list(streams or [])
+        self.completion = completion or _manager_response(model)
+        self.stream_calls = []
+        self.complete_calls = 0
+
+    def prepare_system_prompt(self, system, tools):
+        return f"{system}\nqwen:{self.model}"
+
+    def stream(self, messages, system, tools=None, max_tokens=8192):
+        self.stream_calls.append((system, tools))
+        outcome = self.streams.pop(0)
+
+        async def generate():
+            for item in outcome:
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+
+        return generate()
+
+    async def complete(self, messages, system, tools=None, max_tokens=8192, **kwargs):
+        self.complete_calls += 1
+        if isinstance(self.completion, BaseException):
+            raise self.completion
+        return self.completion
+
+
+def _manager_response(model="qwen3.8-max"):
+    return NonStreamingResponse(
+        message_id=f"complete-{model}",
+        text="ok",
+        tool_uses=[],
+        stop_reason="end_turn",
+        usage=Usage(input_tokens=3, output_tokens=2, reported=True),
+        thinking="",
+        thinking_blocks=[],
+        usage_attribution=None,
+    )
+
+
+def _valid_manager_stream(message_id="msg-1"):
+    return [
+        MessageStartEvent(message_id=message_id),
+        TextDeltaEvent(text="ok"),
+        MessageEndEvent(
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=3, output_tokens=2, reported=True),
+        ),
+    ]
+
+
+class TestQwenRouting:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            (" qwen3.8-max ", True),
+            ("Qwen/Qwen3.5-122B-A10B", True),
+            ("coder-model", True),
+            ("qwq-plus", False),
+            ("not-qwen-model", False),
+        ],
+    )
+    def test_model_family(self, model, expected):
+        assert is_qwen_model(model) is expected
+
+    @pytest.mark.parametrize(
+        "provider_key",
+        ["dashscope", "dashscope_token_plan", "aliyun_codingplan", "aliyun_codingplan_intl"],
+    )
+    def test_explicit_dashscope_qwen_uses_subclass(self, provider_key):
+        provider = create_provider(
+            "qwen3.7-plus",
+            {provider_key: "fake"},
+            provider_key_override=provider_key,
+            provider_config_override={},
+        )
+        assert type(provider) is QwenProvider
+        assert provider._PROVIDER_KEY == provider_key
+        assert provider._logical_provider_key == provider_key
+
+    @pytest.mark.parametrize("model", ["deepseek-v4-pro", "glm-5.2", "MiniMax-M2.5", "kimi-k2.6"])
+    def test_non_qwen_remains_dashscope(self, model):
+        provider = create_provider(
+            model,
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={},
+        )
+        assert type(provider) is DashScopeProvider
+
+    @pytest.mark.parametrize(
+        ("url", "wire"),
+        [
+            ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "dashscope"),
+            ("https://dashscope-us.aliyuncs.com/compatible-mode/v1", "dashscope"),
+            ("https://token-plan.us-east-1.maas.aliyuncs.com/compatible-mode/v1", "dashscope_token_plan"),
+            ("https://coding.dashscope.aliyuncs.com/v1", "aliyun_codingplan"),
+            ("https://coding-intl.dashscope.aliyuncs.com/v1", "aliyun_codingplan_intl"),
+        ],
+    )
+    def test_official_compatible_qwen_routes_to_wire_family(self, url, wire):
+        provider = create_provider(
+            "qwen3.7-plus",
+            {"openai_compatible": "fake"},
+            provider_key_override="openai_compatible",
+            base_url=url,
+            provider_config_override={},
+        )
+        assert type(provider) is QwenProvider
+        assert provider._PROVIDER_KEY == wire
+        assert provider._logical_provider_key == "openai_compatible"
+
+    def test_custom_openai_compatible_qwen_does_not_use_qwen_provider(self):
+        provider = create_provider(
+            "qwen3.7-plus",
+            {"openai_compatible": "fake"},
+            provider_key_override="openai_compatible",
+            base_url="https://proxy.example/v1",
+            provider_config_override={},
+        )
+        assert not isinstance(provider, QwenProvider)
+
+    def test_new_official_route_does_not_reclassify_non_qwen(self):
+        provider = create_provider(
+            "glm-5.2",
+            {"openai_compatible": "fake"},
+            provider_key_override="openai_compatible",
+            base_url="https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+            provider_config_override={},
+        )
+        assert provider._PROVIDER_KEY == "openai_compatible"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://dashscope.aliyuncs.com/compatible-mode/v1",
+            "https://dashscope.aliyuncs.com:8443/compatible-mode/v1",
+            "https://dashscope.aliyuncs.com.example/compatible-mode/v1",
+            "https://dashscope.aliyuncs.com/compatible-mode-evil/v1",
+            "https://dashscope.aliyuncs.com/apps/anthropic",
+            "https://example.com/compatible-mode/v1?target=dashscope.aliyuncs.com",
+        ],
+    )
+    def test_malicious_or_wrong_protocol_urls_do_not_route(self, url):
+        provider = create_provider(
+            "qwen3.7-plus",
+            {"openai_compatible": "fake"},
+            provider_key_override="openai_compatible",
+            base_url=url,
+            provider_config_override={},
+        )
+        assert type(provider) is OpenAIProvider
+
+    @pytest.mark.parametrize(
+        ("url", "wire"),
+        [
+            ("https://dashscope.aliyuncs.com/compatible-mode/v1", "dashscope"),
+            ("https://cn-hongkong.dashscope.aliyuncs.com/compatible-mode/v1", "dashscope"),
+            (
+                "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+                "dashscope_token_plan",
+            ),
+        ],
+    )
+    def test_legacy_official_routes_still_apply_to_non_qwen(self, url, wire):
+        provider = create_provider(
+            "glm-5.2",
+            {"openai_compatible": "fake"},
+            provider_key_override="openai_compatible",
+            base_url=url,
+            provider_config_override={},
+        )
+        assert type(provider) is DashScopeProvider
+        assert provider._PROVIDER_KEY == wire
+
+    def test_global_token_plan_query_cannot_trigger_legacy_non_qwen_route(self):
+        provider = create_provider(
+            "glm-5.2",
+            {"openai_compatible": "fake"},
+            provider_key_override="openai_compatible",
+            base_url=(
+                "https://token-plan.us-east-1.maas.aliyuncs.com/compatible-mode/v1"
+                "?target=token-plan.cn-beijing.maas.aliyuncs.com"
+            ),
+            provider_config_override={},
+        )
+        assert provider._PROVIDER_KEY == "openai_compatible"
+
+    def test_modelscope_qwen_does_not_use_dashscope_adapter(self):
+        provider = create_provider(
+            "Qwen/Qwen3.5-122B-A10B",
+            {"modelscope": "fake"},
+            provider_key_override="modelscope",
+            provider_config_override={},
+        )
+        assert not isinstance(provider, (DashScopeProvider, QwenProvider))
+
+
+class TestQwenRequestAdaptation:
+    def test_inheritance_and_adapter_identity(self):
+        provider = QwenProvider(model="qwen3.7-plus", api_key="fake")
+        assert isinstance(provider, DashScopeProvider)
+        assert provider._ADAPTER_NAME == "qwen"
+
+    @pytest.mark.parametrize("model", ["qwen3-coder-plus", "qwen-vl-max", "qwen3.7-plus"])
+    def test_prompt_is_dynamic_bounded_and_idempotent(self, model):
+        provider = QwenProvider(model=model, api_key="fake")
+        base = f"stable\n{DYNAMIC_BOUNDARY}\ndynamic"
+        prepared = provider.prepare_system_prompt(base, [_tool()])
+        assert prepared.startswith(f"stable\n{DYNAMIC_BOUNDARY}")
+        assert "read_file" in prepared
+        assert provider.prepare_system_prompt(prepared, [_tool()]) == prepared
+        assert provider.prepare_system_prompt(base, None) == base
+
+    def test_prompt_styles_match_qwen_code_formats_and_keep_static_prefix_stable(self):
+        base = f"stable prefix\n{DYNAMIC_BOUNDARY}\nproject facts"
+        coder = QwenProvider(model="qwen3-coder-plus", api_key="fake").prepare_system_prompt(base, [_tool()])
+        vision = QwenProvider(model="qwen-vl-max", api_key="fake").prepare_system_prompt(base, [_tool()])
+        generic = QwenProvider(model="qwen3.7-plus", api_key="fake").prepare_system_prompt(base, [_tool()])
+        assert "<function=read_file>" in coder and "<parameter=path>" in coder
+        assert '<tool_call>{"name":"read_file","arguments":{"path":"VALUE"}}</tool_call>' in vision
+        assert '<tool_call>{"name"' not in generic
+        assert all(item.split(DYNAMIC_BOUNDARY, 1)[0] == "stable prefix\n" for item in (coder, vision, generic))
+        assert all(len(item) - len(base) < 900 for item in (coder, vision, generic))
+
+    def test_custom_proxy_disables_official_cache_protocol(self):
+        provider = QwenProvider(model="qwen3.7-plus", api_key="fake", base_url="https://proxy.example/v1")
+        assert provider._request_headers() == {}
+        messages = provider._build_api_messages([], "system")
+        assert messages == [{"role": "system", "content": "system"}]
+
+    def test_official_endpoint_enables_header_and_stream_tool_marker(self):
+        provider = QwenProvider(model="qwen3.7-plus", api_key="fake")
+        assert provider._request_headers() == {"X-DashScope-CacheControl": "enable"}
+        api_tools = provider._build_api_tools([_tool()], streaming=True)
+        assert api_tools[-1]["cache_control"] == {"type": "ephemeral"}
+        assert "$schema" not in api_tools[0]["function"]["parameters"]
+
+    def test_cache_protocol_requires_policy_model_and_official_endpoint(self):
+        unsupported = QwenProvider(model="qwen2-legacy", api_key="fake")
+        assert unsupported._request_headers() == {}
+        disabled = QwenProvider(model="qwen3.7-plus", api_key="fake")
+        assert disabled._request_headers(cache_policy="no_explicit_cache") == {}
+        tools = disabled._build_api_tools([_tool()], streaming=True, cache_policy="no_explicit_cache")
+        assert "cache_control" not in tools[-1]
+
+    def test_schema_wire_copy_does_not_mutate_original(self):
+        tool = _tool()
+        original = copy.deepcopy(tool.input_schema)
+        provider = QwenProvider(model="qwen3.7-plus", api_key="fake")
+        prepared = provider._build_api_tools([tool], streaming=False)
+        assert tool.input_schema == original
+        assert prepared[0]["function"]["parameters"]["additionalProperties"] is False
+
+    def test_schema_relaxation_is_recursive_and_preserves_map_keyword_names(self):
+        schema = {
+            "$schema": "draft",
+            "$id": "root",
+            "type": "object",
+            "properties": {
+                "$schema": {"type": "string", "uniqueItems": True},
+                "optional": {
+                    "type": "object",
+                    "properties": {"x": {"type": "array", "uniqueItems": True}},
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["$schema"],
+            "additionalProperties": False,
+            "enum": [{"$schema": "literal", "uniqueItems": True}],
+        }
+        original = copy.deepcopy(schema)
+        relaxed = relax_qwen_tool_schema(schema)
+        assert schema == original
+        assert "$schema" not in relaxed and "$id" not in relaxed
+        assert "$schema" in relaxed["properties"]
+        assert "uniqueItems" not in relaxed["properties"]["$schema"]
+        assert "additionalProperties" not in relaxed
+        assert "additionalProperties" not in relaxed["properties"]["optional"]
+        assert relaxed["enum"] == [{"$schema": "literal", "uniqueItems": True}]
+
+    def test_qwen38_efforts_and_token_plan_mandatory(self):
+        default = QwenProvider(model="qwen3.8-max", api_key="fake")
+        assert default._build_thinking_kwargs() == {
+            "reasoning_effort": "xhigh",
+            "extra_body": {"preserve_thinking": True},
+        }
+        provider = QwenProvider(model="qwen3.8-max-latest", api_key="fake", effort="high")
+        assert provider._build_thinking_kwargs()["reasoning_effort"] == "high"
+        provider = QwenProvider(model="qwen3.8-max-2026-08-01", api_key="fake", effort="max")
+        assert provider._build_thinking_kwargs()["reasoning_effort"] == "xhigh"
+        mandatory = QwenProvider(
+            model="qwen3.8-max",
+            api_key="fake",
+            provider_key="dashscope_token_plan",
+            thinking_enabled=False,
+        )
+        assert mandatory._build_thinking_kwargs()["extra_body"]["enable_thinking"] is True
+        assert EffortLevel.HIGH in get_thinking_spec("dashscope", "qwen3.8-max-latest").allowed_efforts
+
+    def test_qwen38_standard_disable_and_cross_source_precedence(self):
+        standard = QwenProvider(model="qwen3.8-max", api_key="fake", thinking_enabled=False)
+        assert standard._build_thinking_kwargs()["reasoning_effort"] == "none"
+
+        request_effort = create_provider(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={"thinkingEnabled": False},
+            request_policy_override=ProviderRequestPolicy(effort="high"),
+        )
+        assert request_effort._build_thinking_kwargs()["reasoning_effort"] == "high"
+
+        request_disable = create_provider(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={"effort": "high"},
+            request_policy_override=ProviderRequestPolicy(thinking_enabled=False, effort="high"),
+        )
+        assert request_disable._build_thinking_kwargs()["reasoning_effort"] == "none"
+
+    def test_qwen_thinking_budget_effort_and_disable_precedence(self):
+        request_budget = create_provider(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={"thinkingEnabled": False, "effort": "low"},
+            request_policy_override=ProviderRequestPolicy(thinking_budget=4096),
+        )
+        assert request_budget._build_thinking_kwargs() == {
+            "extra_body": {
+                "enable_thinking": True,
+                "preserve_thinking": True,
+                "thinking_budget": 4096,
+            }
+        }
+
+        request_effort = create_provider(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={"models": {"qwen3.8-max": {"thinkingBudget": 4096}}},
+            request_policy_override=ProviderRequestPolicy(effort="high"),
+        )
+        assert request_effort._build_thinking_kwargs() == {
+            "reasoning_effort": "high",
+            "extra_body": {"preserve_thinking": True},
+        }
+
+        same_layer_effort = create_provider(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={},
+            request_policy_override=ProviderRequestPolicy(effort="medium", thinking_budget=2048),
+        )
+        assert same_layer_effort._build_thinking_kwargs()["reasoning_effort"] == "medium"
+        assert "thinking_budget" not in same_layer_effort._build_thinking_kwargs().get("extra_body", {})
+
+        same_layer_disable = create_provider(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={},
+            request_policy_override=ProviderRequestPolicy(
+                thinking_enabled=False,
+                effort="high",
+                thinking_budget=2048,
+            ),
+        )
+        assert same_layer_disable._build_thinking_kwargs()["reasoning_effort"] == "none"
+
+        legacy_budget = create_provider(
+            "qwen3.7-plus",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={"thinkingEnabled": False},
+            request_policy_override=ProviderRequestPolicy(thinking_budget=1024),
+        )
+        assert legacy_budget._build_thinking_kwargs()["extra_body"] == {
+            "enable_thinking": True,
+            "preserve_thinking": True,
+            "thinking_budget": 1024,
+        }
+
+    def test_legacy_disable_alias_respects_higher_request_enable(self):
+        provider = create_provider(
+            "qwen3.7-plus",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={"effort": "off"},
+            request_policy_override=ProviderRequestPolicy(thinking_enabled=True),
+        )
+        assert provider._build_thinking_kwargs()["extra_body"]["enable_thinking"] is True
+
+    def test_reasoning_is_nullish_first_and_history_writes_one_field(self):
+        provider = QwenProvider(model="qwen3.7-plus", api_key="fake")
+        value = SimpleNamespace(reasoning_content="", reasoning="fallback")
+        assert provider._extract_reasoning_text(value) == ""
+        api = provider._convert_content_blocks(
+            "assistant",
+            [ContentBlock(type="thinking", text="thought"), ContentBlock(type="text", text="answer")],
+        )
+        assert api[0]["reasoning_content"] == "thought"
+        assert "reasoning" not in api[0]
+
+
+class TestCumulativeDeltaNormalizer:
+    def test_incremental_short_repeat_and_prefix_transition(self):
+        normalizer = CumulativeDeltaNormalizer()
+        assert normalizer.feed("abc") == "abc"
+        assert normalizer.feed("abc") == "abc"
+        assert normalizer.feed("abcdef") == "def"
+        assert normalizer.mode == "cumulative"
+
+    def test_long_repeat_rewind_divergence_and_detection_window(self):
+        repeated = "x" * 64
+        normalizer = CumulativeDeltaNormalizer()
+        assert normalizer.feed(repeated) == repeated
+        assert normalizer.feed(repeated) == ""
+        assert normalizer.feed(repeated[:20]) == ""
+        assert normalizer.feed("fresh") == "fresh"
+        assert normalizer.mode == "incremental"
+
+        normalizer = CumulativeDeltaNormalizer()
+        chunks = ["a" * 600, "b" * 600]
+        assert "".join(normalizer.feed(chunk) for chunk in chunks) == "".join(chunks)
+        cumulative = "".join(chunks) + "tail"
+        assert normalizer.feed(cumulative) == "tail"
+
+
+@pytest.mark.asyncio
+class TestQwenManagerLeaseAndAttribution:
+    async def test_real_qwen_provider_flows_through_agent_usage_store_and_cli_surface(self, monkeypatch, tmp_path):
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(content="Qwen answer"),
+                _chunk(
+                    finish_reason="stop",
+                    usage=ns(prompt_tokens=7, completion_tokens=3),
+                ),
+            ],
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        )
+        provider = QwenProvider(
+            model="qwen3.8-max",
+            client=client,
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            provider_key="dashscope",
+        )
+        provider._logical_provider_key = "dashscope"
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", lambda *_args, **_kwargs: provider)
+        manager = ProviderManager(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            provider_key_override="dashscope",
+            provider_config_override={},
+        )
+        usage_path = tmp_path / "usage.jsonl"
+        usage_store = SessionUsageStore(path_provider=lambda _cwd, _session_id: usage_path)
+        registry = MagicMock()
+        registry.list_tools.return_value = [
+            SimpleNamespace(
+                name="read_file",
+                description="Read a file",
+                input_schema={"type": "object", "properties": {"path": {"type": "string"}}},
+            )
+        ]
+        registry.get.return_value = None
+        loop = AgentLoop(
+            provider_manager=manager,
+            system_prompt="base system",
+            tool_registry=registry,
+            session_id="qwen-integration",
+            cwd=str(tmp_path / "project"),
+            session_usage_store=usage_store,
+        )
+        monkeypatch.setattr(loop, "_refresh_git_branch", lambda: None)
+
+        events = [event async for event in loop.run_streaming("hello")]
+
+        terminal = next(event for event in events if isinstance(event, MessageEndEvent))
+        assert terminal.usage_attribution is not None
+        assert terminal.usage_attribution.logical_provider_key == "dashscope"
+        assert terminal.usage_attribution.wire_provider_key == "dashscope"
+        assert terminal.usage_attribution.telemetry_provider_name == "dashscope"
+        assert terminal.usage_attribution.adapter_name == "qwen"
+        assert terminal.usage.input_tokens == 7
+        assert terminal.usage.output_tokens == 3
+        persisted = json.loads(usage_path.read_text(encoding="utf-8"))
+        assert persisted["provider"] == "dashscope"
+        assert persisted["model"] == "qwen3.8-max"
+        public_terminal = stream_json_event_data(terminal)
+        assert "usage_attribution" not in public_terminal
+        assert public_terminal["usage"]["provider"] == "dashscope"
+        assert "<!-- iac-code:qwen-tools:start -->" in loop.get_last_provider_request_snapshot()["system_prompt"]
+
+    async def test_lease_binds_old_provider_model_and_prompt_across_reconfigure(self, monkeypatch):
+        old = _ManagerFakeProvider("qwen3.8-max", streams=[_valid_manager_stream("old")])
+        new = _ManagerFakeProvider("qwen3.7-plus", streams=[_valid_manager_stream("new")])
+
+        def factory(model, *_args, **_kwargs):
+            return old if model == "qwen3.8-max" else new
+
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", factory)
+        manager = ProviderManager(
+            "qwen3.8-max",
+            {"dashscope_token_plan": "fake"},
+            provider_key_override="dashscope_token_plan",
+        )
+        lease = manager.begin_request("base")
+        assert lease.system_prompt.endswith("qwen:qwen3.8-max")
+        manager.reconfigure(
+            "qwen3.7-plus",
+            {"dashscope_token_plan": "fake"},
+            provider_key_override="dashscope_token_plan",
+        )
+        events = [
+            event
+            async for event in manager.stream(
+                [Message.user("hi")],
+                lease.system_prompt,
+                lease=lease,
+            )
+        ]
+        end = next(event for event in events if isinstance(event, MessageEndEvent))
+        assert old.stream_calls == [(lease.system_prompt, None)]
+        assert not new.stream_calls
+        assert end.usage_attribution.requested_model == "qwen3.8-max"
+        assert end.usage_attribution.actual_model == "qwen3.8-max"
+        manager.release_request(lease)
+
+        events = [event async for event in manager.stream([Message.user("hi")], "base")]
+        assert next(event for event in events if isinstance(event, MessageEndEvent)).usage_attribution.actual_model == (
+            "qwen3.7-plus"
+        )
+
+    async def test_lease_rejects_cross_manager_double_consume_and_double_release(self, monkeypatch):
+        provider = _ManagerFakeProvider("qwen3.8-max", streams=[_valid_manager_stream()])
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", lambda *_args, **_kwargs: provider)
+        first = ProviderManager("qwen3.8-max", {"dashscope_token_plan": "fake"})
+        second = ProviderManager("qwen3.8-max", {"dashscope_token_plan": "fake"})
+        lease = first.begin_request("base")
+        with pytest.raises(ValueError, match="different manager"):
+            second._consume_request_lease(lease)
+        first._consume_request_lease(lease)
+        with pytest.raises(ValueError, match="consumed"):
+            first._consume_request_lease(lease)
+        first.release_request(lease)
+        with pytest.raises(ValueError, match="already released"):
+            first.release_request(lease)
+
+    @pytest.mark.parametrize(
+        ("base_url", "adapter", "official"),
+        [
+            (
+                "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+                "qwen",
+                True,
+            ),
+            ("https://proxy.example/v1", "qwen", False),
+            ("https://dashscope.aliyuncs.com/compatible-mode/v1", "", True),
+        ],
+    )
+    async def test_provider_adapter_and_official_endpoint_are_on_stream_and_complete_telemetry(
+        self,
+        monkeypatch,
+        base_url,
+        adapter,
+        official,
+    ):
+        provider = _ManagerFakeProvider(
+            "qwen3.8-max",
+            streams=[_valid_manager_stream()],
+            base_url=base_url,
+        )
+        provider._PROVIDER_KEY = "dashscope"
+        provider._ADAPTER_NAME = adapter
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", lambda *_args, **_kwargs: provider)
+        telemetry_events = []
+        telemetry_metrics = []
+        stream_span = MagicMock()
+        complete_span = MagicMock()
+        detached = MagicMock(return_value=stream_span)
+        attached = MagicMock(return_value=nullcontext(complete_span))
+        monkeypatch.setattr("iac_code.providers.manager.start_detached_span", detached)
+        monkeypatch.setattr("iac_code.providers.manager.start_span", attached)
+        monkeypatch.setattr(
+            "iac_code.providers.manager.log_event",
+            lambda name, attrs: telemetry_events.append((name, attrs)),
+        )
+        monkeypatch.setattr(
+            "iac_code.providers.manager.add_metric",
+            lambda name, value, attrs: telemetry_metrics.append((name, value, attrs)),
+        )
+
+        manager = ProviderManager("qwen3.8-max", {"dashscope": "fake"})
+        _ = [event async for event in manager.stream([Message.user("hi")], "base")]
+        await manager.complete([Message.user("hi")], "base")
+
+        span_attrs = [detached.call_args.args[1], attached.call_args.args[1]]
+        lifecycle_attrs = [
+            attrs
+            for name, attrs in telemetry_events
+            if name
+            in {
+                Events.API_REQUEST_STARTED,
+                Events.API_REQUEST_SUCCEEDED,
+                Events.API_REQUEST_FAILED,
+            }
+        ]
+        assert len(lifecycle_attrs) == 4
+        for attrs in [*span_attrs, *lifecycle_attrs]:
+            assert attrs[IacCodeAttr.OFFICIAL_ENDPOINT] is official
+            if adapter:
+                assert attrs[IacCodeAttr.PROVIDER_ADAPTER] == adapter
+            else:
+                assert IacCodeAttr.PROVIDER_ADAPTER not in attrs
+        metric_attrs = [
+            attrs
+            for name, _value, attrs in telemetry_metrics
+            if name
+            in {
+                Metrics.API_REQUEST_COUNT,
+                Metrics.API_REQUEST_DURATION,
+                Metrics.TOKEN_USAGE_REPORT_COUNT,
+                Metrics.TOKEN_TOTAL,
+                Metrics.TOKEN_USAGE,
+            }
+        ]
+        assert metric_attrs
+        for attrs in metric_attrs:
+            assert attrs["provider"] == "dashscope"
+            assert attrs[IacCodeAttr.OFFICIAL_ENDPOINT] is official
+            if adapter:
+                assert attrs[IacCodeAttr.PROVIDER_ADAPTER] == adapter
+            else:
+                assert IacCodeAttr.PROVIDER_ADAPTER not in attrs
+
+    async def test_terminal_attribution_separates_logical_wire_service_adapter_and_models(self, monkeypatch):
+        provider = _ManagerFakeProvider("qwen3.8-max", streams=[_valid_manager_stream()])
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", lambda *_args, **_kwargs: provider)
+        manager = ProviderManager(
+            "qwen3.8-max",
+            {"openai_compatible": "fake"},
+            provider_key_override="openai_compatible",
+        )
+        events = [event async for event in manager.stream([Message.user("hi")], "base")]
+        attribution = next(
+            event.usage_attribution for event in events if isinstance(event, MessageEndEvent)
+        )
+        assert (
+            attribution.logical_provider_key,
+            attribution.wire_provider_key,
+            attribution.telemetry_provider_name,
+            attribution.adapter_name,
+        ) == ("openai_compatible", "dashscope_token_plan", "dashscope", "qwen")
+
+        response = await manager.complete([Message.user("hi")], "base")
+        assert response.usage_attribution == attribution
+
+    async def test_model_fallback_attributes_actual_success_model(self, monkeypatch):
+        class ServerError(RuntimeError):
+            status_code = 500
+
+        telemetry_events = []
+        monkeypatch.setattr(
+            "iac_code.providers.manager.log_event",
+            lambda name, attrs: telemetry_events.append((name, attrs)),
+        )
+        primary = _ManagerFakeProvider("qwen3.8-max", completion=ServerError("temporary"))
+        fallback = _ManagerFakeProvider(
+            "qwen3.7-plus",
+            completion=_manager_response("qwen3.7-plus"),
+            base_url="https://proxy.example/v1",
+        )
+
+        def factory(model, *_args, **_kwargs):
+            return primary if model == "qwen3.8-max" else fallback
+
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", factory)
+        manager = ProviderManager(
+            "qwen3.8-max",
+            {"dashscope": "fake"},
+            retry_config=RetryConfig(max_retries=0),
+            provider_key_override="dashscope",
+        )
+        response = await manager.complete([Message.user("hi")], "base")
+        assert response.usage_attribution.requested_model == "qwen3.8-max"
+        assert response.usage_attribution.actual_model == "qwen3.7-plus"
+        started = [attrs for name, attrs in telemetry_events if name == Events.API_REQUEST_STARTED]
+        assert [attrs[IacCodeAttr.OFFICIAL_ENDPOINT] for attrs in started] == [True, False]
+        assert [attrs[IacCodeAttr.PROVIDER_ADAPTER] for attrs in started] == ["qwen", "qwen"]
+
+    async def test_unsafe_stream_tombstones_and_replays_twice_without_complete(self, monkeypatch):
+        telemetry_events = []
+        monkeypatch.setattr(
+            "iac_code.providers.manager.log_event",
+            lambda name, attrs: telemetry_events.append((name, attrs)),
+        )
+        unsafe = UnsafeStreamProtocolError("tag leak")
+        provider = _ManagerFakeProvider(
+            "qwen3.8-max",
+            streams=[
+                [MessageStartEvent(message_id="one"), TextDeltaEvent(text="hidden"), unsafe],
+                [MessageStartEvent(message_id="two"), unsafe],
+                [MessageStartEvent(message_id="three"), unsafe],
+            ],
+        )
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", lambda *_args, **_kwargs: provider)
+        manager = ProviderManager("qwen3.8-max", {"dashscope": "fake"})
+        events = [event async for event in manager.stream([Message.user("hi")], "base")]
+        assert len(provider.stream_calls) == 3
+        assert provider.complete_calls == 0
+        assert [event.message_id for event in events if isinstance(event, TombstoneEvent)] == [
+            "one",
+            "two",
+            "three",
+        ]
+        assert isinstance(events[-1], ErrorEvent)
+        assert not any(isinstance(event, MessageEndEvent) for event in events)
+        assert [name for name, _attrs in telemetry_events].count(Events.API_REQUEST_STARTED) == 3
+        assert [name for name, _attrs in telemetry_events].count(Events.API_REQUEST_FAILED) == 3
+        assert [name for name, _attrs in telemetry_events].count(Events.API_REQUEST_SUCCEEDED) == 0
+
+    async def test_unsafe_stream_successful_replay_keeps_terminal_attribution(self, monkeypatch):
+        telemetry_events = []
+        primary_span = MagicMock()
+        replay_span = MagicMock()
+        monkeypatch.setattr(
+            "iac_code.providers.manager.log_event",
+            lambda name, attrs: telemetry_events.append((name, attrs)),
+        )
+        monkeypatch.setattr(
+            "iac_code.providers.manager.start_detached_span",
+            MagicMock(side_effect=[primary_span, replay_span]),
+        )
+        provider = _ManagerFakeProvider(
+            "qwen3.8-max",
+            streams=[
+                [MessageStartEvent(message_id="one"), UnsafeStreamProtocolError("tag leak")],
+                _valid_manager_stream("two"),
+            ],
+        )
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", lambda *_args, **_kwargs: provider)
+        manager = ProviderManager("qwen3.8-max", {"dashscope": "fake"})
+        events = [event async for event in manager.stream([Message.user("hi")], "base")]
+        assert provider.complete_calls == 0
+        assert any(isinstance(event, TombstoneEvent) and event.message_id == "one" for event in events)
+        end = next(event for event in events if isinstance(event, MessageEndEvent))
+        assert end.usage_attribution.actual_model == "qwen3.8-max"
+        assert end.usage.provider == "dashscope"
+        assert end.usage.model == "qwen3.8-max"
+        assert [name for name, _attrs in telemetry_events].count(Events.API_REQUEST_STARTED) == 2
+        assert [name for name, _attrs in telemetry_events].count(Events.API_REQUEST_FAILED) == 1
+        assert [name for name, _attrs in telemetry_events].count(Events.API_REQUEST_SUCCEEDED) == 1
+        first_token_events = [attrs for name, attrs in telemetry_events if name == Events.API_RESPONSE_FIRST_TOKEN]
+        assert len(first_token_events) == 1
+        assert first_token_events[0]["provider"] == "dashscope"
+        assert first_token_events[0]["replay_attempt"] == 1
+        assert first_token_events[0]["first_token_source"] == "text_delta"
+        assert first_token_events[0][IacCodeAttr.PROVIDER_ADAPTER] == "qwen"
+        assert first_token_events[0][IacCodeAttr.OFFICIAL_ENDPOINT] is True
+        replay_ttft = [
+            call
+            for call in replay_span.set_attribute.call_args_list
+            if call.args[0] == GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN
+        ]
+        assert len(replay_ttft) == 1
+        assert replay_ttft[0].args[1] == first_token_events[0][GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN]
+        for name, attrs in telemetry_events:
+            if name in {
+                Events.API_REQUEST_STARTED,
+                Events.API_REQUEST_FAILED,
+                Events.API_REQUEST_SUCCEEDED,
+            }:
+                assert attrs[IacCodeAttr.PROVIDER_ADAPTER] == "qwen"
+                assert attrs[IacCodeAttr.OFFICIAL_ENDPOINT] is True
+
+
+@pytest.mark.asyncio
+class TestQwenResponses:
+    async def test_streaming_and_non_streaming_cache_marker_scope(self):
+        stream_client = FakeOpenAIClient(
+            stream_chunks=[_chunk(content="ok"), _chunk(finish_reason="stop")]
+        )
+        stream_provider = QwenProvider(model="qwen3.7-plus", client=stream_client)
+        _ = [
+            event
+            async for event in stream_provider.stream(
+                [Message.user("hello")],
+                "system",
+                [_tool()],
+            )
+        ]
+        stream_call = stream_client.chat.completions.calls[0]
+        assert stream_call["extra_headers"] == {"X-DashScope-CacheControl": "enable"}
+        assert stream_call["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+        assert any(
+            isinstance(part, dict) and "cache_control" in part
+            for message in stream_call["messages"]
+            if message["role"] == "user"
+            for part in message["content"]
+        )
+
+        complete_client = FakeOpenAIClient(create_response=_response(content="ok"))
+        complete_provider = QwenProvider(model="qwen3.7-plus", client=complete_client)
+        await complete_provider.complete([Message.user("hello")], "system", [_tool()])
+        complete_call = complete_client.chat.completions.calls[0]
+        assert "cache_control" not in complete_call["tools"][-1]
+        assert complete_call["messages"][0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert all(
+            "cache_control" not in part
+            for message in complete_call["messages"]
+            if message["role"] == "user"
+            for part in message["content"]
+        )
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    async def test_required_thinking_error_rebuilds_once_and_is_learned(self, streaming):
+        error = _RequiredThinkingError(
+            "The value of the enable_thinking parameter is restricted to True."
+        )
+        success = (
+            [_chunk(content="ok"), _chunk(finish_reason="stop")]
+            if streaming
+            else _response(content="ok")
+        )
+        client, completions = _sequential_client(error, success, success)
+        provider = QwenProvider(
+            model="qwen3.8-max",
+            client=client,
+            thinking_enabled=False,
+        )
+        provider._extra_request_kwargs = {"tool_choice": "required"}
+        if streaming:
+            _ = [event async for event in provider.stream([Message.user("hi")], "sys", [_tool()])]
+        else:
+            await provider.complete([Message.user("hi")], "sys", [_tool()])
+        assert completions.calls[0]["reasoning_effort"] == "none"
+        assert completions.calls[0]["tool_choice"] == "required"
+        assert completions.calls[1]["extra_body"]["enable_thinking"] is True
+        assert "reasoning_effort" not in completions.calls[1]
+        assert "tool_choice" not in completions.calls[1]
+
+        if streaming:
+            _ = [event async for event in provider.stream([Message.user("again")], "sys", [_tool()])]
+        else:
+            await provider.complete([Message.user("again")], "sys", [_tool()])
+        assert completions.calls[2]["extra_body"]["enable_thinking"] is True
+
+    async def test_required_thinking_retry_reports_both_real_api_attempts(self, monkeypatch):
+        error = _RequiredThinkingError(
+            "The value of the enable_thinking parameter is restricted to True."
+        )
+        client, completions = _sequential_client(
+            error,
+            [_chunk(content="ok"), _chunk(finish_reason="stop")],
+        )
+        provider = QwenProvider(
+            model="qwen3.8-max",
+            client=client,
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            provider_key="dashscope",
+            thinking_enabled=False,
+        )
+        provider._extra_request_kwargs = {"tool_choice": "required"}
+        events = []
+        metrics = []
+        monkeypatch.setattr("iac_code.providers.manager.create_provider", lambda *_args, **_kwargs: provider)
+        monkeypatch.setattr(
+            "iac_code.providers.manager.log_event",
+            lambda name, attrs: events.append((name, attrs)),
+        )
+        monkeypatch.setattr(
+            "iac_code.providers.qwen_provider.log_event",
+            lambda name, attrs: events.append((name, attrs)),
+        )
+        monkeypatch.setattr(
+            "iac_code.providers.manager.add_metric",
+            lambda name, value, attrs: metrics.append((name, value, attrs)),
+        )
+        monkeypatch.setattr(
+            "iac_code.providers.qwen_provider.add_metric",
+            lambda name, value, attrs: metrics.append((name, value, attrs)),
+        )
+
+        manager = ProviderManager("qwen3.8-max", {"dashscope": "fake"})
+        result = [event async for event in manager.stream([Message.user("hi")], "sys", [_tool()])]
+
+        assert len(completions.calls) == 2
+        assert any(isinstance(event, MessageEndEvent) for event in result)
+        failures = [attrs for name, attrs in events if name == Events.API_REQUEST_FAILED]
+        retries = [attrs for name, attrs in events if name == Events.API_REQUEST_RETRIED]
+        successes = [attrs for name, attrs in events if name == Events.API_REQUEST_SUCCEEDED]
+        assert len(failures) == len(retries) == len(successes) == 1
+        assert failures[0]["status"] == "compatibility_retry"
+        assert retries[0]["reason"] == "mandatory_thinking_compatibility"
+        assert retries[0]["streaming"] is True
+        for attrs in [*failures, *retries, *successes]:
+            assert attrs["provider"] == "dashscope"
+            assert attrs[IacCodeAttr.PROVIDER_ADAPTER] == "qwen"
+            assert attrs[IacCodeAttr.OFFICIAL_ENDPOINT] is True
+        request_metrics = [attrs for name, _value, attrs in metrics if name == Metrics.API_REQUEST_COUNT]
+        assert [attrs["status"] for attrs in request_metrics] == ["compatibility_retry", "ok"]
+        assert all(attrs["provider"] == "dashscope" for attrs in request_metrics)
+        assert all(attrs[IacCodeAttr.PROVIDER_ADAPTER] == "qwen" for attrs in request_metrics)
+
+    async def test_mandatory_learning_does_not_rewrite_an_existing_stream_context(self):
+        error = _RequiredThinkingError(
+            "The value of the enable_thinking parameter is restricted to True."
+        )
+        client, completions = _sequential_client(
+            error,
+            _response(content="learned"),
+            [_chunk(content="old-context"), _chunk(finish_reason="stop")],
+            _response(content="next-context"),
+        )
+        provider = QwenProvider(model="qwen3.8-max", client=client, thinking_enabled=False)
+
+        existing_stream = provider.stream([Message.user("existing")], "sys")
+        assert isinstance(await anext(existing_stream), MessageStartEvent)
+
+        await provider.complete([Message.user("learn")], "sys")
+        _ = [event async for event in existing_stream]
+        await provider.complete([Message.user("next")], "sys")
+
+        assert completions.calls[0]["reasoning_effort"] == "none"
+        assert completions.calls[1]["extra_body"]["enable_thinking"] is True
+        assert completions.calls[2]["reasoning_effort"] == "none"
+        assert completions.calls[3]["extra_body"]["enable_thinking"] is True
+
+    async def test_ordinary_400_or_enabled_request_is_not_mandatory_retry(self):
+        ordinary = _RequiredThinkingError("some other invalid parameter")
+        client, completions = _sequential_client(ordinary)
+        provider = QwenProvider(model="qwen3.8-max", client=client, thinking_enabled=False)
+        with pytest.raises(_RequiredThinkingError):
+            await provider.complete([Message.user("hi")], "sys")
+        assert len(completions.calls) == 1
+
+        required = _RequiredThinkingError("enable_thinking must be true")
+        client, completions = _sequential_client(required)
+        provider = QwenProvider(model="qwen3.8-max", client=client, thinking_enabled=True)
+        with pytest.raises(_RequiredThinkingError):
+            await provider.complete([Message.user("hi")], "sys")
+        assert len(completions.calls) == 1
+
+    async def test_cumulative_content_normalizes_before_balanced_think_guard(self):
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(content="<think>a"),
+                _chunk(content="<think>ab</think>"),
+                _chunk(finish_reason="stop"),
+            ]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        events = [event async for event in provider.stream([Message.user("hi")], "sys")]
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)) == "<think>ab</think>"
+        assert not any(isinstance(event, ThinkingDeltaEvent) for event in events)
+
+    async def test_reasoning_tag_split_across_chunks_blocks_safe_closing_cleanup(self):
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(reasoning="<thi"),
+                _chunk(
+                    reasoning="nk>",
+                    content="</think>",
+                    tool_calls=[
+                        ns(
+                            index=0,
+                            id="call_1",
+                            function=ns(name="read_file", arguments='{"path":"a.py"}'),
+                        )
+                    ],
+                ),
+                _chunk(finish_reason="tool_calls"),
+            ]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        with pytest.raises(UnsafeStreamProtocolError):
+            _ = [event async for event in provider.stream([Message.user("hi")], "sys", [_tool()])]
+
+    async def test_reasoning_channels_are_independent_and_nullish_first(self):
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(reasoning="abc"),
+                _chunk(reasoning="abcdef"),
+                _chunk(content="answer"),
+                _chunk(finish_reason="stop"),
+            ]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        events = [event async for event in provider.stream([Message.user("hi")], "sys")]
+        assert "".join(event.text for event in events if isinstance(event, ThinkingDeltaEvent)) == "abcdef"
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)) == "answer"
+
+    async def test_reasoning_content_wins_once_and_empty_blocks_fallback(self):
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(reasoning_content="primary", reasoning="secondary"),
+                _chunk(reasoning_content="", reasoning="must-not-appear"),
+                _chunk(finish_reason="stop"),
+            ]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        events = [event async for event in provider.stream([Message.user("hi")], "sys")]
+        assert "".join(event.text for event in events if isinstance(event, ThinkingDeltaEvent)) == "primary"
+
+        client = FakeOpenAIClient(
+            create_response=_response(content="answer", reasoning_content="", reasoning="must-not-appear")
+        )
+        response = await QwenProvider(model="qwen3.7-plus", client=client).complete(
+            [Message.user("hi")], "sys"
+        )
+        assert response.thinking == ""
+        assert response.thinking_blocks == []
+
+    async def test_unclosed_thinking_tag_is_unsafe(self):
+        client = FakeOpenAIClient(
+            stream_chunks=[_chunk(content="<think>secret"), _chunk(finish_reason="stop")]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        with pytest.raises(UnsafeStreamProtocolError):
+            _ = [event async for event in provider.stream([Message.user("hi")], "sys")]
+
+    async def test_user_visible_stream_protocol_error_uses_runtime_translation(self, monkeypatch):
+        import iac_code.providers.streaming as streaming
+
+        monkeypatch.setattr(streaming, "_", lambda message: f"translated:{message}")
+        client = FakeOpenAIClient(
+            stream_chunks=[_chunk(content="<think>secret"), _chunk(finish_reason="stop")]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        with pytest.raises(UnsafeStreamProtocolError, match=r"^translated:Qwen emitted"):
+            _ = [event async for event in provider.stream([Message.user("hi")], "sys")]
+
+    async def test_tag_probe_literal_conflict_and_balanced_sequences(self):
+        literal = FakeOpenAIClient(
+            stream_chunks=[_chunk(content="<t"), _chunk(content="ext"), _chunk(finish_reason="stop")]
+        )
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=literal).stream(
+                [Message.user("hi")], "sys"
+            )
+        ]
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)) == "<text"
+
+        balanced = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(content="<think>a</think><thinking>b</thinking> tail"),
+                _chunk(finish_reason="stop"),
+            ]
+        )
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=balanced).stream(
+                [Message.user("hi")], "sys"
+            )
+        ]
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)).endswith(" tail")
+
+        conflict = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(reasoning="structured", content="<think>leak</think>"),
+                _chunk(finish_reason="stop"),
+            ]
+        )
+        with pytest.raises(UnsafeStreamProtocolError):
+            _ = [
+                event
+                async for event in QwenProvider(model="qwen3.7-plus", client=conflict).stream(
+                    [Message.user("hi")], "sys"
+                )
+            ]
+
+        trailing_unclosed = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(content="<think>ok</think><think>leak"),
+                _chunk(finish_reason="stop"),
+            ]
+        )
+        with pytest.raises(UnsafeStreamProtocolError):
+            _ = [
+                event
+                async for event in QwenProvider(model="qwen3.7-plus", client=trailing_unclosed).stream(
+                    [Message.user("hi")], "sys"
+                )
+            ]
+
+    async def test_standalone_closing_tag_is_removed_only_for_strict_native_tool_call(self):
+        valid = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(
+                    content="</think>",
+                    reasoning="thought",
+                    tool_calls=[ns(index=0, id="call_1", function=ns(name="read_file", arguments="{}"))],
+                ),
+                _chunk(finish_reason="tool_calls"),
+            ]
+        )
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=valid).stream(
+                [Message.user("hi")], "sys", [_tool()]
+            )
+        ]
+        assert not any(isinstance(event, TextDeltaEvent) for event in events)
+        assert "".join(event.text for event in events if isinstance(event, ThinkingDeltaEvent)) == "thought"
+        assert len([event for event in events if isinstance(event, ToolUseEndEvent)]) == 1
+
+        invalid = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(
+                    content="</think>",
+                    tool_calls=[ns(index=0, id="call_1", function=ns(name="read_file", arguments="   "))],
+                ),
+                _chunk(finish_reason="tool_calls"),
+            ]
+        )
+        with pytest.raises(UnsafeStreamProtocolError):
+            _ = [
+                event
+                async for event in QwenProvider(model="qwen3.7-plus", client=invalid).stream(
+                    [Message.user("hi")], "sys", [_tool()]
+                )
+            ]
+
+    async def test_strict_native_tool_call_and_xml_fallback(self):
+        native = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(
+                    tool_calls=[ns(index=0, id="call_1", function=ns(name="read_file", arguments='{"path":'))]
+                ),
+                _chunk(tool_calls=[ns(index=0, id=None, function=ns(name=None, arguments='"a.py"}'))]),
+                _chunk(finish_reason="tool_calls"),
+            ]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=native)
+        events = [event async for event in provider.stream([Message.user("hi")], "sys", [_tool()])]
+        assert [event.input for event in events if isinstance(event, ToolUseEndEvent)] == [{"path": "a.py"}]
+
+        xml = (
+            '<function_calls><invoke name="read_file"><parameter name="path">a.py</parameter>'
+            "</invoke></function_calls>"
+        )
+        fallback = FakeOpenAIClient(stream_chunks=[_chunk(content=xml), _chunk(finish_reason="stop")])
+        provider = QwenProvider(model="qwen3.7-plus", client=fallback)
+        events = [event async for event in provider.stream([Message.user("hi")], "sys", [_tool()])]
+        assert [event.input for event in events if isinstance(event, ToolUseEndEvent)] == [{"path": "a.py"}]
+        assert not any(isinstance(event, TextDeltaEvent) for event in events)
+
+    async def test_real_dashscope_empty_tool_delimiters_do_not_create_anonymous_call(self):
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(
+                    tool_calls=[ns(index=0, id="call_1", function=ns(name="read_file", arguments=""))]
+                ),
+                _chunk(tool_calls=[ns(index=0, id="", function=ns(name=None, arguments=""))]),
+                _chunk(tool_calls=[ns(index=0, id="", function=ns(name=None, arguments='{"path": '))]),
+                _chunk(tool_calls=[ns(index=0, id="", function=ns(name=None, arguments='"a.py"}'))]),
+                _chunk(tool_calls=[ns(index=0, id="", function=ns(name=None, arguments=""))]),
+                _chunk(finish_reason="tool_calls"),
+            ]
+        )
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=client).stream(
+                [Message.user("hi")], "sys", [_tool()]
+            )
+        ]
+        assert [event.input for event in events if isinstance(event, ToolUseEndEvent)] == [
+            {"path": "a.py"}
+        ]
+        assert next(event for event in events if isinstance(event, MessageEndEvent)).stop_reason == "tool_use"
+
+    async def test_malformed_native_call_does_not_fall_through_to_xml(self):
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(
+                    content='<invoke name="read_file"><parameter name="path">a.py</parameter></invoke>',
+                    tool_calls=[ns(index=0, id="call_1", function=ns(name="read_file", arguments="   "))],
+                ),
+                _chunk(finish_reason="tool_calls"),
+            ]
+        )
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        with pytest.raises(ValueError):
+            _ = [event async for event in provider.stream([Message.user("hi")], "sys", [_tool()])]
+
+    async def test_non_streaming_reasoning_and_xml(self):
+        xml = '<invoke name="read_file"><parameter name="path">a.py</parameter></invoke>'
+        client = FakeOpenAIClient(create_response=_response(content=xml, reasoning="thought"))
+        provider = QwenProvider(model="qwen3.7-plus", client=client)
+        response = await provider.complete([Message.user("hi")], "sys", [_tool()])
+        assert response.thinking == "thought"
+        assert response.text == ""
+        assert response.tool_uses[0]["input"] == {"path": "a.py"}
+
+    @pytest.mark.parametrize(
+        "quoted",
+        [
+            '> <invoke name="read_file"><parameter name="path">a.py</parameter></invoke>',
+            (
+                '> <function_calls><invoke name="read_file"><parameter name="path">a.py</parameter>'
+                "</invoke></function_calls>"
+            ),
+        ],
+    )
+    async def test_markdown_quoted_xml_is_never_executed(self, quoted):
+        stream_client = FakeOpenAIClient(
+            stream_chunks=[_chunk(content=quoted), _chunk(finish_reason="stop")]
+        )
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=stream_client).stream(
+                [Message.user("hi")], "sys", [_tool()]
+            )
+        ]
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)) == quoted
+        assert not any(isinstance(event, ToolUseEndEvent) for event in events)
+
+        complete_client = FakeOpenAIClient(create_response=_response(content=quoted))
+        response = await QwenProvider(model="qwen3.7-plus", client=complete_client).complete(
+            [Message.user("hi")], "sys", [_tool()]
+        )
+        assert response.text == quoted
+        assert response.tool_uses == []
+
+    @pytest.mark.parametrize("split_at", range(1, len("<invoke")))
+    async def test_streaming_xml_prefix_split_and_leading_text(self, split_at):
+        xml = '<invoke name="read_file"><parameter name="path">a.py</parameter></invoke>'
+        client = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(content="lead" + xml[:split_at]),
+                _chunk(content=xml[split_at:]),
+                _chunk(finish_reason="stop"),
+            ]
+        )
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=client).stream(
+                [Message.user("hi")], "sys", [_tool()]
+            )
+        ]
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)) == "lead"
+        assert [event.input for event in events if isinstance(event, ToolUseEndEvent)] == [{"path": "a.py"}]
+        assert next(event for event in events if isinstance(event, MessageEndEvent)).stop_reason == "tool_use"
+
+    async def test_native_tool_call_wins_over_xml_and_missing_finish_does_not_recover(self):
+        xml = '<invoke name="read_file"><parameter name="path">xml.py</parameter></invoke>'
+        native = FakeOpenAIClient(
+            stream_chunks=[
+                _chunk(
+                    content=xml,
+                    tool_calls=[
+                        ns(index=0, id="call_1", function=ns(name="read_file", arguments='{"path":"native.py"}'))
+                    ],
+                ),
+                _chunk(finish_reason="tool_calls"),
+            ]
+        )
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=native).stream(
+                [Message.user("hi")], "sys", [_tool()]
+            )
+        ]
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)) == xml
+        assert [event.input for event in events if isinstance(event, ToolUseEndEvent)] == [
+            {"path": "native.py"}
+        ]
+
+        no_finish = FakeOpenAIClient(stream_chunks=[_chunk(content=xml)])
+        events = [
+            event
+            async for event in QwenProvider(model="qwen3.7-plus", client=no_finish).stream(
+                [Message.user("hi")], "sys", [_tool()]
+            )
+        ]
+        assert "".join(event.text for event in events if isinstance(event, TextDeltaEvent)) == xml
+        assert not any(isinstance(event, ToolUseEndEvent) for event in events)

--- a/tests/providers/test_qwen_tool_call_parser.py
+++ b/tests/providers/test_qwen_tool_call_parser.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import pytest
+
+from iac_code.providers.base import ToolDefinition
+from iac_code.providers.qwen_tool_call_parser import (
+    StrictToolCallAssembler,
+    ToolCallProtocolError,
+    recover_xml_tool_calls,
+    strict_tool_arguments,
+)
+from tests.providers._fakes import ns
+
+
+def _tools():
+    return [ToolDefinition(name="read_file", description="Read", input_schema={"type": "object"})]
+
+
+def test_strict_arguments_accept_only_missing_empty_or_json_object():
+    assert strict_tool_arguments(None, present=False) == {}
+    assert strict_tool_arguments(None) == {}
+    assert strict_tool_arguments("") == {}
+    assert strict_tool_arguments('{"path":"a"}') == {"path": "a"}
+    for malformed in ("   ", "[]", "null", "{bad", 123):
+        with pytest.raises(ToolCallProtocolError):
+            strict_tool_arguments(malformed)
+
+
+def test_assembler_handles_arguments_before_identity_and_parallel_calls():
+    assembler = StrictToolCallAssembler()
+    assembler.feed([ns(index=0, id=None, function=ns(name=None, arguments='{"path":'))])
+    assembler.feed(
+        [
+            ns(index=1, id="call_2", function=ns(name="read_file", arguments='{"path":"b"}')),
+            ns(index=0, id="call_1", function=ns(name="read_file", arguments='"a"}')),
+        ]
+    )
+    assert [call["input"] for call in assembler.finalize("tool_calls")] == [
+        {"path": "a"},
+        {"path": "b"},
+    ]
+
+
+def test_assembler_rejects_ambiguous_anonymous_fragment():
+    assembler = StrictToolCallAssembler()
+    assembler.feed(
+        [
+            ns(index=0, id="call_1", function=ns(name="read_file", arguments="")),
+            ns(index=0, id="call_2", function=ns(name="read_file", arguments="")),
+            ns(index=0, id=None, function=ns(name=None, arguments="{}")),
+        ]
+    )
+    with pytest.raises(ToolCallProtocolError):
+        assembler.finalize("tool_calls")
+
+
+def test_assembler_claims_name_then_id_and_routes_same_id_across_new_index():
+    assembler = StrictToolCallAssembler()
+    assembler.feed([ns(index=4, id=None, function=ns(name=None, arguments='{"path":'))])
+    assembler.feed([ns(index=4, id=None, function=ns(name="read_file", arguments=None))])
+    assembler.feed([ns(index=7, id="call_1", function=ns(name="read_file", arguments='"a.py"}'))])
+    assert assembler.finalize("tool_calls")[0]["input"] == {"path": "a.py"}
+
+
+def test_assembler_allows_completed_index_reuse_but_rejects_incomplete_conflict():
+    complete = StrictToolCallAssembler()
+    complete.feed([ns(index=0, id="call_1", function=ns(name="read_file", arguments="{}"))])
+    complete.feed([ns(index=0, id="call_2", function=ns(name="read_file", arguments="{}"))])
+    assert [call["id"] for call in complete.finalize("tool_calls")] == ["call_1", "call_2"]
+
+    incomplete = StrictToolCallAssembler()
+    incomplete.feed([ns(index=0, id="call_1", function=ns(name="read_file", arguments="{"))])
+    incomplete.feed([ns(index=0, id="call_2", function=ns(name="read_file", arguments="{}"))])
+    with pytest.raises(ToolCallProtocolError, match="Conflicting"):
+        incomplete.finalize("tool_calls")
+
+
+def test_user_visible_protocol_errors_use_runtime_translation(monkeypatch):
+    import iac_code.providers.qwen_tool_call_parser as parser
+
+    monkeypatch.setattr(parser, "_", lambda message: f"translated:{message}")
+    with pytest.raises(ToolCallProtocolError, match=r"^translated:Qwen tool arguments"):
+        strict_tool_arguments("   ")
+
+
+@pytest.mark.parametrize(
+    "fragments",
+    [
+        [ns(index=-1, id="call_1", function=ns(name="read_file", arguments="{}"))],
+        [ns(index=0, id="call_1", function=ns(name=None, arguments="{}"))],
+        [ns(index=0, id=None, function=ns(name="read_file", arguments="{}"))],
+        [ns(index=0, id="call_1", function=ns(name="read_file", arguments='{"path":"a'))],
+        [ns(index=0, id="call_1", function=ns(name="read_file", arguments="[]"))],
+        [ns(index=0, id="call_1", function=ns(name="read_file", arguments="   "))],
+    ],
+)
+def test_assembler_rejects_invalid_final_shapes(fragments):
+    assembler = StrictToolCallAssembler()
+    assembler.feed(fragments)
+    with pytest.raises(ToolCallProtocolError):
+        assembler.finalize("tool_calls")
+
+
+def test_assembler_requires_a_call_for_tool_calls_finish_and_accepts_zero_arguments():
+    with pytest.raises(ToolCallProtocolError):
+        StrictToolCallAssembler().finalize("tool_calls")
+    assembler = StrictToolCallAssembler()
+    assembler.feed([ns(index=0, id="call_1", function=ns(name="read_file", arguments=None))])
+    assert assembler.finalize("tool_calls")[0]["input"] == {}
+
+
+def test_assembler_ignores_dashscope_identity_free_empty_delimiters():
+    assembler = StrictToolCallAssembler()
+    assembler.feed([ns(index=0, id="", function=ns(name=None, arguments=""))])
+    assembler.feed([ns(index=0, id="call_1", function=ns(name="read_file", arguments=""))])
+    assembler.feed([ns(index=0, id="", function=ns(name=None, arguments='{"path":'))])
+    assembler.feed([ns(index=0, id="", function=ns(name=None, arguments='"a.py"}'))])
+    assembler.feed([ns(index=0, id="", function=ns(name=None, arguments=""))])
+
+    assert assembler.finalize("tool_calls")[0]["input"] == {"path": "a.py"}
+
+
+def test_xml_requires_registered_parameterized_invoke_and_intent_guard():
+    valid = '<invoke name="read_file"><parameter name="path">a.py</parameter></invoke>'
+    assert recover_xml_tool_calls(valid, _tools()).calls[0]["input"] == {"path": "a.py"}
+    assert recover_xml_tool_calls('<invoke name="read_file"></invoke>', _tools()) is None
+    recovery = recover_xml_tool_calls(f"Run: {valid}", _tools())
+    assert recovery.remaining_text == "Run:"
+    tutorial = "This is documentation, not a request to execute a tool. " * 20
+    assert recover_xml_tool_calls(f"{tutorial}{valid}", _tools()) is None
+    assert recover_xml_tool_calls(valid.replace("read_file", "unknown"), _tools()) is None
+    assert recover_xml_tool_calls(f"```xml\n{valid}\n```", _tools()) is None
+    assert recover_xml_tool_calls(f"> {valid}", _tools()) is None
+    assert recover_xml_tool_calls(f"  > example: {valid}", _tools()) is None
+    assert recover_xml_tool_calls(f"> <function_calls>{valid}</function_calls>", _tools()) is None
+
+
+def test_xml_rejects_duplicate_or_nested_parameters_and_preserves_scalar_strings():
+    duplicate = (
+        '<invoke name="read_file"><parameter name="path">a</parameter>'
+        '<parameter name="path">b</parameter></invoke>'
+    )
+    nested = '<invoke name="read_file"><parameter name="path"><value>a</value></parameter></invoke>'
+    assert recover_xml_tool_calls(duplicate, _tools()) is None
+    assert recover_xml_tool_calls(nested, _tools()) is None
+    scalar = '<invoke name="read_file"><parameter name="path">8080</parameter></invoke>'
+    assert recover_xml_tool_calls(scalar, _tools()).calls[0]["input"] == {"path": "8080"}
+
+
+def test_xml_multiple_calls_wrapper_entities_newlines_and_unicode():
+    tools = _tools() + [ToolDefinition(name="write_file", description="Write", input_schema={"type": "object"})]
+    text = (
+        '<function_calls><invoke name="read_file"><parameter name="path">\n目录/a.py\n</parameter></invoke>'
+        '<invoke name="write_file"><parameter name="content">&lt;x&gt;&amp;&quot;&apos;</parameter>'
+        '<parameter name="meta">{"ok":true}</parameter></invoke></function_calls>'
+    )
+    recovery = recover_xml_tool_calls(text, tools)
+    assert recovery.remaining_text == ""
+    assert recovery.calls[0]["input"] == {"path": "目录/a.py"}
+    assert recovery.calls[1]["input"] == {"content": '<x>&"\'', "meta": {"ok": True}}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '<function_calls>text<invoke name="read_file"><parameter name="path">a</parameter></invoke>'
+        "</function_calls>",
+        '<function_calls><invoke name="read_file"><parameter name="path">a</parameter></invoke>',
+        '<invoke name="read_file"><parameter name="path">a</parameter></invoke></function_calls>',
+        '~~~xml\n<invoke name="read_file"><parameter name="path">a</parameter></invoke>\n~~~',
+        '<invoke name="read_file"><parameter name="path"><nested /></parameter></invoke>',
+    ],
+)
+def test_xml_invalid_wrapper_fence_and_nesting_remain_text(text):
+    assert recover_xml_tool_calls(text, _tools()) is None
+
+
+def test_xml_structured_parse_failure_stays_scalar_and_amp_entity_decodes_once():
+    malformed = '<invoke name="read_file"><parameter name="path">{bad</parameter></invoke>'
+    assert recover_xml_tool_calls(malformed, _tools()).calls[0]["input"] == {"path": "{bad"}
+    entity = '<invoke name="read_file"><parameter name="path">&amp;lt;</parameter></invoke>'
+    assert recover_xml_tool_calls(entity, _tools()).calls[0]["input"] == {"path": "&lt;"}
+    numeric = '<invoke name="read_file"><parameter name="path">&#65;</parameter></invoke>'
+    assert recover_xml_tool_calls(numeric, _tools()) is None
+
+
+def test_xml_size_limits_are_conservative():
+    oversized = "x" * (32 * 1024 + 1)
+    text = f'<invoke name="read_file"><parameter name="path">{oversized}</parameter></invoke>'
+    assert recover_xml_tool_calls(text, _tools()) is None

--- a/tests/providers/test_thinking_registry.py
+++ b/tests/providers/test_thinking_registry.py
@@ -120,13 +120,23 @@ class TestGetThinkingSpec:
     def test_qwen38_formal_and_preview_have_distinct_thinking_modes(self):
         for provider_key in ("dashscope", "dashscope_token_plan"):
             formal = get_thinking_spec(provider_key, "qwen3.8-max")
-            assert formal.allowed_efforts == (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.XHIGH)
+            assert formal.allowed_efforts == (
+                EffortLevel.LOW,
+                EffortLevel.MEDIUM,
+                EffortLevel.HIGH,
+                EffortLevel.XHIGH,
+            )
             assert formal.default_effort is EffortLevel.XHIGH
             assert formal.supports_disable is True
             assert formal.thinking_enabled_by_default is True
 
         preview = get_thinking_spec("dashscope_token_plan", "qwen3.8-max-preview")
-        assert preview.allowed_efforts == (EffortLevel.LOW, EffortLevel.MEDIUM, EffortLevel.XHIGH)
+        assert preview.allowed_efforts == (
+            EffortLevel.LOW,
+            EffortLevel.MEDIUM,
+            EffortLevel.HIGH,
+            EffortLevel.XHIGH,
+        )
         assert preview.default_effort is EffortLevel.XHIGH
         assert preview.supports_disable is False
         assert preview.thinking_enabled_by_default is True

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -153,6 +153,35 @@ PIPELINE_USER_VISIBLE_MSGIDS = {
     'Displayed details for "{candidate_name}".',
 }
 
+QWEN_PROVIDER_USER_VISIBLE_MSGIDS = {
+    "Provider request lease cannot be consumed from state {state}.",
+    "Provider request lease was already released.",
+    "Provider request lease belongs to a different manager.",
+    "Explicit request lease system prompt does not match the streamed prompt.",
+    "Explicit request lease system prompt does not match the completion prompt.",
+    "Qwen replay ended before message completion.",
+    "Qwen tool arguments must be a non-empty JSON object.",
+    "Qwen tool arguments are malformed JSON.",
+    "Qwen tool arguments must decode to an object.",
+    "Qwen native tool call is missing its ID or name.",
+    "Invalid Qwen tool-call index.",
+    "Conflicting Qwen tool-call identity.",
+    "Conflicting Qwen tool-call name.",
+    "Qwen tool-call arguments must be a string.",
+    "Duplicate Qwen tool-call identity.",
+    "Ambiguous anonymous Qwen tool-call identity.",
+    "Ambiguous anonymous Qwen tool-call fragment.",
+    "Invalid Qwen tool-call JSON structure.",
+    "Qwen response ended with tool_calls but no complete tool call.",
+    "Qwen tool call is anonymous or nameless.",
+    "Duplicate Qwen tool-call ID.",
+    "Qwen tool-call arguments ended before JSON was complete.",
+    "Qwen thinking-tag candidate exceeded the safety limit.",
+    "Qwen emitted an unsafe or conflicting thinking-tag block.",
+    "Qwen emitted a stray thinking closing tag.",
+    "Qwen emitted a closing thinking tag without a valid native tool call.",
+}
+
 MCP_HOST_ENHANCE_USER_VISIBLE_MSGIDS = {
     "Manage MCP servers",
     "[enable|disable|reconnect [server-name] [--scope scope] [--source-path path]]",
@@ -1144,6 +1173,31 @@ def test_a2a_permission_display_translations_are_complete():
             msgstr = translations.get(msgid, "").strip()
             if not msgstr:
                 errors.append(f"{lang_dir.name}: missing translation for {msgid!r}")
+            elif _format_fields(msgstr) != _format_fields(msgid):
+                errors.append(
+                    f"{lang_dir.name}: format fields changed for {msgid!r}: "
+                    f"expected {sorted(_format_fields(msgid))}, got {sorted(_format_fields(msgstr))}"
+                )
+
+    assert not errors, "\n".join(errors)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="messages.pot not generated on Windows")
+def test_qwen_provider_user_visible_translations_are_complete():
+    """Qwen protocol failures can reach ErrorEvent and must be localized everywhere."""
+    pot_msgids = _get_all_msgids_from_pot(POT_FILE)
+    missing_from_pot = sorted(QWEN_PROVIDER_USER_VISIBLE_MSGIDS - pot_msgids)
+    assert not missing_from_pot, "Qwen Provider msgids missing from messages.pot: {}".format(missing_from_pot)
+
+    errors = []
+    for lang_dir in _discover_language_dirs():
+        translations = _get_all_translations_from_po(lang_dir / "LC_MESSAGES" / "messages.po")
+        for msgid in sorted(QWEN_PROVIDER_USER_VISIBLE_MSGIDS):
+            msgstr = translations.get(msgid, "").strip()
+            if not msgstr:
+                errors.append(f"{lang_dir.name}: missing translation for {msgid!r}")
+            elif msgstr == msgid:
+                errors.append(f"{lang_dir.name}: untranslated placeholder for {msgid!r}")
             elif _format_fields(msgstr) != _format_fields(msgid):
                 errors.append(
                     f"{lang_dir.name}: format fields changed for {msgid!r}: "


### PR DESCRIPTION
## Summary

- route DashScope-family Qwen models through a dedicated QwenProvider subclass
- add request leases, Qwen streaming/tool-call safeguards, thinking adaptation, and terminal usage attribution
- preserve CLI/Web/A2A output contracts and complete zh/es/fr/de/ja/pt translations
- document the Qwen provider design and compatibility behavior

## Validation

- make lint
- make test: 15632 passed, 2 skipped
- focused provider/AgentLoop/A2A/ACP/CLI/Web tests
- translation extraction, completeness, placeholder, and compilation checks
- real DashScope qwen3.8-max smoke, multi-turn, streaming, and native tool-call tests