### PR TITLE
fix: fence permission resume on staged backups

### DIFF
--- a/scripts/a2a/e2e/README.zh-CN.md
+++ b/scripts/a2a/e2e/README.zh-CN.md
@@ -81,6 +81,18 @@ uv run pytest -q tests/a2a_e2e/test_sub_pipeline_permission_timeout.py
 uv run pytest -q tests/a2a_e2e/test_permission_wait_restart.py
 ```
 
+其中 `staged-backup-generation-fence` 场景使用真实 HTTP A2A 进程、生产 staged backup/worker 和两个连续
+权限点：新进程先从共享目录恢复旧 generation；较新的权限 backup 尚未发布时，Resume 必须返回可重试的
+`SESSION_BACKUP_NOT_READY`；worker 发布完成后，同一标准权限响应可恢复最新会话并且两个工具各执行一次。
+可单独运行：
+
+```bash
+uv run python scripts/a2a/e2e/permission_wait/run_permission_wait_restart.py \
+  --run-dir /tmp/iac-pwait-generation-fence \
+  --decision allow_once \
+  --staged-backup-generation-fence
+```
+
 进程重启矩阵覆盖 Normal/Pipeline × allow/deny。Sub Pipeline fixture 断言只生成一次拒绝 ToolResult、
 Agent loop 继续、父 Pipeline 进入 candidate 选择并完成，且全程没有 grace、持久化 permission checkpoint
 或权限关键备份。

--- a/scripts/a2a/e2e/permission_wait/permission_wait_fixture_server.py
+++ b/scripts/a2a/e2e/permission_wait/permission_wait_fixture_server.py
@@ -31,10 +31,20 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--candidate-first", action="store_true")
     parser.add_argument("--pipeline-step-id", choices=SELLING_STAGE_IDS)
     parser.add_argument("--handoff-first", action="store_true")
+    parser.add_argument("--sequential-permissions", action="store_true")
+    parser.add_argument("--defer-staging-publisher", action="store_true")
+    parser.add_argument("--staging-dir", type=Path)
+    parser.add_argument("--backup-dir", type=Path)
     return parser.parse_args()
 
 
-def _create_fixture_runtime(options: Any, *, execution_log: Path, handoff_first: bool = False) -> Any:
+def _create_fixture_runtime(
+    options: Any,
+    *,
+    execution_log: Path,
+    handoff_first: bool = False,
+    sequential_permissions: bool = False,
+) -> Any:
     from iac_code.agent.agent_loop import AgentLoop
     from iac_code.providers.base import ToolDefinition
     from iac_code.services.agent_factory import AgentRuntime
@@ -90,7 +100,7 @@ def _create_fixture_runtime(options: Any, *, execution_log: Path, handoff_first:
             del context
             execution_log.parent.mkdir(parents=True, exist_ok=True)
             with execution_log.open("a", encoding="utf-8") as handle:
-                handle.write("executed\n")
+                handle.write("{}\n".format(tool_input.get("value", "executed")))
                 handle.flush()
                 os.fsync(handle.fileno())
             return ToolResult.success("fixture write completed")
@@ -126,6 +136,13 @@ def _create_fixture_runtime(options: Any, *, execution_log: Path, handoff_first:
                 name=tool_name,
                 input=tool_input,
             )
+            if sequential_permissions:
+                yield ToolUseStartEvent(tool_use_id="fixture-tool-2", name=tool_name)
+                yield ToolUseEndEvent(
+                    tool_use_id="fixture-tool-2",
+                    name=tool_name,
+                    input={"value": "executed-2"},
+                )
             yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
 
     provider = FixtureProvider()
@@ -498,12 +515,18 @@ def main() -> int:
     os.environ["ALIBABA_CLOUD_ACCESS_KEY_ID"] = "permission-wait-fixture-ak"
     os.environ["ALIBABA_CLOUD_ACCESS_KEY_SECRET"] = "permission-wait-fixture-secret"
     os.environ["ALIBABA_CLOUD_REGION_ID"] = "cn-hangzhou"
+    if args.staging_dir is not None or args.backup_dir is not None:
+        if args.staging_dir is None or args.backup_dir is None:
+            raise ValueError("--staging-dir and --backup-dir must be provided together")
+        os.environ["IAC_CODE_CONFIG_BACKUP_TMP_DIR"] = str(args.staging_dir.expanduser().resolve())
+        os.environ["IAC_CODE_CONFIG_BACKUP_DIR"] = str(args.backup_dir.expanduser().resolve())
 
     import uvicorn
 
     from iac_code.a2a import executor as executor_module
     from iac_code.a2a import pipeline_executor as pipeline_executor_module
     from iac_code.a2a.app import create_app
+    from iac_code.services import session_backup_staging as backup_staging_module
     from iac_code.services.providers.aliyun_identity import AliyunCallerIdentity, AliyunCallerIdentityResolver
 
     async def resolve_fixture_identity(
@@ -516,10 +539,15 @@ def main() -> int:
 
     AliyunCallerIdentityResolver.resolve = resolve_fixture_identity
 
+    if args.defer_staging_publisher:
+        backup_staging_module.SessionBackupStagingProcess.start = lambda self: None
+        backup_staging_module.SessionBackupStagingProcess.close = lambda self: None
+
     executor_module.create_agent_runtime = lambda options: _create_fixture_runtime(
         options,
         execution_log=execution_log,
         handoff_first=args.handoff_first,
+        sequential_permissions=args.sequential_permissions,
     )
     pipeline_executor_module.create_agent_runtime = executor_module.create_agent_runtime
     fixture_pipelines: dict[str, Any] = {}

--- a/scripts/a2a/e2e/permission_wait/run_agui_generation_fence.py
+++ b/scripts/a2a/e2e/permission_wait/run_agui_generation_fence.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Run the AG-UI to A2A staged-backup generation-fence scenario."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from run_permission_wait_restart import (
+    _FixtureServer,
+    _free_port,
+    _permission_checkpoint_for_input,
+    _single_json,
+    _tool_execution_lines,
+)
+
+THREAD_ID = "thread-agui-generation-fence"
+ROS_INVOCATION_ID = "ros-invocation-agui-generation-fence"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def _decode_sse_line(line: bytes) -> dict[str, Any] | None:
+    text = line.decode("utf-8", errors="replace").strip()
+    if not text.startswith("data:"):
+        return None
+    try:
+        value = json.loads(text[5:].strip())
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _agui_request(url: str, payload: dict[str, Any], *, timeout: float) -> list[dict[str, Any]]:
+    request = Request(
+        url.rstrip("/") + "/",
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "text/event-stream"},
+        method="POST",
+    )
+    events: list[dict[str, Any]] = []
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            for line in response:
+                event = _decode_sse_line(line)
+                if event is not None:
+                    events.append(event)
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise AssertionError("AG-UI request failed with HTTP {}: {}".format(exc.code, body)) from exc
+    if not events:
+        raise AssertionError("AG-UI request returned no SSE events")
+    return events
+
+
+def _run_payload(
+    workspace: Path,
+    *,
+    run_id: str,
+    prompt: str | None = None,
+    resume: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "threadId": THREAD_ID,
+        "runId": run_id,
+        "state": {},
+        "messages": (
+            []
+            if resume is not None
+            else [{"id": "message-{}".format(run_id), "role": "user", "content": prompt or ""}]
+        ),
+        "tools": [],
+        "context": [],
+        "forwardedProps": {
+            "iacCode": {
+                "schemaVersion": 1,
+                "rosInvocationId": ROS_INVOCATION_ID,
+                "cwd": str(workspace),
+            }
+        },
+        **({"resume": resume} if resume is not None else {}),
+    }
+
+
+def _resolved_permission(interrupt_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "interruptId": interrupt_id,
+            "status": "resolved",
+            "payload": {"decision": "allow_once"},
+        }
+    ]
+
+
+def _terminal_interrupt(events: list[dict[str, Any]]) -> str:
+    terminal = events[-1]
+    outcome = terminal.get("outcome")
+    interrupts = outcome.get("interrupts") if isinstance(outcome, dict) else None
+    if terminal.get("type") != "RUN_FINISHED" or not isinstance(interrupts, list) or len(interrupts) != 1:
+        raise AssertionError("AG-UI run did not finish with exactly one interrupt")
+    interrupt_id = interrupts[0].get("id") if isinstance(interrupts[0], dict) else None
+    if not isinstance(interrupt_id, str) or not interrupt_id:
+        raise AssertionError("AG-UI interrupt has no stable id")
+    return interrupt_id
+
+
+def _thread_state(state_dir: Path) -> dict[str, Any]:
+    path = state_dir / "threads" / "{}.json".format(THREAD_ID)
+    if not path.is_file():
+        raise AssertionError("AG-UI thread state was not persisted")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("AG-UI thread state is not an object")
+    return value
+
+
+def _pending_permission(state_dir: Path, interrupt_id: str) -> dict[str, Any]:
+    state = _thread_state(state_dir)
+    execution = state.get("execution")
+    pending = execution.get("pending") if isinstance(execution, dict) else None
+    entry = pending.get(interrupt_id) if isinstance(pending, dict) else None
+    value = entry.get("value") if isinstance(entry, dict) else None
+    if not isinstance(value, dict) or value.get("inputId") != interrupt_id:
+        raise AssertionError("AG-UI durable state lost the pending permission")
+    return value
+
+
+class _AguiServer:
+    def __init__(self, *, run_dir: Path, repo_root: Path, port: int, state_dir: Path, workspace: Path) -> None:
+        self.run_dir = run_dir
+        self.repo_root = repo_root
+        self.port = port
+        self.state_dir = state_dir
+        self.workspace = workspace
+        self.process: subprocess.Popen[str] | None = None
+        self._stdout = None
+        self._stderr = None
+
+    @property
+    def url(self) -> str:
+        return "http://127.0.0.1:{}".format(self.port)
+
+    def start(self, *, generation: int, a2a_url: str) -> None:
+        self._stdout = (self.run_dir / "agui-{}.stdout.log".format(generation)).open("w", encoding="utf-8")
+        self._stderr = (self.run_dir / "agui-{}.stderr.log".format(generation)).open("w", encoding="utf-8")
+        env = os.environ.copy()
+        src = str(self.repo_root / "src")
+        env["PYTHONPATH"] = os.pathsep.join(part for part in (src, env.get("PYTHONPATH", "")) if part)
+        env["IAC_CODE_AGUI_ALLOWED_CWDS"] = str(self.workspace)
+        env["IAC_CODE_CONFIG_DIR"] = str(self.run_dir / "config")
+        self.process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "iac_code.cli.main",
+                "agui",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(self.port),
+                "--a2a-url",
+                a2a_url,
+                "--state-dir",
+                str(self.state_dir),
+                "--interrupt-ttl",
+                "120",
+            ],
+            cwd=self.repo_root,
+            env=env,
+            stdout=self._stdout,
+            stderr=self._stderr,
+            text=True,
+        )
+        self._wait_healthy()
+
+    def _wait_healthy(self) -> None:
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if self.process is not None and self.process.poll() is not None:
+                raise RuntimeError("AG-UI server exited with code {}".format(self.process.returncode))
+            try:
+                with urlopen(self.url + "/health", timeout=0.5) as response:
+                    if response.status == 200:
+                        return
+            except (TimeoutError, URLError, OSError):
+                time.sleep(0.05)
+        raise TimeoutError("AG-UI server did not become healthy")
+
+    def stop(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=10)
+        for handle in (self._stdout, self._stderr):
+            if handle is not None and not handle.closed:
+                handle.close()
+        self.process = None
+
+
+def run_scenario(*, run_dir: Path, timeout: float) -> dict[str, Any]:
+    from iac_code.services.session_backup import BACKUP_ENV_VAR, BACKUP_STATE_FILENAME, SessionBackupService
+    from iac_code.services.session_backup_staging import SessionBackupStagingWorker
+    from iac_code.services.session_storage import SessionStorage
+
+    run_dir = run_dir.expanduser().resolve()
+    run_dir.mkdir(parents=True, exist_ok=False)
+    workspace = run_dir / "workspace"
+    workspace.mkdir()
+    config_dir = run_dir / "config"
+    persistence_dir = run_dir / "a2a-state"
+    staging_dir = run_dir / "staging"
+    backup_dir = run_dir / "shared-backup"
+    agui_state_dir = run_dir / "agui-state"
+    execution_log = run_dir / "tool-executions.log"
+    repo_root = Path(__file__).resolve().parents[4]
+    a2a = _FixtureServer(
+        run_dir=run_dir,
+        port=_free_port(),
+        repo_root=repo_root,
+        mode="normal",
+        candidate_first=False,
+        pipeline_step_id=None,
+        handoff_first=False,
+        sequential_permissions=True,
+        defer_staging_publisher=True,
+        staging_dir=staging_dir,
+        backup_dir=backup_dir,
+    )
+    agui = _AguiServer(
+        run_dir=run_dir,
+        repo_root=repo_root,
+        port=_free_port(),
+        state_dir=agui_state_dir,
+        workspace=workspace,
+    )
+    try:
+        a2a.start(1)
+        agui.start(generation=1, a2a_url=a2a.url)
+        first_events = _agui_request(
+            agui.url,
+            _run_payload(workspace, run_id="run-1", prompt="request two deterministic writes"),
+            timeout=timeout,
+        )
+        permission_1_id = _terminal_interrupt(first_events)
+        permission_1 = _pending_permission(agui_state_dir, permission_1_id)
+        _context_path, context_snapshot = _single_json("contexts/*.json", persistence_dir)
+        session_id = context_snapshot.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            raise AssertionError("A2A context snapshot lost its session id")
+
+        worker = SessionBackupStagingWorker(staging_dir, backup_dir)
+        if worker.run_once() != 1:
+            raise AssertionError("P1 staged backup was not published as the old shared generation")
+        shared_markers = sorted(backup_dir.rglob("{}/{}".format(session_id, BACKUP_STATE_FILENAME)))
+        if len(shared_markers) != 1:
+            raise AssertionError("shared P1 backup marker was not created")
+        shared_marker = shared_markers[0]
+        old_shared_generation = int(json.loads(shared_marker.read_text(encoding="utf-8"))["generation"])
+
+        hidden_marker = shared_marker.with_name(".backup-state.agui-e2e-hidden.json")
+        os.replace(shared_marker, hidden_marker)
+        try:
+            second_events = _agui_request(
+                agui.url,
+                _run_payload(
+                    workspace,
+                    run_id="run-2",
+                    resume=_resolved_permission(permission_1_id),
+                ),
+                timeout=timeout,
+            )
+        finally:
+            os.replace(hidden_marker, shared_marker)
+        permission_2_id = _terminal_interrupt(second_events)
+        if permission_2_id == permission_1_id:
+            raise AssertionError("successor permission reused the P1 interrupt id")
+        permission_2 = _pending_permission(agui_state_dir, permission_2_id)
+        if permission_2.get("requestTaskId") != permission_1.get("requestTaskId"):
+            raise AssertionError("sequential AG-UI permissions changed A2A task identity")
+        if _tool_execution_lines(execution_log):
+            raise AssertionError("sequential tools executed before both permissions were resolved")
+
+        _task_path, task_snapshot = _single_json("tasks/*.json", persistence_dir)
+        expected_generation = task_snapshot.get("expected_permission_backup_generation")
+        if not isinstance(expected_generation, int) or expected_generation <= old_shared_generation:
+            raise AssertionError("A2A Task snapshot did not advance to the P2 staged generation")
+        public_before_restart = json.dumps(first_events + second_events, ensure_ascii=False)
+        if (
+            "expected_permission_backup_generation" in public_before_restart
+            or "minimum_generation" in public_before_restart
+        ):
+            raise AssertionError("internal backup generation leaked into the public AG-UI stream")
+        staged_snapshot = next(
+            (path for path in staging_dir.rglob("{}_v{}".format(session_id, expected_generation)) if path.is_dir()),
+            None,
+        )
+        if staged_snapshot is None:
+            raise AssertionError("P2 staged snapshot is unavailable")
+
+        agui.stop()
+        a2a.stop()
+        primary_sessions = [path for path in config_dir.rglob(session_id) if path.is_dir()]
+        if len(primary_sessions) != 1:
+            raise AssertionError("expected exactly one primary session before sandbox replacement")
+        shutil.rmtree(primary_sessions[0])
+
+        previous_backup_dir = os.environ.get(BACKUP_ENV_VAR)
+        os.environ[BACKUP_ENV_VAR] = str(backup_dir)
+        try:
+            restore_result = SessionBackupService(
+                session_storage=SessionStorage(config_dir / "projects")
+            ).restore_session(str(workspace), session_id)
+        finally:
+            if previous_backup_dir is None:
+                os.environ.pop(BACKUP_ENV_VAR, None)
+            else:
+                os.environ[BACKUP_ENV_VAR] = previous_backup_dir
+        if not restore_result.restored:
+            raise AssertionError("replacement Sandbox did not restore the old shared P1 backup")
+        restored_old_state = json.loads(
+            (Path(restore_result.destination) / BACKUP_STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        if int(restored_old_state["generation"]) != old_shared_generation:
+            raise AssertionError("replacement Sandbox did not start from the expected old generation")
+
+        a2a.staging_dir = run_dir / "replacement-staging"
+        a2a.start(2)
+        agui.start(generation=2, a2a_url=a2a.url)
+        not_ready_events = _agui_request(
+            agui.url,
+            _run_payload(
+                workspace,
+                run_id="run-3",
+                resume=_resolved_permission(permission_2_id),
+            ),
+            timeout=timeout,
+        )
+        terminal_error = not_ready_events[-1]
+        if terminal_error.get("type") != "RUN_ERROR" or terminal_error.get("code") != "SESSION_BACKUP_NOT_READY":
+            raise AssertionError("cold AG-UI P2 Resume did not return SESSION_BACKUP_NOT_READY")
+        if "Retry after 3 seconds" not in str(terminal_error.get("message")):
+            raise AssertionError("AG-UI not-ready error did not tell the caller when to retry")
+        _pending_permission(agui_state_dir, permission_2_id)
+        if _tool_execution_lines(execution_log):
+            raise AssertionError("not-ready AG-UI P2 Resume executed a tool")
+        _unchanged_path, unchanged_p2 = _permission_checkpoint_for_input(staged_snapshot, permission_2_id)
+        unchanged_decision = unchanged_p2.get("decision")
+        if (
+            unchanged_p2.get("phase") != "WAITING"
+            or not isinstance(unchanged_decision, dict)
+            or unchanged_decision.get("status") != "none"
+            or unchanged_decision.get("value") is not None
+        ):
+            raise AssertionError("not-ready AG-UI P2 Resume claimed or consumed the staged checkpoint")
+
+        if worker.run_once() < 1:
+            raise AssertionError("P2 staged backup was not published to shared storage")
+        shared_state = json.loads(shared_marker.read_text(encoding="utf-8"))
+        if int(shared_state["generation"]) < expected_generation:
+            raise AssertionError("shared backup did not reach the P2 generation")
+
+        recovered_events = _agui_request(
+            agui.url,
+            _run_payload(
+                workspace,
+                run_id="run-4",
+                resume=_resolved_permission(permission_2_id),
+            ),
+            timeout=timeout,
+        )
+        if recovered_events[-1].get("type") != "RUN_FINISHED" or recovered_events[-1].get("outcome") != {
+            "type": "success"
+        }:
+            raise AssertionError("AG-UI P2 retry did not finish successfully")
+        if _tool_execution_lines(execution_log) != ["executed", "executed-2"]:
+            raise AssertionError("AG-UI P2 retry did not execute both sequential tools exactly once")
+
+        primary_sessions = [path for path in config_dir.rglob(session_id) if path.is_dir()]
+        if len(primary_sessions) != 1:
+            raise AssertionError("shared P2 backup was not restored into the new sandbox")
+        local_state = json.loads((primary_sessions[0] / BACKUP_STATE_FILENAME).read_text(encoding="utf-8"))
+        if int(local_state["generation"]) < expected_generation:
+            raise AssertionError("restored local session did not meet the Task generation fence")
+        _p1_path, p1_checkpoint = _permission_checkpoint_for_input(primary_sessions[0], permission_1_id)
+        _p2_path, p2_checkpoint = _permission_checkpoint_for_input(primary_sessions[0], permission_2_id)
+        if p1_checkpoint.get("phase") != "RESOLVED" or p1_checkpoint.get("ack", {}).get(
+            "nextBoundaryId"
+        ) != p2_checkpoint.get("boundaryId"):
+            raise AssertionError("restored session lost the P1 receipt to P2 successor link")
+        if p2_checkpoint.get("phase") != "RESOLVED":
+            raise AssertionError("AG-UI P2 retry did not resolve the restored checkpoint")
+
+        public_payload = json.dumps(
+            first_events + second_events + not_ready_events + recovered_events,
+            ensure_ascii=False,
+        )
+        if "expected_permission_backup_generation" in public_payload or "minimum_generation" in public_payload:
+            raise AssertionError("internal backup generation leaked into AG-UI events")
+        return {
+            "passed": True,
+            "scenario": "agui-staged-backup-generation-fence",
+            "threadId": THREAD_ID,
+            "taskId": permission_2["requestTaskId"],
+            "oldSharedGeneration": old_shared_generation,
+            "expectedGeneration": expected_generation,
+            "restoredGeneration": int(local_state["generation"]),
+            "notReadyObserved": True,
+            "aguiStateRestored": True,
+            "p1ReceiptPreserved": True,
+            "p2ResolvedOnce": True,
+            "toolExecutions": 2,
+            "publicGenerationAbsent": True,
+        }
+    finally:
+        agui.stop()
+        a2a.stop()
+
+
+def main() -> int:
+    args = _parse_args()
+    result = run_scenario(run_dir=args.run_dir, timeout=args.timeout)
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/a2a/e2e/permission_wait/run_permission_wait_restart.py
+++ b/scripts/a2a/e2e/permission_wait/run_permission_wait_restart.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import socket
 import subprocess
 import sys
@@ -34,6 +35,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--candidate-first", action="store_true")
     parser.add_argument("--pipeline-step-id", choices=SELLING_STAGE_IDS)
     parser.add_argument("--handoff-first", action="store_true")
+    parser.add_argument("--staged-backup-generation-fence", action="store_true")
     return parser.parse_args()
 
 
@@ -281,6 +283,44 @@ def _read_checkpoint(path: Path) -> dict[str, Any]:
     return value
 
 
+def _permission_response_query(permission: dict[str, Any], decision: str = "allow_once") -> str:
+    response = {
+        "schemaVersion": 1,
+        "kind": "permission",
+        "requestTaskId": permission["requestTaskId"],
+        "contextId": permission["contextId"],
+        "inputId": permission["inputId"],
+        "toolUseId": permission["toolUseId"],
+        "decision": decision,
+    }
+    return PERMISSION_QUERY_PREFIX + " " + json.dumps(response, separators=(",", ":"))
+
+
+def _single_json(path_pattern: str, root: Path) -> tuple[Path, dict[str, Any]]:
+    paths = sorted(root.glob(path_pattern))
+    if len(paths) != 1:
+        raise AssertionError("expected exactly one {!r} under {}, found {}".format(path_pattern, root, len(paths)))
+    value = json.loads(paths[0].read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("{} is not a JSON object".format(paths[0]))
+    return paths[0], value
+
+
+def _permission_checkpoint_for_input(root: Path, input_id: str) -> tuple[Path, dict[str, Any]]:
+    matches: list[tuple[Path, dict[str, Any]]] = []
+    for path in root.rglob("permission-waits/pwb_*.json"):
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(value, dict) and value.get("inputId") == input_id:
+            matches.append((path, value))
+    if not matches:
+        raise AssertionError("permission checkpoint {} was not found under {}".format(input_id, root))
+    return sorted(matches, key=lambda item: str(item[0]))[-1]
+
+
+def _tool_execution_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+
+
 class _FixtureServer:
     def __init__(
         self,
@@ -292,6 +332,10 @@ class _FixtureServer:
         candidate_first: bool,
         pipeline_step_id: str | None,
         handoff_first: bool,
+        sequential_permissions: bool = False,
+        defer_staging_publisher: bool = False,
+        staging_dir: Path | None = None,
+        backup_dir: Path | None = None,
     ) -> None:
         self.run_dir = run_dir
         self.port = port
@@ -300,6 +344,10 @@ class _FixtureServer:
         self.candidate_first = candidate_first
         self.pipeline_step_id = pipeline_step_id
         self.handoff_first = handoff_first
+        self.sequential_permissions = sequential_permissions
+        self.defer_staging_publisher = defer_staging_publisher
+        self.staging_dir = staging_dir
+        self.backup_dir = backup_dir
         self.process: subprocess.Popen[str] | None = None
         self._stdout = None
         self._stderr = None
@@ -339,6 +387,12 @@ class _FixtureServer:
             command.extend(("--pipeline-step-id", self.pipeline_step_id))
         if self.handoff_first:
             command.append("--handoff-first")
+        if self.sequential_permissions:
+            command.append("--sequential-permissions")
+        if self.defer_staging_publisher:
+            command.append("--defer-staging-publisher")
+        if self.staging_dir is not None and self.backup_dir is not None:
+            command.extend(("--staging-dir", str(self.staging_dir), "--backup-dir", str(self.backup_dir)))
         self.process = subprocess.Popen(
             command,
             cwd=self.repo_root,
@@ -404,6 +458,266 @@ def _pipeline_snapshot_permission(config_dir: Path, input_id: str) -> dict[str, 
     if permission is None:
         raise AssertionError("Pipeline snapshot lost the waiting permission")
     return permission
+
+
+def run_staged_backup_generation_fence(*, run_dir: Path, timeout: float) -> dict[str, Any]:
+    """Exercise not-ready then retry across a real staged-backup A2A restart."""
+
+    from iac_code.services.session_backup import BACKUP_ENV_VAR, BACKUP_STATE_FILENAME, SessionBackupService
+    from iac_code.services.session_backup_staging import SessionBackupStagingWorker
+    from iac_code.services.session_storage import SessionStorage
+
+    run_dir = run_dir.expanduser().resolve()
+    run_dir.mkdir(parents=True, exist_ok=False)
+    workspace = run_dir / "workspace"
+    workspace.mkdir()
+    config_dir = run_dir / "config"
+    persistence_dir = run_dir / "a2a-state"
+    staging_dir = run_dir / "staging"
+    backup_dir = run_dir / "shared-backup"
+    execution_log = run_dir / "tool-executions.log"
+    repo_root = Path(__file__).resolve().parents[4]
+    server = _FixtureServer(
+        run_dir=run_dir,
+        port=_free_port(),
+        repo_root=repo_root,
+        mode="normal",
+        candidate_first=False,
+        pipeline_step_id=None,
+        handoff_first=False,
+        sequential_permissions=True,
+        defer_staging_publisher=True,
+        staging_dir=staging_dir,
+        backup_dir=backup_dir,
+    )
+    try:
+        server.start(1)
+        first_events = _stream_request(
+            server.url,
+            _message_payload(workspace=workspace, prompt="request two deterministic writes"),
+            timeout=timeout,
+        )
+        first_permissions = _unique_permissions(first_events)
+        if len(first_permissions) != 1:
+            raise AssertionError("first turn did not expose exactly one permission")
+        permission_1 = first_permissions[0]
+        _context_path, context_snapshot = _single_json("contexts/*.json", persistence_dir)
+        session_id = context_snapshot.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            raise AssertionError("A2A context snapshot lost its session id")
+
+        worker = SessionBackupStagingWorker(staging_dir, backup_dir)
+        if worker.run_once() != 1:
+            raise AssertionError("P1 staged backup was not published as the old shared generation")
+        shared_markers = sorted(backup_dir.rglob("{}/{}".format(session_id, BACKUP_STATE_FILENAME)))
+        if len(shared_markers) != 1:
+            raise AssertionError("shared P1 backup marker was not created")
+        shared_marker = shared_markers[0]
+        old_shared_state = json.loads(shared_marker.read_text(encoding="utf-8"))
+        old_shared_generation = int(old_shared_state["generation"])
+
+        # Removing only the shared marker makes any accidental shared-state
+        # read observable while the local generation is already sufficient.
+        hidden_marker = shared_marker.with_name(".backup-state.e2e-hidden.json")
+        os.replace(shared_marker, hidden_marker)
+        try:
+            second_events = _stream_request(
+                server.url,
+                _message_payload(
+                    workspace=workspace,
+                    prompt=_permission_response_query(permission_1),
+                    context_id=str(permission_1["contextId"]),
+                    task_id=str(permission_1["requestTaskId"]),
+                ),
+                timeout=timeout,
+            )
+        finally:
+            os.replace(hidden_marker, shared_marker)
+
+        second_permissions = _unique_permissions(second_events)
+        if len(second_permissions) != 1:
+            raise AssertionError("P1 Resume did not expose exactly one successor permission")
+        permission_2 = second_permissions[0]
+        if permission_2["inputId"] == permission_1["inputId"]:
+            raise AssertionError("successor permission reused the P1 input id")
+        if _tool_execution_lines(execution_log):
+            raise AssertionError("sequential tools executed before both permissions were resolved")
+
+        _task_path, task_snapshot = _single_json("tasks/*.json", persistence_dir)
+        expected_generation = task_snapshot.get("expected_permission_backup_generation")
+        if not isinstance(expected_generation, int) or expected_generation <= old_shared_generation:
+            raise AssertionError("A2A Task snapshot did not advance to the P2 staged generation")
+        public_payload = json.dumps(first_events + second_events, ensure_ascii=False)
+        if "expected_permission_backup_generation" in public_payload or "minimum_generation" in public_payload:
+            raise AssertionError("internal backup generation leaked into the public A2A stream")
+        staged_snapshot = next(
+            (
+                path
+                for path in staging_dir.rglob("{}_v{}".format(session_id, expected_generation))
+                if path.is_dir()
+            ),
+            None,
+        )
+        if staged_snapshot is None:
+            raise AssertionError("P2 staged snapshot is unavailable")
+        _p2_staged_path, p2_staged_checkpoint = _permission_checkpoint_for_input(
+            staged_snapshot,
+            str(permission_2["inputId"]),
+        )
+        if p2_staged_checkpoint.get("phase") != "WAITING":
+            raise AssertionError("P2 staged checkpoint is not waiting")
+
+        server.stop()
+        primary_sessions = [path for path in config_dir.rglob(session_id) if path.is_dir()]
+        if len(primary_sessions) != 1:
+            raise AssertionError("expected exactly one primary session before sandbox replacement")
+        shutil.rmtree(primary_sessions[0])
+
+        # Reproduce a replacement Sandbox after its normal startup restore:
+        # the local session is the old shared P1 generation while the newer P2
+        # generation is still only staged.  Use the production restore service
+        # instead of copying fixture files directly.
+        previous_backup_dir = os.environ.get(BACKUP_ENV_VAR)
+        os.environ[BACKUP_ENV_VAR] = str(backup_dir)
+        try:
+            restore_result = SessionBackupService(
+                session_storage=SessionStorage(config_dir / "projects")
+            ).restore_session(str(workspace), session_id)
+        finally:
+            if previous_backup_dir is None:
+                os.environ.pop(BACKUP_ENV_VAR, None)
+            else:
+                os.environ[BACKUP_ENV_VAR] = previous_backup_dir
+        if not restore_result.restored:
+            raise AssertionError("replacement Sandbox did not restore the old shared P1 backup")
+        restored_old_state = json.loads(
+            (Path(restore_result.destination) / BACKUP_STATE_FILENAME).read_text(encoding="utf-8")
+        )
+        if int(restored_old_state["generation"]) != old_shared_generation:
+            raise AssertionError("replacement Sandbox did not start from the expected old generation")
+
+        # A replacement Sandbox has its own empty local staging area.  Keep
+        # the original worker attached to the first Sandbox's staged snapshots
+        # so only the shared publication can make generation N available.
+        replacement_staging_dir = run_dir / "replacement-staging"
+        server.staging_dir = replacement_staging_dir
+        server.start(2)
+        p2_query = _permission_response_query(permission_2)
+        not_ready_events = _stream_request(
+            server.url,
+            _message_payload(
+                workspace=workspace,
+                prompt=p2_query,
+                context_id=str(permission_2["contextId"]),
+            ),
+            timeout=timeout,
+        )
+        errors = [item["error"] for event in not_ready_events for item in _walk_dicts(event) if "error" in item]
+        error = next(
+            (
+                value
+                for value in errors
+                if isinstance(value, dict)
+                and isinstance(value.get("data"), dict)
+                and value["data"].get("code") == "SESSION_BACKUP_NOT_READY"
+            ),
+            None,
+        )
+        if error is None or error["data"].get("retryable") is not True:
+            raise AssertionError("cold P2 Resume did not return retryable SESSION_BACKUP_NOT_READY")
+        if "Retry after 3 seconds" not in str(error.get("message")):
+            raise AssertionError("not-ready error did not tell the caller when to retry")
+        if _tool_execution_lines(execution_log):
+            raise AssertionError("not-ready P2 Resume executed a tool")
+        _unchanged_path, unchanged_p2 = _permission_checkpoint_for_input(
+            staged_snapshot,
+            str(permission_2["inputId"]),
+        )
+        unchanged_decision = unchanged_p2.get("decision")
+        if (
+            unchanged_p2.get("phase") != "WAITING"
+            or not isinstance(unchanged_decision, dict)
+            or unchanged_decision.get("status") != "none"
+            or unchanged_decision.get("value") is not None
+        ):
+            raise AssertionError("not-ready P2 Resume claimed or consumed the staged checkpoint")
+
+        published = worker.run_once()
+        if published < 1:
+            raise AssertionError("P2 staged backup was not published to shared storage")
+        shared_state = json.loads(shared_marker.read_text(encoding="utf-8"))
+        if int(shared_state["generation"]) < expected_generation:
+            raise AssertionError("shared backup did not reach the P2 generation")
+
+        recovered_events = _stream_request(
+            server.url,
+            _message_payload(
+                workspace=workspace,
+                prompt=p2_query,
+                context_id=str(permission_2["contextId"]),
+            ),
+            timeout=timeout,
+        )
+        if not _iac_code_values(recovered_events, "permissionRecovered"):
+            raise AssertionError("P2 retry did not continue through persisted Permission Wait recovery")
+        if _tool_execution_lines(execution_log) != ["executed", "executed-2"]:
+            raise AssertionError("P2 retry did not execute exactly once")
+
+        primary_sessions = [path for path in config_dir.rglob(session_id) if path.is_dir()]
+        if len(primary_sessions) != 1:
+            raise AssertionError("shared P2 backup was not restored into the new sandbox")
+        local_state = json.loads((primary_sessions[0] / BACKUP_STATE_FILENAME).read_text(encoding="utf-8"))
+        if int(local_state["generation"]) < expected_generation:
+            raise AssertionError("restored local session did not meet the Task generation fence")
+        _p1_path, p1_checkpoint = _permission_checkpoint_for_input(
+            primary_sessions[0],
+            str(permission_1["inputId"]),
+        )
+        _p2_path, p2_checkpoint = _permission_checkpoint_for_input(
+            primary_sessions[0],
+            str(permission_2["inputId"]),
+        )
+        if p1_checkpoint.get("phase") != "RESOLVED" or p1_checkpoint.get("ack", {}).get(
+            "nextBoundaryId"
+        ) != p2_checkpoint.get("boundaryId"):
+            raise AssertionError("restored session lost the P1 receipt to P2 successor link")
+        if p2_checkpoint.get("phase") != "RESOLVED":
+            raise AssertionError("P2 retry did not resolve the restored checkpoint")
+
+        duplicate_events = _stream_request(
+            server.url,
+            _message_payload(
+                workspace=workspace,
+                prompt=p2_query,
+                context_id=str(permission_2["contextId"]),
+            ),
+            timeout=timeout,
+        )
+        duplicate_acks = [
+            value for value in _iac_code_values(duplicate_events, "inputReceived") if isinstance(value, dict)
+        ]
+        if not any(value.get("duplicate") is True for value in duplicate_acks):
+            raise AssertionError("duplicate P2 retry was not acknowledged idempotently")
+        if _tool_execution_lines(execution_log) != ["executed", "executed-2"]:
+            raise AssertionError("duplicate P2 retry executed a tool again")
+
+        return {
+            "passed": True,
+            "scenario": "staged-backup-generation-fence",
+            "taskId": permission_2["requestTaskId"],
+            "contextId": permission_2["contextId"],
+            "oldSharedGeneration": old_shared_generation,
+            "expectedGeneration": expected_generation,
+            "restoredGeneration": int(local_state["generation"]),
+            "notReadyObserved": True,
+            "sameSandboxResumeWithoutSharedMarker": True,
+            "p1ReceiptPreserved": True,
+            "p2ResolvedOnce": True,
+            "toolExecutions": 2,
+            "publicGenerationAbsent": True,
+        }
+    finally:
+        server.stop()
 
 
 def run_scenario(
@@ -695,15 +1009,18 @@ def run_scenario(
 
 def main() -> int:
     args = _parse_args()
-    result = run_scenario(
-        run_dir=args.run_dir,
-        decision=args.decision,
-        timeout=args.timeout,
-        mode=args.mode,
-        candidate_first=args.candidate_first,
-        pipeline_step_id=args.pipeline_step_id,
-        handoff_first=args.handoff_first,
-    )
+    if args.staged_backup_generation_fence:
+        result = run_staged_backup_generation_fence(run_dir=args.run_dir, timeout=args.timeout)
+    else:
+        result = run_scenario(
+            run_dir=args.run_dir,
+            decision=args.decision,
+            timeout=args.timeout,
+            mode=args.mode,
+            candidate_first=args.candidate_first,
+            pipeline_step_id=args.pipeline_step_id,
+            handoff_first=args.handoff_first,
+        )
     print(json.dumps(result, ensure_ascii=False, sort_keys=True))
     return 0
 

--- a/skills/alicloud-ros-agent/scripts/_ros_agent_core.py
+++ b/skills/alicloud-ros-agent/scripts/_ros_agent_core.py
@@ -10,6 +10,20 @@ class BridgeError(Exception):
         self.retryable = retryable
 
 
+def _session_backup_not_ready_error(value: Any) -> Optional[BridgeError]:
+    if not isinstance(value, dict):
+        return None
+    raw_error = value.get("error") if isinstance(value.get("error"), dict) else value
+    data = raw_error.get("data") if isinstance(raw_error.get("data"), dict) else {}
+    code = data.get("code") or raw_error.get("code") or raw_error.get("Code")
+    if code != SESSION_BACKUP_NOT_READY_CODE:
+        return None
+    message = raw_error.get("message") or raw_error.get("Message")
+    if not isinstance(message, str) or not message:
+        message = "Session backup is still synchronizing. Retry after 3 seconds."
+    return BridgeError(SESSION_BACKUP_NOT_READY_CODE, sanitize_text(message, 2000), True)
+
+
 def _json_bytes(value: Any) -> bytes:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -1061,6 +1075,9 @@ def _open_code_request(
             with contextlib.suppress(UnicodeError, ValueError):
                 value = json.loads(raw.decode("utf-8"))
                 if isinstance(value, dict):
+                    backup_not_ready = _session_backup_not_ready_error(value)
+                    if backup_not_ready is not None:
+                        raise backup_not_ready
                     code = value.get("Code", value.get("code"))
                     detail = value.get("Message", value.get("message"))
                     if isinstance(code, str) or isinstance(detail, str):

--- a/skills/alicloud-ros-agent/scripts/_ros_agent_projection.py
+++ b/skills/alicloud-ros-agent/scripts/_ros_agent_projection.py
@@ -818,9 +818,20 @@ class StreamSummary:
         if not isinstance(raw_error, dict):
             raw_error = result.get("error") if isinstance(result.get("error"), dict) else None
         if isinstance(raw_error, dict):
-            code = raw_error.get("code") or raw_error.get("Code") or "StartChatFailed"
-            message = raw_error.get("message") or raw_error.get("Message") or "StartChat returned an error."
-            self.error = {"code": sanitize_text(str(code), 160), "message": sanitize_text(str(message), 2000)}
+            backup_not_ready = _session_backup_not_ready_error(raw_error)
+            if backup_not_ready is not None:
+                self.error = {
+                    "code": backup_not_ready.code,
+                    "message": backup_not_ready.message,
+                    "retryable": True,
+                }
+            else:
+                code = raw_error.get("code") or raw_error.get("Code") or "StartChatFailed"
+                message = raw_error.get("message") or raw_error.get("Message") or "StartChat returned an error."
+                self.error = {
+                    "code": sanitize_text(str(code), 160),
+                    "message": sanitize_text(str(message), 2000),
+                }
         if str(payload.get("object", "")).lower() == "response" and str(payload.get("status", "")).lower() == "failed":
             self.state = "failed"
 
@@ -1071,12 +1082,22 @@ def _project_stream_event(
     if isinstance(raw_error, dict):
         projection["type"] = "failed"
         projection["state"] = "failed"
-        projection["error"] = {
-            "code": sanitize_text(str(raw_error.get("code") or raw_error.get("Code") or "StartChatFailed"), 160),
-            "message": sanitize_text(
-                str(raw_error.get("message") or raw_error.get("Message") or "StartChat failed."), 2000
-            ),
-        }
+        backup_not_ready = _session_backup_not_ready_error(raw_error)
+        if backup_not_ready is not None:
+            projection["error"] = {
+                "code": backup_not_ready.code,
+                "message": backup_not_ready.message,
+                "retryable": True,
+            }
+        else:
+            projection["error"] = {
+                "code": sanitize_text(
+                    str(raw_error.get("code") or raw_error.get("Code") or "StartChatFailed"), 160
+                ),
+                "message": sanitize_text(
+                    str(raw_error.get("message") or raw_error.get("Message") or "StartChat failed."), 2000
+                ),
+            }
     elif state in TERMINAL_STATES:
         projection["type"] = "terminal"
 
@@ -1119,6 +1140,17 @@ def _append_projection(job_id: str, projection: Dict[str, Any]) -> None:
         worker_token = projection.get("workerToken")
         if worker_role == "sideband" and worker_token != job.get("sidebandWorkerToken"):
             return
+        projection_error = projection.get("error")
+        if (
+            worker_role != "sideband"
+            and isinstance(job.get("permissionResponseInput"), dict)
+            and isinstance(projection_error, dict)
+            and projection_error.get("code") == SESSION_BACKUP_NOT_READY_CODE
+            and projection_error.get("retryable") is True
+        ):
+            projection["type"] = "input-required"
+            projection["state"] = "input-required"
+            projection["inputRequired"] = job["permissionResponseInput"]
         primary_terminal = job.get("primaryStreamTerminalSeen") is True or job.get("state") in TERMINAL_STATES
         if primary_terminal:
             projection = _without_wait_boundaries(projection)
@@ -1326,7 +1358,17 @@ def _finish_job(
             if isinstance(value, str) and value:
                 job[key] = value
         state = result.get("state") if isinstance(result.get("state"), str) else "stream-ended"
-        if state == "input-required":
+        error = result.get("error")
+        retry_permission = (
+            isinstance(job.get("permissionResponseInput"), dict)
+            and isinstance(error, dict)
+            and error.get("code") == SESSION_BACKUP_NOT_READY_CODE
+            and error.get("retryable") is True
+        )
+        if retry_permission:
+            state = "input-required"
+            job["inputRequired"] = job["permissionResponseInput"]
+        elif state == "input-required":
             input_required = result.get("inputRequired")
             acknowledged_input_ids = {
                 value for value in job.get("acknowledgedPermissionIds", []) if isinstance(value, str)
@@ -1366,6 +1408,8 @@ def _finish_job(
         elif state in TERMINAL_STATES:
             job.pop("inputRequired", None)
             job.pop("pendingPermissions", None)
+        if not retry_permission:
+            job.pop("permissionResponseInput", None)
         if isinstance(result.get("pipelineResult"), dict):
             job["pipelineResult"] = result["pipelineResult"]
         if result.get("normalHandoffReady") is True and job.get("mode") == "pipeline":

--- a/skills/alicloud-ros-agent/scripts/_ros_agent_runtime.py
+++ b/skills/alicloud-ros-agent/scripts/_ros_agent_runtime.py
@@ -530,6 +530,7 @@ def _respond_job_local(payload: Dict[str, Any]) -> Dict[str, Any]:
                 raise BridgeError("job_busy", "The current StartChat request is still running.", True)
             job["activeRequestSeq"] = int(job.get("activeRequestSeq") or 0) + 1
             job["state"] = "submitted"
+            job["permissionResponseInput"] = pending
         job["lastPermissionResponse"] = response
         remaining = [
             value

--- a/skills/alicloud-ros-agent/scripts/ros_agent.py
+++ b/skills/alicloud-ros-agent/scripts/ros_agent.py
@@ -98,6 +98,7 @@ SKILL_CONFIG_PATH = pathlib.Path(__file__).resolve().parent.parent / "config.jso
 SUPPORTED_IMAGE_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
 PERMISSION_DECISIONS = {"allow_once", "deny"}
 PERMISSION_QUERY_PREFIX = "IAC_CODE_PERMISSION:"
+SESSION_BACKUP_NOT_READY_CODE = "SESSION_BACKUP_NOT_READY"
 TERMINAL_STATES = {"completed", "failed", "canceled", "rejected"}
 PIPELINE_EVENT_TYPES = {
     "pipeline_started",

--- a/src/iac_code/a2a/app.py
+++ b/src/iac_code/a2a/app.py
@@ -43,7 +43,11 @@ from iac_code.a2a.types import validate_protocol_id
 from iac_code.i18n import _
 from iac_code.pipeline.config import get_run_mode
 from iac_code.services.configuration_readiness import configuration_readiness
-from iac_code.services.session_backup import SessionBackupError
+from iac_code.services.session_backup import (
+    SESSION_BACKUP_NOT_READY_CODE,
+    SessionBackupError,
+    SessionBackupNotReadyError,
+)
 from iac_code.services.session_storage import SessionStorage
 
 logger = logging.getLogger(__name__)
@@ -489,21 +493,39 @@ def create_app(
             return JSONResponse({"error": "Invalid session restore request."}, status_code=400)
         raw_cwd = payload.get("cwd")
         raw_session_id = payload.get("sessionId")
-        if not isinstance(raw_cwd, str) or not raw_cwd or not isinstance(raw_session_id, str):
+        raw_task_id = payload.get("taskId")
+        if (
+            not isinstance(raw_cwd, str)
+            or not raw_cwd
+            or not isinstance(raw_session_id, str)
+            or (raw_task_id is not None and not isinstance(raw_task_id, str))
+        ):
             return JSONResponse({"error": "Invalid session restore request."}, status_code=400)
 
         executor = getattr(components.handler, "agent_executor", None)
         resolve_cwd = getattr(executor, "_resolve_cwd", None)
-        backup_service = components.backup_service
-        if not callable(resolve_cwd) or backup_service is None:
+        ensure_restored = getattr(executor, "ensure_session_restored", None)
+        if not callable(resolve_cwd) or not callable(ensure_restored):
             return JSONResponse({"error": "Session restore is unavailable."}, status_code=503)
         try:
             session_id = validate_protocol_id(raw_session_id)
+            task_id = validate_protocol_id(raw_task_id) if raw_task_id is not None else None
             cwd = resolve_cwd({"iac_code": {"cwd": raw_cwd}})
-            result = await asyncio.to_thread(backup_service.reconcile_session, cwd, session_id)
+            result = await ensure_restored(cwd=cwd, session_id=session_id, task_id=task_id)
             exists = SessionStorage().exists(cwd, session_id)
         except ValueError:
             return JSONResponse({"error": "Invalid session restore request."}, status_code=400)
+        except SessionBackupNotReadyError as exc:
+            return JSONResponse(
+                {
+                    "error": {
+                        "code": SESSION_BACKUP_NOT_READY_CODE,
+                        "message": str(exc),
+                        "retryable": True,
+                    }
+                },
+                status_code=409,
+            )
         except SessionBackupError as exc:
             logger.warning("A2A session restore failed error_type=%s", type(exc).__name__)
             return JSONResponse({"error": "Unable to restore the A2A session."}, status_code=503)

--- a/src/iac_code/a2a/client.py
+++ b/src/iac_code/a2a/client.py
@@ -13,10 +13,15 @@ from iac_code.a2a.signing import AgentCardSignature, agent_card_signature_jwks_u
 from iac_code.a2a.transport import A2AAuthConfig, A2ATransportBinding, UnsupportedA2ATransportError, headers_for_auth
 from iac_code.a2a.transports.base import A2ATransportClient, TransportClientOptions, binding_from_url
 from iac_code.a2a.transports.http import HttpA2AClient
+from iac_code.services.session_backup import SESSION_BACKUP_NOT_READY_CODE
 
 
 class A2ACardVerificationError(ValueError):
     """Raised when a discovered Agent Card fails configured verification."""
+
+
+class A2ASessionBackupNotReadyError(RuntimeError):
+    """The internal A2A restore endpoint has not reached the required backup generation."""
 
 
 TransportClientFactory = Callable[[TransportClientOptions], A2ATransportClient]
@@ -315,17 +320,38 @@ class A2AClient:
             raise ValueError("A2A pipeline state response must be a JSON object")
         return data
 
-    async def ensure_session_restored(self, url: str, *, cwd: str, session_id: str) -> bool:
+    async def ensure_session_restored(
+        self,
+        url: str,
+        *,
+        cwd: str,
+        session_id: str,
+        task_id: str | None = None,
+    ) -> bool:
         """Ensure the A2A session payload is locally available before a cold resume."""
 
         endpoint = url.rstrip("/") + "/iac-code/session/ensure-restored"
         response = await self._http_client.post(
             endpoint,
-            json={"cwd": cwd, "sessionId": session_id},
+            json=_without_none({"cwd": cwd, "sessionId": session_id, "taskId": task_id}),
             headers=self._jsonrpc_headers(),
         )
         if response.status_code == 404:
             return False
+        if response.status_code == 409:
+            payload = response.json()
+            error = payload.get("error") if isinstance(payload, dict) else None
+            if (
+                isinstance(error, dict)
+                and error.get("code") == SESSION_BACKUP_NOT_READY_CODE
+                and error.get("retryable") is True
+            ):
+                message = error.get("message")
+                raise A2ASessionBackupNotReadyError(
+                    message
+                    if isinstance(message, str) and message
+                    else "Session backup is still synchronizing. Retry after 3 seconds."
+                )
         response.raise_for_status()
         data = response.json()
         if not isinstance(data, dict) or data.get("status") not in {"current", "restored"}:

--- a/src/iac_code/a2a/events.py
+++ b/src/iac_code/a2a/events.py
@@ -572,6 +572,7 @@ async def publish_interactive_permission_boundary(
     permission_wait_metrics: Any | None = None,
     before_permission_backup: Callable[[Any], Awaitable[None]] | None = None,
     before_permission_claim_backup: Callable[[Any, dict[str, Any]], Awaitable[None]] | None = None,
+    record_expected_backup_generation: Callable[[str, int], Awaitable[None]] | None = None,
     wait_for_response: bool,
 ) -> Any:
     """Publish one real external permission wait, optionally detaching Normal SSE."""
@@ -598,6 +599,9 @@ async def publish_interactive_permission_boundary(
                 before_backup=before_permission_backup,
                 before_claim_backup=before_permission_claim_backup,
             )
+            generation = pending.expected_backup_generation
+            if generation is not None and record_expected_backup_generation is not None:
+                await record_expected_backup_generation(task_id, generation)
         await _enqueue_status(
             event_queue,
             task_id=task_id,

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -118,9 +118,11 @@ from iac_code.services.permissions.audit import emit_permission_boundary_audit
 from iac_code.services.providers.aliyun import DEFAULT_REGION, AliyunCredential, AliyunCredentials
 from iac_code.services.providers.aliyun_identity import AliyunCallerIdentityUnavailableError
 from iac_code.services.session_backup import (
+    SESSION_BACKUP_NOT_READY_CODE,
     BackupReason,
     SessionBackupBlocked,
     SessionBackupError,
+    SessionBackupNotReadyError,
     SessionBackupService,
     SessionReconcileResult,
 )
@@ -148,6 +150,11 @@ _CANCEL_ACTIVE_TASK_DRAIN_TIMEOUT_SECONDS = 30
 _ERROR_TEXT_MAX_CHARS = 1000
 _DEFERRED_CLEANUP_PROMPTS_FILENAME = "cleanup-deferred-prompts.json"
 _CLEANUP_ONLY_METADATA_KEY = "cleanupOnly"
+
+
+class SessionBackupNotReadyInvalidParamsError(InvalidParamsError):
+    code = -32602
+    jsonrpc_error_data_passthrough = True
 
 
 def _format_exception(exc: BaseException) -> str:
@@ -2007,6 +2014,9 @@ class IacCodeA2AExecutor(AgentExecutor):
                                     permission_wait_metrics=self._metrics,
                                     before_permission_backup=persist_request_before_backup,
                                     before_permission_claim_backup=persist_resolution_before_backup,
+                                    record_expected_backup_generation=(
+                                        self._task_store.record_expected_permission_backup_generation
+                                    ),
                                     wait_for_response=False,
                                 )
                                 detached_permission = pending
@@ -2166,6 +2176,11 @@ class IacCodeA2AExecutor(AgentExecutor):
     ) -> bool:
         """Claim and resume a permission whose process-local registry was lost."""
 
+        response_metadata = getattr(context, "metadata", None) or getattr(
+            getattr(context, "message", None), "metadata", None
+        )
+        preferred_language = self._resolve_preferred_language(response_metadata)
+
         try:
             task_record = await self._task_store.get_task_record(response.task_id)
             context_record = await self._task_store.get_context_record(response.context_id)
@@ -2173,11 +2188,25 @@ class IacCodeA2AExecutor(AgentExecutor):
             return False
         if task_record.context_id != response.context_id:
             raise InvalidParamsError("input_response_mismatch: permission task context changed.")
+        minimum_generation = getattr(task_record, "expected_permission_backup_generation", None)
         try:
             reconcile_result = await self._reconcile_session_before_route(
                 context_id=response.context_id,
                 cwd=context_record.cwd,
+                minimum_generation=minimum_generation,
             )
+        except SessionBackupNotReadyError as exc:
+            message = translate_message(
+                "Session backup is still synchronizing. Retry after 3 seconds.",
+                language=preferred_language or "en",
+            )
+            raise SessionBackupNotReadyInvalidParamsError(
+                message,
+                data={
+                    "code": SESSION_BACKUP_NOT_READY_CODE,
+                    "retryable": True,
+                },
+            ) from exc
         except SessionBackupError:
             logger.warning("Failed to restore the A2A session before resuming a persisted permission", exc_info=True)
             return False
@@ -2225,7 +2254,7 @@ class IacCodeA2AExecutor(AgentExecutor):
             )
             return True
 
-        metadata = getattr(context, "metadata", None) or getattr(getattr(context, "message", None), "metadata", None)
+        metadata = response_metadata
         model = self._resolve_model(metadata) or self._model
         metadata_api_key = self._resolve_api_key(metadata)
         request_policy_override = self._resolve_request_policy(metadata)
@@ -3041,19 +3070,25 @@ class IacCodeA2AExecutor(AgentExecutor):
         *,
         context_id: str,
         cwd: str,
+        minimum_generation: int | None = None,
     ) -> SessionReconcileResult | None:
         reconcile = getattr(self._backup_service, "reconcile_session", None)
         if not callable(reconcile):
             return None
         async with self._task_store.reconciliation_lock(context_id):
             await self._task_store.ensure_context_reconciliation_safe(context_id)
-            return await self._reconcile_session_before_route_locked(context_id=context_id, cwd=cwd)
+            return await self._reconcile_session_before_route_locked(
+                context_id=context_id,
+                cwd=cwd,
+                minimum_generation=minimum_generation,
+            )
 
     async def _reconcile_session_before_route_locked(
         self,
         *,
         context_id: str,
         cwd: str,
+        minimum_generation: int | None = None,
     ) -> SessionReconcileResult | None:
         reconcile = getattr(self._backup_service, "reconcile_session", None)
         if not callable(reconcile):
@@ -3064,17 +3099,17 @@ class IacCodeA2AExecutor(AgentExecutor):
             return None
         if context.cwd != cwd:
             return None
-        result = await run_sync_fenced(
-            reconcile,
-            cwd,
-            context.session_id,
-            attempted_proof_validator=lambda key, proof: self._validate_attempted_publication_proof(
+        reconcile_kwargs: dict[str, Any] = {
+            "attempted_proof_validator": lambda key, proof: self._validate_attempted_publication_proof(
                 cwd=cwd,
                 session_id=context.session_id,
                 key=key,
                 proof=proof,
-            ),
-        )
+            )
+        }
+        if minimum_generation is not None:
+            reconcile_kwargs["minimum_generation"] = minimum_generation
+        result = await run_sync_fenced(reconcile, cwd, context.session_id, **reconcile_kwargs)
         if not isinstance(result, SessionReconcileResult):
             raise TypeError("session backup reconciliation returned an invalid result")
         proven_handoff = self._normal_handoff_has_state_proof(
@@ -3089,6 +3124,60 @@ class IacCodeA2AExecutor(AgentExecutor):
                 session_id=context.session_id,
                 clear_active_task_for_proven_handoff=proven_handoff,
             )
+        return result
+
+    async def ensure_session_restored(
+        self,
+        *,
+        cwd: str,
+        session_id: str,
+        task_id: str | None = None,
+    ) -> SessionReconcileResult | None:
+        """Restore one internal A2A session, applying a Task's permission generation fence when present."""
+
+        if task_id is None:
+            return await self._reconcile_session_direct(cwd=cwd, session_id=session_id)
+
+        task_record = await self._task_store.get_task_record(task_id)
+        context_record = await self._task_store.get_context_record(task_record.context_id)
+        if context_record.cwd != cwd or context_record.session_id != session_id:
+            raise ValueError("A2A task session binding changed")
+        minimum_generation = task_record.expected_permission_backup_generation
+        if minimum_generation is None:
+            return await self._reconcile_session_direct(cwd=cwd, session_id=session_id)
+
+        read_local_state = getattr(self._backup_service, "read_local_state", None)
+        if callable(read_local_state):
+            local_state = await run_sync_fenced(read_local_state, cwd, session_id)
+            if (
+                isinstance(local_state, SessionBackupState)
+                and local_state.status == "succeeded"
+                and local_state.generation >= minimum_generation
+            ):
+                return SessionReconcileResult(
+                    enabled=True,
+                    action="current",
+                    source=Path(SessionStorage().session_dir(cwd, session_id)),
+                    state=local_state,
+                )
+        return await self._reconcile_session_before_route(
+            context_id=context_record.context_id,
+            cwd=cwd,
+            minimum_generation=minimum_generation,
+        )
+
+    async def _reconcile_session_direct(
+        self,
+        *,
+        cwd: str,
+        session_id: str,
+    ) -> SessionReconcileResult | None:
+        reconcile = getattr(self._backup_service, "reconcile_session", None)
+        if not callable(reconcile):
+            return None
+        result = await run_sync_fenced(reconcile, cwd, session_id)
+        if not isinstance(result, SessionReconcileResult):
+            raise TypeError("session backup reconciliation returned an invalid result")
         return result
 
     def _validate_attempted_publication_proof(

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -131,6 +131,7 @@ class PendingPermission:
     backup_session_id: str | None = field(default=None, repr=False)
     backup_service: Any | None = field(default=None, repr=False)
     backup_metrics: Any | None = field(default=None, repr=False)
+    expected_backup_generation: int | None = field(default=None, repr=False)
     before_claim_backup: Callable[[PendingPermission, dict[str, Any]], Awaitable[None]] | None = field(
         default=None,
         repr=False,
@@ -164,6 +165,22 @@ class PermissionTaskClosingToken:
 class _PermissionTaskClosingState:
     permanent: bool = False
     reversible_tokens: set[str] = field(default_factory=set)
+
+
+def staged_permission_backup_generation(result: Any) -> int | None:
+    """Return the internal restore floor for an asynchronously published backup."""
+
+    generation = getattr(result, "generation", None)
+    if (
+        bool(getattr(result, "enabled", False))
+        and bool(getattr(result, "staged_committed", False))
+        and not bool(getattr(result, "shared_committed", False))
+        and isinstance(generation, int)
+        and not isinstance(generation, bool)
+        and generation > 0
+    ):
+        return generation
+    return None
 
 
 def permission_input_envelope(
@@ -1043,7 +1060,7 @@ class PermissionInputRegistry:
         pending.backup_session_id = session_id
         pending.backup_service = backup_service
         pending.backup_metrics = metrics
-        return await backup_permission_wait_checkpoint(
+        result = await backup_permission_wait_checkpoint(
             store=store,
             boundary_id=boundary_id,
             cwd=cwd,
@@ -1051,6 +1068,11 @@ class PermissionInputRegistry:
             backup_service=backup_service,
             metrics=metrics,
         )
+        generation = staged_permission_backup_generation(result)
+        if generation is not None:
+            current = pending.expected_backup_generation
+            pending.expected_backup_generation = generation if current is None else max(current, generation)
+        return result
 
     def activate_durable_boundary(
         self,

--- a/src/iac_code/a2a/persistence.py
+++ b/src/iac_code/a2a/persistence.py
@@ -42,6 +42,7 @@ class A2ATaskSnapshot:
     status_message: str = ""
     updated_at: float = field(default_factory=time.time)
     owner: str = ""
+    expected_permission_backup_generation: int | None = None
 
 
 @dataclass(frozen=True)
@@ -96,6 +97,7 @@ class A2APersistenceStore:
                 output_text=snapshot.output_text,
                 status_message="Task was interrupted by process exit and cannot be revived automatically.",
                 updated_at=snapshot.updated_at,
+                expected_permission_backup_generation=snapshot.expected_permission_backup_generation,
             )
             self.save_task(interrupted)
             return interrupted
@@ -164,6 +166,14 @@ class A2APersistenceStore:
         owner = data.get("owner")
         status_message = data.get("status_message")
         updated_at = data.get("updated_at")
+        raw_expected_generation = data.get("expected_permission_backup_generation")
+        expected_generation = (
+            raw_expected_generation
+            if isinstance(raw_expected_generation, int)
+            and not isinstance(raw_expected_generation, bool)
+            and raw_expected_generation > 0
+            else None
+        )
         return A2ATaskSnapshot(
             task_id=task_id,
             context_id=context_id,
@@ -172,6 +182,7 @@ class A2APersistenceStore:
             output_text=output_text,
             status_message=status_message if isinstance(status_message, str) else "",
             updated_at=float(updated_at) if isinstance(updated_at, (int, float)) else time.time(),
+            expected_permission_backup_generation=expected_generation,
         )
 
     @staticmethod

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -21,7 +21,7 @@ from google.protobuf.json_format import ParseDict
 from iac_code.a2a.artifacts import artifact_store_for_session
 from iac_code.a2a.backup import backup_session_async
 from iac_code.a2a.events import make_text_part, publish_mcp_warnings
-from iac_code.a2a.input_required import PendingPermission
+from iac_code.a2a.input_required import PendingPermission, staged_permission_backup_generation
 from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
 from iac_code.a2a.pipeline_flow_monitor import (
     PipelineA2AFlowIdentity,
@@ -2574,7 +2574,7 @@ class IacCodeA2APipelineExecutor:
         try:
             pending = publisher.pending_durable_permission if reason == BackupReason.INPUT_REQUIRED else None
             if pending is not None and self._permission_input_registry is not None:
-                await self._permission_input_registry.backup_durable_boundary(
+                backup_result = await self._permission_input_registry.backup_durable_boundary(
                     pending,
                     cwd,
                     session_id,
@@ -2582,7 +2582,7 @@ class IacCodeA2APipelineExecutor:
                     metrics=self._metrics,
                 )
             else:
-                await backup_session_async(
+                backup_result = await backup_session_async(
                     self._backup_service,
                     cwd,
                     session_id,
@@ -2591,6 +2591,10 @@ class IacCodeA2APipelineExecutor:
                     metrics=self._metrics,
                     publication_proofs=publication_proofs,
                 )
+            if pending is not None:
+                generation = staged_permission_backup_generation(backup_result)
+                if generation is not None:
+                    await self._task_store.record_expected_permission_backup_generation(task.task_id, generation)
         except SessionBackupBlocked as exc:
             sidecar_synced = await _sync_pipeline_backup_blocked_sidecar(
                 pipeline,

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -176,6 +176,21 @@ class A2ATaskStore(TaskStore):
                     self._attach_pending_permissions(task)
             self._task_persistence_dirty.add(task_id)
 
+    async def record_expected_permission_backup_generation(self, task_id: str, generation: int) -> None:
+        """Raise the internal restore floor for the next persisted permission Resume."""
+
+        task_id = validate_protocol_id(task_id)
+        if isinstance(generation, bool) or not isinstance(generation, int) or generation <= 0:
+            raise ValueError("Invalid permission backup generation")
+        async with self._mutation_lock:
+            record = self._tasks.get(task_id)
+            if record is None:
+                raise ValueError(_("A2A task not found"))
+            current = record.expected_permission_backup_generation
+            if current is None or generation > current:
+                record.expected_permission_backup_generation = generation
+                self._task_persistence_dirty.add(task_id)
+
     async def delete(self, task_id: str, context: ServerCallContext | None = None) -> None:
         owner = self._owner(context)
         task_id = validate_protocol_id(task_id)
@@ -786,6 +801,7 @@ class A2ATaskStore(TaskStore):
                     state=record.state,
                     owner=record.owner,
                     output_text=list(record.output_text),
+                    expected_permission_backup_generation=record.expected_permission_backup_generation,
                     expired=record.expired,
                     updated_at=record.updated_at,
                     created_at=record.created_at,
@@ -1006,6 +1022,7 @@ class A2ATaskStore(TaskStore):
             owner=record.owner,
             output_text=list(record.output_text),
             updated_at=record.updated_at,
+            expected_permission_backup_generation=record.expected_permission_backup_generation,
         )
         if self._persistence is not None and persist_shared_snapshot:
             try:
@@ -1332,6 +1349,7 @@ def _record_from_snapshot(snapshot: A2ATaskSnapshot) -> A2ATaskRecord:
         state=snapshot.state,
         owner=snapshot.owner,
         output_text=list(snapshot.output_text),
+        expected_permission_backup_generation=snapshot.expected_permission_backup_generation,
         updated_at=snapshot.updated_at,
     )
 

--- a/src/iac_code/a2a/types.py
+++ b/src/iac_code/a2a/types.py
@@ -31,6 +31,7 @@ class A2ATaskRecord:
     state: str = TASK_STATE_SUBMITTED
     owner: str = ""
     output_text: list[str] = field(default_factory=list)
+    expected_permission_backup_generation: int | None = None
     active_task: asyncio.Task[Any] | None = None
     expired: bool = False
     updated_at: float = field(default_factory=time.time)

--- a/src/iac_code/agui/adapter.py
+++ b/src/iac_code/agui/adapter.py
@@ -28,7 +28,7 @@ from ag_ui.core import (
 from jsonschema import ValidationError as JsonSchemaValidationError
 from jsonschema import validate as validate_json_schema
 
-from iac_code.a2a.client import A2AClient
+from iac_code.a2a.client import A2AClient, A2ASessionBackupNotReadyError
 from iac_code.agui.errors import AdmissionError, AguiError, normalize_agui_language, translate_agui_error
 from iac_code.agui.events import (
     A2AEventMapper,
@@ -58,6 +58,7 @@ from iac_code.agui.state import (
     AguiStateStoreError,
     FileAguiThreadStateStore,
 )
+from iac_code.services.session_backup import SESSION_BACKUP_NOT_READY_CODE
 
 logger = logging.getLogger(__name__)
 _FAILED_STATES = frozenset({"auth-required", "failed", "rejected"})
@@ -872,11 +873,15 @@ class AguiA2AAdapter:
 
         ensure_session_restored = getattr(self.client, "ensure_session_restored", None)
         if binding.iac_code_session_id is not None and callable(ensure_session_restored):
-            session_ready = await ensure_session_restored(
-                self.a2a_url,
-                cwd=binding.cwd,
-                session_id=binding.iac_code_session_id,
-            )
+            try:
+                session_ready = await ensure_session_restored(
+                    self.a2a_url,
+                    cwd=binding.cwd,
+                    session_id=binding.iac_code_session_id,
+                    task_id=binding.task_id,
+                )
+            except A2ASessionBackupNotReadyError as exc:
+                raise AguiError(SESSION_BACKUP_NOT_READY_CODE, str(exc)) from exc
             if not session_ready:
                 raise AguiError("EXECUTION_LOST", "The iac-code session to resume is unavailable.")
 
@@ -910,18 +915,22 @@ class AguiA2AAdapter:
         binding.pipeline_open_steps = set(mapper.open_pipeline_steps)
 
         known_pending_ids = set(binding.pending)
+        resumed_pending_ids = known_pending_ids.intersection(
+            entry.interrupt_id for entry in ticket.run_input.resume or []
+        )
         current_inputs = a2a_inputs(task)
         task_metadata = a2a_iac_code_metadata(task)
         # A task restored after an A2A process restart is only a durable
         # summary and does not contain the original input metadata.  Absence of
         # that projection is not evidence that the adapter's durable interrupt
         # disappeared: the following permission response is what lets A2A load
-        # its permission checkpoint.  Explicit projections (including an empty
-        # one) remain authoritative, as do terminal task states.
-        replace_pending = (
-            "input" in task_metadata
-            or "pendingPermissions" in task_metadata
-            or a2a_state(task) in _FAILED_STATES | {"canceled", "completed"}
+        # its permission checkpoint.  A non-terminal projection must not erase
+        # an interrupt this Resume is answering; A2A remains authoritative when
+        # it accepts or rejects the response.  Terminal task states always win.
+        task_is_terminal = a2a_state(task) in _FAILED_STATES | {"canceled", "completed"}
+        replace_pending = task_is_terminal or (
+            not resumed_pending_ids
+            and ("input" in task_metadata or "pendingPermissions" in task_metadata)
         )
         self._merge_pending(
             binding,
@@ -1446,7 +1455,18 @@ def _pending_expires_at(binding: ThreadBinding) -> datetime | None:
 
 def _raise_for_a2a_error(response: Any) -> None:
     payload = getattr(response, "payload", response)
-    if isinstance(payload, Mapping) and isinstance(payload.get("error"), Mapping):
+    error = payload.get("error") if isinstance(payload, Mapping) else None
+    if isinstance(error, Mapping):
+        data = error.get("data")
+        if (
+            isinstance(data, Mapping)
+            and data.get("code") == SESSION_BACKUP_NOT_READY_CODE
+            and data.get("retryable") is True
+        ):
+            raise AguiError(
+                SESSION_BACKUP_NOT_READY_CODE,
+                "Session backup is still synchronizing. Retry after 3 seconds.",
+            )
         raise AguiError("A2A_UNAVAILABLE", "The local A2A execution service rejected the interrupt response.")
 
 

--- a/src/iac_code/agui/errors.py
+++ b/src/iac_code/agui/errors.py
@@ -20,6 +20,10 @@ _PUBLIC_AGUI_ERROR_MESSAGES = frozenset(
         translate_message("Invalid iac-code forwarded properties.", language="en"),
         translate_message("Only text and inline data images are supported.", language="en"),
         translate_message("Remote media URLs are not supported.", language="en"),
+        translate_message(
+            "Session backup is still synchronizing. Retry after 3 seconds.",
+            language="en",
+        ),
         translate_message("The A2A context identity changed unexpectedly.", language="en"),
         translate_message("The A2A execution failed.", language="en"),
         translate_message("The A2A interrupt response was not accepted.", language="en"),

--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -84,6 +84,12 @@ msgstr ""
 "Cloud-Ressourcen manuell."
 
 #: src/iac_code/a2a/executor.py
+msgid "Normal permission restore snapshot could not be persisted."
+msgstr ""
+"Der Wiederherstellungs-Snapshot für die Berechtigung des normalen Chats "
+"konnte nicht gespeichert werden."
+
+#: src/iac_code/a2a/executor.py
 msgid "Normal permission restore snapshot identity is incomplete."
 msgstr ""
 "Die Identität des Wiederherstellungs-Snapshots für die Berechtigung des "
@@ -106,12 +112,6 @@ msgid "Normal permission restore decision conflicts with the snapshot."
 msgstr ""
 "Die Wiederherstellungsentscheidung für die Berechtigung des normalen "
 "Chats steht im Konflikt mit dem Snapshot."
-
-#: src/iac_code/a2a/executor.py
-msgid "Normal permission restore snapshot could not be persisted."
-msgstr ""
-"Der Wiederherstellungs-Snapshot für die Berechtigung des normalen Chats "
-"konnte nicht gespeichert werden."
 
 #: src/iac_code/a2a/executor.py
 msgid ""
@@ -157,6 +157,12 @@ msgid "Normal permission decision is unavailable before backup."
 msgstr ""
 "Die Berechtigungsentscheidung des normalen Chats ist vor der Sicherung "
 "nicht verfügbar."
+
+#: src/iac_code/a2a/executor.py src/iac_code/agui/errors.py
+msgid "Session backup is still synchronizing. Retry after 3 seconds."
+msgstr ""
+"Die Sitzungssicherung wird noch synchronisiert. Versuchen Sie es in 3 "
+"Sekunden erneut."
 
 #: src/iac_code/a2a/executor.py
 msgid "Unsupported pipeline name."

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -85,6 +85,12 @@ msgstr ""
 "sesión y los recursos en la nube."
 
 #: src/iac_code/a2a/executor.py
+msgid "Normal permission restore snapshot could not be persisted."
+msgstr ""
+"No se pudo conservar la instantánea de restauración del permiso del chat "
+"normal."
+
+#: src/iac_code/a2a/executor.py
 msgid "Normal permission restore snapshot identity is incomplete."
 msgstr ""
 "La identidad de la instantánea de restauración del permiso del chat "
@@ -107,12 +113,6 @@ msgid "Normal permission restore decision conflicts with the snapshot."
 msgstr ""
 "La decisión de restauración del permiso del chat normal entra en "
 "conflicto con la instantánea."
-
-#: src/iac_code/a2a/executor.py
-msgid "Normal permission restore snapshot could not be persisted."
-msgstr ""
-"No se pudo conservar la instantánea de restauración del permiso del chat "
-"normal."
 
 #: src/iac_code/a2a/executor.py
 msgid ""
@@ -158,6 +158,12 @@ msgid "Normal permission decision is unavailable before backup."
 msgstr ""
 "La decisión de permiso del chat normal no está disponible antes de la "
 "copia de seguridad."
+
+#: src/iac_code/a2a/executor.py src/iac_code/agui/errors.py
+msgid "Session backup is still synchronizing. Retry after 3 seconds."
+msgstr ""
+"La copia de seguridad de la sesión aún se está sincronizando. Vuelve a "
+"intentarlo en 3 segundos."
 
 #: src/iac_code/a2a/executor.py
 msgid "Unsupported pipeline name."

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -85,6 +85,12 @@ msgstr ""
 "session et les ressources cloud."
 
 #: src/iac_code/a2a/executor.py
+msgid "Normal permission restore snapshot could not be persisted."
+msgstr ""
+"L’instantané de restauration d’autorisation du chat normal n’a pas pu "
+"être enregistré."
+
+#: src/iac_code/a2a/executor.py
 msgid "Normal permission restore snapshot identity is incomplete."
 msgstr ""
 "L’identité de l’instantané de restauration d’autorisation du chat normal "
@@ -107,12 +113,6 @@ msgid "Normal permission restore decision conflicts with the snapshot."
 msgstr ""
 "La décision de restauration d’autorisation du chat normal est en conflit "
 "avec l’instantané."
-
-#: src/iac_code/a2a/executor.py
-msgid "Normal permission restore snapshot could not be persisted."
-msgstr ""
-"L’instantané de restauration d’autorisation du chat normal n’a pas pu "
-"être enregistré."
 
 #: src/iac_code/a2a/executor.py
 msgid ""
@@ -158,6 +158,12 @@ msgid "Normal permission decision is unavailable before backup."
 msgstr ""
 "La décision d’autorisation du chat normal est indisponible avant la "
 "sauvegarde."
+
+#: src/iac_code/a2a/executor.py src/iac_code/agui/errors.py
+msgid "Session backup is still synchronizing. Retry after 3 seconds."
+msgstr ""
+"La sauvegarde de la session est toujours en cours de synchronisation. "
+"Réessayez dans 3 secondes."
 
 #: src/iac_code/a2a/executor.py
 msgid "Unsupported pipeline name."

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -76,6 +76,10 @@ msgid ""
 msgstr "クリーンアップ状態を利用できません。セッションファイルとクラウドリソースを手動で確認してください。"
 
 #: src/iac_code/a2a/executor.py
+msgid "Normal permission restore snapshot could not be persisted."
+msgstr "通常チャットの権限復元スナップショットを保存できませんでした。"
+
+#: src/iac_code/a2a/executor.py
 msgid "Normal permission restore snapshot identity is incomplete."
 msgstr "通常チャットの権限復元スナップショットの識別情報が不完全です。"
 
@@ -90,10 +94,6 @@ msgstr "通常チャットの権限復元リクエストがスナップショッ
 #: src/iac_code/a2a/executor.py
 msgid "Normal permission restore decision conflicts with the snapshot."
 msgstr "通常チャットの権限復元判断がスナップショットと競合しています。"
-
-#: src/iac_code/a2a/executor.py
-msgid "Normal permission restore snapshot could not be persisted."
-msgstr "通常チャットの権限復元スナップショットを保存できませんでした。"
 
 #: src/iac_code/a2a/executor.py
 msgid ""
@@ -129,6 +129,10 @@ msgstr "タスクがキャンセルされました。"
 #: src/iac_code/a2a/executor.py
 msgid "Normal permission decision is unavailable before backup."
 msgstr "バックアップ前に通常チャットの権限判断を取得できません。"
+
+#: src/iac_code/a2a/executor.py src/iac_code/agui/errors.py
+msgid "Session backup is still synchronizing. Retry after 3 seconds."
+msgstr "セッションのバックアップはまだ同期中です。3秒後に再試行してください。"
 
 #: src/iac_code/a2a/executor.py
 msgid "Unsupported pipeline name."

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -84,6 +84,12 @@ msgstr ""
 "sessão e os recursos de nuvem."
 
 #: src/iac_code/a2a/executor.py
+msgid "Normal permission restore snapshot could not be persisted."
+msgstr ""
+"Não foi possível persistir o snapshot de restauração da permissão do chat"
+" normal."
+
+#: src/iac_code/a2a/executor.py
 msgid "Normal permission restore snapshot identity is incomplete."
 msgstr ""
 "A identidade do snapshot de restauração da permissão do chat normal está "
@@ -104,12 +110,6 @@ msgid "Normal permission restore decision conflicts with the snapshot."
 msgstr ""
 "A decisão de restauração da permissão do chat normal entra em conflito "
 "com o snapshot."
-
-#: src/iac_code/a2a/executor.py
-msgid "Normal permission restore snapshot could not be persisted."
-msgstr ""
-"Não foi possível persistir o snapshot de restauração da permissão do chat"
-" normal."
 
 #: src/iac_code/a2a/executor.py
 msgid ""
@@ -153,6 +153,12 @@ msgstr "Tarefa cancelada."
 #: src/iac_code/a2a/executor.py
 msgid "Normal permission decision is unavailable before backup."
 msgstr "A decisão de permissão do chat normal não está disponível antes do backup."
+
+#: src/iac_code/a2a/executor.py src/iac_code/agui/errors.py
+msgid "Session backup is still synchronizing. Retry after 3 seconds."
+msgstr ""
+"O backup da sessão ainda está sendo sincronizado. Tente novamente em 3 "
+"segundos."
 
 #: src/iac_code/a2a/executor.py
 msgid "Unsupported pipeline name."

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -76,6 +76,10 @@ msgid ""
 msgstr "清理状态不可用。请手动检查会话文件和云资源。"
 
 #: src/iac_code/a2a/executor.py
+msgid "Normal permission restore snapshot could not be persisted."
+msgstr "无法持久化普通对话权限恢复快照。"
+
+#: src/iac_code/a2a/executor.py
 msgid "Normal permission restore snapshot identity is incomplete."
 msgstr "普通对话权限恢复快照标识不完整。"
 
@@ -90,10 +94,6 @@ msgstr "快照中缺少普通对话权限恢复请求。"
 #: src/iac_code/a2a/executor.py
 msgid "Normal permission restore decision conflicts with the snapshot."
 msgstr "普通对话权限恢复决定与快照冲突。"
-
-#: src/iac_code/a2a/executor.py
-msgid "Normal permission restore snapshot could not be persisted."
-msgstr "无法持久化普通对话权限恢复快照。"
 
 #: src/iac_code/a2a/executor.py
 msgid ""
@@ -129,6 +129,10 @@ msgstr "任务已取消。"
 #: src/iac_code/a2a/executor.py
 msgid "Normal permission decision is unavailable before backup."
 msgstr "备份前无法获取普通对话权限决定。"
+
+#: src/iac_code/a2a/executor.py src/iac_code/agui/errors.py
+msgid "Session backup is still synchronizing. Retry after 3 seconds."
+msgstr "会话备份仍在同步中，请在 3 秒后重试。"
 
 #: src/iac_code/a2a/executor.py
 msgid "Unsupported pipeline name."

--- a/src/iac_code/services/session_backup.py
+++ b/src/iac_code/services/session_backup.py
@@ -36,6 +36,7 @@ from iac_code.utils.state_io import atomic_write_json, fsync_parent_dir, safe_re
 BACKUP_ENV_VAR = "IAC_CODE_CONFIG_BACKUP_DIR"
 BACKUP_STATE_FILENAME = ".backup-state.json"
 BACKUP_LOCK_FILENAME = ".backup-lock"
+SESSION_BACKUP_NOT_READY_CODE = "SESSION_BACKUP_NOT_READY"
 _PREPARED_DIR_CACHE_LIMIT = 4096
 logger = logging.getLogger(__name__)
 _SAFE_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -166,6 +167,22 @@ class SessionReconcileResult:
 
 class SessionBackupError(Exception):
     """Base session backup error."""
+
+
+class SessionBackupNotReadyError(SessionBackupError):
+    """The shared backup has not reached a required staged generation yet."""
+
+    def __init__(
+        self,
+        *,
+        minimum_generation: int,
+        local_generation: int | None,
+        shared_generation: int | None,
+    ) -> None:
+        super().__init__("Session backup is still synchronizing. Retry after 3 seconds.")
+        self.minimum_generation = minimum_generation
+        self.local_generation = local_generation
+        self.shared_generation = shared_generation
 
 
 class SessionBackupConflict(SessionBackupError):  # noqa: N818 - protocol conflict is a public domain name.
@@ -403,7 +420,14 @@ class SessionBackupService:
         session_id: str,
         *,
         attempted_proof_validator: Callable[[str, BackupPublicationProof], bool] | None = None,
+        minimum_generation: int | None = None,
     ) -> SessionReconcileResult:
+        if minimum_generation is not None and (
+            isinstance(minimum_generation, bool)
+            or not isinstance(minimum_generation, int)
+            or minimum_generation <= 0
+        ):
+            raise ValueError("minimum_generation must be a positive integer")
         if not self._backup_enabled():
             return SessionReconcileResult(enabled=False, action="disabled")
         self._validate_session_id(session_id)
@@ -416,7 +440,25 @@ class SessionBackupService:
             local = self._source_for_backup(cwd, session_id)
             local_state = self._read_state(local, session_id=session_id, missing_ok=True) if local is not None else None
             shared = self._source_for_restore(cwd, session_id, backup_root)
-            shared_state = self._read_state(shared, session_id=session_id, shared=True) if shared is not None else None
+            shared_state = (
+                self._read_state(
+                    shared,
+                    session_id=session_id,
+                    shared=True,
+                    missing_ok=minimum_generation is not None,
+                )
+                if shared is not None
+                else None
+            )
+            if minimum_generation is not None and (
+                local_state is None or local_state.generation < minimum_generation
+            ):
+                if shared_state is None or shared_state.generation < minimum_generation:
+                    raise SessionBackupNotReadyError(
+                        minimum_generation=minimum_generation,
+                        local_generation=local_state.generation if local_state is not None else None,
+                        shared_generation=shared_state.generation if shared_state is not None else None,
+                    )
 
             if local is None:
                 if shared is None or shared_state is None:

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -246,7 +246,14 @@ class StagedSessionBackupService(SessionBackupService):
         session_id: str,
         *,
         attempted_proof_validator: Callable[[str, BackupPublicationProof], bool] | None = None,
+        minimum_generation: int | None = None,
     ) -> SessionReconcileResult:
+        if minimum_generation is not None and (
+            isinstance(minimum_generation, bool)
+            or not isinstance(minimum_generation, int)
+            or minimum_generation <= 0
+        ):
+            raise ValueError("minimum_generation must be a positive integer")
         if not self._backup_enabled():
             return SessionReconcileResult(enabled=False, action="disabled")
         self._validate_session_id(session_id)
@@ -256,6 +263,7 @@ class StagedSessionBackupService(SessionBackupService):
                 cwd,
                 session_id,
                 attempted_proof_validator=attempted_proof_validator,
+                minimum_generation=minimum_generation,
             )
 
         local_state = self._read_state(local, session_id=session_id, missing_ok=True)
@@ -278,7 +286,7 @@ class StagedSessionBackupService(SessionBackupService):
             )
             repaired_state = self._read_state(local, session_id=session_id)
             assert repaired_state is not None
-            return SessionReconcileResult(
+            repaired = SessionReconcileResult(
                 enabled=True,
                 action="repaired",
                 source=result.destination,
@@ -287,10 +295,30 @@ class StagedSessionBackupService(SessionBackupService):
                 deleted_files=result.deleted_files,
                 payload_changed=True,
             )
+            if minimum_generation is None or repaired_state.generation >= minimum_generation:
+                return repaired
+            local_state = repaired_state
+
+        if minimum_generation is not None and local_state.generation >= minimum_generation:
+            action = "staged_current" if self._snapshot_entries(local, session_id) else "current"
+            return SessionReconcileResult(enabled=True, action=action, source=local, state=local_state)
 
         adopted = self._adopt_next_snapshot(local, session_id, local_state)
         if adopted is not None:
-            return adopted
+            if minimum_generation is None or (
+                adopted.state is not None and adopted.state.generation >= minimum_generation
+            ):
+                return adopted
+            assert adopted.state is not None
+            local_state = adopted.state
+
+        if minimum_generation is not None:
+            return super().reconcile_session(
+                cwd,
+                session_id,
+                attempted_proof_validator=attempted_proof_validator,
+                minimum_generation=minimum_generation,
+            )
         action = "staged_current" if self._snapshot_entries(local, session_id) else "current"
         return SessionReconcileResult(enabled=True, action=action, source=local, state=local_state)
 

--- a/tests/a2a/test_app.py
+++ b/tests/a2a/test_app.py
@@ -51,7 +51,12 @@ from iac_code.services.permission_wait import (
     PermissionWaitPolicy,
     build_permission_checkpoint,
 )
-from iac_code.services.session_backup import BackupReason, SessionBackupBlocked, SessionBackupService
+from iac_code.services.session_backup import (
+    BackupReason,
+    SessionBackupBlocked,
+    SessionBackupNotReadyError,
+    SessionBackupService,
+)
 from iac_code.services.session_backup_state import NORMAL_HANDOFF_PROOF_KEY, BackupPublicationProof
 from iac_code.services.session_metadata import SESSION_LAYOUT_VERSION_V2, SessionMetadata, write_session_metadata
 from iac_code.services.session_storage import SessionStorage
@@ -204,6 +209,43 @@ def test_ensure_session_restored_is_authenticated_idempotent_and_restores_backup
     assert missing.json() == {"status": "not_found"}
     assert (restored_pipeline_dir / "a2a-events.jsonl").read_text(encoding="utf-8") == '{"sequence":1}\n'
     assert (restored_pipeline_dir / "a2a-snapshot.json").read_text(encoding="utf-8") == '{"lastSequence":1}\n'
+
+
+def test_ensure_session_restored_for_task_returns_retryable_generation_error(monkeypatch, tmp_path) -> None:
+    workspace_root = tmp_path / "workspace"
+    cwd = workspace_root / "session"
+    cwd.mkdir(parents=True)
+    monkeypatch.setenv("IACCODE_A2A_ALLOWED_CWDS", str(workspace_root))
+    calls: list[tuple[str, str, str | None]] = []
+
+    async def not_ready(self, *, cwd, session_id, task_id=None):
+        del self
+        calls.append((cwd, session_id, task_id))
+        raise SessionBackupNotReadyError(
+            minimum_generation=2,
+            local_generation=1,
+            shared_generation=1,
+        )
+
+    monkeypatch.setattr("iac_code.a2a.executor.IacCodeA2AExecutor.ensure_session_restored", not_ready)
+    app = create_app(host="127.0.0.1", port=41242, token="runtime-token", model="qwen3.6-plus")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/iac-code/session/ensure-restored",
+            json={"cwd": str(cwd), "sessionId": "session-1", "taskId": "task-1"},
+            headers={"Authorization": "Bearer runtime-token"},
+        )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": {
+            "code": "SESSION_BACKUP_NOT_READY",
+            "message": "Session backup is still synchronizing. Retry after 3 seconds.",
+            "retryable": True,
+        }
+    }
+    assert calls == [(str(cwd), "session-1", "task-1")]
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_client.py
+++ b/tests/a2a/test_client.py
@@ -6,7 +6,13 @@ from a2a.utils.signing import ProtectedHeader, create_agent_card_signer
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from iac_code.a2a.client import A2ACardVerificationError, A2AClient, A2AClientResponse, _BoundHttpA2AClient
+from iac_code.a2a.client import (
+    A2ACardVerificationError,
+    A2AClient,
+    A2AClientResponse,
+    A2ASessionBackupNotReadyError,
+    _BoundHttpA2AClient,
+)
 from iac_code.a2a.signing import (
     ASYMMETRIC_SIGNATURE_ALGORITHM,
     _agent_card_from_dict,
@@ -85,14 +91,15 @@ class PipelineStateHTTPClient(FakeHTTPClient):
 
 
 class SessionRestoreHTTPClient(FakeHTTPClient):
-    def __init__(self, *, status_code: int = 200, status: str = "restored") -> None:
+    def __init__(self, *, status_code: int = 200, status: str = "restored", payload: dict | None = None) -> None:
         super().__init__()
         self.status_code = status_code
         self.status = status
+        self.payload = payload
 
     async def post(self, url: str, json: dict[str, object], headers=None) -> FakeHTTPResponse:
         self.requests.append(("POST", url, json, headers))
-        return FakeHTTPResponse({"status": self.status}, self.status_code)
+        return FakeHTTPResponse(self.payload or {"status": self.status}, self.status_code)
 
 
 class HangingInputRequiredHTTPClient(FakeHTTPClient):
@@ -156,14 +163,19 @@ async def test_ensure_session_restored_uses_internal_http_extension_and_auth() -
     http = SessionRestoreHTTPClient()
     client = A2AClient(http_client=http, auth=A2AAuthConfig(bearer_token="secret"))
 
-    ready = await client.ensure_session_restored("http://remote/", cwd="/workspace/session", session_id="session-1")
+    ready = await client.ensure_session_restored(
+        "http://remote/",
+        cwd="/workspace/session",
+        session_id="session-1",
+        task_id="task-1",
+    )
 
     assert ready is True
     assert http.requests == [
         (
             "POST",
             "http://remote/iac-code/session/ensure-restored",
-            {"cwd": "/workspace/session", "sessionId": "session-1"},
+            {"cwd": "/workspace/session", "sessionId": "session-1", "taskId": "task-1"},
             {"A2A-Version": "1.0", "Authorization": "Bearer secret"},
         )
     ]
@@ -177,6 +189,30 @@ async def test_ensure_session_restored_returns_false_when_backup_is_missing() ->
         await client.ensure_session_restored("http://remote/", cwd="/workspace/session", session_id="session-1")
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_restored_surfaces_retryable_generation_fence() -> None:
+    client = A2AClient(
+        http_client=SessionRestoreHTTPClient(
+            status_code=409,
+            payload={
+                "error": {
+                    "code": "SESSION_BACKUP_NOT_READY",
+                    "message": "Session backup is still synchronizing. Retry after 3 seconds.",
+                    "retryable": True,
+                }
+            },
+        )
+    )
+
+    with pytest.raises(A2ASessionBackupNotReadyError, match="Retry after 3 seconds"):
+        await client.ensure_session_restored(
+            "http://remote/",
+            cwd="/workspace/session",
+            session_id="session-1",
+            task_id="task-1",
+        )
 
 
 def _base64url_uint(value: int) -> str:

--- a/tests/a2a/test_events.py
+++ b/tests/a2a/test_events.py
@@ -60,12 +60,14 @@ class _ObservedBoundaryBackup:
         fail: bool = False,
         shared_committed: bool = True,
         staged_committed: bool = False,
+        generation: int | None = None,
     ) -> None:
         self.queue = queue
         self.store = store
         self.fail = fail
         self.shared_committed = shared_committed
         self.staged_committed = staged_committed
+        self.generation = generation
         self.calls: list[tuple[BackupReason, bool]] = []
 
     def backup_session(self, _cwd, _session_id, *, reason, critical):
@@ -83,6 +85,7 @@ class _ObservedBoundaryBackup:
             retry_count=0,
             shared_committed=self.shared_committed,
             staged_committed=self.staged_committed,
+            generation=self.generation,
         )
 
 
@@ -889,8 +892,19 @@ async def test_uncommitted_shared_permission_backup_is_not_visible_or_recoverabl
 async def test_staged_permission_backup_is_visible_without_shared_commit(tmp_path, monkeypatch) -> None:
     workspace, session_id, store, registry = _durable_permission_fixture(tmp_path, monkeypatch)
     queue = FakeEventQueue()
-    backup = _ObservedBoundaryBackup(queue, store, shared_committed=False, staged_committed=True)
+    backup = _ObservedBoundaryBackup(
+        queue,
+        store,
+        shared_committed=False,
+        staged_committed=True,
+        generation=4,
+    )
     future = pending_future()
+    recorded: list[tuple[str, int]] = []
+
+    async def record_generation(task_id: str, generation: int) -> None:
+        assert queue.events == []
+        recorded.append((task_id, generation))
 
     pending = await publish_interactive_permission_boundary(
         queue,
@@ -907,10 +921,12 @@ async def test_staged_permission_backup_is_visible_without_shared_commit(tmp_pat
         iac_code_session_id=session_id,
         permission_wait_cwd=str(workspace),
         permission_wait_backup_service=backup,
+        record_expected_backup_generation=record_generation,
         wait_for_response=False,
     )
 
     assert len(queue.events) == 1
+    assert recorded == [("task-1", 4)]
     assert store.load(str(pending.boundary_id))["phase"] == "WAITING"
     await registry.complete(pending)
     future.cancel()

--- a/tests/a2a/test_executor.py
+++ b/tests/a2a/test_executor.py
@@ -40,6 +40,7 @@ from iac_code.services.session_backup import (
     BackupReason,
     BackupResult,
     SessionBackupBlocked,
+    SessionBackupNotReadyError,
     SessionBackupService,
     SessionReconcileResult,
 )
@@ -75,6 +76,39 @@ def _image_only_pipeline_input() -> PipelineUserInput:
 
 def _ensure_v2_session(cwd: str, session_id: str) -> Path:
     return SessionStorage().ensure_v2_session_dir_for_new_session(cwd, session_id)
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_restored_uses_task_permission_generation_floor(tmp_path: Path) -> None:
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    persistence = A2APersistenceStore(tmp_path / "a2a")
+    persistence.save_context(A2AContextSnapshot(context_id="ctx-1", session_id="session-1", cwd=str(cwd)))
+    persistence.save_task(
+        A2ATaskSnapshot(
+            task_id="task-1",
+            context_id="ctx-1",
+            state="input-required",
+            expected_permission_backup_generation=7,
+        )
+    )
+    calls: list[tuple[str, str, int | None]] = []
+
+    class RecordingBackupService:
+        def reconcile_session(self, restore_cwd, session_id, *, minimum_generation=None, **_kwargs):
+            calls.append((restore_cwd, session_id, minimum_generation))
+            return SessionReconcileResult(enabled=False, action="disabled")
+
+    executor = IacCodeA2AExecutor(
+        task_store=A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence),
+        model="qwen3.6-plus",
+        backup_service=RecordingBackupService(),
+    )
+
+    result = await executor.ensure_session_restored(cwd=str(cwd), session_id="session-1", task_id="task-1")
+
+    assert result == SessionReconcileResult(enabled=False, action="disabled")
+    assert calls == [(str(cwd), "session-1", 7)]
 
 
 def _committed_normal_handoff_events(
@@ -4992,6 +5026,111 @@ async def test_persisted_permission_without_backup_does_not_create_empty_session
         response=response,
     )
     assert not storage.exists(cwd, session_id)
+
+
+@pytest.mark.asyncio
+async def test_persisted_permission_reports_retryable_error_when_checkpoint_backup_is_still_syncing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    cwd = str(workspace)
+    session_id = "session-syncing"
+    context_id = "ctx-syncing"
+    task_id = "task-syncing"
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(config_dir))
+    SessionStorage().ensure_v2_session_dir_for_new_session(cwd, session_id)
+
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    executor = IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus")
+    task_record = SimpleNamespace(context_id=context_id, expected_permission_backup_generation=9)
+    context_record = SimpleNamespace(cwd=cwd, session_id=session_id)
+
+    async def get_task_record(_task_id):
+        return task_record
+
+    async def get_context_record(_context_id):
+        return context_record
+
+    async def reconcile(**kwargs):
+        assert kwargs["minimum_generation"] == 9
+        raise SessionBackupNotReadyError(
+            minimum_generation=9,
+            local_generation=8,
+            shared_generation=8,
+        )
+
+    monkeypatch.setattr(store, "get_task_record", get_task_record)
+    monkeypatch.setattr(store, "get_context_record", get_context_record)
+    monkeypatch.setattr(executor, "_reconcile_session_before_route", reconcile)
+    response = PermissionResponse(
+        task_id=task_id,
+        context_id=context_id,
+        request_task_id=task_id,
+        input_id="input-syncing",
+        tool_use_id="tool-syncing",
+        decision="allow_once",
+    )
+
+    with pytest.raises(
+        InvalidParamsError,
+        match=r"Session backup is still synchronizing\. Retry after 3 seconds\.",
+    ) as exc:
+        await executor._resume_persisted_permission(
+            FakeRequestContext(task_id=task_id, context_id=context_id),
+            FakeEventQueue(),
+            response=response,
+        )
+    assert exc.value.data == {"code": "SESSION_BACKUP_NOT_READY", "retryable": True}
+
+
+@pytest.mark.asyncio
+async def test_persisted_permission_missing_after_generation_is_current_keeps_existing_invalid_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    cwd = str(workspace)
+    session_id = "session-current-without-permission"
+    context_id = "ctx-current-without-permission"
+    task_id = "task-current-without-permission"
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(config_dir))
+    session_dir = SessionStorage().ensure_v2_session_dir_for_new_session(cwd, session_id)
+
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    executor = IacCodeA2AExecutor(task_store=store, model="qwen3.6-plus")
+
+    async def get_task_record(_task_id):
+        return SimpleNamespace(context_id=context_id, expected_permission_backup_generation=9)
+
+    async def get_context_record(_context_id):
+        return SimpleNamespace(cwd=cwd, session_id=session_id)
+
+    async def reconcile(**kwargs):
+        assert kwargs["minimum_generation"] == 9
+        return SessionReconcileResult(enabled=True, action="current", source=session_dir)
+
+    monkeypatch.setattr(store, "get_task_record", get_task_record)
+    monkeypatch.setattr(store, "get_context_record", get_context_record)
+    monkeypatch.setattr(executor, "_reconcile_session_before_route", reconcile)
+    response = PermissionResponse(
+        task_id=task_id,
+        context_id=context_id,
+        request_task_id=task_id,
+        input_id="missing-input",
+        tool_use_id="missing-tool",
+        decision="allow_once",
+    )
+
+    assert not await executor._resume_persisted_permission(
+        FakeRequestContext(task_id=task_id, context_id=context_id),
+        FakeEventQueue(),
+        response=response,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -19,6 +19,7 @@ from iac_code.a2a.input_required import (
     parse_permission_response,
     permission_input_envelope,
     permission_safe_summary,
+    staged_permission_backup_generation,
 )
 from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
 from iac_code.a2a.pipeline_journal import A2APipelineJournal
@@ -33,6 +34,7 @@ from iac_code.services.permission_wait import (
     PermissionWaitPolicy,
     build_permission_checkpoint,
 )
+from iac_code.services.session_backup import BackupResult
 from iac_code.services.session_storage import SessionStorage
 from iac_code.types.permissions import PermissionAuditMetadata, PermissionResult
 from iac_code.types.stream_events import PermissionRequestEvent, SubPipelineStreamEvent
@@ -75,6 +77,22 @@ def _permission_message(
         role=Role.ROLE_USER,
         parts=parts,
     )
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (BackupResult(enabled=False, generation=4, staged_committed=True, shared_committed=False), None),
+        (BackupResult(enabled=True, generation=4, staged_committed=True, shared_committed=True), None),
+        (BackupResult(enabled=True, generation=0, staged_committed=True, shared_committed=False), None),
+        (BackupResult(enabled=True, generation=4, staged_committed=True, shared_committed=False), 4),
+    ],
+)
+def test_only_unsynchronized_staged_permission_backup_creates_generation_fence(
+    result: BackupResult,
+    expected: int | None,
+) -> None:
+    assert staged_permission_backup_generation(result) == expected
 
 
 def _text_permission_message(

--- a/tests/a2a/test_persistence.py
+++ b/tests/a2a/test_persistence.py
@@ -25,6 +25,33 @@ def test_persistence_round_trips_task_and_context(tmp_path) -> None:
     assert store.load_context("ctx-1").telemetry_channel == "skill"
 
 
+def test_persistence_round_trips_internal_permission_backup_generation(tmp_path) -> None:
+    store = A2APersistenceStore(tmp_path)
+    store.save_task(
+        A2ATaskSnapshot(
+            task_id="task-1",
+            context_id="ctx-1",
+            state="input-required",
+            expected_permission_backup_generation=7,
+        )
+    )
+
+    restored = store.load_task("task-1")
+
+    assert restored is not None
+    assert restored.expected_permission_backup_generation == 7
+
+
+def test_persistence_loads_task_without_permission_backup_generation(tmp_path) -> None:
+    store = A2APersistenceStore(tmp_path)
+    store.save_task(A2ATaskSnapshot(task_id="task-1", context_id="ctx-1", state="input-required"))
+
+    restored = store.load_task("task-1")
+
+    assert restored is not None
+    assert restored.expected_permission_backup_generation is None
+
+
 def test_persistence_loads_legacy_context_without_telemetry_channel(tmp_path) -> None:
     store = A2APersistenceStore(tmp_path)
     store.save_context(A2AContextSnapshot(context_id="ctx-1", session_id="session-1", cwd=str(tmp_path)))

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -21,6 +21,7 @@ from iac_code.a2a.executor import IacCodeA2AExecutor
 from iac_code.a2a.input_required import PermissionResponse
 from iac_code.a2a.metrics import NoOpA2AMetrics
 from iac_code.a2a.persistence import A2APersistenceStore
+from iac_code.a2a.pipeline_executor import IacCodeA2APipelineExecutor
 from iac_code.a2a.pipeline_journal import A2APipelineJournal
 from iac_code.a2a.pipeline_snapshot import A2APipelineSnapshotStore, reduce_pipeline_events
 from iac_code.a2a.pipeline_transport_delivery import (
@@ -227,6 +228,86 @@ def _pipeline_executor(*, aliyun_delegated_executor_factory=None, candidate_pres
         aliyun_delegated_executor_factory=aliyun_delegated_executor_factory,
         candidate_presentation=candidate_presentation,
     )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_permission_backup_records_staged_generation_before_publication() -> None:
+    task_store = MagicMock()
+    task_store.record_expected_permission_backup_generation = AsyncMock()
+    permission_registry = MagicMock()
+    permission_registry.backup_durable_boundary = AsyncMock(
+        return_value=BackupResult(
+            enabled=True,
+            generation=6,
+            staged_committed=True,
+            shared_committed=False,
+        )
+    )
+    pending = object()
+    executor = IacCodeA2APipelineExecutor(
+        task_store=task_store,
+        model="qwen3.6-plus",
+        metrics=NoOpA2AMetrics(),
+        artifact_store=None,
+        push_notifier=None,
+        permission_resolver=None,
+        permission_input_registry=permission_registry,
+        auto_approve_permissions=False,
+        thinking_exposure_types=None,
+    )
+
+    await executor._backup_pipeline_publication(
+        {"eventType": "input_required", "status": "input_required"},
+        publisher=SimpleNamespace(pending_durable_permission=pending),
+        pipeline=object(),
+        cwd="/workspace",
+        session_id="session-1",
+        task=SimpleNamespace(task_id="task-1"),
+        ctx=object(),
+        reason=BackupReason.INPUT_REQUIRED,
+    )
+
+    task_store.record_expected_permission_backup_generation.assert_awaited_once_with("task-1", 6)
+    permission_registry.backup_durable_boundary.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_non_permission_input_does_not_record_permission_backup_generation() -> None:
+    class StagedBackup:
+        def backup_session(self, *_args, **_kwargs) -> BackupResult:
+            return BackupResult(
+                enabled=True,
+                generation=6,
+                staged_committed=True,
+                shared_committed=False,
+            )
+
+    task_store = MagicMock()
+    task_store.record_expected_permission_backup_generation = AsyncMock()
+    executor = IacCodeA2APipelineExecutor(
+        task_store=task_store,
+        model="qwen3.6-plus",
+        metrics=NoOpA2AMetrics(),
+        artifact_store=None,
+        push_notifier=None,
+        permission_resolver=None,
+        auto_approve_permissions=False,
+        thinking_exposure_types=None,
+        backup_service=StagedBackup(),
+    )
+
+    await executor._backup_pipeline_publication(
+        {"eventType": "input_required", "status": "input_required"},
+        publisher=SimpleNamespace(pending_durable_permission=None),
+        pipeline=object(),
+        cwd="/workspace",
+        session_id="session-1",
+        task=SimpleNamespace(task_id="task-1"),
+        ctx=object(),
+        reason=BackupReason.INPUT_REQUIRED,
+    )
+
+    task_store.record_expected_permission_backup_generation.assert_not_awaited()
 
 
 def test_active_sidecar_mismatch_error_exposes_jsonrpc_data() -> None:

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -130,6 +130,25 @@ async def test_context_reuses_runtime_until_evicted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_permission_backup_generation_uses_next_existing_task_save(tmp_path) -> None:
+    persistence = CountingTaskPersistence(tmp_path / "a2a")
+    store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
+    await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    saves_before_generation = persistence.task_save_count
+
+    await store.record_expected_permission_backup_generation("task-1", 7)
+    await store.record_expected_permission_backup_generation("task-1", 5)
+
+    assert persistence.task_save_count == saves_before_generation
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_INPUT_REQUIRED))
+    assert persistence.task_save_count == saves_before_generation + 1
+    snapshot = persistence.load_task("task-1")
+    assert snapshot is not None
+    assert snapshot.expected_permission_backup_generation == 7
+    assert "expected_permission_backup_generation" not in str(await store.get("task-1"))
+
+
+@pytest.mark.asyncio
 async def test_context_telemetry_channel_binding_persists_and_can_be_updated(monkeypatch, tmp_path) -> None:
     config_dir = tmp_path / "config"
     cwd = tmp_path / "workspace"

--- a/tests/a2a_e2e/test_permission_wait_restart.py
+++ b/tests/a2a_e2e/test_permission_wait_restart.py
@@ -9,6 +9,81 @@ import pytest
 
 
 @pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_agui_staged_backup_generation_fence_retries_after_shared_publication(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    runner = repo_root / "scripts" / "a2a" / "e2e" / "permission_wait" / "run_agui_generation_fence.py"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--run-dir",
+            str(tmp_path / "agui-staged-backup-generation-fence"),
+            "--timeout",
+            "25",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=110,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert result["passed"] is True
+    assert result["scenario"] == "agui-staged-backup-generation-fence"
+    assert result["notReadyObserved"] is True
+    assert result["aguiStateRestored"] is True
+    assert result["oldSharedGeneration"] < result["expectedGeneration"]
+    assert result["restoredGeneration"] >= result["expectedGeneration"]
+    assert result["p1ReceiptPreserved"] is True
+    assert result["p2ResolvedOnce"] is True
+    assert result["toolExecutions"] == 2
+    assert result["publicGenerationAbsent"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(90)
+def test_staged_backup_generation_fence_retries_after_shared_publication(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    runner = repo_root / "scripts" / "a2a" / "e2e" / "permission_wait" / "run_permission_wait_restart.py"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--run-dir",
+            str(tmp_path / "staged-backup-generation-fence"),
+            "--decision",
+            "allow_once",
+            "--staged-backup-generation-fence",
+            "--timeout",
+            "20",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=80,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert result["passed"] is True
+    assert result["scenario"] == "staged-backup-generation-fence"
+    assert result["notReadyObserved"] is True
+    assert result["sameSandboxResumeWithoutSharedMarker"] is True
+    assert result["oldSharedGeneration"] < result["expectedGeneration"]
+    assert result["restoredGeneration"] >= result["expectedGeneration"]
+    assert result["p1ReceiptPreserved"] is True
+    assert result["p2ResolvedOnce"] is True
+    assert result["toolExecutions"] == 2
+    assert result["publicGenerationAbsent"] is True
+
+
+@pytest.mark.integration
 @pytest.mark.timeout(90)
 @pytest.mark.parametrize(
     ("mode", "decision", "expected_executions"),

--- a/tests/agui/test_app.py
+++ b/tests/agui/test_app.py
@@ -9,7 +9,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from iac_code.a2a.app import create_app as create_a2a_app
-from iac_code.a2a.client import A2AClientResponse
+from iac_code.a2a.client import A2AClientResponse, A2ASessionBackupNotReadyError
 from iac_code.agui.adapter import AguiA2AAdapter, ThreadBinding
 from iac_code.agui.app import create_app
 from iac_code.agui.events import A2AEventMapper, a2a_state
@@ -26,7 +26,7 @@ class FakeA2AClient:
         self.stream_contexts: list[str] = []
         self.stream_options: list[dict[str, Any]] = []
         self.cancelled: list[str] = []
-        self.restored_sessions: list[tuple[str, str]] = []
+        self.restored_sessions: list[tuple[str, str, str | None]] = []
         self.resume_preflight_calls: list[str] = []
         self.session_available = True
         self.closed = False
@@ -114,8 +114,8 @@ class FakeA2AClient:
         self.resume_preflight_calls.append("get_pipeline_state")
         return None
 
-    async def ensure_session_restored(self, _url, *, cwd, session_id):
-        self.restored_sessions.append((cwd, session_id))
+    async def ensure_session_restored(self, _url, *, cwd, session_id, task_id=None):
+        self.restored_sessions.append((cwd, session_id, task_id))
         self.resume_preflight_calls.append("ensure_session_restored")
         return self.session_available
 
@@ -592,6 +592,103 @@ async def test_permission_resume_jsonrpc_error_is_not_accepted(tmp_path, monkeyp
     events = _events(failed)
     assert [event["type"] for event in events] == ["RUN_STARTED", "RUN_ERROR"]
     assert events[-1]["code"] == "A2A_UNAVAILABLE"
+    assert set(adapter._threads["thread-1"].pending) == {"permission-1"}
+
+
+@pytest.mark.asyncio
+async def test_permission_resume_maps_backup_sync_error_to_retryable_agui_error(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("IAC_CODE_AGUI_ALLOWED_CWDS", str(tmp_path))
+
+    class SyncingPermissionClient(FakeA2AClient):
+        def stream_message_parts(self, url, parts, *, context_id, **kwargs):
+            if kwargs.get("task_id") is None:
+                return super().stream_message_parts(url, parts, context_id=context_id, **kwargs)
+
+            async def events():
+                yield {
+                    "jsonrpc": "2.0",
+                    "id": "resume",
+                    "error": {
+                        "code": -32602,
+                        "message": "Session backup is still synchronizing. Retry after 3 seconds.",
+                        "data": {"code": "SESSION_BACKUP_NOT_READY", "retryable": True},
+                    },
+                }
+
+            return events()
+
+    fake = SyncingPermissionClient(interrupt=True)
+    adapter = AguiA2AAdapter(a2a_url="http://a2a/", client=fake)
+    app = create_app(adapter=adapter)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        await client.post("/", json=_payload(tmp_path))
+        fake.context_id = adapter._threads["thread-1"].context_id
+        response = await client.post(
+            "/",
+            json=_payload(
+                tmp_path,
+                run_id="run-syncing",
+                resume=[
+                    {
+                        "interruptId": "permission-1",
+                        "status": "resolved",
+                        "payload": {"decision": "allow_once"},
+                    }
+                ],
+            ),
+        )
+
+    terminal = _events(response)[-1]
+    assert terminal["type"] == "RUN_ERROR"
+    assert terminal["code"] == "SESSION_BACKUP_NOT_READY"
+    assert terminal["message"] == "Session backup is still synchronizing. Retry after 3 seconds."
+    assert set(adapter._threads["thread-1"].pending) == {"permission-1"}
+
+
+@pytest.mark.asyncio
+async def test_permission_resume_maps_preflight_backup_sync_error_without_sending_response(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("IAC_CODE_AGUI_ALLOWED_CWDS", str(tmp_path))
+
+    class SyncingPreflightClient(FakeA2AClient):
+        async def ensure_session_restored(self, _url, *, cwd, session_id, task_id=None):
+            self.restored_sessions.append((cwd, session_id, task_id))
+            self.resume_preflight_calls.append("ensure_session_restored")
+            raise A2ASessionBackupNotReadyError(
+                "Session backup is still synchronizing. Retry after 3 seconds."
+            )
+
+    fake = SyncingPreflightClient(interrupt=True)
+    adapter = AguiA2AAdapter(a2a_url="http://a2a/", client=fake)
+    app = create_app(adapter=adapter)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        await client.post("/", json=_payload(tmp_path))
+        fake.context_id = adapter._threads["thread-1"].context_id
+        response = await client.post(
+            "/",
+            json=_payload(
+                tmp_path,
+                run_id="run-syncing-preflight",
+                resume=[
+                    {
+                        "interruptId": "permission-1",
+                        "status": "resolved",
+                        "payload": {"decision": "allow_once"},
+                    }
+                ],
+            ),
+        )
+
+    terminal = _events(response)[-1]
+    assert terminal["type"] == "RUN_ERROR"
+    assert terminal["code"] == "SESSION_BACKUP_NOT_READY"
+    assert terminal["message"] == "Session backup is still synchronizing. Retry after 3 seconds."
+    assert fake.restored_sessions[-1] == (str(tmp_path), "session-1", "task-1")
+    assert fake.sent_parts == []
     assert set(adapter._threads["thread-1"].pending) == {"permission-1"}
 
 

--- a/tests/agui/test_persistence.py
+++ b/tests/agui/test_persistence.py
@@ -305,7 +305,7 @@ async def test_restart_restores_interrupt_resume_and_cancel_identity(tmp_path) -
             ),
         )
     assert _events(resumed)[-1]["outcome"] == {"type": "success"}
-    assert fake.restored_sessions[-1] == (str(tmp_path), "session-1")
+    assert fake.restored_sessions[-1] == (str(tmp_path), "session-1", "task-1")
     assert fake.resume_preflight_calls[:3] == [
         "ensure_session_restored",
         "get_task",
@@ -420,7 +420,7 @@ async def test_a2a_restart_summary_without_input_projection_preserves_durable_in
 
 
 @pytest.mark.asyncio
-async def test_explicit_empty_input_projection_remains_authoritative_after_restart(tmp_path) -> None:
+async def test_explicit_empty_input_projection_preserves_durable_resume_after_restart(tmp_path) -> None:
     state_dir = tmp_path / "state"
     first_fake = FakeA2AClient(interrupt=True)
     first_adapter = AguiA2AAdapter(a2a_url="http://a2a/", client=first_fake, state_dir=state_dir)
@@ -452,9 +452,113 @@ async def test_explicit_empty_input_projection_remains_authoritative_after_resta
             ),
         )
 
-    assert _events(resumed)[-1]["code"] == "UNKNOWN_INTERRUPT"
-    assert snapshot.sent_parts == []
+    assert _events(resumed)[-1]["outcome"] == {"type": "success"}
+    assert snapshot.sent_parts == [
+        {
+            "data": {
+                "schemaVersion": 1,
+                "kind": "permission",
+                "requestTaskId": "task-1",
+                "inputId": "permission-1",
+                "toolUseId": "tool-1",
+                "decision": "allow_once",
+            },
+            "mediaType": "application/json",
+        }
+    ]
     await second_adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_second_permission_resume_survives_stale_a2a_projection(tmp_path) -> None:
+    class SequentialPermissionClient(FakeA2AClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.get_task_calls = 0
+            self.resume_stream_calls = 0
+
+        def stream_message_parts(self, _url, parts, *, context_id, **kwargs):
+            self.context_id = context_id
+
+            async def events():
+                if kwargs.get("task_id") is None:
+                    yield _event(context_id=context_id)
+                    event = _event(context_id=context_id, state="TASK_STATE_INPUT_REQUIRED")
+                    event["result"]["metadata"] = {
+                        "iac_code": {"input": _permission(context_id, "permission-1", "tool-1")}
+                    }
+                    yield event
+                    return
+                self.resume_stream_calls += 1
+                self.sent_parts.extend(parts)
+                if self.resume_stream_calls == 1:
+                    event = _event(context_id=context_id, state="TASK_STATE_INPUT_REQUIRED")
+                    event["result"]["metadata"] = {
+                        "iac_code": {"input": _permission(context_id, "permission-2", "tool-2")}
+                    }
+                    yield event
+                    return
+                yield _event(context_id=context_id, state="TASK_STATE_COMPLETED")
+
+            return events()
+
+        async def get_task(self, _url, _task_id, *, history_length=None):
+            del history_length
+            self.get_task_calls += 1
+            if self.get_task_calls == 1:
+                event = _event(context_id=self.context_id, state="TASK_STATE_INPUT_REQUIRED")
+                event["result"]["metadata"] = {
+                    "iac_code": {"input": _permission(self.context_id, "permission-1", "tool-1")}
+                }
+                return event
+            event = _event(context_id=self.context_id, state="TASK_STATE_INPUT_REQUIRED")
+            event["result"]["metadata"] = {
+                "iac_code": {
+                    "iacCodeSessionId": "session-1",
+                    "input": _permission(self.context_id, "permission-1", "tool-1"),
+                }
+            }
+            return event
+
+        def subscribe_task(self, _url, _task_id):
+            async def events():
+                if False:
+                    yield {}
+
+            return events()
+
+    def permission_resume(input_id: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "interruptId": input_id,
+                "status": "resolved",
+                "payload": {"decision": "allow_once"},
+            }
+        ]
+
+    state_dir = tmp_path / "state"
+    fake = SequentialPermissionClient()
+    adapter = AguiA2AAdapter(a2a_url="http://a2a/", client=fake, state_dir=state_dir)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=create_app(adapter=adapter)), base_url="http://test"
+    ) as client:
+        first = await client.post("/", json=_payload(tmp_path))
+        first_resume = await client.post(
+            "/",
+            json=_payload(tmp_path, run_id="run-2", resume=permission_resume("permission-1")),
+        )
+        persisted = json.loads(_thread_state_path(state_dir).read_text(encoding="utf-8"))
+        second_resume = await client.post(
+            "/",
+            json=_payload(tmp_path, run_id="run-3", resume=permission_resume("permission-2")),
+        )
+
+    assert _events(first)[-1]["outcome"]["interrupts"][0]["id"] == "permission-1"
+    assert _events(first_resume)[-1]["outcome"]["interrupts"][0]["id"] == "permission-2"
+    assert set(persisted["execution"]["pending"]) == {"permission-2"}
+    assert _events(second_resume)[-1]["outcome"] == {"type": "success"}
+    assert [part["data"]["inputId"] for part in fake.sent_parts] == ["permission-1", "permission-2"]
+    await adapter.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_session_backup.py
+++ b/tests/services/test_session_backup.py
@@ -12,6 +12,7 @@ from iac_code.services.session_backup import (
     BackupReason,
     SessionBackupBlocked,
     SessionBackupError,
+    SessionBackupNotReadyError,
     SessionBackupService,
     SessionRestoreResult,
 )
@@ -59,6 +60,43 @@ def test_backup_disabled_when_env_unset(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     assert result.enabled is False
     assert result.copied_files == 0
+
+
+def test_reconcile_backup_disabled_accepts_permission_generation_floor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_DIR", raising=False)
+    service = SessionBackupService(SessionStorage(projects_dir=tmp_path / "projects"))
+
+    result = service.reconcile_session("/repo", "s1", minimum_generation=2)
+
+    assert result.enabled is False
+    assert result.action == "disabled"
+
+
+def test_reconcile_generation_floor_reports_partial_first_shared_backup_as_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cwd = "/repo"
+    session_id = "s1"
+    backup_root = tmp_path / "backup"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(backup_root))
+    shared_storage = SessionStorage(projects_dir=backup_root / "projects")
+    shared_dir = shared_storage.session_dir(cwd, session_id)
+    write_session_metadata(
+        shared_dir,
+        SessionMetadata(session_id=session_id, cwd=cwd, layout_version=SESSION_LAYOUT_VERSION_V2),
+    )
+    service = SessionBackupService(SessionStorage(projects_dir=tmp_path / "local" / "projects"))
+
+    with pytest.raises(SessionBackupNotReadyError) as exc_info:
+        service.reconcile_session(cwd, session_id, minimum_generation=1)
+
+    assert exc_info.value.minimum_generation == 1
+    assert exc_info.value.local_generation is None
+    assert exc_info.value.shared_generation is None
 
 
 def test_backup_timing_wrapper_preserves_keyword_call_form(

--- a/tests/services/test_session_backup_staging.py
+++ b/tests/services/test_session_backup_staging.py
@@ -9,6 +9,7 @@ from iac_code.services.session_backup import (
     BACKUP_STATE_FILENAME,
     BackupReason,
     SessionBackupError,
+    SessionBackupNotReadyError,
     SessionBackupService,
 )
 from iac_code.services.session_backup_staging import (
@@ -51,6 +52,20 @@ def _create_staged_service(
 def _read_state(path: Path, *, shared: bool = False) -> SessionBackupState:
     payload = json.loads((path / BACKUP_STATE_FILENAME).read_text(encoding="utf-8"))
     return SessionBackupState.from_dict(payload, shared=shared)
+
+
+def test_staged_reconcile_generation_fence_keeps_backup_disabled_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_DIR", raising=False)
+    storage = SessionStorage(projects_dir=tmp_path / "config" / "projects")
+    service = StagedSessionBackupService(tmp_path / "staging", storage, retry_delays=())
+
+    result = service.reconcile_session("/repo", "s1", minimum_generation=2)
+
+    assert result.enabled is False
+    assert result.action == "disabled"
 
 
 def test_staged_backup_creates_immutable_versions_without_writing_final_root(
@@ -368,6 +383,73 @@ def test_terminal_publication_restores_in_another_sandbox(
         "metadata.json",
         "session.jsonl",
     ]
+
+
+def test_staged_reconcile_refreshes_old_sandbox_after_async_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service, session_dir, staging_root, backup_root = _create_staged_service(monkeypatch, tmp_path)
+    project = session_dir.parent.name
+    shared_dir = backup_root / "projects" / project / "s1"
+    (session_dir / "session.jsonl").write_text("generation-1\n", encoding="utf-8")
+    service.backup_session("/repo", "s1", reason=BackupReason.INPUT_REQUIRED, critical=True)
+    worker = SessionBackupStagingWorker(staging_root, backup_root)
+    assert worker.run_once() == 1
+
+    sandbox_storage = SessionStorage(projects_dir=tmp_path / "sandbox-a-config" / "projects")
+    sandbox_service = StagedSessionBackupService(
+        tmp_path / "sandbox-a-staging",
+        sandbox_storage,
+        retry_delays=(),
+    )
+    first_restore = sandbox_service.reconcile_session("/repo", "s1")
+    sandbox_session = sandbox_storage.session_dir("/repo", "s1")
+    assert first_restore.action == "restored"
+    assert (sandbox_session / "session.jsonl").read_text(encoding="utf-8") == "generation-1\n"
+
+    shared_state_reads = 0
+    original_read_state = sandbox_service._read_state
+
+    def count_shared_state_reads(*args, **kwargs):
+        nonlocal shared_state_reads
+        if kwargs.get("shared") is True:
+            shared_state_reads += 1
+        return original_read_state(*args, **kwargs)
+
+    monkeypatch.setattr(sandbox_service, "_read_state", count_shared_state_reads)
+    local_current = sandbox_service.reconcile_session("/repo", "s1", minimum_generation=1)
+    assert local_current.action == "current"
+    assert shared_state_reads == 0
+
+    (session_dir / "session.jsonl").write_text("generation-2\n", encoding="utf-8")
+    service.backup_session("/repo", "s1", reason=BackupReason.INPUT_REQUIRED, critical=True)
+
+    # Model an OSS-mounted destination while generation 2 is only partly
+    # mirrored: payload changed, but the generation-2 state marker has not
+    # committed yet.  Sandbox A must keep its coherent generation 1 copy.
+    (shared_dir / "session.jsonl").write_text("partial-generation-2\n", encoding="utf-8")
+    with pytest.raises(SessionBackupNotReadyError) as exc_info:
+        sandbox_service.reconcile_session("/repo", "s1", minimum_generation=2)
+    assert exc_info.value.minimum_generation == 2
+    assert exc_info.value.local_generation == 1
+    assert exc_info.value.shared_generation == 1
+    assert shared_state_reads == 1
+    assert (sandbox_session / "session.jsonl").read_text(encoding="utf-8") == "generation-1\n"
+
+    # Local staged generation 2 remains authoritative while OSS is behind.
+    staged_current = service.reconcile_session("/repo", "s1")
+    assert staged_current.action == "staged_current"
+    assert staged_current.state is not None and staged_current.state.generation == 2
+
+    assert worker.run_once() == 1
+    refreshed = sandbox_service.reconcile_session("/repo", "s1", minimum_generation=2)
+
+    assert refreshed.action == "restored"
+    assert refreshed.state is not None and refreshed.state.generation == 2
+    assert refreshed.payload_changed is True
+    assert (sandbox_session / "session.jsonl").read_text(encoding="utf-8") == "generation-2\n"
+    assert shared_state_reads == 2
 
 
 def test_staging_worker_does_not_skip_failed_version_for_same_session(

--- a/tests/skill_bridge/test_alicloud_ros_agent_bridge.py
+++ b/tests/skill_bridge/test_alicloud_ros_agent_bridge.py
@@ -1907,6 +1907,52 @@ def test_cli_failure_redacts_secrets_from_error() -> None:
     assert message.count("[REDACTED]") == 3
 
 
+def test_stream_summary_preserves_retryable_session_backup_error() -> None:
+    summary = bridge.StreamSummary("session-1")
+    summary.apply(
+        {
+            "object": "response",
+            "status": "failed",
+            "error": {
+                "code": -32602,
+                "message": "Session backup is still synchronizing. Retry after 3 seconds.",
+                "data": {"code": bridge.SESSION_BACKUP_NOT_READY_CODE, "retryable": True},
+            },
+        }
+    )
+
+    result = summary.to_result(0, "")
+
+    assert result["state"] == "failed"
+    assert result["error"] == {
+        "code": bridge.SESSION_BACKUP_NOT_READY_CODE,
+        "message": "Session backup is still synchronizing. Retry after 3 seconds.",
+        "retryable": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "code": -32602,
+            "message": "Session backup is still synchronizing. Retry after 3 seconds.",
+            "data": {"code": "SESSION_BACKUP_NOT_READY", "retryable": True},
+        },
+        {
+            "Code": "SESSION_BACKUP_NOT_READY",
+            "Message": "Session backup is still synchronizing. Retry after 3 seconds.",
+        },
+    ],
+)
+def test_session_backup_not_ready_error_accepts_sse_and_http_shapes(payload) -> None:
+    error = bridge._session_backup_not_ready_error(payload)
+
+    assert error is not None
+    assert error.code == bridge.SESSION_BACKUP_NOT_READY_CODE
+    assert error.retryable is True
+
+
 def test_run_chat_consumes_fake_cli_stream_without_network(monkeypatch, tmp_path: Path) -> None:
     prompt = tmp_path / "prompt.txt"
     prompt.write_text("hello", encoding="utf-8")
@@ -3923,6 +3969,117 @@ def test_managed_respond_preserves_serial_permission_correlation(
     assert query["inputId"] == pending["inputId"]
     assert query["toolUseId"] == pending["toolUseId"]
     assert query["decision"] == decision
+
+
+@pytest.mark.parametrize(
+    ("mode", "permission_class"),
+    [("normal", "normal"), ("pipeline", "pipeline")],
+)
+def test_managed_permission_backup_not_ready_remains_retryable(
+    monkeypatch, tmp_path: Path, mode: str, permission_class: str
+) -> None:
+    monkeypatch.setenv(bridge.STATE_DIR_ENV, str(tmp_path / "state"))
+    job_id = ("1" if mode == "normal" else "2") * 32
+    workspace = tmp_path / mode
+    workspace.mkdir()
+    root, job_path, spool = bridge._job_paths(job_id)
+    bridge._secure_directory(root)
+    spool.touch()
+    pending = {
+        "schemaVersion": 1,
+        "kind": "permission",
+        "requestTaskId": "task-1",
+        "contextId": "session-1",
+        "inputId": "permission-1",
+        "toolUseId": "tool-1",
+        "permissionClass": permission_class,
+    }
+    response = {
+        "requestTaskId": "task-1",
+        "contextId": "session-1",
+        "inputId": "permission-1",
+        "toolUseId": "tool-1",
+        "decision": "allow_once",
+    }
+    bridge._atomic_json(
+        job_path,
+        {
+            "schemaVersion": 1,
+            "jobId": job_id,
+            "workspace": str(workspace),
+            "state": "submitted",
+            "mode": mode,
+            "endpoint": "ros.aliyuncs.com",
+            "sessionId": "session-1",
+            "preferredLanguage": "en",
+            "activeRequestSeq": 2,
+            "workerPid": 12345,
+            "turn": 1,
+            "lastPermissionResponse": response,
+            "permissionResponseInput": pending,
+            "artifacts": [],
+        },
+    )
+    error = {
+        "code": bridge.SESSION_BACKUP_NOT_READY_CODE,
+        "message": "Session backup is still synchronizing. Retry after 3 seconds.",
+        "retryable": True,
+    }
+    payload = {
+        "object": "response",
+        "status": "failed",
+        "error": {
+            "code": -32602,
+            "message": error["message"],
+            "data": {"code": bridge.SESSION_BACKUP_NOT_READY_CODE, "retryable": True},
+        },
+    }
+    summary = bridge.StreamSummary("session-1", mode=mode)
+    summary.apply(payload)
+    bridge._append_projection(
+        job_id,
+        bridge._project_managed_stream_event(payload, summary, mode, 2, "primary", None),
+    )
+    projected = bridge._load_state_json(job_path)
+    assert projected["state"] == "input-required"
+    assert projected["inputRequired"] == pending
+    assert bridge._read_spool(spool)[-1]["type"] == "input-required"
+
+    assert bridge._finish_job(
+        job_id,
+        2,
+        summary.to_result(0, ""),
+        12345,
+    )
+    waiting = bridge._load_state_json(job_path)
+    assert waiting["state"] == "input-required"
+    assert waiting["inputRequired"] == pending
+    assert waiting["error"] == error
+    assert waiting["permissionResponseInput"] == pending
+    assert "workerPid" not in waiting
+
+    captured = {}
+
+    def spawn(captured_job_id, request):
+        captured["jobId"] = captured_job_id
+        captured["request"] = request
+        return 23456
+
+    monkeypatch.setattr(bridge, "_spawn_worker", spawn)
+    retried = bridge._respond_job_local(
+        {
+            "jobId": job_id,
+            "decision": "allow_once",
+            "transientEnvironment": {},
+        }
+    )
+
+    assert retried["workerPid"] == 23456
+    assert captured["jobId"] == job_id
+    assert captured["request"]["permissionResponse"] == response
+    retried_job = bridge._load_state_json(job_path)
+    assert retried_job["state"] == "submitted"
+    assert retried_job["permissionResponseInput"] == pending
 
 
 def test_managed_respond_requires_short_ref_for_multiple_permissions(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Fence permission Resume against the staged-backup generation without changing public A2A or AG-UI request formats.
- Reuse the existing session backup restore/reconcile path and return a retryable error while shared backup synchronization is still in progress.
- Preserve retryable permission state in the external ROS Agent Skill so a later response can resume successfully.

## Validation

- Relevant Skill/Runtime tests: 169 passed.
- A2A and AG-UI generation-fence E2E tests: 2 passed.
- Relevant Ruff checks and git diff --check passed.