### PR TITLE
fix: enforce EIP-bound ECS public IP settings

### DIFF
--- a/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/de/LC_MESSAGES/messages.po
@@ -11466,6 +11466,24 @@ msgstr "{} benötigt ein Array"
 msgid "the condition is invalid"
 msgstr "die Bedingung ist ungültig"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"ECS resource {} is associated with an EIP but does not explicitly disable"
+" public IP allocation."
+msgstr "Die ECS-Ressource {} ist mit einer EIP verknüpft, deaktiviert die Zuweisung einer öffentlichen IP jedoch nicht ausdrücklich."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"EIPAssociation {} provides the public entry point; the associated ECS "
+"resource must set AllocatePublicIP to false."
+msgstr "EIPAssociation {} stellt den öffentlichen Zugangspunkt bereit; die verknüpfte ECS-Ressource muss AllocatePublicIP auf false setzen."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+msgid "Set AllocatePublicIP: false on the associated ECS resource."
+msgstr "Setzen Sie AllocatePublicIP: false für die verknüpfte ECS-Ressource."
+
 #: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
@@ -14839,4 +14857,3 @@ msgstr "Bash zulassen?"
 
 #~ msgid "架构图优化中..."
 #~ msgstr "Architekturdiagramm wird optimiert..."
-

--- a/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/es/LC_MESSAGES/messages.po
@@ -11380,6 +11380,24 @@ msgstr "{} requiere una matriz"
 msgid "the condition is invalid"
 msgstr "la condición no es válida"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"ECS resource {} is associated with an EIP but does not explicitly disable"
+" public IP allocation."
+msgstr "El recurso ECS {} está asociado a una EIP, pero no deshabilita explícitamente la asignación de IP pública."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"EIPAssociation {} provides the public entry point; the associated ECS "
+"resource must set AllocatePublicIP to false."
+msgstr "EIPAssociation {} proporciona el punto de entrada público; el recurso ECS asociado debe establecer AllocatePublicIP en false."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+msgid "Set AllocatePublicIP: false on the associated ECS resource."
+msgstr "Establece AllocatePublicIP: false en el recurso ECS asociado."
+
 #: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
@@ -14728,4 +14746,3 @@ msgstr "¿Permitir Bash?"
 
 #~ msgid "架构图优化中..."
 #~ msgstr "Optimizando diagrama de arquitectura..."
-

--- a/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/fr/LC_MESSAGES/messages.po
@@ -11427,6 +11427,24 @@ msgstr "{} nécessite un tableau"
 msgid "the condition is invalid"
 msgstr "la condition est invalide"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"ECS resource {} is associated with an EIP but does not explicitly disable"
+" public IP allocation."
+msgstr "La ressource ECS {} est associée à une EIP, mais ne désactive pas explicitement l’allocation d’une adresse IP publique."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"EIPAssociation {} provides the public entry point; the associated ECS "
+"resource must set AllocatePublicIP to false."
+msgstr "EIPAssociation {} fournit le point d’entrée public ; la ressource ECS associée doit définir AllocatePublicIP sur false."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+msgid "Set AllocatePublicIP: false on the associated ECS resource."
+msgstr "Définissez AllocatePublicIP: false sur la ressource ECS associée."
+
 #: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
@@ -14788,4 +14806,3 @@ msgstr "Autoriser Bash ?"
 
 #~ msgid "架构图优化中..."
 #~ msgstr "Optimisation du diagramme d’architecture..."
-

--- a/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/ja/LC_MESSAGES/messages.po
@@ -10510,6 +10510,24 @@ msgstr "{} には配列が必要です"
 msgid "the condition is invalid"
 msgstr "条件が無効です"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"ECS resource {} is associated with an EIP but does not explicitly disable"
+" public IP allocation."
+msgstr "ECS リソース {} は EIP に関連付けられていますが、パブリック IP の割り当てが明示的に無効化されていません。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"EIPAssociation {} provides the public entry point; the associated ECS "
+"resource must set AllocatePublicIP to false."
+msgstr "EIPAssociation {} がパブリックエントリーポイントを提供するため、関連付けられた ECS リソースでは AllocatePublicIP を false に設定する必要があります。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+msgid "Set AllocatePublicIP: false on the associated ECS resource."
+msgstr "関連付けられた ECS リソースで AllocatePublicIP: false を設定してください。"
+
 #: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
