### PR TITLE
fix: preserve AG-UI image filenames

### DIFF
--- a/src/iac_code/agui/inputs.py
+++ b/src/iac_code/agui/inputs.py
@@ -8,12 +8,14 @@ import hashlib
 import json
 import os
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Literal
 
 from ag_ui.core import RunAgentInput
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from iac_code.a2a.artifacts import UnsafeArtifactNameError, safe_artifact_filename
 from iac_code.agui.errors import AguiError
 from iac_code.utils.image.resizer import maybe_resize_and_downsample
 
@@ -21,6 +23,7 @@ MAX_REQUEST_BYTES = 12 * 1024 * 1024
 MAX_IMAGE_BYTES = 8 * 1024 * 1024
 MAX_TOTAL_IMAGE_BYTES = 10 * 1024 * 1024
 SUPPORTED_IMAGE_MIME_TYPES = frozenset({"image/png", "image/jpeg", "image/gif", "image/webp"})
+MAX_IMAGE_FILENAME_BYTES = 255
 
 
 class StrictModel(BaseModel):
@@ -173,7 +176,7 @@ def latest_user_message(run_input: RunAgentInput) -> tuple[str, list[dict[str, A
             parts.append(
                 {
                     "data": {
-                        "filename": f"agui-image-{len(parts) + 1}",
+                        "filename": _image_filename(part, fallback=f"agui-image-{len(parts) + 1}"),
                         "bytes": base64.b64encode(resized.data).decode("ascii"),
                     },
                     "mediaType": resized.media_type,
@@ -181,6 +184,22 @@ def latest_user_message(run_input: RunAgentInput) -> tuple[str, list[dict[str, A
             )
         return message_id, parts
     return None
+
+
+def _image_filename(part: Any, *, fallback: str) -> str:
+    metadata = getattr(part, "metadata", None)
+    if not isinstance(metadata, Mapping):
+        return fallback
+    filename = metadata.get("filename")
+    if not isinstance(filename, str):
+        return fallback
+    try:
+        if len(filename.encode("utf-8")) > MAX_IMAGE_FILENAME_BYTES:
+            return fallback
+        safe_filename = safe_artifact_filename(filename)
+    except (UnicodeError, UnsafeArtifactNameError):
+        return fallback
+    return filename if safe_filename == filename else fallback
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:

--- a/tests/agui/test_inputs.py
+++ b/tests/agui/test_inputs.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+from ag_ui.core import ImageInputContent, InputContentDataSource, RunAgentInput, UserMessage
 
 from iac_code.agui.errors import AguiError
-from iac_code.agui.inputs import parse_forwarded_props, resolve_cwd
+from iac_code.agui.inputs import latest_user_message, parse_forwarded_props, resolve_cwd
 
 
 def test_forwarded_props_require_request_workspace_and_identity(tmp_path) -> None:
@@ -32,3 +35,49 @@ def test_cwd_is_checked_against_adapter_roots(tmp_path, monkeypatch) -> None:
     assert resolve_cwd(str(allowed / "session")) == str((allowed / "session").resolve())
     with pytest.raises(AguiError, match="outside the allowed roots"):
         resolve_cwd(str(tmp_path / "outside"))
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected_filename"),
+    [
+        ({"filename": "before.png"}, "before.png"),
+        ({"filename": "../before.png"}, "agui-image-1"),
+        ({"filename": "CON"}, "agui-image-1"),
+        (None, "agui-image-1"),
+    ],
+)
+def test_latest_user_message_uses_safe_image_metadata_filename(
+    metadata,
+    expected_filename,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "iac_code.agui.inputs.maybe_resize_and_downsample",
+        lambda _raw: SimpleNamespace(data=b"resized", media_type="image/png"),
+    )
+    run_input = RunAgentInput(
+        thread_id="thread-1",
+        run_id="run-1",
+        state={},
+        messages=[
+            UserMessage(
+                id="message-1",
+                content=[
+                    ImageInputContent(
+                        source=InputContentDataSource(
+                            value="YWJj",
+                            mime_type="image/png",
+                        ),
+                        metadata=metadata,
+                    )
+                ],
+            )
+        ],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+    _message_id, parts = latest_user_message(run_input)
+
+    assert parts[0]["data"]["filename"] == expected_filename


### PR DESCRIPTION
## Summary

- read the standard AG-UI `ImageInputContent.metadata.filename` when converting image input to A2A parts
- preserve safe filenames so multimodal prompts can distinguish attachments by name
- fall back to the existing `agui-image-N` name for missing, unsafe, Windows-reserved, or oversized values

## Tests

- `uv run pytest -q tests/agui`
- `make lint`
- local real AG-UI E2E through ROS StartChat, relay, iac-code AG-UI/A2A, real LLM, and Alibaba Cloud canaries
