### PR TITLE
fix(a2a): localize permission identity errors

### DIFF
--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -1262,6 +1262,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                     response=permission_response,
                     code=exc.code,
                     retryable=exc.retryable,
+                    language=self._resolve_preferred_language(response_metadata),
                 )
                 return
             except InvalidParamsError:
@@ -2273,6 +2274,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                         response=response,
                         code="legacy_permission_identity",
                         retryable=False,
+                        language=preferred_language,
                         session_id=context_record.session_id,
                     )
                     return True
@@ -2290,6 +2292,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                         response=response,
                         code=exc.reason,
                         retryable=exc.retryable,
+                        language=preferred_language,
                         session_id=context_record.session_id,
                     )
                     return True
@@ -2303,6 +2306,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                         response=response,
                         code="cloud_execution_identity_changed",
                         retryable=False,
+                        language=preferred_language,
                         session_id=context_record.session_id,
                     )
                     return True
@@ -2648,6 +2652,7 @@ class IacCodeA2AExecutor(AgentExecutor):
         response: PermissionResponse,
         code: str,
         retryable: bool,
+        language: str | None = None,
         session_id: str | None = None,
     ) -> None:
         await self._publish_status(
@@ -2655,7 +2660,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             task_id=response.task_id,
             context_id=response.context_id,
             state=TaskState.TASK_STATE_INPUT_REQUIRED,
-            text=_("A temporary error occurred. Please retry."),
+            text=translate_message("A temporary error occurred. Please retry.", language=language or "en"),
             metadata={
                 "iac_code": {
                     "permissionIdentityError": {

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -4720,13 +4720,18 @@ async def test_identity_lookup_failure_keeps_live_permission_pending(monkeypatch
     monkeypatch.setattr(executor, "_publish_status", publish)
 
     await executor._execute(
-        FakeRequestContext(task_id="task-1", context_id="ctx-1"),
+        FakeRequestContext(
+            task_id="task-1",
+            context_id="ctx-1",
+            metadata={"iac_code": {"preferredLanguage": "zh-CN"}},
+        ),
         FakeEventQueue(),
         context_id="ctx-1",
     )
 
     assert len(published) == 1
     assert published[0]["state"] == TaskState.TASK_STATE_INPUT_REQUIRED
+    assert published[0]["text"] == "发生临时错误，请重试。"
     error = published[0]["metadata"]["iac_code"]["permissionIdentityError"]
     assert error == {
         "code": "InternalError",


### PR DESCRIPTION
## Summary
- honor A2A request-scoped preferredLanguage for permission identity errors
- apply the same language handling to persisted permission recovery paths
- add a Chinese regression assertion for the early identity-validation failure path

## Validation
- make translate
- targeted A2A tests: 337 passed
- make lint
- make test: 15534 passed, 2 skipped