@@ -13636,4 +13654,3 @@ msgstr "Bash を許可しますか？"
 
 #~ msgid "架构图优化中..."
 #~ msgstr "アーキテクチャ図を最適化中..."
-

--- a/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/pt/LC_MESSAGES/messages.po
@@ -11268,6 +11268,24 @@ msgstr "{} requer uma matriz"
 msgid "the condition is invalid"
 msgstr "a condição é inválida"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"ECS resource {} is associated with an EIP but does not explicitly disable"
+" public IP allocation."
+msgstr "O recurso ECS {} está associado a uma EIP, mas não desativa explicitamente a alocação de IP público."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"EIPAssociation {} provides the public entry point; the associated ECS "
+"resource must set AllocatePublicIP to false."
+msgstr "A EIPAssociation {} fornece o ponto de entrada público; o recurso ECS associado deve definir AllocatePublicIP como false."
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+msgid "Set AllocatePublicIP: false on the associated ECS resource."
+msgstr "Defina AllocatePublicIP: false no recurso ECS associado."
+
 #: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
@@ -14596,4 +14614,3 @@ msgstr "Permitir Bash?"
 
 #~ msgid "架构图优化中..."
 #~ msgstr "Otimizando diagrama de arquitetura..."
-

--- a/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
+++ b/src/iac_code/i18n/locales/zh/LC_MESSAGES/messages.po
@@ -10304,6 +10304,24 @@ msgstr "{} 需要一个数组"
 msgid "the condition is invalid"
 msgstr "条件无效"
 
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"ECS resource {} is associated with an EIP but does not explicitly disable"
+" public IP allocation."
+msgstr "ECS 资源 {} 已与 EIP 关联，但未明确禁用公网 IP 分配。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+#, python-brace-format
+msgid ""
+"EIPAssociation {} provides the public entry point; the associated ECS "
+"resource must set AllocatePublicIP to false."
+msgstr "EIPAssociation {} 提供公网入口；关联的 ECS 资源必须将 AllocatePublicIP 设置为 false。"
+
+#: src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+msgid "Set AllocatePublicIP: false on the associated ECS resource."
+msgstr "请在关联的 ECS 资源上设置 AllocatePublicIP: false。"
+
 #: src/iac_code/ui/banner.py
 #, python-brace-format
 msgid "Update available! {} -> {}"
@@ -13384,4 +13402,3 @@ msgstr "允许 Bash?"
 
 #~ msgid "架构图优化中..."
 #~ msgstr "架构图优化中..."
-

--- a/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
+++ b/src/iac_code/pipeline/selling/skills/iac-aliyun-cost/SKILL.md
@@ -255,7 +255,7 @@ ros_estimate_template_cost(
     parameters={
         "ZoneId": "cn-hangzhou-k",
         "InstanceType": "ecs.g7.large",
-        "ImageId": "centos_stream_9_x64_20G_alibase_20260414.vhd",
+        "ImageId": "ubuntu_24_04_x64_20G_alibase_20260720.vhd",
         "SystemDiskCategory": "cloud_essd",
     },
     region_id="cn-hangzhou",

--- a/src/iac_code/pipeline/selling_solution_first/skills/iac-aliyun-materialize-selected-candidate/SKILL.md
+++ b/src/iac_code/pipeline/selling_solution_first/skills/iac-aliyun-materialize-selected-candidate/SKILL.md
@@ -169,7 +169,7 @@ ros_estimate_template_cost(
     parameters={
         "ZoneId": "cn-hangzhou-k",
         "InstanceType": "ecs.g7.large",
-        "ImageId": "centos_stream_9_x64_20G_alibase_20260414.vhd",
+        "ImageId": "ubuntu_24_04_x64_20G_alibase_20260720.vhd",
         "SystemDiskCategory": "cloud_essd",
     },
     region_id="cn-hangzhou",

--- a/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/SKILL.md
@@ -128,7 +128,7 @@ auto_trigger:
            "Parameters": {
                "zone_id": "cn-hangzhou-k",
                "instance_type": "ecs.g7.large",
-               "image_id": "centos_stream_9_x64_20G_alibase_20260414.vhd",
+               "image_id": "ubuntu_24_04_x64_20G_alibase_20260720.vhd",
                "system_disk_category": "cloud_essd",
            },
        },

--- a/src/iac_code/skills/bundled/iac_aliyun/references/cloud-products/ecs.md
+++ b/src/iac_code/skills/bundled/iac_aliyun/references/cloud-products/ecs.md
@@ -83,18 +83,21 @@
 
 ## 镜像选择
 
-- **Alibaba Cloud Linux 4**：推荐，针对阿里云优化，内核定制
-- **Ubuntu 24.04**：社区支持好，生态丰富
+- **Ubuntu 24.04**：默认首选，社区支持好，生态丰富，优先使用 x86_64 镜像
+- **Alibaba Cloud Linux 4**：仅在用户明确要求或存在兼容性约束时使用
 - **CentOS Stream 9**：兼容 RHEL，适合企业场景
 - **Windows Server 2025**：Windows 工作负载
 
-调用 DescribeImages 可指定 ImageName 进行模糊搜索。比如 ImageName="aliyun_4_*
+调用 DescribeImages 可指定 ImageName 进行模糊搜索。默认优先搜索 Ubuntu 24.04，
+例如 `ImageName="ubuntu_24_04_x64_*"`；不要直接复用过期的固定日期镜像 ID，
+应使用查询结果中当前地域和实例规格可用的镜像。
 
 ## 网络带宽
 
 - 默认按流量计费：适合流量不稳定的业务
 - 按带宽计费：适合流量持续稳定、高带宽场景
 - 公网 IP 可选按量购买 EIP，支持弹性绑定/解绑
+- ECS 绑定 EIP 时，必须显式设置 `AllocatePublicIP: false`，公网入口只保留 EIP；该约束由模板校验硬门禁强制执行。
 
 ## 安全组最佳实践
 

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/rules/eip_association.py
@@ -1,0 +1,131 @@
+"""Cross-resource checks for EIP associations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from iac_code.i18n import _
+from iac_code.tools.cloud.aliyun.ros_validation.facts import RulePhase
+from iac_code.tools.cloud.aliyun.ros_validation.model import (
+    Category,
+    Diagnostic,
+    Severity,
+    make_diagnostic,
+    mapping_segment,
+)
+
+_PARSED_TEMPLATE = "parsed-template"
+_EIP_ASSOCIATION_TYPES = frozenset({"ALIYUN::VPC::EIPAssociation"})
+_ECS_TYPES = frozenset({"ALIYUN::ECS::Instance", "ALIYUN::ECS::InstanceGroup"})
+
+
+def _path(*parts: Any) -> tuple:
+    return tuple(mapping_segment(part) for part in parts)
+
+
+def _resource_references(value: Any) -> set[str]:
+    references: set[str] = set()
+    if isinstance(value, Mapping):
+        ref = value.get("Ref")
+        if isinstance(ref, str):
+            references.add(ref)
+
+        getatt = value.get("Fn::GetAtt")
+        if isinstance(getatt, list) and getatt and isinstance(getatt[0], str):
+            references.add(getatt[0])
+        elif isinstance(getatt, str):
+            references.add(getatt.split(".", 1)[0])
+
+        for child in value.values():
+            references.update(_resource_references(child))
+    elif isinstance(value, list):
+        for child in value:
+            references.update(_resource_references(child))
+    return references
+
+
+def _is_explicit_false(value: Any) -> bool:
+    return value is False
+
+
+@dataclass(frozen=True)
+class EipAssociationCheck:
+    """Check the public-IP invariant for one EIP-to-ECS relationship."""
+
+    def check(self, context: Any) -> tuple[Diagnostic, ...]:
+        parsed = context.fact_store.get_required(_PARSED_TEMPLATE)
+        template = parsed.data
+        if not isinstance(template, Mapping):
+            return ()
+        resources = template.get("Resources")
+        if not isinstance(resources, Mapping):
+            return ()
+
+        ecs_resources = {
+            name: definition
+            for name, definition in resources.items()
+            if isinstance(name, str)
+            and isinstance(definition, Mapping)
+            and definition.get("Type") in _ECS_TYPES
+        }
+        diagnostics: list[Diagnostic] = []
+        for association_name, association in resources.items():
+            if not isinstance(association_name, str) or not isinstance(association, Mapping):
+                continue
+            if association.get("Type") not in _EIP_ASSOCIATION_TYPES:
+                continue
+            properties = association.get("Properties")
+            if not isinstance(properties, Mapping):
+                continue
+            target_names = _resource_references(properties.get("InstanceId"))
+            for target_name in sorted(target_names & set(ecs_resources)):
+                target = ecs_resources[target_name]
+                target_properties = target.get("Properties")
+                allocate_public_ip = (
+                    target_properties.get("AllocatePublicIP")
+                    if isinstance(target_properties, Mapping)
+                    else None
+                )
+                if _is_explicit_false(allocate_public_ip):
+                    continue
+                diagnostics.append(
+                    make_diagnostic(
+                        code="ROS5103",
+                        severity=Severity.ERROR,
+                        category=Category.QUALITY,
+                        summary=_(
+                            "ECS resource {} is associated with an EIP but does not explicitly disable "
+                            "public IP allocation."
+                        ).format(target_name),
+                        detail=_(
+                            "EIPAssociation {} provides the public entry point; the associated ECS resource "
+                            "must set AllocatePublicIP to false."
+                        ).format(association_name),
+                        path=_path("Resources", target_name, "Properties", "AllocatePublicIP"),
+                        source_map=parsed.source_map,
+                        subject=target_name,
+                        stable_args=(association_name, target_name, type(allocate_public_ip).__name__),
+                        expected="false",
+                        actual="missing" if allocate_public_ip is None else str(allocate_public_ip),
+                        suggestion=_("Set AllocatePublicIP: false on the associated ECS resource."),
+                    )
+                )
+        return tuple(diagnostics)
+
+
+@dataclass(frozen=True)
+class ResourceRelationshipRule:
+    """Run checks that validate relationships between ROS resources."""
+
+    rule_id: str = "builtin.resource-relationships"
+    phase: RulePhase = RulePhase.STRUCTURE
+    requires: frozenset[str] = frozenset({_PARSED_TEMPLATE})
+    optional_requires: frozenset[str] = frozenset()
+    checks: tuple[EipAssociationCheck, ...] = (EipAssociationCheck(),)
+
+    def check(self, context: Any) -> tuple[Diagnostic, ...]:
+        diagnostics: list[Diagnostic] = []
+        for relationship_check in self.checks:
+            diagnostics.extend(relationship_check.check(context))
+        return tuple(diagnostics)

--- a/src/iac_code/tools/cloud/aliyun/ros_validation/validator.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_validation/validator.py
@@ -33,6 +33,7 @@ from iac_code.tools.cloud.aliyun.ros_validation.rules.association_property impor
     AssociationPropertyRule,
     AssociationPropertySpecsProvider,
 )
+from iac_code.tools.cloud.aliyun.ros_validation.rules.eip_association import ResourceRelationshipRule
 from iac_code.tools.cloud.aliyun.ros_validation.rules.registry import create_validation_registry
 from iac_code.tools.cloud.aliyun.ros_validation.symbols import collect_symbols
 
@@ -250,7 +251,7 @@ _VALIDATION_REGISTRY = create_validation_registry(
         _LocalsPrecompileProvider(),
         _CountPrecompileProvider(),
     ),
-    rules=(AssociationPropertyRule(), _StructureRule(), _ConditionRule(), _ResourceRule()),
+    rules=(AssociationPropertyRule(), _StructureRule(), _ConditionRule(), _ResourceRule(), ResourceRelationshipRule()),
 )
 
 

--- a/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
+++ b/tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py
@@ -238,6 +238,10 @@ class TestSkillContentRosOnly:
     def test_contains_validate_template(self, body):
         assert "ros_validate_template" in body
 
+    def test_prefers_ubuntu_24_04_image_example(self, body):
+        assert "ubuntu_24_04_x64_20G_alibase_20260720.vhd" in body
+        assert "centos_stream_9_x64_20G_alibase_20260414.vhd" not in body
+
     def test_template_path_examples_use_the_working_directory(self, body):
         assert "`./template.yml`" in body
         assert 'template_url="./ros-template.yml"' in body
@@ -469,6 +473,7 @@ class TestReferencesExist:
         assert "CpuCoreCount" in content
         assert "MemorySize" in content
         assert "用户已明确 vCPU/内存时，不得选择最接近值" in content
+        assert "ECS 绑定 EIP 时，必须显式设置 `AllocatePublicIP: false`" in content
 
 
 class TestSkillDiscovery:

--- a/tests/tools/cloud/aliyun/test_ros_validate_hook.py
+++ b/tests/tools/cloud/aliyun/test_ros_validate_hook.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from iac_code.tools.cloud.aliyun.hooks.ros_validate import (
     _format_json_error,
     _format_yaml_error,
@@ -376,3 +378,83 @@ class TestCheckTemplate:
 
         assert result is not None and result.blocking_result is None
         assert params == {"TemplateBody": body}
+
+    @pytest.mark.parametrize("allocate_public_ip", [None, True, "false", {"Ref": "AllocatePublicIp"}])
+    def test_eip_bound_ecs_requires_explicitly_disabled_public_ip(self, allocate_public_ip) -> None:
+        instance_properties = {}
+        if allocate_public_ip is not None:
+            instance_properties["AllocatePublicIP"] = allocate_public_ip
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Resources": {
+                "Instance": {
+                    "Type": "ALIYUN::ECS::Instance",
+                    "Properties": instance_properties,
+                },
+                "Eip": {"Type": "ALIYUN::VPC::EIP"},
+                "EipAssociation": {
+                    "Type": "ALIYUN::VPC::EIPAssociation",
+                    "Properties": {
+                        "AllocationId": {"Ref": "Eip"},
+                        "InstanceId": {"Ref": "Instance"},
+                    },
+                },
+            },
+        }
+
+        result = check_template("ros", "ValidateTemplate", {"TemplateBody": body})
+
+        assert result is not None and result.blocking_result is not None
+        assert "ROS5103" in result.blocking_result.content
+        assert result.report.counts_by_code["ROS5103"] == 1
+
+    @pytest.mark.parametrize("allocate_public_ip", [False])
+    def test_eip_bound_ecs_accepts_explicitly_disabled_public_ip(self, allocate_public_ip) -> None:
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Resources": {
+                "Instance": {
+                    "Type": "ALIYUN::ECS::Instance",
+                    "Properties": {"AllocatePublicIP": allocate_public_ip},
+                },
+                "Eip": {"Type": "ALIYUN::VPC::EIP"},
+                "EipAssociation": {
+                    "Type": "ALIYUN::VPC::EIPAssociation",
+                    "Properties": {
+                        "AllocationId": {"Ref": "Eip"},
+                        "InstanceId": {"Ref": "Instance"},
+                    },
+                },
+            },
+        }
+
+        result = check_template("ros", "ValidateTemplate", {"TemplateBody": body})
+
+        assert result is not None and result.blocking_result is None
+        assert "ROS5103" not in result.report.counts_by_code
+
+    def test_eip_bound_instance_group_detects_select_getatt_reference(self) -> None:
+        body = {
+            "ROSTemplateFormatVersion": "2015-09-01",
+            "Resources": {
+                "InstanceGroup": {
+                    "Type": "ALIYUN::ECS::InstanceGroup",
+                    "Properties": {"AllocatePublicIP": True},
+                },
+                "Eip": {"Type": "ALIYUN::VPC::EIP"},
+                "EipAssociation": {
+                    "Type": "ALIYUN::VPC::EIPAssociation",
+                    "Properties": {
+                        "AllocationId": {"Ref": "Eip"},
+                        "InstanceId": {
+                            "Fn::Select": [0, {"Fn::GetAtt": ["InstanceGroup", "InstanceIds"]}]
+                        },
+                    },
+                },
+            },
+        }
+
+        result = check_template("ros", "ValidateTemplate", {"TemplateBody": body})
+
+        assert result is not None and result.blocking_result is not None
+        assert result.report.counts_by_code["ROS5103"] == 1


### PR DESCRIPTION
## Summary
- Prefer Ubuntu 24.04 x86_64 in the normal and pipeline ECS guidance/examples.
- Add a shared ROS validation hard gate for EIP-bound ECS resources: `AllocatePublicIP` must be the boolean `false`.
- Keep `iac-code-web.md` and `iac-code-web.ros.yml` unchanged.

## Validation
- `make lint`
- `uv run pytest -q tests/test_i18n.py tests/tools/cloud/aliyun/test_ros_validate_hook.py tests/tools/cloud/aliyun/test_ros_validation_registry.py tests/tools/cloud/aliyun/test_ros_validation_semantics.py tests/tools/cloud/aliyun/test_ros_association_property_validation.py tests/pipeline/selling/skills/test_iac_aliyun_cost_skill.py`
- 461 passed
- Full suite had 2 frontend environment failures because `node` is unavailable; remaining tests passed.