### PR TITLE
feat(a2a): add execution pause resume and termination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,9 +147,13 @@ jobs:
             tests/a2a/test_execution_control_regressions.py \
             tests/a2a/test_execution_control_review_regressions.py \
             tests/a2a/test_permission_execution_control.py \
-            tests/a2a_e2e/test_execution_control_scenarios.py \
             -v --cov --cov-report= \
             --junitxml=execution-control-testcase.xml
+
+      - name: Run A2A execution-control process tests serially
+        # Coverage instrumentation slows the fixture server enough to exceed
+        # the scenarios' own watchdogs. Unit tests above retain source coverage.
+        run: uv run pytest tests/a2a_e2e/test_execution_control_scenarios.py -v
 
       - name: Run remaining tests with coverage
         run: |
@@ -194,8 +198,10 @@ jobs:
             tests/a2a/test_execution_control_regressions.py \
             tests/a2a/test_execution_control_review_regressions.py \
             tests/a2a/test_permission_execution_control.py \
-            tests/a2a_e2e/test_execution_control_scenarios.py \
             -v --no-header
+
+      - name: Run A2A execution-control process tests serially
+        run: uv run pytest tests/a2a_e2e/test_execution_control_scenarios.py -v --no-header
 
       - name: Run remaining tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,10 +137,29 @@ jobs:
       - name: Compile translations
         run: make translate
 
-      - name: Run tests with coverage
+      - name: Run A2A execution-control tests serially with coverage
+        # These tests deliberately gate durable writes, backups, timers, and
+        # subprocesses. Running them together under xdist makes their real-time
+        # assertions depend on shared runner I/O load, especially on Windows.
+        run: |
+          uv run pytest \
+            tests/a2a/test_execution_control.py \
+            tests/a2a/test_execution_control_regressions.py \
+            tests/a2a/test_execution_control_review_regressions.py \
+            tests/a2a/test_permission_execution_control.py \
+            tests/a2a_e2e/test_execution_control_scenarios.py \
+            -v --cov --cov-report= \
+            --junitxml=execution-control-testcase.xml
+
+      - name: Run remaining tests with coverage
         run: |
           uv run pytest tests/ -v -n auto \
-            --cov --cov-report=term-missing \
+            --ignore=tests/a2a/test_execution_control.py \
+            --ignore=tests/a2a/test_execution_control_regressions.py \
+            --ignore=tests/a2a/test_execution_control_review_regressions.py \
+            --ignore=tests/a2a/test_permission_execution_control.py \
+            --ignore=tests/a2a_e2e/test_execution_control_scenarios.py \
+            --cov --cov-append --cov-report=term-missing \
             --junitxml=testcase.xml
 
       - name: Check coverage threshold
@@ -163,11 +182,27 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run A2A app lifecycle tests serially
+      - name: Run A2A lifecycle and execution-control tests serially
         # These async lifecycle tests can terminate an xdist worker without a
-        # Python traceback on Windows. Keep the coverage, but run the module in
-        # the pytest coordinator process so worker loss cannot mask the result.
-        run: uv run pytest tests/a2a/test_app.py -v --no-header
+        # Python traceback on Windows. Execution-control tests also gate real
+        # durable writes, backups, timers, and subprocesses, so run both groups
+        # in the pytest coordinator process.
+        run: |
+          uv run pytest \
+            tests/a2a/test_app.py \
+            tests/a2a/test_execution_control.py \
+            tests/a2a/test_execution_control_regressions.py \
+            tests/a2a/test_execution_control_review_regressions.py \
+            tests/a2a/test_permission_execution_control.py \
+            tests/a2a_e2e/test_execution_control_scenarios.py \
+            -v --no-header
 
       - name: Run remaining tests
-        run: uv run pytest tests/ -v --no-header -n auto --ignore=tests/a2a/test_app.py
+        run: |
+          uv run pytest tests/ -v --no-header -n auto \
+            --ignore=tests/a2a/test_app.py \
+            --ignore=tests/a2a/test_execution_control.py \
+            --ignore=tests/a2a/test_execution_control_regressions.py \
+            --ignore=tests/a2a/test_execution_control_review_regressions.py \
+            --ignore=tests/a2a/test_permission_execution_control.py \
+            --ignore=tests/a2a_e2e/test_execution_control_scenarios.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,24 +191,24 @@ jobs:
         # Python traceback on Windows. Execution-control tests also gate real
         # durable writes, backups, timers, and subprocesses, so run both groups
         # in the pytest coordinator process.
-        run: |
-          uv run pytest \
-            tests/a2a/test_app.py \
-            tests/a2a/test_execution_control.py \
-            tests/a2a/test_execution_control_regressions.py \
-            tests/a2a/test_execution_control_review_regressions.py \
-            tests/a2a/test_permission_execution_control.py \
-            -v --no-header
+        run: >-
+          uv run pytest
+          tests/a2a/test_app.py
+          tests/a2a/test_execution_control.py
+          tests/a2a/test_execution_control_regressions.py
+          tests/a2a/test_execution_control_review_regressions.py
+          tests/a2a/test_permission_execution_control.py
+          -v --no-header
 
       - name: Run A2A execution-control process tests serially
         run: uv run pytest tests/a2a_e2e/test_execution_control_scenarios.py -v --no-header
 
       - name: Run remaining tests
-        run: |
-          uv run pytest tests/ -v --no-header -n auto \
-            --ignore=tests/a2a/test_app.py \
-            --ignore=tests/a2a/test_execution_control.py \
-            --ignore=tests/a2a/test_execution_control_regressions.py \
-            --ignore=tests/a2a/test_execution_control_review_regressions.py \
-            --ignore=tests/a2a/test_permission_execution_control.py \
-            --ignore=tests/a2a_e2e/test_execution_control_scenarios.py
+        run: >-
+          uv run pytest tests/ -v --no-header -n auto
+          --ignore=tests/a2a/test_app.py
+          --ignore=tests/a2a/test_execution_control.py
+          --ignore=tests/a2a/test_execution_control_regressions.py
+          --ignore=tests/a2a/test_execution_control_review_regressions.py
+          --ignore=tests/a2a/test_permission_execution_control.py
+          --ignore=tests/a2a_e2e/test_execution_control_scenarios.py

--- a/scripts/a2a/e2e/README.md
+++ b/scripts/a2a/e2e/README.md
@@ -1,5 +1,32 @@
 # A2A E2E Session Recovery and Redaction
 
+## Execution pause, resume, and timeout-termination matrix
+
+`execution_control/run_execution_control_scenarios.py` starts a separate real
+HTTP A2A server process and uses deterministic provider, long-tool, and sync-SDK
+boundaries to verify pause, in-place resume, timeout termination, shared backup,
+and safe-release gating for Normal and Pipeline executions. It uses no real LLM,
+cloud account, or ROS resource.
+
+```bash
+uv run python scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py \
+  --run-dir /tmp/iac-execution-control \
+  --scenario warm-resume-pausing \
+  --mode normal
+
+uv run pytest -q tests/a2a_e2e/test_execution_control_scenarios.py
+```
+
+`--scenario` may be repeated; compatible scenarios run serially in independent
+child directories for the selected `--mode`. Each scenario preserves
+`summary.json`, `requests.jsonl`, `*.events.jsonl`, `control-requests.json`,
+`execution-state-timeline.json`, provider/tool lifecycle logs,
+`backup-audit.json`, recovery snapshots, Pipeline journal/snapshot/sidecar,
+shared-backup contents, `server-lifecycle.json`, and `server.log`. `--timeout`
+bounds one wait step and `--overall-timeout` bounds the whole scenario. Failure
+cleanup releases every marker, closes streams, and stops the server with bounded
+waits.
+
 ## Real StartChat permission-wait matrix
 
 `run_start_chat_permission_wait.py` is the credential-gated, repeatable chain

--- a/scripts/a2a/e2e/README.zh-CN.md
+++ b/scripts/a2a/e2e/README.zh-CN.md
@@ -1,5 +1,66 @@
 # A2A 会话恢复与脱敏 E2E
 
+## 执行暂停、恢复与超时终止矩阵
+
+`execution_control/run_execution_control_scenarios.py` 启动独立的真实 HTTP A2A server 进程，使用确定性
+provider、长工具和同步 SDK 边界验证 Normal/Pipeline 执行的暂停、原地恢复、超时终止、共享备份和安全回收门禁。
+它不使用真实模型、云账号或 ROS 资源。
+
+```bash
+uv run python scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py \
+  --run-dir /tmp/iac-execution-control \
+  --scenario warm-resume-pausing \
+  --mode normal
+
+uv run pytest -q tests/a2a_e2e/test_execution_control_scenarios.py
+```
+
+可以重复传入 `--scenario`，兼容所选 `--mode` 的场景会串行运行到独立子目录。每次场景运行会保存
+`summary.json`、`requests.jsonl`、`*.events.jsonl`、`control-requests.json`、
+`execution-state-timeline.json`、`provider-lifecycle.jsonl`、`tool-lifecycle.jsonl`、
+`backup-audit.json`、恢复快照、Pipeline journal/snapshot/sidecar、共享备份内容、
+`server-lifecycle.json` 和 `server.log`。`--timeout` 限制单个等待步骤，`--overall-timeout` 限制整个场景；
+失败清理会释放全部 marker、关闭流，并在有界等待后终止 server。
+
+兼容性与慢存储回归包含以下进程级用例：
+
+| 用例 | 模式 | 关键断言 |
+| --- | --- | --- |
+| `disconnect-timeout-after-operation-id` | Normal | 真实 `RosStack` 获得 StackId 后进入生产轮询；暂停超时取消轮询，共享备份和状态都保留同一外部操作，SDK 只提交一次。 |
+| `disconnect-timeout-after-operation-id` | Pipeline | 同上，并验证 task 为 canceled，没有进入 Pipeline handoff。 |
+| `slow-termination-storage` | Normal | 待审批任务的终止持久化被阻塞期间，health、状态查询及另一会话完整一轮仍可完成；落盘与共享备份完成前不能回收，未批准的工具不执行。 |
+| `terminate-during-bootstrap` | Normal、Pipeline | 保持 SSE 连接，在初始化中终止；初始化和 runtime 清理都必须排空，任务及备份均为 canceled，SSE 正常结束；共享备份提交前 `releaseReady=false`，不发起 LLM 请求。 |
+| `terminate-during-bootstrap-disconnected` | Normal、Pipeline | 初始化中先断开 SSE 再终止；同样验证任务终态、备份与回收信号一致。 |
+| `disconnect-timeout-during-turn-backup` | Normal | 本轮输出完成后阻塞备份，断线暂停直到超时；health 可用，备份结束前不可回收，最终保留正常 input-required 状态和完整结果，不改成 canceled。 |
+| `legacy-cancel-idle` | Pipeline | 首段文本发布后使用原 `CancelTask`；provider 关闭，server 按空闲策略自行退出，不调用新控制接口。 |
+| `slow-rollover-storage` | Normal | 有后台任务存活时正常换轮，阻塞该会话的状态写入；另一会话仍能完成一轮，原后台任务不被误取消，不调用新控制接口。 |
+| `stack-instances-timeout-after-operation-id` | Normal | 真实 `RosStackInstances` 提交成功并开始轮询后暂停至超时；停止本地工具，状态和共享备份保留同一 operation ID，SDK 只提交一次；共享备份放行前不可回收。 |
+| `stack-instances-terminate-inflight` | Normal | 阻塞 SDK 返回时显式 terminate，health 仍可用且不可回收；SDK 返回后记录真实 operation ID，再等待共享备份提交，最终 task 为 canceled。 |
+| `recovery-during-normal-rollover` | Normal | 保留后台任务，阻塞旧 recovery 历史读取，通过第二轮真实 A2A 请求换轮；旧请求返回 409，新快照返回 200 且身份、输出一致，两轮历史完整，新一轮共享备份可用。 |
+
+这些用例同时启用 backup 与 tmp backup，使用真实 HTTP、SSE、AgentLoop 和备份流程。ROS 用例仅替换
+SDK 响应与云端前置检查，不手工调用外部操作记录接口；慢存储通过生产写入边界的 marker 模拟，
+不依赖真实 OSS。它们验证阻塞期间的行为和提交顺序，不测量真实 OSS 吞吐。
+
+仅运行这些兼容性与慢存储用例：
+
+```bash
+uv run pytest -q tests/a2a_e2e/test_execution_control_scenarios.py \
+  -k 'disconnect-timeout-after-operation-id or slow-termination-storage or terminate-during-bootstrap or disconnect-timeout-during-turn-backup or legacy-cancel-idle or slow-rollover-storage or stack-instances or recovery-during-normal-rollover'
+```
+
+`NaN` 超时参数由 HTTP 层自动化测试覆盖，不额外增加进程级用例。
+
+仅运行 operation ID 与 recovery 换轮的 3 个补充用例：
+
+```bash
+uv run pytest -q tests/a2a_e2e/test_execution_control_scenarios.py \
+  -k 'stack-instances or recovery-during-normal-rollover'
+```
+
+recovery 换轮用例另存 `recovery-conflict.json`、`recovery-after-rollover.json` 和换轮前状态时间线，
+通过 `fixture-lifecycle.jsonl` 确认实际调用了生产换轮逻辑。三个用例均不访问真实云资源。
+
 ## 真实 StartChat 权限等待矩阵
 
 `run_start_chat_permission_wait.py` 是本功能可重复执行、受凭证开关保护的真实链路：Qoder 真实 LLM

--- a/scripts/a2a/e2e/execution_control/execution_control_fixture_server.py
+++ b/scripts/a2a/e2e/execution_control/execution_control_fixture_server.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""Deterministic real-process fixture for A2A execution-control E2E tests."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+TOKEN = "execution-control-e2e-token"
+TOOL_NAME = "fixture_long_operation"
+TOOL_USE_ID = "fixture-long-tool-1"
+STACK_ID = "stack-execution-control-e2e-0001"
+STACK_INSTANCES_OPERATION_ID = "stack-instances-operation-e2e-0001"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--config-dir", type=Path, required=True)
+    parser.add_argument("--persistence-dir", type=Path, required=True)
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--staging-dir", type=Path, required=True)
+    parser.add_argument("--backup-dir", type=Path, required=True)
+    parser.add_argument("--mode", choices=("normal", "pipeline"), required=True)
+    parser.add_argument(
+        "--scenario",
+        choices=(
+            "warm-resume-pausing",
+            "warm-resume-paused",
+            "disconnect-timeout-after-operation-id",
+            "disconnect-timeout-inflight-sync-call",
+            "disconnect-timeout-backup-blocked",
+            "natural-completion-while-pausing",
+            "slow-termination-storage",
+            "terminate-during-bootstrap",
+            "terminate-during-bootstrap-disconnected",
+            "disconnect-timeout-during-turn-backup",
+            "legacy-cancel-idle",
+            "slow-rollover-storage",
+            "stack-instances-timeout-after-operation-id",
+            "stack-instances-terminate-inflight",
+            "recovery-during-normal-rollover",
+        ),
+        required=True,
+    )
+    return parser.parse_args()
+
+
+class _LifecycleLog:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+
+    def write(self, event: str, **data: Any) -> None:
+        record = {"event": event, "time": time.time(), **data}
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock, self._path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+
+def _marker(control_dir: Path, name: str) -> Path:
+    return control_dir / name
+
+
+async def _wait_for_marker(control_dir: Path, name: str, *, timeout: float = 90.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not _marker(control_dir, name).exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for marker {}".format(name))
+        await asyncio.sleep(0.02)
+
+
+def _wait_for_marker_sync(control_dir: Path, name: str, *, timeout: float = 90.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not _marker(control_dir, name).exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for marker {}".format(name))
+        time.sleep(0.02)
+
+
+def _has_tool_result(messages: list[Any], tool_use_id: str) -> bool:
+    return any(
+        getattr(block, "type", None) == "tool_result" and getattr(block, "tool_use_id", None) == tool_use_id
+        for message in messages
+        for block in (message.content if isinstance(getattr(message, "content", None), list) else [])
+    )
+
+
+def _create_fixture_runtime(options: Any, *, scenario: str, run_dir: Path) -> Any:
+    from iac_code.a2a.backup import run_sync_fenced_with_cancel_completion
+    from iac_code.a2a.execution_control import record_execution_external_operation
+    from iac_code.agent.agent_loop import AgentLoop
+    from iac_code.services.agent_factory import AgentRuntime
+    from iac_code.services.session_storage import SessionStorage
+    from iac_code.tools.base import Tool, ToolContext, ToolRegistry, ToolResult
+    from iac_code.types.permissions import PermissionResult
+
+    control_dir = run_dir / "control"
+    provider_log = _LifecycleLog(run_dir / "provider-lifecycle.jsonl")
+    tool_log = _LifecycleLog(run_dir / "tool-lifecycle.jsonl")
+    provider = _FixtureProvider(scenario=scenario, control_dir=control_dir, lifecycle=provider_log)
+
+    class FixtureLongOperation(Tool):
+        @property
+        def name(self) -> str:
+            return TOOL_NAME
+
+        @property
+        def description(self) -> str:
+            return "Wait at a deterministic remote-operation boundary."
+
+        @property
+        def input_schema(self) -> dict[str, Any]:
+            return {"type": "object", "additionalProperties": False}
+
+        @property
+        def timeout(self) -> float | None:
+            return None
+
+        def is_read_only(self, input: dict[str, Any] | None = None) -> bool:  # noqa: A002 - Tool protocol
+            del input
+            return True
+
+        async def check_permissions(self, input: dict[str, Any], context: Any = None) -> PermissionResult:
+            if scenario == "slow-termination-storage":
+                tool_log.write("permission.requested")
+                return PermissionResult(behavior="ask", message="Allow the fixture operation?")
+            return PermissionResult(behavior="allow")
+
+        async def execute(self, *, tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+            del tool_input
+            tool_log.write("tool.started", toolUseId=context.tool_use_id, scenario=scenario)
+            if scenario == "disconnect-timeout-inflight-sync-call":
+                return await self._run_sync_call(context)
+            if scenario == "disconnect-timeout-after-operation-id":
+                return await self._run_ros_stack(context)
+            if scenario.startswith("stack-instances-"):
+                return await self._run_ros_stack_instances(context)
+
+            try:
+                await _wait_for_marker(control_dir, "release-tool")
+            except asyncio.CancelledError:
+                tool_log.write("tool.cancelled")
+                raise
+            tool_log.write("tool.completed", result="DURABLE_FIXTURE_RESULT")
+            return ToolResult.success("DURABLE_FIXTURE_RESULT")
+
+        async def _run_ros_stack(self, context: ToolContext) -> ToolResult:
+            from iac_code.tools.cloud.aliyun.ros_stack import RosStack
+
+            def create_stack(request: Any) -> Any:
+                del request
+                tool_log.write("sdk.started")
+                tool_log.write("sdk.returned", stackId=STACK_ID)
+                return SimpleNamespace(body=SimpleNamespace(stack_id=STACK_ID))
+
+            class OfflineRosStack(RosStack):
+                def _get_client(self, region: str) -> Any:
+                    return SimpleNamespace(create_stack=create_stack)
+
+                async def wait_for_stack_operation(self, *args: Any, **kwargs: Any) -> ToolResult:
+                    tool_log.write("polling.started", stackId=STACK_ID)
+                    try:
+                        return await super().wait_for_stack_operation(*args, **kwargs)
+                    except asyncio.CancelledError:
+                        tool_log.write("polling.cancelled", stackId=STACK_ID)
+                        raise
+
+            stack = OfflineRosStack(allow_pipeline_deployment_actions=True)
+            stack.poll_interval = 3600
+            params = {
+                "StackName": "execution-control-fixture",
+                "TemplateBody": '{"ROSTemplateFormatVersion":"2015-09-01","Resources":{}}',
+            }
+            if context.pipeline_mode:
+                template_path = Path(context.cwd) / "fixture-template.json"
+                template_path.write_text(params.pop("TemplateBody"), encoding="utf-8")
+                params["TemplateURL"] = str(template_path)
+            # Keep cloud preflight offline; submission, result recording and
+            # polling cancellation all run through the production RosStack.
+            with patch("iac_code.tools.cloud.aliyun.api_hooks.run_hooks", return_value=None):
+                return await stack.execute(
+                    tool_input={
+                        "action": "CreateStack",
+                        "region_id": "cn-hangzhou",
+                        "params": params,
+                    },
+                    context=context,
+                )
+
+        async def _run_ros_stack_instances(self, context: ToolContext) -> ToolResult:
+            from iac_code.tools.cloud.aliyun.ros_stack_instances import RosStackInstances
+
+            def create_stack_instances(request: Any) -> Any:
+                del request
+                tool_log.write("sdk.started", action="CreateStackInstances")
+                if scenario == "stack-instances-terminate-inflight":
+                    _wait_for_marker_sync(control_dir, "release-sdk")
+                tool_log.write("sdk.returned", operationId=STACK_INSTANCES_OPERATION_ID)
+                return SimpleNamespace(body=SimpleNamespace(operation_id=STACK_INSTANCES_OPERATION_ID))
+
+            class OfflineRosStackInstances(RosStackInstances):
+                poll_interval = 3600
+
+                def _get_client(self, region: str) -> Any:
+                    return SimpleNamespace(create_stack_instances=create_stack_instances)
+
+                async def _initiate(self, *args: Any, **kwargs: Any) -> str:
+                    # Observe the production submission/recording boundary;
+                    # never inject externalOperations from the fixture.
+                    operation_id = await super()._initiate(*args, **kwargs)
+                    tool_log.write("polling.started", operationId=operation_id)
+                    return operation_id
+
+            try:
+                return await OfflineRosStackInstances().execute(
+                    tool_input={
+                        "action": "CreateStackInstances",
+                        "region_id": "cn-hangzhou",
+                        "params": {"StackGroupName": "execution-control-fixture"},
+                    },
+                    context=context,
+                )
+            except asyncio.CancelledError:
+                tool_log.write("tool.cancelled")
+                raise
+
+        async def _run_sync_call(self, context: ToolContext) -> ToolResult:
+            def blocking_create_stack() -> str:
+                tool_log.write("sdk.started")
+                _wait_for_marker_sync(control_dir, "release-sdk")
+                tool_log.write("sdk.returned", stackId=STACK_ID)
+                return STACK_ID
+
+            async def save_late_result(result: str | None, error: BaseException | None) -> None:
+                if error is None and result:
+                    await record_execution_external_operation(
+                        product="ROS",
+                        action="CreateStack",
+                        outcome="accepted",
+                        resource_type="ALIYUN::ROS::Stack",
+                        resource_id=result,
+                        region_id="cn-hangzhou",
+                        tool_use_id=context.tool_use_id,
+                    )
+                    tool_log.write("operation.recorded", operationId=result, late=True)
+
+            result = await run_sync_fenced_with_cancel_completion(blocking_create_stack, save_late_result)
+            await record_execution_external_operation(
+                product="ROS",
+                action="CreateStack",
+                outcome="accepted",
+                resource_type="ALIYUN::ROS::Stack",
+                resource_id=result,
+                region_id="cn-hangzhou",
+                tool_use_id=context.tool_use_id,
+            )
+            tool_log.write("operation.recorded", operationId=result, late=False)
+            return ToolResult.success(result)
+
+    registry = ToolRegistry()
+    registry.register(FixtureLongOperation())
+    storage = SessionStorage()
+    storage.ensure_v2_session_dir_for_new_session(str(options.cwd), str(options.session_id))
+    loop = AgentLoop(
+        provider_manager=provider,
+        system_prompt="Deterministic execution-control fixture.",
+        tool_registry=registry,
+        max_turns=4,
+        session_storage=storage,
+        session_id=options.session_id,
+        resume_messages=options.resume_messages,
+        cwd=options.cwd,
+    )
+    return AgentRuntime(
+        agent_loop=loop,
+        session_id=loop.session_id,
+        tool_registry=registry,
+        provider_manager=provider,
+        command_registry=None,
+        task_manager=None,
+        memory_manager=None,
+        legacy_memory_manager=None,
+    )
+
+
+class _FixtureProvider:
+    def __init__(self, *, scenario: str, control_dir: Path, lifecycle: _LifecycleLog) -> None:
+        self._scenario = scenario
+        self._control_dir = control_dir
+        self._lifecycle = lifecycle
+        self._calls = 0
+
+    def get_model_name(self) -> str:
+        return "execution-control-fixture"
+
+    def get_provider_display(self) -> str:
+        return "Execution control fixture"
+
+    async def stream(
+        self,
+        messages: list[Any],
+        system: str,
+        tools: list[Any] | None = None,
+        max_tokens: int = 8192,
+        **kwargs: Any,
+    ):
+        del system, max_tokens, kwargs
+        from iac_code.types.stream_events import (
+            MessageEndEvent,
+            MessageStartEvent,
+            TextDeltaEvent,
+            ToolUseEndEvent,
+            ToolUseStartEvent,
+            Usage,
+        )
+
+        self._calls += 1
+        tool_names = [str(getattr(tool, "name", "")) for tool in tools or []]
+        message_summary = []
+        for message in messages:
+            content = getattr(message, "content", None)
+            blocks = content if isinstance(content, list) else []
+            message_summary.append(
+                {
+                    "role": str(getattr(message, "role", "")),
+                    "contentTypes": [str(getattr(block, "type", type(block).__name__)) for block in blocks],
+                    "toolUseIds": [
+                        str(tool_use_id)
+                        for block in blocks
+                        if (tool_use_id := getattr(block, "tool_use_id", None)) is not None
+                    ],
+                }
+            )
+        self._lifecycle.write(
+            "provider.called",
+            call=self._calls,
+            tools=tool_names,
+            messageCount=len(messages),
+            messageSummary=message_summary,
+        )
+        if self._scenario == "slow-termination-storage" and not (self._control_dir / "other-context").exists():
+            yield MessageStartEvent(message_id="fixture-permission-call")
+            yield ToolUseStartEvent(tool_use_id=TOOL_USE_ID, name=TOOL_NAME)
+            yield ToolUseEndEvent(tool_use_id=TOOL_USE_ID, name=TOOL_NAME, input={})
+            yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+            return
+        if self._scenario in {
+            "slow-termination-storage",
+            "terminate-during-bootstrap",
+            "terminate-during-bootstrap-disconnected",
+            "slow-rollover-storage",
+            "disconnect-timeout-during-turn-backup",
+            "recovery-during-normal-rollover",
+        }:
+            if self._scenario in {"slow-rollover-storage", "recovery-during-normal-rollover"} and self._calls == 1:
+                from iac_code.a2a.execution_control import register_execution_task
+
+                async def background() -> None:
+                    self._lifecycle.write("background.started")
+                    try:
+                        await _wait_for_marker(self._control_dir, "release-background")
+                    finally:
+                        self._lifecycle.write("background.finished")
+
+                register_execution_task(asyncio.create_task(background()), kind="background_agent")
+            yield MessageStartEvent(message_id="fixture-simple-final")
+            yield TextDeltaEvent(
+                text="RECOVERY_ROLLOVER_TURN_{}".format(self._calls)
+                if self._scenario == "recovery-during-normal-rollover"
+                else "ISOLATION_FIXTURE_FINAL"
+            )
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+            self._lifecycle.write("provider.completed", call=self._calls)
+            return
+        if self._scenario == "legacy-cancel-idle":
+            try:
+                yield MessageStartEvent(message_id="fixture-legacy-cancel")
+                yield TextDeltaEvent(text="LEGACY_CANCEL_FIRST_TOKEN")
+                yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+            finally:
+                self._lifecycle.write("provider.closed")
+            return
+        if self._scenario == "natural-completion-while-pausing":
+            yield MessageStartEvent(message_id="fixture-natural-final")
+            yield TextDeltaEvent(text="NATURAL_FIXTURE_FINAL")
+            self._lifecycle.write("provider.awaiting_message_end", call=self._calls)
+            await _wait_for_marker(self._control_dir, "release-provider")
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+            self._lifecycle.write("provider.completed", call=self._calls)
+            return
+
+        if not _has_tool_result(messages, TOOL_USE_ID):
+            yield MessageStartEvent(message_id="fixture-tool-call")
+            yield ToolUseStartEvent(tool_use_id=TOOL_USE_ID, name=TOOL_NAME)
+            yield ToolUseEndEvent(tool_use_id=TOOL_USE_ID, name=TOOL_NAME, input={})
+            yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+            return
+
+        if "complete_step" in tool_names and not _has_tool_result(messages, "fixture-complete-step-1"):
+            yield MessageStartEvent(message_id="fixture-complete-step")
+            yield ToolUseStartEvent(tool_use_id="fixture-complete-step-1", name="complete_step")
+            yield ToolUseEndEvent(
+                tool_use_id="fixture-complete-step-1",
+                name="complete_step",
+                input={"conclusion": {"status": "completed", "result": "DURABLE_FIXTURE_RESULT"}},
+            )
+            yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+            return
+
+        yield MessageStartEvent(message_id="fixture-final")
+        yield TextDeltaEvent(text="EXECUTION_CONTROL_FIXTURE_FINAL")
+        yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+
+
+def _write_pipeline(pipeline_dir: Path) -> None:
+    (pipeline_dir / "prompts").mkdir(parents=True, exist_ok=True)
+    (pipeline_dir / "pipeline.yaml").write_text(
+        "name: execution_control_fixture\n"
+        "context_dependencies:\n"
+        "  result: []\n"
+        "max_rollbacks: 1\n"
+        "steps:\n"
+        "  - id: fixture_step\n"
+        "    conclusion_field: result\n"
+        "    forward: null\n"
+        "    description: Execute one deterministic long operation.\n"
+        "    prompt: prompts/fixture.md\n"
+        "    max_agent_turns: 4\n"
+        "    tools:\n"
+        "      include: [fixture_long_operation]\n"
+        "      exclude: []\n",
+        encoding="utf-8",
+    )
+    (pipeline_dir / "prompts" / "fixture.md").write_text(
+        "Call fixture_long_operation once, then call complete_step with its result.",
+        encoding="utf-8",
+    )
+
+
+class _GatedPublisher:
+    """Use the production worker, but begin publication only after a marker."""
+
+    def __init__(self, staging_root: Path, backup_root: Path, marker: Path) -> None:
+        self._staging_root = staging_root
+        self._backup_root = backup_root
+        self._marker = marker
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        from iac_code.services.session_backup_staging import SessionBackupStagingWorker
+
+        worker = SessionBackupStagingWorker(self._staging_root, self._backup_root)
+
+        def run() -> None:
+            while not self._stop.wait(0.05):
+                if self._marker.exists():
+                    worker.run_once()
+
+        self._thread = threading.Thread(target=run, name="execution-control-gated-backup", daemon=True)
+        self._thread.start()
+
+    def close(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+
+def main() -> int:
+    args = _parse_args()
+    paths = [
+        args.run_dir,
+        args.config_dir,
+        args.persistence_dir,
+        args.artifact_dir,
+        args.workspace,
+        args.staging_dir,
+        args.backup_dir,
+        args.run_dir / "control",
+    ]
+    for path in paths:
+        path.expanduser().resolve().mkdir(parents=True, exist_ok=True)
+
+    run_dir = args.run_dir.expanduser().resolve()
+    pipeline_dir = run_dir / "fixture-pipeline"
+    _write_pipeline(pipeline_dir)
+    os.environ["IAC_CODE_CONFIG_DIR"] = str(args.config_dir.expanduser().resolve())
+    os.environ["IAC_CODE_MODE"] = args.mode
+    os.environ["IACCODE_A2A_ALLOWED_CWDS"] = str(args.workspace.expanduser().resolve())
+    os.environ["IAC_CODE_CONFIG_BACKUP_TMP_DIR"] = str(args.staging_dir.expanduser().resolve())
+    os.environ["IAC_CODE_CONFIG_BACKUP_DIR"] = str(args.backup_dir.expanduser().resolve())
+
+    import uvicorn
+
+    from iac_code.a2a import executor as executor_module
+    from iac_code.a2a import pipeline_executor as pipeline_executor_module
+    from iac_code.a2a.app import create_app
+    from iac_code.pipeline.engine.pipeline_runner import PipelineRunner
+
+    lifecycle = _LifecycleLog(run_dir / "fixture-lifecycle.jsonl")
+    control_dir = run_dir / "control"
+
+    def runtime_factory(options: Any) -> Any:
+        if args.scenario.startswith("terminate-during-bootstrap"):
+            lifecycle.write("bootstrap.started", sessionId=options.session_id)
+            _wait_for_marker_sync(control_dir, "release-bootstrap")
+        runtime = _create_fixture_runtime(options, scenario=args.scenario, run_dir=run_dir)
+        if args.scenario.startswith("terminate-during-bootstrap"):
+            original_close = runtime.aclose
+
+            async def gated_close() -> None:
+                lifecycle.write("bootstrap.cleanup_started")
+                await _wait_for_marker(control_dir, "release-bootstrap-cleanup")
+                await original_close()
+                lifecycle.write("bootstrap.closed")
+
+            runtime.aclose = gated_close
+            lifecycle.write("bootstrap.returned")
+        return runtime
+
+    executor_module.create_agent_runtime = runtime_factory
+    pipeline_executor_module.create_agent_runtime = runtime_factory
+
+    def create_fixture_pipeline(*unused_args: Any, **kwargs: Any) -> PipelineRunner:
+        del unused_args
+        return PipelineRunner(pipeline_dir=pipeline_dir, **kwargs)
+
+    pipeline_executor_module.create_pipeline = create_fixture_pipeline
+
+    if (
+        args.scenario == "disconnect-timeout-backup-blocked"
+        or args.scenario.startswith("terminate-during-bootstrap")
+        or args.scenario.startswith("stack-instances-")
+    ):
+        from iac_code.a2a.transports import dispatcher as dispatcher_module
+        from iac_code.services.session_backup_staging import (
+            A2ASessionBackupRuntime,
+            StagedSessionBackupService,
+        )
+
+        service = StagedSessionBackupService(args.staging_dir.expanduser().resolve())
+        original_wait = service.wait_until_shared_committed
+
+        def short_wait(*wait_args: Any, **wait_kwargs: Any) -> Any:
+            wait_kwargs["timeout_seconds"] = min(float(wait_kwargs.get("timeout_seconds", 30.0)), 0.35)
+            return original_wait(*wait_args, **wait_kwargs)
+
+        if args.scenario == "disconnect-timeout-backup-blocked":
+            service.wait_until_shared_committed = short_wait  # type: ignore[method-assign]
+        publisher = _GatedPublisher(
+            args.staging_dir.expanduser().resolve(),
+            args.backup_dir.expanduser().resolve(),
+            run_dir / "control" / "allow-shared",
+        )
+        dispatcher_module.create_a2a_session_backup_runtime = lambda: A2ASessionBackupRuntime(
+            service=service,
+            staging_process=publisher,  # type: ignore[arg-type]
+        )
+
+    if args.scenario == "disconnect-timeout-during-turn-backup":
+        from iac_code.services.session_backup import BackupReason
+        from iac_code.services.session_backup_staging import StagedSessionBackupService
+
+        original_backup = StagedSessionBackupService.backup_session
+
+        def gated_turn_backup(self: Any, *backup_args: Any, **backup_kwargs: Any) -> Any:
+            if backup_kwargs.get("reason") == BackupReason.NORMAL_TURN_END:
+                lifecycle.write("turn-backup.started")
+                _wait_for_marker_sync(control_dir, "release-turn-backup")
+            return original_backup(self, *backup_args, **backup_kwargs)
+
+        StagedSessionBackupService.backup_session = gated_turn_backup
+
+    if args.scenario == "slow-termination-storage":
+        from iac_code.a2a.persistence import A2APersistenceStore
+
+        original_context_write = A2APersistenceStore.save_context
+
+        def gated_context_write(self: Any, snapshot: Any) -> None:
+            target = control_dir / "arm-termination-storage"
+            gated = target.exists() and snapshot.context_id == json.loads(target.read_text())["contextId"]
+            if gated:
+                on_event_loop = threading.current_thread() is threading.main_thread()
+                lifecycle.write("termination.commit_started", onEventLoop=on_event_loop)
+                _wait_for_marker_sync(control_dir, "release-storage")
+                assert not on_event_loop, "termination context write blocked the server event loop"
+            original_context_write(self, snapshot)
+            if gated:
+                lifecycle.write("termination.commit_finished")
+
+        A2APersistenceStore.save_context = gated_context_write
+    if args.scenario == "recovery-during-normal-rollover":
+        from iac_code.a2a.execution_control import ExecutionController
+        from iac_code.services.session_storage import SessionStorage
+
+        original_load = SessionStorage.load
+        load_lock = threading.Lock()
+        recovery_read_claimed = False
+
+        def gated_recovery_load(self: Any, *load_args: Any, **load_kwargs: Any) -> Any:
+            nonlocal recovery_read_claimed
+            with load_lock:
+                gated = (control_dir / "arm-recovery").exists() and not recovery_read_claimed
+                if gated:
+                    recovery_read_claimed = True
+            messages = original_load(self, *load_args, **load_kwargs)
+            if gated:
+                lifecycle.write("recovery.read_started", messageCount=len(messages))
+                _wait_for_marker_sync(control_dir, "release-recovery")
+                lifecycle.write("recovery.read_finished")
+            return messages
+
+        SessionStorage.load = gated_recovery_load
+        original_rollover = ExecutionController.rollover_normal_execution
+
+        async def observed_rollover(self: Any, **kwargs: Any) -> None:
+            old_execution_id = self.execution_id
+            await original_rollover(self, **kwargs)
+            lifecycle.write(
+                "recovery.rollover_completed",
+                oldExecutionId=old_execution_id,
+                executionId=self.execution_id,
+                taskId=self.task_id,
+            )
+
+        ExecutionController.rollover_normal_execution = observed_rollover
+
+    if args.scenario == "slow-rollover-storage":
+        from iac_code.a2a import execution_control as control_module
+
+        original_write = control_module.atomic_write_json
+
+        def gated_rollover(path: Path, value: Any) -> None:
+            if (control_dir / "arm-rollover").exists() and value.get("phase") == "running":
+                lifecycle.write("rollover.commit_started", contextId=value.get("contextId"))
+                _wait_for_marker_sync(control_dir, "release-storage")
+            original_write(path, value)
+            if (control_dir / "arm-rollover").exists() and value.get("phase") == "running":
+                lifecycle.write("rollover.commit_finished")
+
+        control_module.atomic_write_json = gated_rollover
+    if args.scenario == "legacy-cancel-idle":
+        from iac_code.a2a.pipeline_stream import PipelineA2AEventPublisher
+
+        # Park publication after the first delta so the stream driver waits for
+        # its next pull. This is the cancellation boundary that leaked activity.
+        os.environ["IAC_CODE_A2A_EXTREME_PERFORMANCE"] = "0"
+        original_publish = PipelineA2AEventPublisher.publish
+
+        async def gated_publish(self: Any, event: Any, **kwargs: Any) -> Any:
+            result = await original_publish(self, event, **kwargs)
+            if pipeline_executor_module._text_delta_output(event) == "LEGACY_CANCEL_FIRST_TOKEN":
+                lifecycle.write("publication.blocked")
+                await _wait_for_marker(control_dir, "release-publication")
+            return result
+
+        PipelineA2AEventPublisher.publish = gated_publish
+
+    def idle_shutdown() -> None:
+        lifecycle.write("idle.shutdown")
+        server.should_exit = True
+
+    app = create_app(
+        host=args.host,
+        port=args.port,
+        token=TOKEN,
+        model="execution-control-fixture",
+        persistence_dir=args.persistence_dir.expanduser().resolve(),
+        artifact_dir=args.artifact_dir.expanduser().resolve(),
+        auto_approve_permissions=False,
+        idle_shutdown_seconds=1.0 if args.scenario == "legacy-cancel-idle" else 0,
+        idle_shutdown_callback=idle_shutdown,
+    )
+    server = uvicorn.Server(uvicorn.Config(app, host=args.host, port=args.port, log_level="warning"))
+    server.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
+++ b/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
@@ -1,0 +1,1388 @@
+#!/usr/bin/env python3
+"""Drive deterministic A2A execution-control scenarios through public endpoints."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+import traceback
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+TOKEN = "execution-control-e2e-token"
+STACK_ID = "stack-execution-control-e2e-0001"
+STACK_INSTANCES_OPERATION_ID = "stack-instances-operation-e2e-0001"
+SCENARIO_MODES = {
+    "warm-resume-pausing": ("normal", "pipeline"),
+    "warm-resume-paused": ("normal", "pipeline"),
+    "disconnect-timeout-after-operation-id": ("normal", "pipeline"),
+    "disconnect-timeout-inflight-sync-call": ("pipeline",),
+    "disconnect-timeout-backup-blocked": ("pipeline",),
+    "natural-completion-while-pausing": ("normal",),
+    "slow-termination-storage": ("normal",),
+    "terminate-during-bootstrap": ("normal", "pipeline"),
+    "terminate-during-bootstrap-disconnected": ("normal", "pipeline"),
+    "disconnect-timeout-during-turn-backup": ("normal",),
+    "legacy-cancel-idle": ("pipeline",),
+    "slow-rollover-storage": ("normal",),
+    "stack-instances-timeout-after-operation-id": ("normal",),
+    "stack-instances-terminate-inflight": ("normal",),
+    "recovery-during-normal-rollover": ("normal",),
+}
+REGRESSION_SCENARIOS = {
+    "slow-termination-storage",
+    "terminate-during-bootstrap",
+    "terminate-during-bootstrap-disconnected",
+    "disconnect-timeout-during-turn-backup",
+    "legacy-cancel-idle",
+    "slow-rollover-storage",
+    "recovery-during-normal-rollover",
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--scenario", choices=tuple(SCENARIO_MODES), action="append", required=True)
+    parser.add_argument("--mode", choices=("normal", "pipeline"), required=True)
+    parser.add_argument("--timeout", type=float, default=25.0)
+    parser.add_argument("--overall-timeout", type=float, default=35.0)
+    return parser.parse_args()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _headers(*, json_body: bool = False) -> dict[str, str]:
+    result = {"Authorization": "Bearer {}".format(TOKEN), "A2A-Version": "1.0"}
+    if json_body:
+        result["Content-Type"] = "application/json"
+    return result
+
+
+def _decode_line(line: bytes) -> dict[str, Any] | None:
+    text = line.decode("utf-8", errors="replace").strip()
+    if text.startswith("data:"):
+        text = text[5:].strip()
+    if not text:
+        return None
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _walk(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _first(events: list[dict[str, Any]], key: str) -> str | None:
+    for event in events:
+        for item in _walk(event):
+            value = item.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _all_strings(value: Any) -> list[str]:
+    result: list[str] = []
+    if isinstance(value, str):
+        result.append(value)
+    elif isinstance(value, dict):
+        for child in value.values():
+            result.extend(_all_strings(child))
+    elif isinstance(value, list):
+        for child in value:
+            result.extend(_all_strings(child))
+    return result
+
+
+def _atomic_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name("{}.{}.tmp".format(path.name, uuid.uuid4().hex))
+    temporary.write_text(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _append_jsonl(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(value, ensure_ascii=False, sort_keys=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _write_marker(control_dir: Path, name: str) -> None:
+    _atomic_json(control_dir / name, {"createdAt": time.time(), "name": name})
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            records.append(value)
+    return records
+
+
+def _wait_until(predicate: Callable[[], Any], *, timeout: float, description: str) -> Any:
+    deadline = time.monotonic() + timeout
+    last_error: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            value = predicate()
+            if value:
+                return value
+        except BaseException as exc:
+            last_error = exc
+        time.sleep(0.02)
+    if last_error is not None:
+        raise TimeoutError("timed out waiting for {}: {}".format(description, last_error)) from last_error
+    raise TimeoutError("timed out waiting for {}".format(description))
+
+
+class _BackgroundStream:
+    def __init__(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+        name: str,
+        artifact_path: Path,
+    ) -> None:
+        self._url = url
+        self._payload = payload
+        self._timeout = timeout
+        self.name = name
+        self.artifact_path = artifact_path
+        self._response: Any = None
+        self._closed = False
+        self.events: list[dict[str, Any]] = []
+        self.error: BaseException | None = None
+        self.done = threading.Event()
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, name="execution-control-{}-stream".format(name), daemon=True)
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.touch()
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return list(self.events)
+
+    def close(self) -> None:
+        self._closed = True
+        response = self._response
+        if response is not None:
+            raw = getattr(getattr(response, "fp", None), "raw", None)
+            stream_socket = getattr(raw, "_sock", None)
+            if stream_socket is not None:
+                try:
+                    stream_socket.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                stream_socket.close()
+        self._thread.join(timeout=2.0)
+
+    def join(self, timeout: float) -> None:
+        self._thread.join(timeout)
+        if self._thread.is_alive():
+            raise TimeoutError("A2A stream did not finish")
+        if self.error is not None and not self._closed:
+            raise RuntimeError("A2A stream failed: {}".format(self.error)) from self.error
+
+    def _run(self) -> None:
+        request = Request(
+            self._url.rstrip("/") + "/",
+            data=json.dumps(self._payload, ensure_ascii=False).encode("utf-8"),
+            headers=_headers(json_body=True),
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self._timeout) as response:
+                self._response = response
+                for line in response:
+                    event = _decode_line(line)
+                    if event is not None:
+                        with self._lock:
+                            self.events.append(event)
+                        _append_jsonl(self.artifact_path, event)
+        except BaseException as exc:
+            if not self._closed:
+                self.error = exc
+                _append_jsonl(self.artifact_path, {"streamError": "{}: {}".format(type(exc).__name__, exc)})
+        finally:
+            self._response = None
+            self.done.set()
+
+
+class _FixtureServer:
+    def __init__(self, *, repo_root: Path, run_dir: Path, scenario: str, mode: str, timeout: float) -> None:
+        self._run_dir = run_dir
+        self._timeout = timeout
+        self.port = _free_port()
+        self.url = "http://127.0.0.1:{}".format(self.port)
+        self._log_handle = (run_dir / "server.log").open("w", encoding="utf-8")
+        self._started_at = time.time()
+        self._stopped_at: float | None = None
+        self._forced_kill = False
+        self._stop_lock = threading.Lock()
+        fixture = Path(__file__).with_name("execution_control_fixture_server.py")
+        command = [
+            sys.executable,
+            str(fixture),
+            "--port",
+            str(self.port),
+            "--run-dir",
+            str(run_dir),
+            "--config-dir",
+            str(run_dir / "config"),
+            "--persistence-dir",
+            str(run_dir / "persistence"),
+            "--artifact-dir",
+            str(run_dir / "artifacts"),
+            "--workspace",
+            str(run_dir / "workspace"),
+            "--staging-dir",
+            str(run_dir / "staging"),
+            "--backup-dir",
+            str(run_dir / "shared-backup"),
+            "--scenario",
+            scenario,
+            "--mode",
+            mode,
+        ]
+        environment = os.environ.copy()
+        source_path = str(repo_root / "src")
+        environment["PYTHONPATH"] = source_path + os.pathsep + environment.get("PYTHONPATH", "")
+        self._process = subprocess.Popen(
+            command,
+            cwd=repo_root,
+            env=environment,
+            stdout=self._log_handle,
+            stderr=subprocess.STDOUT,
+        )
+
+    def wait_ready(self) -> None:
+        def healthy() -> bool:
+            if self._process.poll() is not None:
+                raise RuntimeError("fixture server exited with {}".format(self._process.returncode))
+            try:
+                status, body = _http_json("GET", self.url + "/health", timeout=0.5)
+            except (URLError, TimeoutError):
+                return False
+            return status == 200 and body.get("status") == "healthy"
+
+        _wait_until(healthy, timeout=self._timeout, description="fixture server health")
+
+    def assert_running(self) -> None:
+        return_code = self._process.poll()
+        if return_code is not None:
+            raise RuntimeError("fixture server exited with {}".format(return_code))
+
+    def wait_for_idle_exit(self) -> None:
+        assert self._process.wait(timeout=min(self._timeout, 5.0)) == 0
+
+    def stop(self) -> None:
+        with self._stop_lock:
+            if self._stopped_at is not None:
+                return
+            for marker in (
+                "release-tool",
+                "release-provider",
+                "release-sdk",
+                "cloud-complete",
+                "allow-shared",
+                "release-bootstrap",
+                "release-bootstrap-cleanup",
+                "release-turn-backup",
+                "release-storage",
+                "release-background",
+                "release-publication",
+                "release-recovery",
+            ):
+                _write_marker(self._run_dir / "control", marker)
+            if self._process.poll() is None:
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=3.0)
+                except subprocess.TimeoutExpired:
+                    self._forced_kill = True
+                    self._process.kill()
+                    self._process.wait(timeout=5.0)
+            self._stopped_at = time.time()
+            self._log_handle.close()
+            _atomic_json(self._run_dir / "server-lifecycle.json", self.lifecycle())
+
+    def lifecycle(self) -> dict[str, Any]:
+        return {
+            "pid": self._process.pid,
+            "startedAt": self._started_at,
+            "stoppedAt": self._stopped_at,
+            "returnCode": self._process.poll(),
+            "forcedKill": self._forced_kill,
+        }
+
+
+def _http_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: float = 2.0,
+) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8") if payload is not None else None
+    request = Request(url, data=data, headers=_headers(json_body=payload is not None), method=method)
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            value = json.loads(body) if body else {}
+            return int(response.status), value if isinstance(value, dict) else {"value": value}
+    except HTTPError as exc:
+        body = exc.read()
+        try:
+            value = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            value = {"error": body.decode("utf-8", errors="replace")}
+        return int(exc.code), value if isinstance(value, dict) else {"value": value}
+
+
+def _message_payload(workspace: Path) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": "SendStreamingMessage",
+        "params": {
+            "message": {
+                "messageId": str(uuid.uuid4()),
+                "role": "ROLE_USER",
+                "parts": [{"text": "Run the deterministic execution-control fixture."}],
+                "metadata": {"iac_code": {"cwd": str(workspace)}},
+            },
+            "configuration": {"acceptedOutputModes": ["text/plain"]},
+        },
+    }
+
+
+def _subscribe_payload(task_id: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": "SubscribeToTask",
+        "params": {"id": task_id},
+    }
+
+
+class _Scenario:
+    def __init__(self, *, run_dir: Path, server: _FixtureServer, scenario: str, mode: str, timeout: float) -> None:
+        self.run_dir = run_dir
+        self.server = server
+        self.scenario = scenario
+        self.mode = mode
+        self.timeout = timeout
+        self.control_dir = run_dir / "control"
+        self.workspace = run_dir / "workspace"
+        self.timeline: list[dict[str, Any]] = []
+        self.controls: list[dict[str, Any]] = []
+        self.task_id = ""
+        self.context_id = ""
+        self.execution_id = ""
+        self.server_instance_id = ""
+        self.pause_id = ""
+        self.streams: list[_BackgroundStream] = []
+        self._subscription_count = 0
+
+    def run(self) -> dict[str, Any]:
+        self._verify_agent_card()
+        if self.scenario in REGRESSION_SCENARIOS:
+            self._run_regression()
+            self._verify_state_timeline()
+            return self._summary("passed")
+        initial = self._stream(
+            _message_payload(self.workspace),
+            name="initial",
+        )
+        initial.start()
+        boundary = (
+            "provider.awaiting_message_end" if self.scenario == "natural-completion-while-pausing" else "tool.started"
+        )
+        self._wait_log_event(
+            self.run_dir / ("provider-lifecycle.jsonl" if boundary.startswith("provider") else "tool-lifecycle.jsonl"),
+            boundary,
+        )
+        self.context_id = str(
+            _wait_until(lambda: _first(initial.snapshot(), "contextId"), timeout=self.timeout, description="context id")
+        )
+        state = self._state()
+        self.task_id = str(state["taskId"])
+        self.execution_id = str(state["executionId"])
+        self.server_instance_id = str(state["serverInstanceId"])
+        self._assert_task_not_input_required()
+        initial.close()
+
+        dispatch = {
+            "warm-resume-pausing": self._warm_resume_pausing,
+            "warm-resume-paused": self._warm_resume_paused,
+            "disconnect-timeout-after-operation-id": self._timeout_after_operation,
+            "disconnect-timeout-inflight-sync-call": self._timeout_inflight_sync,
+            "disconnect-timeout-backup-blocked": self._timeout_backup_blocked,
+            "natural-completion-while-pausing": self._natural_completion,
+            "stack-instances-timeout-after-operation-id": self._stack_instances_termination,
+            "stack-instances-terminate-inflight": self._stack_instances_termination,
+        }
+        dispatch[self.scenario]()
+        self._verify_state_timeline()
+        return self._summary("passed")
+
+    def _run_regression(self) -> None:
+        initial = self._stream(_message_payload(self.workspace), name="initial")
+        initial.start()
+        boundary = {
+            "slow-termination-storage": "permission.requested",
+            "slow-rollover-storage": "provider.completed",
+            "terminate-during-bootstrap": "bootstrap.started",
+            "terminate-during-bootstrap-disconnected": "bootstrap.started",
+            "disconnect-timeout-during-turn-backup": "turn-backup.started",
+            "legacy-cancel-idle": "publication.blocked",
+            "recovery-during-normal-rollover": "provider.completed",
+        }[self.scenario]
+        self._wait_log_event(
+            self.run_dir
+            / (
+                "tool-lifecycle.jsonl"
+                if boundary.startswith("permission")
+                else "provider-lifecycle.jsonl"
+                if boundary.startswith("provider")
+                else "fixture-lifecycle.jsonl"
+            ),
+            boundary,
+        )
+        self.context_id = str(
+            _wait_until(
+                lambda: _first(initial.snapshot(), "contextId"),
+                timeout=self.timeout,
+                description="primary context id",
+            )
+        )
+        state = self._state()
+        self.task_id, self.execution_id = str(state["taskId"]), str(state["executionId"])
+        self.server_instance_id = str(state["serverInstanceId"])
+        if self.scenario.startswith("terminate-during-bootstrap"):
+            if self.scenario.endswith("-disconnected"):
+                initial.close()
+            self._terminate_during_bootstrap()
+            initial.join(min(self.timeout, 3.0))
+        elif self.scenario == "disconnect-timeout-during-turn-backup":
+            self._terminate_during_turn_backup(initial)
+        elif self.scenario == "legacy-cancel-idle":
+            self._legacy_cancel_idle(initial)
+        else:
+            initial.join(self.timeout)
+            self._wait_state(lambda value: not value["streamAvailable"], "first normal turn finished")
+            assert "input_required" in str(self._task()["result"]["status"]["state"]).lower()
+            if self.scenario == "slow-termination-storage":
+                self._slow_termination_storage()
+            elif self.scenario == "recovery-during-normal-rollover":
+                self._recovery_during_rollover()
+            else:
+                self._slow_rollover_storage()
+
+    def _explicit_terminate(self) -> None:
+        self._control(
+            "/iac-code/execution/terminate",
+            {
+                "contextId": self.context_id,
+                "expectedExecutionId": self.execution_id,
+                "requestId": "explicit-termination",
+                "connectionEpoch": 1,
+                "reason": "explicit_terminate",
+            },
+        )
+
+    def _assert_other_context_progress(self) -> None:
+        assert not (self.control_dir / "release-storage").exists()
+        status, health = _http_json("GET", self.server.url + "/health", timeout=1.0)
+        assert status == 200 and health.get("status") == "healthy"
+        primary = self._state()
+        _write_marker(self.control_dir, "other-context")
+        other = self._stream(_message_payload(self.workspace), name="other-context")
+        started = time.monotonic()
+        other.start()
+        other.join(min(self.timeout, 2.0))
+        other_context = _first(other.snapshot(), "contextId")
+        assert other_context and other_context != self.context_id
+        assert "ISOLATION_FIXTURE_FINAL" in json.dumps(other.snapshot())
+        status, other_state = _http_json(
+            "GET",
+            self.server.url + "/iac-code/execution/state?" + urlencode({"contextId": other_context}),
+            timeout=1.0,
+        )
+        assert status == 200 and other_state["phase"] == "running"
+        assert not (self.control_dir / "release-storage").exists()
+        lifecycle = _read_jsonl(self.run_dir / "fixture-lifecycle.jsonl")
+        assert not any(value["event"].endswith("commit_finished") for value in lifecycle)
+        _atomic_json(
+            self.run_dir / "isolation-audit.json",
+            {
+                "primaryContextId": self.context_id,
+                "otherContextId": other_context,
+                "primaryPhase": primary["phase"],
+                "otherCompletedBeforeStorageRelease": True,
+                "otherElapsedSeconds": time.monotonic() - started,
+            },
+        )
+
+    def _slow_termination_storage(self) -> None:
+        _atomic_json(self.control_dir / "arm-termination-storage", {"contextId": self.context_id})
+        self._explicit_terminate()
+        write = self._wait_log_event(self.run_dir / "fixture-lifecycle.jsonl", "termination.commit_started")
+        assert write["onEventLoop"] is False
+        state = self._state()
+        assert state["phase"] == "terminating" and not state["releaseReady"]
+        self._assert_other_context_progress()
+        _write_marker(self.control_dir, "release-storage")
+        terminal = self._wait_state(lambda value: value["releaseReady"], "slow termination committed")
+        self._assert_shared_backup(terminal, None, require_reason=False)
+        self._assert_task_canceled(require_reason=False)
+        assert not any(value["event"] == "tool.started" for value in self._tool_events())
+
+    def _terminate_during_bootstrap(self) -> None:
+        self._explicit_terminate()
+        for boundary, marker in (
+            ("bootstrap.started", "release-bootstrap"),
+            ("bootstrap.cleanup_started", "release-bootstrap-cleanup"),
+        ):
+            self._wait_log_event(self.run_dir / "fixture-lifecycle.jsonl", boundary)
+            state = self._state()
+            assert state["phase"] == "terminating" and not state["releaseReady"]
+            assert state["backup"]["status"] != "disabled"
+            assert not (self.control_dir / marker).exists()
+            _write_marker(self.control_dir, marker)
+        self._wait_log_event(self.run_dir / "fixture-lifecycle.jsonl", "bootstrap.closed")
+        local = self._wait_state(lambda value: value["phase"] == "terminated", "bootstrap local termination")
+        assert not local["releaseReady"] and local["backup"]["status"] != "disabled"
+        _write_marker(self.control_dir, "allow-shared")
+        terminal = self._wait_state(lambda value: value["releaseReady"], "bootstrap shared backup")
+        self._assert_shared_backup(terminal, None, require_reason=False)
+        self._assert_task_canceled(require_reason=False)
+        snapshots = list((self.run_dir / "shared-backup").rglob("a2a/task.json"))
+        assert len(snapshots) == 1
+        assert json.loads(snapshots[0].read_text(encoding="utf-8"))["state"] == "canceled"
+        assert not self._provider_calls(), "bootstrap cancellation must not start an LLM request"
+
+    def _terminate_during_turn_backup(self, initial: _BackgroundStream) -> None:
+        assert "ISOLATION_FIXTURE_FINAL" in json.dumps(initial.snapshot())
+        initial.close()
+        self._pause(epoch=1, request_id="pause-turn-backup", timeout=1.0)
+        state = self._wait_state(lambda value: value["phase"] == "terminating", "timeout during normal turn backup")
+        assert not state["releaseReady"]
+        status, health = _http_json("GET", self.server.url + "/health", timeout=1.0)
+        assert status == 200 and health.get("status") == "healthy"
+        _write_marker(self.control_dir, "release-turn-backup")
+        terminal = self._wait_state(lambda value: value["releaseReady"], "completed turn final backup")
+        assert terminal["executionStatus"] == "input-required"
+        assert "input_required" in str(self._task()["result"]["status"]["state"]).lower()
+        self._assert_shared_backup(terminal, None)
+        snapshot = next((self.run_dir / "shared-backup").rglob("a2a/task.json"))
+        assert json.loads(snapshot.read_text(encoding="utf-8"))["state"] == "input-required"
+        recovery = self._capture_recovery("completed-turn")
+        assert recovery["outputText"] == ["ISOLATION_FIXTURE_FINAL"]
+        assert json.dumps(recovery["messages"]).count("ISOLATION_FIXTURE_FINAL") == 1
+        assert len(self._provider_calls()) == 1
+
+    def _legacy_cancel_idle(self, initial: _BackgroundStream) -> None:
+        _wait_until(
+            lambda: "LEGACY_CANCEL_FIRST_TOKEN" in json.dumps(initial.snapshot()),
+            timeout=self.timeout,
+            description="first pipeline text received before legacy cancel",
+        )
+        payload = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": "CancelTask", "params": {"id": self.task_id}}
+        _append_jsonl(self.run_dir / "requests.jsonl", {"name": "legacy-cancel", "payload": payload, "at": time.time()})
+        status, result = _http_json("POST", self.server.url + "/", payload)
+        assert status == 200 and "result" in result, result
+        assert "cancel" in str(result["result"]["status"]["state"]).lower()
+        initial.join(self.timeout)
+        self._wait_log_event(self.run_dir / "provider-lifecycle.jsonl", "provider.closed")
+        assert not self.controls, "legacy compatibility must not call execution control commands"
+        self.server.wait_for_idle_exit()
+        assert "a2a_execution_activity_ids" not in (self.run_dir / "server.log").read_text(encoding="utf-8")
+        assert any(value["event"] == "idle.shutdown" for value in _read_jsonl(self.run_dir / "fixture-lifecycle.jsonl"))
+        assert not (self.control_dir / "release-publication").exists()
+        _atomic_json(self.run_dir / "task-final.json", result)
+
+    def _slow_rollover_storage(self) -> None:
+        self._wait_log_event(self.run_dir / "provider-lifecycle.jsonl", "background.started")
+        before = self._state()
+        _atomic_json(self.run_dir / "execution-state-before-rollover.json", self.timeline)
+        self.timeline = []
+        _write_marker(self.control_dir, "arm-rollover")
+        payload = _message_payload(self.workspace)
+        payload["params"]["message"]["contextId"] = self.context_id
+        second = self._stream(payload, name="second-turn")
+        second.start()
+        self._wait_log_event(self.run_dir / "fixture-lifecycle.jsonl", "rollover.commit_started")
+        state = self._state()
+        assert state["executionId"] != before["executionId"]
+        self.task_id, self.execution_id = str(state["taskId"]), str(state["executionId"])
+        assert not second.done.is_set()
+        self._assert_other_context_progress()
+        assert not any(value["event"] == "background.finished" for value in self._provider_events())
+        _write_marker(self.control_dir, "release-storage")
+        second.join(self.timeout)
+        assert "ISOLATION_FIXTURE_FINAL" in json.dumps(second.snapshot())
+        self._wait_state(lambda value: not value["streamAvailable"], "second normal turn finished")
+        assert not self.controls, "normal rollover must not call execution control commands"
+        _write_marker(self.control_dir, "release-background")
+
+    def _recovery_during_rollover(self) -> None:
+        self._wait_log_event(self.run_dir / "provider-lifecycle.jsonl", "background.started")
+        old_execution_id, old_task_id = self.execution_id, self.task_id
+        query = urlencode({"contextId": self.context_id, "executionId": old_execution_id})
+        _atomic_json(self.run_dir / "execution-state-before-rollover.json", self.timeline)
+        _write_marker(self.control_dir, "arm-recovery")
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            recovery_request = pool.submit(
+                _http_json,
+                "GET",
+                self.server.url + "/iac-code/session/recovery?" + query,
+                timeout=self.timeout,
+            )
+            try:
+                self._wait_log_event(self.run_dir / "fixture-lifecycle.jsonl", "recovery.read_started")
+                assert not recovery_request.done()
+                payload = _message_payload(self.workspace)
+                payload["params"]["message"]["contextId"] = self.context_id
+                second = self._stream(payload, name="second-turn")
+                second.start()
+                second.join(self.timeout)
+                assert "RECOVERY_ROLLOVER_TURN_2" in json.dumps(second.snapshot())
+                rollover = self._wait_log_event(self.run_dir / "fixture-lifecycle.jsonl", "recovery.rollover_completed")
+                assert rollover["oldExecutionId"] == old_execution_id
+                self.timeline = []
+                state = self._state()
+                self.execution_id, self.task_id = str(state["executionId"]), str(state["taskId"])
+                assert self.execution_id == rollover["executionId"] != old_execution_id
+                assert self.task_id == rollover["taskId"] != old_task_id
+                assert not recovery_request.done()
+                assert not any(value["event"] == "background.finished" for value in self._provider_events())
+                _write_marker(self.control_dir, "release-recovery")
+                status, response = recovery_request.result(timeout=min(self.timeout, 3.0))
+                _atomic_json(self.run_dir / "recovery-conflict.json", {"status": status, "response": response})
+                assert status == 409, response
+            finally:
+                _write_marker(self.control_dir, "release-recovery")
+        self._wait_state(lambda value: not value["streamAvailable"], "new turn finished after recovery conflict")
+        recovery = self._capture_recovery("after-rollover")
+        assert recovery["executionId"] == recovery["executionControl"]["executionId"] == self.execution_id
+        assert recovery["taskId"] == recovery["task"]["id"] == recovery["executionControl"]["taskId"] == self.task_id
+        assert recovery["outputText"] == ["RECOVERY_ROLLOVER_TURN_2"]
+        transcript = json.dumps(recovery["messages"])
+        assert transcript.count("RECOVERY_ROLLOVER_TURN_1") == 1
+        assert transcript.count("RECOVERY_ROLLOVER_TURN_2") == 1
+
+        def new_turn_shared() -> bool:
+            return any(
+                value.get("task_id") == self.task_id and value.get("state") == "input-required"
+                for path in (self.run_dir / "shared-backup").rglob("a2a/task.json")
+                if isinstance(value := json.loads(path.read_text(encoding="utf-8")), dict)
+            )
+
+        _wait_until(new_turn_shared, timeout=self.timeout, description="new turn shared backup")
+        assert len(self._provider_calls()) == 2
+        assert not self.controls, "recovery rollover must use normal A2A requests"
+        _write_marker(self.control_dir, "release-background")
+        self._wait_log_event(self.run_dir / "provider-lifecycle.jsonl", "background.finished")
+
+    def _provider_events(self) -> list[dict[str, Any]]:
+        return _read_jsonl(self.run_dir / "provider-lifecycle.jsonl")
+
+    def _verify_agent_card(self) -> None:
+        status, card = _http_json("GET", self.server.url + "/.well-known/agent-card.json")
+        assert status == 200, card
+        serialized = json.dumps(card, sort_keys=True)
+        for value in (
+            "urn:iac-code:a2a:execution-control:v1",
+            "/iac-code/execution/pause",
+            "/iac-code/execution/state",
+            "/iac-code/execution/resume",
+            "/iac-code/execution/terminate",
+            "/iac-code/session/recovery",
+        ):
+            assert value in serialized, "agent card is missing {}".format(value)
+        _atomic_json(self.run_dir / "agent-card.json", card)
+
+    def _state(self) -> dict[str, Any]:
+        self.server.assert_running()
+        query = urlencode({"contextId": self.context_id})
+        status, state = _http_json("GET", self.server.url + "/iac-code/execution/state?" + query)
+        assert status == 200, state
+        self.timeline.append({"observedAt": time.time(), **state})
+        _atomic_json(self.run_dir / "execution-state-timeline.json", self.timeline)
+        return state
+
+    def _wait_state(self, predicate: Callable[[dict[str, Any]], bool], description: str) -> dict[str, Any]:
+        return _wait_until(
+            lambda: state if predicate(state := self._state()) else None,
+            timeout=self.timeout,
+            description=description,
+        )
+
+    def _control(self, endpoint: str, payload: dict[str, Any], expected: set[int] = {200, 202}) -> dict[str, Any]:
+        started = time.monotonic()
+        status, body = _http_json("POST", self.server.url + endpoint, payload, timeout=2.0)
+        elapsed = time.monotonic() - started
+        record = {
+            "endpoint": endpoint,
+            "payload": payload,
+            "status": status,
+            "elapsedSeconds": elapsed,
+            "response": body,
+        }
+        self.controls.append(record)
+        _atomic_json(self.run_dir / "control-requests.json", self.controls)
+        assert elapsed < 2.0, "{} waited {:.3f}s".format(endpoint, elapsed)
+        assert status in expected, record
+        return body
+
+    def _pause(self, *, epoch: int, request_id: str, timeout: float) -> dict[str, Any]:
+        payload = {
+            "contextId": self.context_id,
+            "taskId": self.task_id,
+            "expectedExecutionId": self.execution_id,
+            "requestId": request_id,
+            "connectionEpoch": epoch,
+            "reason": "client_disconnected",
+            "reconnectTimeoutSeconds": timeout,
+        }
+        response = self._control("/iac-code/execution/pause", payload)
+        duplicate = self._control("/iac-code/execution/pause", payload)
+        self._assert_same_operation(response, duplicate)
+        self.pause_id = str(response["pauseId"])
+        self._assert_task_not_input_required()
+        before = self._state()
+        stale_payload = {**payload, "requestId": "{}-stale".format(request_id), "connectionEpoch": epoch - 1}
+        self._control("/iac-code/execution/pause", stale_payload, expected={409})
+        after = self._state()
+        assert (after["revision"], after["phase"]) == (before["revision"], before["phase"])
+        return response
+
+    def _resume(self, *, epoch: int, request_id: str) -> dict[str, Any]:
+        payload = {
+            "contextId": self.context_id,
+            "executionId": self.execution_id,
+            "pauseId": self.pause_id,
+            "requestId": request_id,
+            "connectionEpoch": epoch,
+        }
+        response = self._control(
+            "/iac-code/execution/resume",
+            payload,
+        )
+        duplicate = self._control("/iac-code/execution/resume", payload)
+        self._assert_same_operation(response, duplicate)
+        return response
+
+    def _terminate(self, *, epoch: int, request_id: str) -> dict[str, Any]:
+        payload = {
+            "contextId": self.context_id,
+            "expectedExecutionId": self.execution_id,
+            "pauseId": self.pause_id,
+            "requestId": request_id,
+            "connectionEpoch": epoch,
+            "reason": "disconnect_timeout",
+        }
+        response = self._control(
+            "/iac-code/execution/terminate",
+            payload,
+        )
+        duplicate = self._control("/iac-code/execution/terminate", payload)
+        self._assert_same_operation(response, duplicate)
+        return response
+
+    def _subscribe(self) -> _BackgroundStream:
+        self._subscription_count += 1
+        stream = self._stream(
+            _subscribe_payload(self.task_id),
+            name="subscribe-{}".format(self._subscription_count),
+        )
+        stream.start()
+        return stream
+
+    def _stream(self, payload: dict[str, Any], *, name: str) -> _BackgroundStream:
+        _append_jsonl(self.run_dir / "requests.jsonl", {"name": name, "payload": payload, "at": time.time()})
+        stream = _BackgroundStream(
+            self.server.url,
+            payload,
+            timeout=max(self.timeout, 60.0),
+            name=name,
+            artifact_path=self.run_dir / "{}.events.jsonl".format(name),
+        )
+        self.streams.append(stream)
+        return stream
+
+    def close_streams(self) -> None:
+        errors: list[str] = []
+        for stream in self.streams:
+            try:
+                stream.close()
+            except BaseException as exc:
+                errors.append("{}: {}".format(stream.name, exc))
+        if errors:
+            raise RuntimeError("stream cleanup failed: {}".format("; ".join(errors)))
+
+    def write_audits(self) -> None:
+        _atomic_json(self.run_dir / "execution-state-timeline.json", self.timeline)
+        _atomic_json(self.run_dir / "control-requests.json", self.controls)
+        for path in (
+            self.run_dir / "requests.jsonl",
+            self.run_dir / "provider-lifecycle.jsonl",
+            self.run_dir / "tool-lifecycle.jsonl",
+        ):
+            path.touch(exist_ok=True)
+        _atomic_json(
+            self.run_dir / "stream-summaries.json",
+            [
+                {
+                    "name": stream.name,
+                    "artifact": stream.artifact_path.name,
+                    "eventCount": len(stream.snapshot()),
+                    "done": stream.done.is_set(),
+                    "error": None
+                    if stream.error is None
+                    else "{}: {}".format(type(stream.error).__name__, stream.error),
+                }
+                for stream in self.streams
+            ],
+        )
+        observations = [
+            {
+                "observedAt": state.get("observedAt"),
+                "phase": state.get("phase"),
+                "releaseReady": state.get("releaseReady"),
+                "backup": state.get("backup"),
+            }
+            for state in self.timeline
+        ]
+        shared_root = self.run_dir / "shared-backup"
+        shared_files = sorted(str(path.relative_to(shared_root)) for path in shared_root.rglob("*") if path.is_file())
+        _atomic_json(
+            self.run_dir / "backup-audit.json",
+            {
+                "observations": observations,
+                "final": observations[-1] if observations else None,
+                "sharedFiles": shared_files,
+            },
+        )
+
+    def _warm_resume_pausing(self) -> None:
+        pause = self._pause(epoch=1, request_id="pause-pausing", timeout=4.0)
+        assert pause["phase"] == "pausing" and pause["pauseComplete"] is False
+        assert any(blocker.get("kind") == "tool" for blocker in pause.get("blockers", []))
+        subscription = self._subscribe()
+        self._resume(epoch=2, request_id="resume-pausing")
+        self._wait_state(lambda value: value["phase"] == "running", "running after pausing resume")
+        time.sleep(4.25)
+        assert self._state()["phase"] == "running"
+        _write_marker(self.control_dir, "release-tool")
+        subscription.join(self.timeout)
+        self._assert_normal_completion(subscription.snapshot())
+
+    def _warm_resume_paused(self) -> None:
+        self._pause(epoch=1, request_id="pause-until-paused", timeout=10.0)
+        _write_marker(self.control_dir, "release-tool")
+        paused = self._wait_state(
+            lambda value: value["phase"] == "paused" and value["pauseComplete"] is True,
+            "fully paused execution",
+        )
+        assert not paused.get("blockers")
+        calls_before = len(self._provider_calls())
+        time.sleep(0.5)
+        assert len(self._provider_calls()) == calls_before
+        paused_recovery = self._capture_recovery("paused")
+        assert "DURABLE_FIXTURE_RESULT" in json.dumps(paused_recovery, ensure_ascii=False)
+        subscription = self._subscribe()
+        self._resume(epoch=2, request_id="resume-paused")
+        self._wait_state(lambda value: value["phase"] == "running", "running after paused resume")
+        subscription.join(self.timeout)
+        self._assert_normal_completion(subscription.snapshot())
+
+    def _timeout_after_operation(self) -> None:
+        self._wait_log_event(self.run_dir / "tool-lifecycle.jsonl", "polling.started")
+        self._pause(epoch=1, request_id="pause-operation", timeout=1.0)
+        terminal = self._wait_state(
+            lambda value: (
+                value.get("terminationReason") == "disconnect_timeout"
+                and value["phase"] == "terminated"
+                and value.get("releaseReady") is True
+            ),
+            "deadline termination and shared backup",
+        )
+        self._assert_shared_backup(terminal, STACK_ID)
+        self._assert_task_canceled()
+        assert not (self.control_dir / "cloud-complete").exists()
+        assert len([v for v in self._tool_events() if v.get("event") == "sdk.started"]) == 1
+        assert len([v for v in self._tool_events() if v.get("event") == "sdk.returned"]) == 1
+        assert len([v for v in self._tool_events() if v.get("event") == "polling.cancelled"]) == 1
+        operation_files = list((self.run_dir / "shared-backup").rglob("external-operations.json"))
+        assert len(operation_files) == 1
+        assert (
+            json.loads(operation_files[0].read_text(encoding="utf-8"))["operations"] == terminal["externalOperations"]
+        )
+        assert len(self._provider_calls()) == 1
+
+    def _stack_instances_termination(self) -> None:
+        inflight = self.scenario == "stack-instances-terminate-inflight"
+        boundary = "sdk.started" if inflight else "polling.started"
+        self._wait_log_event(self.run_dir / "tool-lifecycle.jsonl", boundary)
+        if inflight:
+            self._explicit_terminate()
+            draining = self._wait_state(lambda value: value["phase"] == "terminating", "stack instances SDK draining")
+            assert not draining["releaseReady"]
+            assert not draining["externalOperations"]
+            assert not any(value["event"] == "sdk.returned" for value in self._tool_events())
+            status, health = _http_json("GET", self.server.url + "/health", timeout=1.0)
+            assert status == 200 and health.get("status") == "healthy"
+            _write_marker(self.control_dir, "release-sdk")
+        else:
+            self._pause(epoch=1, request_id="pause-stack-instances", timeout=1.0)
+        local = self._wait_state(lambda value: value["phase"] == "terminated", "stack instances local termination")
+        assert local["terminationReason"] == ("explicit_terminate" if inflight else "disconnect_timeout")
+        assert not local["releaseReady"] and local["backup"]["status"] == "pending"
+        assert not list((self.run_dir / "shared-backup").rglob("external-operations.json"))
+        assert local["externalOperations"] == [
+            {
+                "product": "ros",
+                "action": "CreateStackInstances",
+                "outcome": "accepted",
+                "resourceType": "stack-group-operation",
+                "resourceId": STACK_INSTANCES_OPERATION_ID,
+                "regionId": "cn-hangzhou",
+                "toolUseId": "fixture-long-tool-1",
+            }
+        ]
+        _write_marker(self.control_dir, "allow-shared")
+        terminal = self._wait_state(lambda value: value["releaseReady"], "stack instances shared backup")
+        self._assert_shared_backup(terminal, STACK_INSTANCES_OPERATION_ID, require_reason=not inflight)
+        self._assert_task_canceled(require_reason=not inflight)
+        operations = list((self.run_dir / "shared-backup").rglob("external-operations.json"))
+        assert len(operations) == 1
+        assert json.loads(operations[0].read_text(encoding="utf-8"))["operations"] == terminal["externalOperations"]
+        events = self._tool_events()
+        assert len([value for value in events if value["event"] == "sdk.started"]) == 1
+        assert len([value for value in events if value["event"] == "sdk.returned"]) == 1
+        assert len([value for value in events if value["event"] == "tool.cancelled"]) == 1
+        assert len([value for value in events if value["event"] == "polling.started"]) == (0 if inflight else 1)
+        assert len(self._provider_calls()) == 1
+        self._capture_recovery("terminated")
+
+    def _timeout_inflight_sync(self) -> None:
+        self._wait_log_event(self.run_dir / "tool-lifecycle.jsonl", "sdk.started")
+        self._pause(epoch=1, request_id="pause-sync", timeout=1.0)
+        draining = self._wait_state(lambda value: value["phase"] == "terminating", "sync call draining")
+        assert draining.get("releaseReady") is False
+        status, health = _http_json("GET", self.server.url + "/health", timeout=1.0)
+        assert status == 200 and health.get("status") == "healthy"
+        assert not any(operation.get("resourceId") == STACK_ID for operation in draining.get("externalOperations", []))
+        _write_marker(self.control_dir, "release-sdk")
+        terminal = self._wait_state(
+            lambda value: value["phase"] == "terminated" and value.get("releaseReady") is True,
+            "sync late-result termination",
+        )
+        self._assert_shared_backup(terminal, STACK_ID)
+        assert len([value for value in self._tool_events() if value.get("event") == "sdk.started"]) == 1
+        assert len([value for value in self._tool_events() if value.get("event") == "operation.recorded"]) == 1
+        assert len(self._provider_calls()) == 1
+
+    def _timeout_backup_blocked(self) -> None:
+        self._pause(epoch=1, request_id="pause-backup-blocked", timeout=1.0)
+        blocked = self._wait_state(
+            lambda value: (
+                value["phase"] == "terminated"
+                and value.get("backup", {}).get("status") == "blocked"
+                and value.get("releaseReady") is False
+            ),
+            "blocked shared backup",
+        )
+        generation = blocked["backup"]["generation"]
+        commit_id = blocked["backup"]["commitId"]
+        status, health = _http_json("GET", self.server.url + "/health", timeout=1.0)
+        assert status == 200 and health.get("status") == "healthy"
+        counts_before = self._counts()
+        _write_marker(self.control_dir, "allow-shared")
+        self._terminate(epoch=2, request_id="retry-backup-finalization")
+        terminal = self._wait_state(
+            lambda value: (
+                value["phase"] == "terminated"
+                and value.get("backup", {}).get("status") == "shared_committed"
+                and value.get("releaseReady") is True
+            ),
+            "shared backup retry",
+        )
+        assert terminal["backup"]["generation"] == generation
+        assert terminal["backup"]["commitId"] == commit_id
+        assert self._counts() == counts_before
+        self._assert_shared_backup(terminal, None)
+
+    def _natural_completion(self) -> None:
+        self._pause(epoch=1, request_id="pause-natural", timeout=10.0)
+        _write_marker(self.control_dir, "release-provider")
+        completed = self._wait_state(
+            lambda value: (
+                value.get("executionStatus") not in {None, "working"}
+                and value.get("executionStatus") != "canceled"
+                and value.get("streamAvailable") is False
+            ),
+            "natural completion while pausing",
+        )
+        assert completed.get("terminationReason") is None
+        subscription = self._subscribe()
+        subscription.join(min(self.timeout, 3.0))
+        recovery = self._capture_recovery("natural-completion")
+        transcript = json.dumps(recovery["messages"], ensure_ascii=False)
+        assert transcript.count("NATURAL_FIXTURE_FINAL") == 1
+        assert recovery["outputText"] == ["NATURAL_FIXTURE_FINAL"]
+        self._resume(epoch=2, request_id="resume-natural")
+        final = self._wait_state(lambda value: value["phase"] == "running", "natural completion hold release")
+        assert final.get("executionStatus") == completed.get("executionStatus")
+        assert final.get("streamAvailable") is False
+        assert len(self._provider_calls()) == 1
+
+    def _capture_recovery(self, suffix: str) -> dict[str, Any]:
+        if self.mode == "normal":
+            query = urlencode({"contextId": self.context_id, "executionId": self.execution_id})
+            status, recovery = _http_json("GET", self.server.url + "/iac-code/session/recovery?" + query)
+        else:
+            query = urlencode({"contextId": self.context_id})
+            status, recovery = _http_json("GET", self.server.url + "/iac-code/pipeline/state?" + query)
+        assert status == 200, recovery
+        _atomic_json(self.run_dir / "recovery-{}.json".format(suffix), recovery)
+        return recovery
+
+    def _assert_normal_completion(self, events: list[dict[str, Any]]) -> None:
+        assert events, "reconnected stream did not receive any events"
+        if self.mode == "pipeline":
+            task = self._wait_task_terminal()
+        else:
+            self._wait_state(
+                lambda value: (
+                    value.get("streamAvailable") is False
+                    and value.get("executionStatus") not in {None, "working", "canceled"}
+                ),
+                "completed normal turn",
+            )
+            task = self._task()
+        state = self._state()
+        assert state["phase"] == "running"
+        assert state.get("terminationReason") is None
+        assert state.get("backup", {}).get("status") == "not_requested"
+        assert state["executionId"] == self.execution_id
+        assert state["serverInstanceId"] == self.server_instance_id
+        assert len([value for value in self._tool_events() if value.get("event") == "tool.started"]) == 1
+        assert len(self._provider_calls()) == 2
+        recovery = self._capture_recovery("completed")
+        serialized = json.dumps([task, events, recovery], ensure_ascii=False)
+        if self.mode == "normal":
+            assert "EXECUTION_CONTROL_FIXTURE_FINAL" in serialized
+        else:
+            assert "completed" in serialized
+        assert "DURABLE_FIXTURE_RESULT" in serialized
+        if self.mode == "pipeline":
+            pipeline_events = self._pipeline_events()
+            sequences = [value["sequence"] for value in pipeline_events]
+            assert sequences == list(range(sequences[0], sequences[-1] + 1))
+            assert len(sequences) == len(set(sequences))
+            assert len([value for value in pipeline_events if value.get("eventType") == "step_completed"]) == 1
+            projects = self.run_dir / "config" / "projects"
+            assert list(projects.rglob("pipeline/meta.yaml"))
+            assert list(projects.rglob("pipeline/context.yaml"))
+            assert list(projects.rglob("a2a/pipeline/a2a-events.jsonl"))
+            assert list(projects.rglob("a2a/pipeline/a2a-snapshot.json"))
+
+    def _assert_task_not_input_required(self) -> None:
+        status = self._task()["result"]["status"]["state"]
+        assert "input_required" not in str(status).lower()
+
+    def _assert_task_canceled(self, *, require_reason: bool = True) -> None:
+        task = self._wait_task_terminal()
+        status = str(task["result"]["status"]["state"]).lower()
+        assert "cancel" in status, task
+        if require_reason:
+            assert "disconnect_timeout" in json.dumps(task, ensure_ascii=False)
+        if self.mode == "pipeline":
+            assert not any(value.get("eventType") == "pipeline_handoff_ready" for value in self._pipeline_events())
+
+    def _task(self) -> dict[str, Any]:
+        status, body = _http_json(
+            "POST",
+            self.server.url + "/",
+            {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": "GetTask", "params": {"id": self.task_id}},
+        )
+        assert status == 200 and "result" in body, body
+        return body
+
+    def _wait_task_terminal(self) -> dict[str, Any]:
+        def terminal() -> dict[str, Any] | None:
+            task = self._task()
+            state = str(task["result"]["status"]["state"]).lower()
+            return task if any(value in state for value in ("completed", "failed", "canceled", "cancelled")) else None
+
+        task = _wait_until(terminal, timeout=self.timeout, description="terminal A2A task")
+        _atomic_json(self.run_dir / "task-final.json", task)
+        return task
+
+    def _assert_shared_backup(
+        self,
+        state: dict[str, Any],
+        expected_operation: str | None,
+        *,
+        require_reason: bool = True,
+    ) -> None:
+        backup = state.get("backup", {})
+        assert backup.get("status") == "shared_committed", backup
+        assert backup.get("generation") and backup.get("commitId")
+        shared_files = [path for path in (self.run_dir / "shared-backup").rglob("*") if path.is_file()]
+        assert shared_files, "shared backup is empty"
+        texts = []
+        for path in shared_files:
+            try:
+                texts.append(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError):
+                continue
+        joined = "\n".join(texts)
+        assert str(backup["commitId"]) in joined
+        if require_reason:
+            assert "disconnect_timeout" in joined
+        if expected_operation is not None:
+            assert any(
+                operation.get("resourceId") == expected_operation for operation in state.get("externalOperations", [])
+            )
+            assert expected_operation in joined
+
+    def _wait_log_event(self, path: Path, event: str) -> dict[str, Any]:
+        def observed() -> dict[str, Any] | None:
+            self.server.assert_running()
+            return next((value for value in _read_jsonl(path) if value.get("event") == event), None)
+
+        return _wait_until(
+            observed,
+            timeout=self.timeout,
+            description=event,
+        )
+
+    def _provider_calls(self) -> list[dict[str, Any]]:
+        return [
+            value
+            for value in _read_jsonl(self.run_dir / "provider-lifecycle.jsonl")
+            if value.get("event") == "provider.called"
+        ]
+
+    def _tool_events(self) -> list[dict[str, Any]]:
+        return _read_jsonl(self.run_dir / "tool-lifecycle.jsonl")
+
+    def _pipeline_events(self) -> list[dict[str, Any]]:
+        projects = self.run_dir / "config" / "projects"
+        events: list[dict[str, Any]] = []
+        for path in projects.rglob("a2a/pipeline/a2a-events.jsonl"):
+            events.extend(_read_jsonl(path))
+        return events
+
+    def _counts(self) -> dict[str, int]:
+        return {
+            "provider": len(self._provider_calls()),
+            "tool_started": len([value for value in self._tool_events() if value.get("event") == "tool.started"]),
+            "pipeline_step_completed": len(
+                [value for value in self._pipeline_events() if value.get("eventType") == "step_completed"]
+            ),
+        }
+
+    def _assert_same_operation(self, first: dict[str, Any], duplicate: dict[str, Any]) -> None:
+        assert first["contextId"] == duplicate["contextId"] == self.context_id
+        assert first["taskId"] == duplicate["taskId"] == self.task_id
+        assert first["executionId"] == duplicate["executionId"] == self.execution_id
+        assert first["revision"] == duplicate["revision"]
+        assert first["connectionEpoch"] == duplicate["connectionEpoch"]
+
+    def _verify_state_timeline(self) -> None:
+        revisions = [value.get("revision") for value in self.timeline]
+        persisted = [value.get("persistedRevision") for value in self.timeline]
+        assert revisions == sorted(revisions)
+        assert persisted == sorted(persisted)
+        assert all(value.get("taskId") == self.task_id for value in self.timeline)
+        assert all(value.get("contextId") == self.context_id for value in self.timeline)
+        assert all(value.get("executionId") == self.execution_id for value in self.timeline)
+        assert all(value.get("serverInstanceId") == self.server_instance_id for value in self.timeline)
+
+    def _summary(self, status: str, error: str | None = None) -> dict[str, Any]:
+        return {
+            "status": status,
+            "scenario": self.scenario,
+            "mode": self.mode,
+            "taskId": self.task_id or None,
+            "contextId": self.context_id or None,
+            "executionId": self.execution_id or None,
+            "serverInstanceId": self.server_instance_id or None,
+            "pauseId": self.pause_id or None,
+            "providerCalls": len(self._provider_calls()),
+            "toolEvents": len(self._tool_events()),
+            "pipelineStepCompletions": len(
+                [value for value in self._pipeline_events() if value.get("eventType") == "step_completed"]
+            ),
+            "controlRequests": len(self.controls),
+            "stateObservations": len(self.timeline),
+            "streams": [
+                {"name": stream.name, "eventCount": len(stream.snapshot()), "done": stream.done.is_set()}
+                for stream in self.streams
+            ],
+            "error": error,
+        }
+
+
+def _run_scenario(
+    *,
+    args: argparse.Namespace,
+    repo_root: Path,
+    run_dir: Path,
+    scenario_name: str,
+) -> tuple[int, dict[str, Any]]:
+    started = time.monotonic()
+    run_dir.mkdir(parents=True)
+    server = _FixtureServer(
+        repo_root=repo_root,
+        run_dir=run_dir,
+        scenario=scenario_name,
+        mode=args.mode,
+        timeout=args.timeout,
+    )
+    scenario = _Scenario(
+        run_dir=run_dir,
+        server=server,
+        scenario=scenario_name,
+        mode=args.mode,
+        timeout=args.timeout,
+    )
+    overall_expired = threading.Event()
+
+    def expire() -> None:
+        overall_expired.set()
+        server.stop()
+
+    overall_timer = threading.Timer(args.overall_timeout, expire)
+    overall_timer.daemon = True
+    overall_timer.start()
+    exit_code = 0
+    cleanup_errors: list[str] = []
+    try:
+        server.wait_ready()
+        summary = scenario.run()
+    except BaseException as exc:
+        exit_code = 1
+        error = (
+            "TimeoutError: overall scenario timeout after {:.3f}s".format(args.overall_timeout)
+            if overall_expired.is_set()
+            else "{}: {}".format(type(exc).__name__, exc)
+        )
+        summary = scenario._summary("failed", error)
+        (run_dir / "runner-error.txt").write_text(traceback.format_exc(), encoding="utf-8")
+    finally:
+        overall_timer.cancel()
+        for name, cleanup in (
+            ("streams", scenario.close_streams),
+            ("server", server.stop),
+            ("audits", scenario.write_audits),
+        ):
+            try:
+                cleanup()
+            except BaseException as exc:
+                cleanup_errors.append("{}: {}: {}".format(name, type(exc).__name__, exc))
+    if cleanup_errors:
+        exit_code = 1
+        prior_error = summary.get("error")
+        details = "cleanup failed: {}".format("; ".join(cleanup_errors))
+        summary = scenario._summary("failed", "{}; {}".format(prior_error, details) if prior_error else details)
+    summary["elapsedSeconds"] = round(time.monotonic() - started, 3)
+    summary["server"] = server.lifecycle()
+    _atomic_json(run_dir / "summary.json", summary)
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    return exit_code, summary
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.timeout <= 0 or args.overall_timeout <= 0:
+        raise SystemExit("timeouts must be positive")
+    scenario_names = list(args.scenario)
+    for scenario_name in scenario_names:
+        if args.mode not in SCENARIO_MODES[scenario_name]:
+            raise SystemExit("{} does not support mode {}".format(scenario_name, args.mode))
+    root_run_dir = args.run_dir.expanduser().resolve()
+    if root_run_dir.exists():
+        shutil.rmtree(root_run_dir)
+    repo_root = Path(__file__).resolve().parents[4]
+    if len(scenario_names) == 1:
+        exit_code, _summary_payload = _run_scenario(
+            args=args,
+            repo_root=repo_root,
+            run_dir=root_run_dir,
+            scenario_name=scenario_names[0],
+        )
+        return exit_code
+
+    root_run_dir.mkdir(parents=True)
+    started = time.monotonic()
+    summaries: list[dict[str, Any]] = []
+    exit_code = 0
+    for index, scenario_name in enumerate(scenario_names, start=1):
+        child_name = "{:02d}-{}-{}".format(index, scenario_name, args.mode)
+        child_exit_code, summary = _run_scenario(
+            args=args,
+            repo_root=repo_root,
+            run_dir=root_run_dir / child_name,
+            scenario_name=scenario_name,
+        )
+        summary["artifactDirectory"] = child_name
+        summaries.append(summary)
+        exit_code = max(exit_code, child_exit_code)
+    aggregate = {
+        "status": "passed" if exit_code == 0 else "failed",
+        "mode": args.mode,
+        "elapsedSeconds": round(time.monotonic() - started, 3),
+        "runs": summaries,
+    }
+    _atomic_json(root_run_dir / "summary.json", aggregate)
+    print(json.dumps(aggregate, ensure_ascii=False, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
+++ b/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
@@ -1046,6 +1046,15 @@ class _Scenario:
         assert status == 200 and health.get("status") == "healthy"
         counts_before = self._counts()
         _write_marker(self.control_dir, "allow-shared")
+        _wait_until(
+            lambda: any(
+                str(commit_id) in path.read_text(encoding="utf-8")
+                for path in (self.run_dir / "shared-backup").rglob("*")
+                if path.is_file()
+            ),
+            timeout=self.timeout,
+            description="blocked commit publication",
+        )
         self._terminate(epoch=2, request_id="retry-backup-finalization")
         terminal = self._wait_state(
             lambda value: (
@@ -1236,7 +1245,7 @@ class _Scenario:
         assert first["contextId"] == duplicate["contextId"] == self.context_id
         assert first["taskId"] == duplicate["taskId"] == self.task_id
         assert first["executionId"] == duplicate["executionId"] == self.execution_id
-        assert first["revision"] == duplicate["revision"]
+        assert first["revision"] <= duplicate["revision"]
         assert first["connectionEpoch"] == duplicate["connectionEpoch"]
 
     def _verify_state_timeline(self) -> None:

--- a/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
+++ b/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
@@ -602,7 +602,13 @@ class _Scenario:
         assert not self._provider_calls(), "bootstrap cancellation must not start an LLM request"
 
     def _terminate_during_turn_backup(self, initial: _BackgroundStream) -> None:
-        assert "ISOLATION_FIXTURE_FINAL" in json.dumps(initial.snapshot())
+        _wait_until(
+            lambda: snapshot
+            if "ISOLATION_FIXTURE_FINAL" in json.dumps(snapshot := initial.snapshot())
+            else None,
+            timeout=self.timeout,
+            description="final stream event before turn backup disconnect",
+        )
         initial.close()
         self._pause(epoch=1, request_id="pause-turn-backup", timeout=5.0)
         state = self._wait_state(lambda value: value["phase"] == "terminating", "timeout during normal turn backup")

--- a/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
+++ b/scripts/a2a/e2e/execution_control/run_execution_control_scenarios.py
@@ -604,7 +604,7 @@ class _Scenario:
     def _terminate_during_turn_backup(self, initial: _BackgroundStream) -> None:
         assert "ISOLATION_FIXTURE_FINAL" in json.dumps(initial.snapshot())
         initial.close()
-        self._pause(epoch=1, request_id="pause-turn-backup", timeout=1.0)
+        self._pause(epoch=1, request_id="pause-turn-backup", timeout=5.0)
         state = self._wait_state(lambda value: value["phase"] == "terminating", "timeout during normal turn backup")
         assert not state["releaseReady"]
         status, health = _http_json("GET", self.server.url + "/health", timeout=1.0)

--- a/src/iac_code/a2a/agent_card.py
+++ b/src/iac_code/a2a/agent_card.py
@@ -31,9 +31,11 @@ from iac_code.i18n import _
 from iac_code.pipeline.config import RunMode, get_run_mode
 
 IAC_CODE_ARTIFACT_METADATA_EXTENSION_URI = "urn:iac-code:a2a:artifact-metadata:v1"
+IAC_CODE_EXECUTION_CONTROL_EXTENSION_URI = "urn:iac-code:a2a:execution-control:v1"
 IAC_CODE_PIPELINE_EVENTS_EXTENSION_URI = PIPELINE_EVENTS_EXTENSION_URI
 IAC_CODE_THINKING_EXPOSURE_EXTENSION_URI = "urn:iac-code:a2a:thinking-exposure:v1"
 CANONICAL_CALLER_EXTENSION_URIS = {
+    IAC_CODE_EXECUTION_CONTROL_EXTENSION_URI,
     IAC_CODE_PIPELINE_EVENTS_EXTENSION_URI,
 }
 
@@ -167,6 +169,40 @@ def build_agent_card(
             required=False,
         )
     )
+    has_http_extension_surface = any(
+        interface.url.startswith(("http://", "https://"))
+        and interface.protocol_binding.upper() in {"JSONRPC", "HTTP+JSON"}
+        for interface in interfaces
+    )
+    if has_http_extension_surface:
+        execution_control_extension = AgentExtension(
+            uri=IAC_CODE_EXECUTION_CONTROL_EXTENSION_URI,
+            description="Control and recover a live iac-code A2A execution during sandbox reconnects.",
+            required=False,
+        )
+        ParseDict(
+            {
+                "schemaVersion": "1.0",
+                "pauseEndpoint": "/iac-code/execution/pause",
+                "stateEndpoint": "/iac-code/execution/state",
+                "resumeEndpoint": "/iac-code/execution/resume",
+                "terminateEndpoint": "/iac-code/execution/terminate",
+                "sessionRecoveryEndpoint": "/iac-code/session/recovery",
+                "phases": [
+                    "running",
+                    "pausing",
+                    "pause_committing",
+                    "paused",
+                    "resuming",
+                    "terminating",
+                    "terminated",
+                ],
+                "toolBatchDrainOnPause": True,
+                "transportScope": "http",
+            },
+            execution_control_extension.params,
+        )
+        card.capabilities.extensions.append(execution_control_extension)
     if thinking_exposure_types is not None:
         enabled_types = format_a2a_exposure_types(thinking_exposure_types)
         if enabled_types:

--- a/src/iac_code/a2a/app.py
+++ b/src/iac_code/a2a/app.py
@@ -20,6 +20,7 @@ from a2a.auth.user import User
 from a2a.server.context import ServerCallContext
 from a2a.server.routes import create_jsonrpc_routes, create_rest_routes
 from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+from google.protobuf.json_format import MessageToDict
 from starlette.applications import Starlette
 from starlette.authentication import AuthCredentials, SimpleUser
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -29,6 +30,7 @@ from starlette.routing import BaseRoute, Route
 
 from iac_code import __version__
 from iac_code.a2a.agent_card import agent_card_to_client_dict
+from iac_code.a2a.execution_control import ExecutionControlConflictError, ExecutionControlNotFoundError
 from iac_code.a2a.jsonrpc_passthrough import (
     install_jsonrpc_error_data_passthrough,
     install_v03_jsonrpc_error_data_passthrough,
@@ -557,6 +559,9 @@ def create_app(
         if parse_error is not None:
             return JSONResponse({"error": parse_error}, status_code=400)
         lean = _parse_lean(request.query_params.get("lean"))
+        include_snapshot = _parse_include_snapshot(request.query_params.get("includeSnapshot"))
+        if not include_snapshot and after_sequence is None:
+            return JSONResponse({"error": _("afterSequence must be a non-negative integer")}, status_code=400)
 
         call_context = _call_context_from_request(request)
         try:
@@ -580,7 +585,178 @@ def create_app(
             task_id=task_id,
         )
         # 先裁掉不发给客户端的字段，再投影：既少发一大半字节，也少一大半要脱敏的字符串
-        return JSONResponse(project_a2a_data(client_pipeline_state(state, lean=lean), public_path_roots=roots))
+        return JSONResponse(
+            project_a2a_data(
+                client_pipeline_state(
+                    state,
+                    lean=lean,
+                    include_snapshot=include_snapshot,
+                    after_sequence=after_sequence,
+                ),
+                public_path_roots=roots,
+            )
+        )
+
+    def execution_owner(request: Request) -> str:
+        return components.task_store.owner_for_context(_call_context_from_request(request))
+
+    async def execution_control_from_request(request: Request, context_id: str):
+        service = components.execution_control_service
+        if service is None:
+            raise ExecutionControlNotFoundError("Execution control is unavailable")
+        return await service.require(
+            context_id=validate_protocol_id(context_id),
+            owner=execution_owner(request),
+        )
+
+    async def execution_error_response(exc: Exception) -> JSONResponse:
+        if isinstance(exc, ExecutionControlNotFoundError):
+            return JSONResponse({"error": str(exc)}, status_code=404)
+        if isinstance(exc, ExecutionControlConflictError):
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        if isinstance(exc, (TypeError, ValueError)):
+            return JSONResponse({"error": "Invalid execution control request."}, status_code=400)
+        logger.exception("A2A execution control request failed")
+        return JSONResponse({"error": "Execution control is unavailable."}, status_code=503)
+
+    async def read_control_payload(request: Request) -> dict[str, Any]:
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise ValueError("payload must be an object")
+        return payload
+
+    def required_string(payload: dict[str, Any], name: str) -> str:
+        value = payload.get(name)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{name} is required")
+        return value
+
+    def required_epoch(payload: dict[str, Any]) -> int:
+        value = payload.get("connectionEpoch")
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("connectionEpoch is required")
+        return value
+
+    async def pause_execution(request: Request) -> JSONResponse:
+        try:
+            payload = await read_control_payload(request)
+            context_id = required_string(payload, "contextId")
+            control = await execution_control_from_request(request, context_id)
+            timeout = payload.get("reconnectTimeoutSeconds", 300)
+            if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+                raise ValueError("invalid reconnect timeout")
+            state = await control.pause(
+                task_id=validate_protocol_id(required_string(payload, "taskId")),
+                expected_execution_id=validate_protocol_id(required_string(payload, "expectedExecutionId")),
+                request_id=validate_protocol_id(required_string(payload, "requestId")),
+                connection_epoch=required_epoch(payload),
+                reason=required_string(payload, "reason"),
+                reconnect_timeout_seconds=float(timeout),
+            )
+            return JSONResponse(state, status_code=200 if state["phase"] == "paused" else 202)
+        except Exception as exc:
+            return await execution_error_response(exc)
+
+    async def get_execution_state(request: Request) -> JSONResponse:
+        try:
+            context_id = request.query_params.get("contextId")
+            if not context_id:
+                raise ValueError("contextId is required")
+            control = await execution_control_from_request(request, context_id)
+            expected_execution_id = request.query_params.get("executionId")
+            pause_id = request.query_params.get("pauseId")
+            if expected_execution_id is not None and expected_execution_id != control.execution_id:
+                raise ExecutionControlConflictError("executionId does not identify the current execution")
+            if pause_id is not None and pause_id != control.pause_id:
+                raise ExecutionControlConflictError("pauseId does not identify the current pause")
+            return JSONResponse(control.snapshot())
+        except Exception as exc:
+            return await execution_error_response(exc)
+
+    async def resume_execution(request: Request) -> JSONResponse:
+        try:
+            payload = await read_control_payload(request)
+            context_id = required_string(payload, "contextId")
+            control = await execution_control_from_request(request, context_id)
+            state = await control.resume(
+                execution_id=validate_protocol_id(required_string(payload, "executionId")),
+                pause_id=validate_protocol_id(required_string(payload, "pauseId")),
+                request_id=validate_protocol_id(required_string(payload, "requestId")),
+                connection_epoch=required_epoch(payload),
+            )
+            return JSONResponse(state, status_code=200 if state["phase"] == "running" else 202)
+        except Exception as exc:
+            return await execution_error_response(exc)
+
+    async def terminate_execution(request: Request) -> JSONResponse:
+        try:
+            payload = await read_control_payload(request)
+            context_id = required_string(payload, "contextId")
+            control = await execution_control_from_request(request, context_id)
+            reason = payload.get("reason", "explicit_terminate")
+            if not isinstance(reason, str) or not reason:
+                raise ValueError("reason must be a non-empty string")
+            pause_id = payload.get("pauseId")
+            if pause_id is not None:
+                if not isinstance(pause_id, str) or not pause_id:
+                    raise ValueError("pauseId must be a non-empty string")
+                pause_id = validate_protocol_id(pause_id)
+            state = await control.terminate(
+                execution_id=validate_protocol_id(required_string(payload, "expectedExecutionId")),
+                request_id=validate_protocol_id(required_string(payload, "requestId")),
+                connection_epoch=required_epoch(payload),
+                reason=reason,
+                pause_id=pause_id,
+            )
+            return JSONResponse(state, status_code=200 if state["phase"] == "terminated" else 202)
+        except Exception as exc:
+            return await execution_error_response(exc)
+
+    async def get_session_recovery(request: Request) -> JSONResponse:
+        try:
+            context_id = request.query_params.get("contextId")
+            execution_id = request.query_params.get("executionId")
+            if not context_id or not execution_id:
+                raise ValueError("contextId and executionId are required")
+            control = await execution_control_from_request(request, context_id)
+            if execution_id != control.execution_id:
+                raise ExecutionControlConflictError("executionId does not identify the current execution")
+            task_id = control.task_id
+            context_record = await components.task_store.get_context_record(context_id)
+            session_id = context_record.session_id
+            task_record = await components.task_store.get_task_record(task_id)
+            task = await components.task_store.get(task_id, _call_context_from_request(request))
+            if task is None:
+                raise ExecutionControlNotFoundError("Execution was not found")
+            messages = await asyncio.to_thread(SessionStorage().load, context_record.cwd, session_id)
+            roots = await recovery_path_roots(context_id=context_id, task_id=task_id)
+            current_context = await components.task_store.get_context_record(context_id)
+            service = components.execution_control_service
+            current_control = service.get_for_context(context_id) if service is not None else None
+            if (
+                current_control is not control
+                or control.execution_id != execution_id
+                or control.task_id != task_id
+                or current_context.session_id != session_id
+                or current_context.cwd != context_record.cwd
+            ):
+                raise ExecutionControlConflictError("executionId does not identify the current execution")
+            # No awaits after identity validation: rollover must not mix a new
+            # execution's control with the task/messages read above.
+            recovery = {
+                "contextId": context_id,
+                "taskId": task_id,
+                "executionId": execution_id,
+                "revision": control.revision,
+                "executionStatus": task_record.state,
+                "outputText": list(task_record.output_text),
+                "task": MessageToDict(task, preserving_proto_field_name=False),
+                "messages": [message.to_dict() for message in messages],
+                "executionControl": control.snapshot(),
+            }
+            return JSONResponse(project_a2a_data(recovery, public_path_roots=roots))
+        except Exception as exc:
+            return await execution_error_response(exc)
 
     routes: list[BaseRoute] = [
         Route("/health", health, methods=["GET"]),
@@ -588,6 +764,11 @@ def create_app(
         Route("/iac-code/readiness", get_readiness, methods=["GET"]),
         Route("/iac-code/session/ensure-restored", ensure_session_restored, methods=["POST"]),
         Route("/iac-code/pipeline/state", get_pipeline_state, methods=["GET"]),
+        Route("/iac-code/execution/pause", pause_execution, methods=["POST"]),
+        Route("/iac-code/execution/state", get_execution_state, methods=["GET"]),
+        Route("/iac-code/execution/resume", resume_execution, methods=["POST"]),
+        Route("/iac-code/execution/terminate", terminate_execution, methods=["POST"]),
+        Route("/iac-code/session/recovery", get_session_recovery, methods=["GET"]),
     ]
     install_jsonrpc_error_data_passthrough()
     jsonrpc_endpoint = create_jsonrpc_routes(components.handler, rpc_url="/", enable_v0_3_compat=True)[0].endpoint
@@ -600,6 +781,7 @@ def create_app(
     routes.append(Route("/", handle_jsonrpc, methods=["POST"]))
     routes.extend(create_rest_routes(components.handler, enable_v0_3_compat=True))
     app = Starlette(routes=routes, lifespan=lifespan)
+    app.state.a2a_components = components
     app.add_middleware(A2AProjectionMiddleware, task_store=components.task_store)
     app.add_middleware(
         A2AAuthMiddleware,
@@ -641,6 +823,19 @@ def _parse_lean(value: str | None) -> bool:
     if normalized not in {"0", "false"}:
         logger.warning("Ignoring unrecognized pipeline state lean value %r; returning the full snapshot", value)
     return False
+
+
+def _parse_include_snapshot(value: str | None) -> bool:
+    """Default to the compatible full response unless omission is explicit."""
+
+    if value is None or value == "":
+        return True
+    normalized = value.strip().lower()
+    if normalized in {"0", "false"}:
+        return False
+    if normalized not in _LEAN_TRUTHY_VALUES:
+        logger.warning("Ignoring unrecognized pipeline state includeSnapshot value %r", value)
+    return True
 
 
 def _parse_after_sequence(value: str | None) -> tuple[int | None, str | None]:

--- a/src/iac_code/a2a/backup.py
+++ b/src/iac_code/a2a/backup.py
@@ -1,24 +1,64 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
+import inspect
 import logging
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, ParamSpec, TypeVar, cast
 
 from iac_code.i18n import _
 from iac_code.services.session_backup import BackupReason, SessionBackupBlocked
 from iac_code.services.session_backup_state import BackupPublicationProof
 
 logger = logging.getLogger(__name__)
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
-async def run_sync_fenced(function: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+async def await_fenced(awaitable: Awaitable[_T]) -> _T:
+    """Finish an owned cleanup/commit before propagating cancellation to its caller."""
+    task = asyncio.ensure_future(awaitable)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        if not task.cancelled():
+            task.exception()
+        raise
+
+
+async def run_sync_fenced(function: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
     """Delay coroutine cancellation until the synchronous mutation has actually stopped."""
+    return await _run_sync_fenced(function, None, args, kwargs)
+
+
+async def run_sync_fenced_with_cancel_completion(
+    function: Callable[_P, _T],
+    on_cancel_completion: Callable[[_T | None, BaseException | None], Awaitable[None] | None],
+    /,
+    *args: _P.args,
+    **kwargs: _P.kwargs,
+) -> _T:
+    """Fence a synchronous mutation and save its late result before propagating cancellation."""
+    return cast(_T, await _run_sync_fenced(function, on_cancel_completion, args, kwargs))
+
+
+async def _run_sync_fenced(
+    function: Callable[..., _T],
+    on_cancel_completion: Callable[[_T | None, BaseException | None], Awaitable[None] | None] | None,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> _T:
     thread_task = asyncio.create_task(asyncio.to_thread(function, *args, **kwargs))
     try:
         return await asyncio.shield(thread_task)
-    except asyncio.CancelledError:
+    except asyncio.CancelledError as cancellation:
         while not thread_task.done():
             try:
                 await asyncio.shield(thread_task)
@@ -26,10 +66,27 @@ async def run_sync_fenced(function: Callable[..., Any], /, *args: Any, **kwargs:
                 continue
             except Exception:
                 break
+        result: _T | None = None
+        error: BaseException | None = None
         if thread_task.done() and not thread_task.cancelled():
-            with contextlib.suppress(Exception):
-                thread_task.result()
-        raise
+            try:
+                result = thread_task.result()
+            except BaseException as exc:
+                error = exc
+        if on_cancel_completion is not None:
+            try:
+                completion = on_cancel_completion(result, error)
+                if inspect.isawaitable(completion):
+                    completion_task = asyncio.ensure_future(completion)
+                    while not completion_task.done():
+                        try:
+                            await asyncio.shield(completion_task)
+                        except asyncio.CancelledError:
+                            continue
+                    completion_task.result()
+            except BaseException:
+                logger.exception("Failed to record a synchronous mutation result returned during cancellation")
+        raise cancellation
 
 
 async def backup_session_async(

--- a/src/iac_code/a2a/client.py
+++ b/src/iac_code/a2a/client.py
@@ -108,6 +108,14 @@ def _extract_parts_text(message: Any) -> str:
     return "".join(pieces)
 
 
+def _validated_extension_response(response: Any, name: str) -> dict[str, Any]:
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError(f"A2A {name} response must be a JSON object")
+    return data
+
+
 class A2AClient:
     def __init__(
         self,
@@ -306,11 +314,16 @@ class A2AClient:
         *,
         task_id: str,
         after_sequence: int | None = None,
+        include_snapshot: bool = True,
     ) -> dict[str, Any] | None:
-        """Read iac-code's existing A2A pipeline recovery extension over HTTP."""
+        """Read an A2A pipeline snapshot or a cursor-based event delta over HTTP."""
 
+        if not include_snapshot and after_sequence is None:
+            raise ValueError("after_sequence is required when include_snapshot is False")
         endpoint = url.rstrip("/") + "/iac-code/pipeline/state"
         params = _without_none({"taskId": task_id, "afterSequence": after_sequence})
+        if not include_snapshot:
+            params["includeSnapshot"] = "false"
         response = await self._http_client.get(endpoint, params=params, headers=self._jsonrpc_headers())
         if response.status_code == 404:
             return None
@@ -357,6 +370,127 @@ class A2AClient:
         if not isinstance(data, dict) or data.get("status") not in {"current", "restored"}:
             raise ValueError("A2A session restore response must report a ready session")
         return True
+
+    async def pause_execution(
+        self,
+        url: str,
+        *,
+        context_id: str,
+        task_id: str,
+        execution_id: str,
+        request_id: str,
+        connection_epoch: int,
+        reason: str = "client_disconnected",
+        reconnect_timeout_seconds: float = 300,
+    ) -> dict[str, Any]:
+        return await self._execution_control_post(
+            url,
+            "pause",
+            {
+                "contextId": context_id,
+                "taskId": task_id,
+                "expectedExecutionId": execution_id,
+                "requestId": request_id,
+                "connectionEpoch": connection_epoch,
+                "reason": reason,
+                "reconnectTimeoutSeconds": reconnect_timeout_seconds,
+            },
+        )
+
+    async def get_execution_state(
+        self,
+        url: str,
+        *,
+        context_id: str,
+        execution_id: str | None = None,
+        pause_id: str | None = None,
+    ) -> dict[str, Any]:
+        endpoint = url.rstrip("/") + "/iac-code/execution/state"
+        response = await self._http_client.get(
+            endpoint,
+            params=_without_none(
+                {
+                    "contextId": context_id,
+                    "executionId": execution_id,
+                    "pauseId": pause_id,
+                }
+            ),
+            headers=self._jsonrpc_headers(),
+        )
+        return _validated_extension_response(response, "execution state")
+
+    async def resume_execution(
+        self,
+        url: str,
+        *,
+        context_id: str,
+        execution_id: str,
+        pause_id: str,
+        request_id: str,
+        connection_epoch: int,
+    ) -> dict[str, Any]:
+        return await self._execution_control_post(
+            url,
+            "resume",
+            {
+                "contextId": context_id,
+                "executionId": execution_id,
+                "pauseId": pause_id,
+                "requestId": request_id,
+                "connectionEpoch": connection_epoch,
+            },
+        )
+
+    async def terminate_execution(
+        self,
+        url: str,
+        *,
+        context_id: str,
+        execution_id: str,
+        request_id: str,
+        connection_epoch: int,
+        reason: str = "explicit_terminate",
+        pause_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._execution_control_post(
+            url,
+            "terminate",
+            _without_none(
+                {
+                    "contextId": context_id,
+                    "expectedExecutionId": execution_id,
+                    "requestId": request_id,
+                    "connectionEpoch": connection_epoch,
+                    "reason": reason,
+                    "pauseId": pause_id,
+                }
+            ),
+        )
+
+    async def get_session_recovery(
+        self,
+        url: str,
+        *,
+        context_id: str,
+        execution_id: str,
+    ) -> dict[str, Any]:
+        endpoint = url.rstrip("/") + "/iac-code/session/recovery"
+        response = await self._http_client.get(
+            endpoint,
+            params={"contextId": context_id, "executionId": execution_id},
+            headers=self._jsonrpc_headers(),
+        )
+        return _validated_extension_response(response, "session recovery")
+
+    async def _execution_control_post(
+        self,
+        url: str,
+        action: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        endpoint = url.rstrip("/") + f"/iac-code/execution/{action}"
+        response = await self._http_client.post(endpoint, json=payload, headers=self._jsonrpc_headers())
+        return _validated_extension_response(response, f"execution {action}")
 
     async def list_tasks(
         self,

--- a/src/iac_code/a2a/execution_control.py
+++ b/src/iac_code/a2a/execution_control.py
@@ -995,9 +995,11 @@ class ExecutionController:
             async with self._condition:
                 self._commit_error = "state_commit_failed"
         if cleanup_error is not None:
-            await self._commit_blocked_backup_state("execution termination cleanup failed", cleanup_error)
-            async with self._condition:
-                self._termination_cleanup_inflight = False
+            await self._commit_blocked_backup_state(
+                "execution termination cleanup failed",
+                cleanup_error,
+                clear_cleanup_inflight=True,
+            )
             return
         await self._perform_backup()
 
@@ -1024,9 +1026,11 @@ class ExecutionController:
     async def _retry_termination_cleanup(self) -> None:
         error = await self._run_termination_cleanup(self._termination_cleanup)
         if error is not None:
-            await self._commit_blocked_backup_state("execution termination cleanup failed", error)
-            async with self._condition:
-                self._termination_cleanup_inflight = False
+            await self._commit_blocked_backup_state(
+                "execution termination cleanup failed",
+                error,
+                clear_cleanup_inflight=True,
+            )
             return
         await self._perform_backup()
 
@@ -1120,23 +1124,37 @@ class ExecutionController:
                 self._commit_error = None
                 self._backup_state_committed = True
 
-    async def _commit_blocked_backup_state(self, message: str, exc: BaseException) -> None:
+    async def _commit_blocked_backup_state(
+        self,
+        message: str,
+        exc: BaseException,
+        *,
+        clear_cleanup_inflight: bool = False,
+    ) -> None:
         async with self._condition:
             self.backup = {"status": "blocked", "error": f"{message}: {type(exc).__name__}"}
+            if clear_cleanup_inflight:
+                # A retry that observes the blocked state must also be able to
+                # claim cleanup. Publishing these two changes separately can
+                # lose a retry in the gap between them.
+                self._termination_cleanup_inflight = False
             self._backup_state_committed = False
             self.release_ready = False
             self.revision += 1
+            revision = self.revision
             snapshot = self.snapshot()
             snapshot["commitError"] = None
         try:
             await self._persist_snapshot(snapshot)
         except Exception:
             async with self._condition:
-                self._commit_error = "state_commit_failed"
+                if self.revision == revision and self.backup.get("status") == "blocked":
+                    self._commit_error = "state_commit_failed"
             return
         async with self._condition:
-            self._commit_error = None
-            self._backup_state_committed = True
+            if self.revision == revision and self.backup.get("status") == "blocked":
+                self._commit_error = None
+                self._backup_state_committed = True
 
     async def _persist_external_operations(self) -> None:
         if not self.external_operations or self.session_id is None:

--- a/src/iac_code/a2a/execution_control.py
+++ b/src/iac_code/a2a/execution_control.py
@@ -1,0 +1,1515 @@
+"""Transport-independent control for a live A2A execution.
+
+The public A2A task state remains unchanged.  This module owns the connection
+pause gate, its durable control snapshot, and the local termination workflow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager, suppress
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Literal, TypeVar, cast
+
+from iac_code.a2a.backup import await_fenced, run_sync_fenced
+from iac_code.services.session_backup import BackupReason, BackupResult
+from iac_code.services.session_storage import SessionStorage
+from iac_code.utils.state_io import atomic_write_json
+
+ExecutionPhase = Literal[
+    "running",
+    "pausing",
+    "pause_committing",
+    "paused",
+    "resuming",
+    "terminating",
+    "terminated",
+]
+
+_PAUSE_PHASES = frozenset({"pausing", "pause_committing", "paused"})
+_TERMINAL_TASK_STATES = frozenset({"completed", "failed", "canceled", "input-required", "normal-turn-ended"})
+_CURRENT_CONTROL: ContextVar[Any] = ContextVar("a2a_execution_control", default=None)
+_CURRENT_ACTIVITY_IDS: ContextVar[tuple[str, ...]] = ContextVar("a2a_execution_activity_ids", default=())
+_CURRENT_PARTICIPANT_IDS: ContextVar[tuple[str, ...]] = ContextVar("a2a_execution_participant_ids", default=())
+_T = TypeVar("_T")
+
+
+class ExecutionControlError(RuntimeError):
+    """Base error returned by execution-control endpoints."""
+
+
+class ExecutionControlNotFoundError(ExecutionControlError):
+    pass
+
+
+class ExecutionControlConflictError(ExecutionControlError):
+    pass
+
+
+class ExecutionTerminatedError(asyncio.CancelledError):
+    """Raised at a safe point after termination has been claimed."""
+
+
+def _utc_timestamp(epoch_seconds: float | None) -> str | None:
+    if epoch_seconds is None:
+        return None
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _fingerprint(action: str, payload: dict[str, Any]) -> str:
+    encoded = json.dumps({"action": action, **payload}, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class _Activity:
+    activity_id: str
+    kind: str
+    task: asyncio.Task[Any] | None
+    ancestor_activity_ids: tuple[str, ...]
+    handoff_participant_ids: tuple[str, ...]
+    blocked: bool = False
+    budget_changed: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+@dataclass
+class _Participant:
+    participant_id: str
+    kind: str
+    task: asyncio.Task[Any]
+    safe: bool = False
+
+
+@dataclass(frozen=True)
+class ActivityHandle:
+    controller: ExecutionController
+    activity_id: str
+
+    @property
+    def blocked(self) -> bool:
+        return self.controller._activity_budget_blocked(self.activity_id)
+
+    @property
+    def budget_changed(self) -> asyncio.Event:
+        activity = self.controller._activities.get(self.activity_id)
+        if activity is None:
+            event = asyncio.Event()
+            event.set()
+            return event
+        return activity.budget_changed
+
+
+class ExecutionController:
+    """Single-event-loop state machine for one context execution instance."""
+
+    def __init__(
+        self,
+        *,
+        context_id: str,
+        task_id: str,
+        owner: str,
+        cwd: str,
+        server_instance_id: str,
+        persistence_path: Path | None,
+        backup_service: Any | None,
+        termination_cleanup: Callable[[str, str, str], Awaitable[str | None]] | None = None,
+        on_resume: Callable[[str], None] | None = None,
+        execution_id: str | None = None,
+    ) -> None:
+        self.context_id = context_id
+        self.task_id = task_id
+        self.owner = owner
+        self.cwd = cwd
+        self.session_id: str | None = None
+        self.execution_id = execution_id or "exec-" + uuid.uuid4().hex
+        self.server_instance_id = server_instance_id
+        self.phase: ExecutionPhase = "running"
+        self.execution_status = "working"
+        self.stream_available = True
+        self.pause_id: str | None = None
+        self.pause_reason: str | None = None
+        self.expires_at: float | None = None
+        self._expires_monotonic: float | None = None
+        self.connection_epoch = -1
+        self.revision = 0
+        self.persisted_revision = 0
+        self.release_ready = False
+        self.termination_reason: str | None = None
+        self._termination_pause_id: str | None = None
+        self.backup: dict[str, Any] = {"status": "not_requested"}
+        self.external_operations: list[dict[str, Any]] = []
+        self._lock = asyncio.Lock()
+        self._condition = asyncio.Condition(self._lock)
+        self._commit_lock = asyncio.Lock()
+        self._operation_commit_lock = asyncio.Lock()
+        self._activities: dict[str, _Activity] = {}
+        self._participants: dict[str, _Participant] = {}
+        self._participant_ids_by_task: dict[asyncio.Task[Any], str] = {}
+        self._passive_waiters: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {}
+        self._execution_tasks: set[asyncio.Task[Any]] = set()
+        self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._request_ids: dict[str, tuple[str, str, str | None]] = {}
+        self._connection_hold = False
+        self._resume_barrier_revision: int | None = None
+        self._pause_generation = 0
+        self._commit_error: str | None = None
+        self._release_commit_inflight = False
+        self._backup_state_committed = False
+        self._pending_staged_backup: BackupResult | None = None
+        self._persistence_path = persistence_path
+        self._backup_service = backup_service
+        self._termination_cleanup = termination_cleanup
+        self._on_resume = on_resume
+        self._termination_cleanup_complete = termination_cleanup is None
+        self._termination_cleanup_inflight = False
+
+    def bind_session(self, session_id: str) -> None:
+        self.session_id = session_id
+
+    def permission_suspension_allowed(self) -> bool:
+        return self.phase == "running" and not self._connection_hold and self._resume_barrier_revision is None
+
+    async def run_permission_suspension(self, operation: Callable[[], Awaitable[bool]]) -> bool | None:
+        """Reserve automatic permission cleanup atomically with the connection hold."""
+        async with self._condition:
+            await self._condition.wait_for(
+                lambda: self.permission_suspension_allowed() or self.phase in {"terminating", "terminated"}
+            )
+            if self.phase in {"terminating", "terminated"}:
+                return None
+            activity_id = uuid.uuid4().hex
+            self._activities[activity_id] = _Activity(
+                activity_id=activity_id,
+                kind="permission_cleanup",
+                task=asyncio.current_task(),
+                ancestor_activity_ids=(),
+                handoff_participant_ids=(),
+            )
+            self._invalidate_pause_commit_locked()
+        try:
+            # A decision or termination can cancel the timer while its worker
+            # is writing the checkpoint or closing the runtime. Drain that
+            # cleanup before allowing pause/termination to declare completion.
+            return await await_fenced(operation())
+        finally:
+            await self.end_activity(activity_id)
+
+    async def attach_task(self, task: asyncio.Task[Any], *, mark_working: bool = True) -> None:
+        async with self._condition:
+            if self.phase in {"terminating", "terminated"}:
+                raise ExecutionControlConflictError("Execution is terminating")
+            self._execution_tasks.add(task)
+            participant_id = self._ensure_participant_locked(task, "execution")
+            participant_ids = _CURRENT_PARTICIPANT_IDS.get()
+            if participant_id not in participant_ids:
+                _CURRENT_PARTICIPANT_IDS.set((*participant_ids, participant_id))
+            self.stream_available = True
+            if mark_working:
+                self.execution_status = "working"
+            self._invalidate_pause_commit_locked()
+            self._condition.notify_all()
+
+    def register_spawned_task(self, task: asyncio.Task[Any], *, kind: str) -> None:
+        """Synchronously reserve a newly-created Task before it can be scheduled."""
+
+        if self.phase in {"terminating", "terminated"}:
+            task.cancel()
+            raise ExecutionTerminatedError()
+        self._ensure_participant_locked(task, kind)
+        self._invalidate_pause_commit_locked()
+
+    async def mark_execution_started(self) -> None:
+        async with self._condition:
+            self.execution_status = "working"
+            self.stream_available = True
+
+    async def mark_execution_status(self, execution_status: str) -> None:
+        """Keep control-plane status aligned when a detached producer finishes."""
+
+        async with self._condition:
+            self.execution_status = execution_status
+            self._condition.notify_all()
+
+    async def rollover_normal_execution(self, *, task_id: str, cwd: str) -> None:
+        """Give a new normal turn a fresh identity while retaining live background participants."""
+
+        async with self._condition:
+            if self.phase != "running" or self.stream_available or not self.has_managed_work():
+                raise ExecutionControlConflictError("Execution cannot roll over while its foreground is active")
+            self.task_id = task_id
+            self.cwd = cwd
+            self.execution_id = "exec-" + uuid.uuid4().hex
+            self.execution_status = "working"
+            self.stream_available = False
+            self.pause_id = None
+            self.pause_reason = None
+            self.expires_at = None
+            self._expires_monotonic = None
+            self.connection_epoch = -1
+            self.release_ready = False
+            self.termination_reason = None
+            self._termination_pause_id = None
+            self.backup = {"status": "not_requested"}
+            self._request_ids.clear()
+            self._commit_error = None
+            self._backup_state_committed = False
+            self._pending_staged_backup = None
+            self._termination_cleanup_complete = self._termination_cleanup is None
+            self._termination_cleanup_inflight = False
+            self.revision += 1
+            snapshot = self.snapshot()
+        await self._persist_snapshot(snapshot)
+
+    async def detach_task(self, task: asyncio.Task[Any], *, execution_status: str) -> None:
+        async with self._condition:
+            self._execution_tasks.discard(task)
+            self._remove_participant_locked(task)
+            if not self._execution_tasks:
+                self.stream_available = False
+                if execution_status != "working" or self.execution_status == "working":
+                    self.execution_status = execution_status
+            self._condition.notify_all()
+            self._schedule_pause_commit_locked()
+            self._maybe_mark_release_ready_locked()
+
+    async def pause(
+        self,
+        *,
+        task_id: str,
+        expected_execution_id: str,
+        request_id: str,
+        connection_epoch: int,
+        reason: str,
+        reconnect_timeout_seconds: float,
+    ) -> dict[str, Any]:
+        if not math.isfinite(reconnect_timeout_seconds):
+            raise ValueError("reconnectTimeoutSeconds must be finite")
+        payload = {
+            "contextId": self.context_id,
+            "taskId": task_id,
+            "executionId": expected_execution_id,
+            "connectionEpoch": connection_epoch,
+            "reason": reason,
+            "reconnectTimeoutSeconds": reconnect_timeout_seconds,
+        }
+        fingerprint = _fingerprint("pause", payload)
+        async with self._condition:
+            self._validate_target_locked(task_id=task_id, execution_id=expected_execution_id)
+            duplicate = self._idempotent_locked(request_id, "pause", fingerprint)
+            if duplicate:
+                if self.phase == "pause_committing" and self._commit_error is not None:
+                    self._commit_error = None
+                    self._spawn(
+                        self._finish_pause(
+                            self._pause_generation,
+                            self.pause_id,
+                            self.revision,
+                            self._paused_commit_target_locked(),
+                        ),
+                        "retry-pause-commit",
+                    )
+                return self.snapshot()
+            self._validate_epoch_locked(connection_epoch)
+            if self.phase == "resuming":
+                raise ExecutionControlConflictError("Execution is resuming; retry pause after it reaches running")
+            if self.phase in {"terminating", "terminated"}:
+                raise ExecutionControlConflictError("Execution is terminating or terminated")
+            if self.phase in _PAUSE_PHASES:
+                raise ExecutionControlConflictError("A different pause request is already active")
+            if reconnect_timeout_seconds < 1 or reconnect_timeout_seconds > 3600:
+                raise ExecutionControlConflictError("reconnectTimeoutSeconds must be between 1 and 3600")
+
+            loop = asyncio.get_running_loop()
+            self._pause_generation += 1
+            generation = self._pause_generation
+            self.pause_id = "pause-" + uuid.uuid4().hex
+            self.pause_reason = reason
+            self._connection_hold = True
+            self._resume_barrier_revision = None
+            self.phase = "pausing"
+            self.revision += 1
+            self.connection_epoch = connection_epoch
+            self._expires_monotonic = loop.time() + reconnect_timeout_seconds
+            self.expires_at = time.time() + reconnect_timeout_seconds
+            self._request_ids[request_id] = ("pause", fingerprint, self.pause_id)
+            self._refresh_passive_waiters_locked()
+            snapshot = self.snapshot()
+            self._spawn(self._persist_snapshot(snapshot), "persist-pausing")
+            self._spawn(self._deadline(generation, self.pause_id, reconnect_timeout_seconds), "pause-deadline")
+            self._schedule_pause_commit_locked()
+            self._condition.notify_all()
+            return snapshot
+
+    async def resume(
+        self,
+        *,
+        execution_id: str,
+        pause_id: str,
+        request_id: str,
+        connection_epoch: int,
+    ) -> dict[str, Any]:
+        payload = {
+            "contextId": self.context_id,
+            "executionId": execution_id,
+            "pauseId": pause_id,
+            "connectionEpoch": connection_epoch,
+        }
+        fingerprint = _fingerprint("resume", payload)
+        should_terminate = False
+        async with self._condition:
+            self._validate_target_locked(task_id=self.task_id, execution_id=execution_id)
+            duplicate = self._idempotent_locked(request_id, "resume", fingerprint)
+            if duplicate:
+                if self.phase == "resuming" and self._commit_error is not None:
+                    self._commit_error = None
+                    if self.external_operations:
+                        self._spawn(self._retry_external_operations_and_resume(), "retry-resume-external-operations")
+                    else:
+                        self._spawn(
+                            self._finish_resume(self.revision, self._running_commit_target_locked()),
+                            "retry-resume-commit",
+                        )
+                return self.snapshot()
+            self._validate_epoch_locked(connection_epoch)
+            if self.phase in {"terminating", "terminated"}:
+                raise ExecutionControlConflictError("Execution is terminating or terminated")
+            if self.phase == "running":
+                raise ExecutionControlConflictError("Execution is not paused")
+            if self.phase == "resuming":
+                raise ExecutionControlConflictError("A different resume request is already active")
+            if self.pause_id != pause_id:
+                raise ExecutionControlConflictError("pauseId does not identify the active pause")
+            loop = asyncio.get_running_loop()
+            if self._expires_monotonic is not None and loop.time() >= self._expires_monotonic:
+                self._claim_termination_locked("disconnect_timeout")
+                should_terminate = True
+                snapshot = self.snapshot()
+            else:
+                self._connection_hold = False
+                self._pause_generation += 1
+                self.phase = "resuming"
+                self.revision += 1
+                self.connection_epoch = connection_epoch
+                self._resume_barrier_revision = self.revision
+                self._refresh_passive_waiters_locked()
+                self._request_ids[request_id] = ("resume", fingerprint, pause_id)
+                snapshot = self.snapshot()
+                self._spawn(
+                    self._finish_resume(self.revision, self._running_commit_target_locked()),
+                    "resume-commit",
+                )
+                self._condition.notify_all()
+        if should_terminate:
+            self._spawn(self._finish_termination(), "deadline-termination")
+            raise ExecutionControlConflictError("Reconnect deadline has expired; termination was claimed")
+        return snapshot
+
+    async def terminate(
+        self,
+        *,
+        execution_id: str,
+        request_id: str,
+        connection_epoch: int,
+        reason: str,
+        pause_id: str | None = None,
+    ) -> dict[str, Any]:
+        payload = {
+            "contextId": self.context_id,
+            "executionId": execution_id,
+            "connectionEpoch": connection_epoch,
+            "reason": reason,
+            "pauseId": pause_id,
+        }
+        fingerprint = _fingerprint("terminate", payload)
+        async with self._condition:
+            self._validate_target_locked(task_id=self.task_id, execution_id=execution_id)
+            duplicate = self._idempotent_locked(request_id, "terminate", fingerprint)
+            if duplicate:
+                self._retry_termination_if_needed_locked()
+                return self.snapshot()
+            self._validate_epoch_locked(connection_epoch)
+            if reason == "disconnect_timeout":
+                expected_pause_id = (
+                    self._termination_pause_id if self.phase in {"terminating", "terminated"} else self.pause_id
+                )
+                if (
+                    not pause_id
+                    or pause_id != expected_pause_id
+                    or (
+                        self.phase not in {"terminating", "terminated"}
+                        and (self.phase not in _PAUSE_PHASES or not self._connection_hold)
+                    )
+                ):
+                    raise ExecutionControlConflictError("disconnect_timeout no longer identifies the active pause")
+            self._request_ids[request_id] = ("terminate", fingerprint, pause_id)
+            self.connection_epoch = connection_epoch
+            if self.phase == "terminated":
+                self._retry_termination_if_needed_locked()
+                return self.snapshot()
+            if self.phase == "terminating":
+                return self.snapshot()
+            self._claim_termination_locked(reason)
+            snapshot = self.snapshot()
+            self._spawn(self._finish_termination(), "explicit-termination")
+            return snapshot
+
+    async def checkpoint(self) -> None:
+        async with self._condition:
+            task = asyncio.current_task()
+            participant_ids = _CURRENT_PARTICIPANT_IDS.get()
+            if task is not None:
+                own_id = self._ensure_participant_locked(task, "agent_loop")
+                if own_id not in participant_ids:
+                    participant_ids = (*participant_ids, own_id)
+                    _CURRENT_PARTICIPANT_IDS.set(participant_ids)
+                participant_ids = (own_id,)
+            activity_ids = _CURRENT_ACTIVITY_IDS.get()
+            while True:
+                if self.phase in {"terminating", "terminated"}:
+                    raise ExecutionTerminatedError()
+                held = self._connection_hold or self._resume_barrier_revision is not None
+                if not held:
+                    self._set_activities_blocked_locked(activity_ids, False)
+                    self._set_participants_safe_locked(participant_ids, False)
+                    return
+                self._set_activities_blocked_locked(activity_ids, True)
+                self._set_participants_safe_locked(participant_ids, True)
+                self._schedule_pause_commit_locked()
+                await self._condition.wait()
+
+    async def begin_activity(
+        self,
+        kind: str,
+        *,
+        check_gate: bool = True,
+        handoff_to_parent: bool = False,
+    ) -> ActivityHandle:
+        inherited_participant_ids = _CURRENT_PARTICIPANT_IDS.get()
+        handoff_participant_ids = inherited_participant_ids[-1:] if handoff_to_parent else ()
+        if check_gate:
+            await self.checkpoint()
+        async with self._condition:
+            if self.phase in {"terminating", "terminated"}:
+                raise ExecutionTerminatedError()
+            activity_id = uuid.uuid4().hex
+            self._activities[activity_id] = _Activity(
+                activity_id=activity_id,
+                kind=kind,
+                task=asyncio.current_task(),
+                ancestor_activity_ids=_CURRENT_ACTIVITY_IDS.get(),
+                handoff_participant_ids=handoff_participant_ids,
+            )
+            self._invalidate_pause_commit_locked()
+            self._notify_activity_budgets_locked()
+            self._condition.notify_all()
+            return ActivityHandle(self, activity_id)
+
+    async def begin_non_advancing_wait(self) -> str:
+        async with self._condition:
+            task = asyncio.current_task()
+            participant_ids = _CURRENT_PARTICIPANT_IDS.get()
+            if task is not None:
+                own_id = self._ensure_participant_locked(task, "agent_loop")
+                if own_id not in participant_ids:
+                    participant_ids = (*participant_ids, own_id)
+                    _CURRENT_PARTICIPANT_IDS.set(participant_ids)
+                participant_ids = (own_id,)
+            waiter_id = uuid.uuid4().hex
+            activity_ids = _CURRENT_ACTIVITY_IDS.get()
+            self._passive_waiters[waiter_id] = (participant_ids, activity_ids)
+            self._set_participants_safe_locked(participant_ids, True)
+            if self._connection_hold or self._resume_barrier_revision is not None:
+                self._set_activities_blocked_locked(activity_ids, True)
+            self._schedule_pause_commit_locked()
+            self._condition.notify_all()
+            return waiter_id
+
+    async def end_non_advancing_wait(self, waiter_id: str) -> None:
+        async with self._condition:
+            waiter = self._passive_waiters.pop(waiter_id, None)
+            if waiter is None:
+                return
+            participant_ids, activity_ids = waiter
+            self._set_participants_safe_locked(participant_ids, False)
+            if not self._connection_hold and self._resume_barrier_revision is None:
+                self._set_activities_blocked_locked(activity_ids, False)
+            self._refresh_passive_waiters_locked()
+            self._invalidate_pause_commit_locked()
+            self._condition.notify_all()
+
+    async def end_activity(self, activity_id: str) -> None:
+        async with self._condition:
+            activity = self._activities.pop(activity_id, None)
+            if activity is not None:
+                # A child activity can finish while its parent is parked in a
+                # non-advancing wait.  Keep the parent unsafe until it consumes
+                # and durably records the child's result at its next checkpoint.
+                self._revoke_passive_waiters_locked(activity.handoff_participant_ids)
+                self._set_participants_safe_locked(activity.handoff_participant_ids, False)
+                activity.budget_changed.set()
+                self._notify_activity_budgets_locked()
+                self._invalidate_pause_commit_locked()
+            self._condition.notify_all()
+            self._schedule_pause_commit_locked()
+            self._maybe_mark_release_ready_locked()
+
+    async def record_external_operation(
+        self,
+        *,
+        product: str,
+        action: str,
+        outcome: Literal["accepted", "unknown"],
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        region_id: str | None = None,
+        tool_use_id: str | None = None,
+    ) -> None:
+        """Persist the result of a write request that completed while its caller was being cancelled."""
+        operation = {
+            "product": product,
+            "action": action,
+            "outcome": outcome,
+            "resourceType": resource_type,
+            "resourceId": resource_id,
+            "regionId": region_id,
+            "toolUseId": tool_use_id,
+        }
+        operation = {key: value for key, value in operation.items() if value is not None}
+        async with self._condition:
+            if operation not in self.external_operations:
+                self.external_operations.append(operation)
+                self.revision += 1
+            resume_revision = self.revision if self.phase == "resuming" else None
+            if resume_revision is not None:
+                self._resume_barrier_revision = resume_revision
+            snapshot = self.snapshot()
+        try:
+            await self._persist_external_operations()
+            await self._persist_snapshot(snapshot)
+        except Exception:
+            async with self._condition:
+                self._commit_error = "external_operation_commit_failed"
+            raise
+        if resume_revision is not None:
+            async with self._condition:
+                if (
+                    self.phase == "resuming"
+                    and self.revision == resume_revision
+                    and self._resume_barrier_revision == resume_revision
+                ):
+                    self.revision += 1
+                    self._resume_barrier_revision = self.revision
+                    self._spawn(
+                        self._finish_resume(self.revision, self._running_commit_target_locked()),
+                        "resume-after-external-operation",
+                    )
+
+    def snapshot(self) -> dict[str, Any]:
+        blockers: dict[str, int] = {}
+        for participant in self._participants.values():
+            if not participant.safe:
+                blockers[participant.kind] = blockers.get(participant.kind, 0) + 1
+        for activity in self._activities.values():
+            if not activity.blocked:
+                blockers[activity.kind] = blockers.get(activity.kind, 0) + 1
+        return {
+            "contextId": self.context_id,
+            "taskId": self.task_id,
+            "executionId": self.execution_id,
+            "serverInstanceId": self.server_instance_id,
+            "pauseId": self.pause_id,
+            "pauseReason": self.pause_reason,
+            "connectionEpoch": self.connection_epoch,
+            "revision": self.revision,
+            "persistedRevision": self.persisted_revision,
+            "phase": self.phase,
+            "pauseComplete": self.phase == "paused",
+            "executionStatus": self.execution_status,
+            "streamAvailable": self.stream_available,
+            "blockers": [{"kind": kind, "count": count} for kind, count in sorted(blockers.items())],
+            "expiresAt": _utc_timestamp(self.expires_at),
+            "terminationReason": self.termination_reason,
+            "commitError": self._commit_error,
+            "backup": dict(self.backup),
+            "externalOperations": [dict(operation) for operation in self.external_operations],
+            "releaseReady": self.release_ready,
+        }
+
+    def has_managed_work(self) -> bool:
+        return bool(
+            any(not task.done() for task in self._execution_tasks)
+            or self._activities
+            or any(not participant.task.done() for participant in self._participants.values())
+        )
+
+    async def close(self) -> None:
+        current = asyncio.current_task()
+        managed_tasks = tuple(
+            dict.fromkeys(
+                task
+                for task in (
+                    *self._execution_tasks,
+                    *(activity.task for activity in self._activities.values() if activity.task is not None),
+                    *(participant.task for participant in self._participants.values()),
+                )
+                if task is not current and not task.done()
+            )
+        )
+        for task in managed_tasks:
+            task.cancel()
+        if managed_tasks:
+            await asyncio.gather(*managed_tasks, return_exceptions=True)
+        tasks = tuple(self._background_tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _validate_target_locked(self, *, task_id: str, execution_id: str) -> None:
+        if task_id != self.task_id or execution_id != self.execution_id:
+            raise ExecutionControlConflictError("Execution identity does not match the current execution")
+
+    def _validate_epoch_locked(self, connection_epoch: int) -> None:
+        if connection_epoch < 0 or connection_epoch < self.connection_epoch:
+            raise ExecutionControlConflictError("connectionEpoch is stale")
+
+    def _idempotent_locked(self, request_id: str, action: str, fingerprint: str) -> bool:
+        previous = self._request_ids.get(request_id)
+        if previous is None:
+            return False
+        if previous[0] != action or previous[1] != fingerprint:
+            raise ExecutionControlConflictError("requestId was already used with different content")
+        return True
+
+    def _set_activities_blocked_locked(self, activity_ids: tuple[str, ...], blocked: bool) -> None:
+        changed = False
+        for activity_id in activity_ids:
+            activity = self._activities.get(activity_id)
+            if activity is None or activity.blocked == blocked:
+                continue
+            activity.blocked = blocked
+            activity.budget_changed.set()
+            changed = True
+        if changed:
+            self._notify_activity_budgets_locked()
+
+    def _notify_activity_budgets_locked(self) -> None:
+        for activity in self._activities.values():
+            activity.budget_changed.set()
+
+    def _activity_budget_blocked(self, activity_id: str) -> bool:
+        activity = self._activities.get(activity_id)
+        if activity is None or not activity.blocked:
+            return False
+        return not any(
+            activity_id in descendant.ancestor_activity_ids and not descendant.blocked
+            for descendant in self._activities.values()
+        )
+
+    def _set_participants_safe_locked(self, participant_ids: tuple[str, ...], safe: bool) -> None:
+        for participant_id in participant_ids:
+            participant = self._participants.get(participant_id)
+            if participant is not None:
+                participant.safe = safe
+
+    def _refresh_passive_waiters_locked(self) -> None:
+        blocked = self._connection_hold or self._resume_barrier_revision is not None
+        for participant_ids, activity_ids in self._passive_waiters.values():
+            self._set_participants_safe_locked(participant_ids, True)
+            self._set_activities_blocked_locked(activity_ids, blocked)
+
+    def _revoke_passive_waiters_locked(self, participant_ids: tuple[str, ...]) -> None:
+        if not participant_ids:
+            return
+        participant_id_set = set(participant_ids)
+        for waiter_id, (waiter_participant_ids, _activity_ids) in tuple(self._passive_waiters.items()):
+            if participant_id_set.intersection(waiter_participant_ids):
+                self._passive_waiters.pop(waiter_id, None)
+
+    def _ensure_participant_locked(self, task: asyncio.Task[Any], kind: str) -> str:
+        participant_id = self._participant_ids_by_task.get(task)
+        if participant_id is not None:
+            return participant_id
+        participant_id = uuid.uuid4().hex
+        self._participant_ids_by_task[task] = participant_id
+        self._participants[participant_id] = _Participant(participant_id, kind, task)
+
+        def remove_finished(finished: asyncio.Task[Any]) -> None:
+            try:
+                self._spawn(self._remove_finished_participant(finished), "participant-finished")
+            except RuntimeError:
+                pass
+
+        task.add_done_callback(remove_finished)
+        return participant_id
+
+    def _remove_participant_locked(self, task: asyncio.Task[Any]) -> None:
+        participant_id = self._participant_ids_by_task.pop(task, None)
+        if participant_id is not None:
+            self._participants.pop(participant_id, None)
+
+    async def _remove_finished_participant(self, task: asyncio.Task[Any]) -> None:
+        async with self._condition:
+            self._remove_participant_locked(task)
+            self._schedule_pause_commit_locked()
+            self._maybe_mark_release_ready_locked()
+            self._condition.notify_all()
+
+    def _maybe_mark_release_ready_locked(self) -> None:
+        if (
+            self.phase == "terminated"
+            and self.backup.get("status") in {"disabled", "shared_committed"}
+            and not self._execution_tasks
+            and not self._activities
+            and not self._participants
+            and not self.release_ready
+            and not self._release_commit_inflight
+            and self._backup_state_committed
+        ):
+            self._release_commit_inflight = True
+            self._spawn(self._commit_release_ready(), "release-ready")
+
+    async def _commit_release_ready(self) -> None:
+        async with self._condition:
+            if (
+                self.phase != "terminated"
+                or self.backup.get("status") not in {"disabled", "shared_committed"}
+                or self._execution_tasks
+                or self._activities
+                or self._participants
+            ):
+                self._release_commit_inflight = False
+                return
+            self.revision += 1
+            revision = self.revision
+            target = self.snapshot()
+            target["releaseReady"] = True
+            target["commitError"] = None
+        try:
+            await self._persist_snapshot(target)
+        except Exception:
+            async with self._condition:
+                if self.revision == revision:
+                    self._commit_error = "state_commit_failed"
+                self._release_commit_inflight = False
+            return
+        async with self._condition:
+            if self.phase == "terminated" and self.revision == revision:
+                self.release_ready = True
+                self._commit_error = None
+            self._release_commit_inflight = False
+
+    def _schedule_pause_commit_locked(self) -> None:
+        if self.phase != "pausing" or not self._connection_hold:
+            return
+        if any(not activity.blocked for activity in self._activities.values()) or any(
+            not participant.safe for participant in self._participants.values()
+        ):
+            return
+        pause_id = self.pause_id
+        generation = self._pause_generation
+        self.phase = "pause_committing"
+        self.revision += 1
+        self._spawn(
+            self._finish_pause(generation, pause_id, self.revision, self._paused_commit_target_locked()),
+            "pause-commit",
+        )
+
+    def _invalidate_pause_commit_locked(self) -> None:
+        if self.phase != "pause_committing" or not self._connection_hold:
+            return
+        if not any(not activity.blocked for activity in self._activities.values()) and not any(
+            not participant.safe for participant in self._participants.values()
+        ):
+            return
+        self.phase = "pausing"
+        self.revision += 1
+        self._spawn(self._persist_snapshot(self.snapshot()), "persist-pause-invalidated")
+
+    def _paused_commit_target_locked(self) -> dict[str, Any]:
+        target = self.snapshot()
+        target["phase"] = "paused"
+        target["pauseComplete"] = True
+        return target
+
+    def _running_commit_target_locked(self) -> dict[str, Any]:
+        target = self.snapshot()
+        target["phase"] = "running"
+        target["pauseComplete"] = False
+        target["expiresAt"] = None
+        return target
+
+    async def _finish_pause(
+        self,
+        generation: int,
+        pause_id: str | None,
+        revision: int,
+        target: dict[str, Any],
+    ) -> None:
+        try:
+            await self._persist_snapshot(target)
+        except Exception:
+            async with self._condition:
+                if self.phase == "pause_committing" and self.revision == revision:
+                    self._commit_error = "state_commit_failed"
+            return
+        async with self._condition:
+            if (
+                self.phase == "pause_committing"
+                and self._connection_hold
+                and self.pause_id == pause_id
+                and self._pause_generation == generation
+                and self.revision == revision
+            ):
+                self._commit_error = None
+                self.phase = "paused"
+                self._condition.notify_all()
+
+    async def _finish_resume(self, revision: int, target: dict[str, Any]) -> None:
+        try:
+            await self._persist_snapshot(target)
+        except Exception:
+            async with self._condition:
+                if self.phase == "resuming" and self.revision == revision:
+                    self._commit_error = "state_commit_failed"
+            return
+        async with self._condition:
+            if self.phase == "resuming" and self._resume_barrier_revision == revision and self.revision == revision:
+                if self._on_resume is not None:
+                    self._on_resume(self.context_id)
+                self._commit_error = None
+                self._resume_barrier_revision = None
+                self.phase = "running"
+                self.pause_id = None
+                self.pause_reason = None
+                self.expires_at = None
+                self._expires_monotonic = None
+                self._refresh_passive_waiters_locked()
+                self._condition.notify_all()
+
+    async def _deadline(self, generation: int, pause_id: str, delay: float) -> None:
+        await asyncio.sleep(delay)
+        async with self._condition:
+            if (
+                self._pause_generation != generation
+                or self.pause_id != pause_id
+                or self.phase not in _PAUSE_PHASES
+                or not self._connection_hold
+            ):
+                return
+            self._claim_termination_locked("disconnect_timeout")
+        await self._finish_termination()
+
+    def _claim_termination_locked(self, reason: str) -> None:
+        self._termination_pause_id = self.pause_id if reason == "disconnect_timeout" else None
+        self._pause_generation += 1
+        self._connection_hold = False
+        self._resume_barrier_revision = None
+        self.phase = "terminating"
+        self.revision += 1
+        self.termination_reason = reason
+        self.backup = {"status": "pending"}
+        self._backup_state_committed = False
+        self._termination_cleanup_complete = self._termination_cleanup is None
+        self._termination_cleanup_inflight = False
+        self.release_ready = False
+        self._condition.notify_all()
+
+    def _retry_termination_if_needed_locked(self) -> None:
+        if self.phase != "terminated" or self.release_ready:
+            return
+        if not self._termination_cleanup_complete:
+            if not self._termination_cleanup_inflight:
+                self._termination_cleanup_inflight = True
+                self.backup = {"status": "pending"}
+                self._backup_state_committed = False
+                self._spawn(self._retry_termination_cleanup(), "retry-termination-cleanup")
+            return
+        if self.backup.get("status") == "blocked":
+            self.backup = {"status": "pending"}
+            self._backup_state_committed = False
+            self._spawn(self._retry_backup(), "retry-termination-backup")
+        elif self._commit_error is not None:
+            self._commit_error = None
+            if self._backup_state_committed:
+                self._maybe_mark_release_ready_locked()
+            else:
+                self._spawn(self._retry_backup_state_commit(), "retry-backup-state-commit")
+
+    async def _finish_termination(self) -> None:
+        current = asyncio.current_task()
+        async with self._condition:
+            cleanup = None
+            if not self._termination_cleanup_complete and not self._termination_cleanup_inflight:
+                self._termination_cleanup_inflight = True
+                cleanup = self._termination_cleanup
+            execution_tasks = tuple(task for task in self._execution_tasks if task is not current and not task.done())
+            activity_tasks = tuple(
+                activity.task
+                for activity in self._activities.values()
+                if activity.task is not None and activity.task is not current and not activity.task.done()
+            )
+            participant_tasks = tuple(
+                participant.task
+                for participant in self._participants.values()
+                if participant.task is not current and not participant.task.done()
+            )
+        cleanup_error = await self._run_termination_cleanup(cleanup, mark_complete=False)
+        tasks = tuple(dict.fromkeys((*execution_tasks, *activity_tasks, *participant_tasks)))
+        for task in tasks:
+            task.cancel()
+        # A transport may reuse its producer Task after execute() returns (the
+        # SDK does this for normal input-required turns). Its execution scope
+        # ends at detach_task(), after executor cleanup, not at producer exit.
+        async with self._condition:
+            await self._condition.wait_for(
+                lambda: all(task not in self._execution_tasks or task.done() for task in execution_tasks)
+            )
+        owned_tasks = tuple(task for task in tasks if task not in execution_tasks)
+        if owned_tasks:
+            await asyncio.gather(*owned_tasks, return_exceptions=True)
+        if cleanup_error is None:
+            cleanup_error = await self._run_termination_cleanup(cleanup, mark_complete=True)
+        async with self._condition:
+            for task in tuple(self._participant_ids_by_task):
+                if task.done():
+                    self._remove_participant_locked(task)
+            self.stream_available = False
+            if self.execution_status not in _TERMINAL_TASK_STATES:
+                self.execution_status = "canceled"
+            self.phase = "terminated"
+            self.revision += 1
+            terminated = self.snapshot()
+        try:
+            await self._persist_snapshot(terminated)
+        except Exception:
+            async with self._condition:
+                self._commit_error = "state_commit_failed"
+        if cleanup_error is not None:
+            await self._commit_blocked_backup_state("execution termination cleanup failed", cleanup_error)
+            async with self._condition:
+                self._termination_cleanup_inflight = False
+            return
+        await self._perform_backup()
+
+    async def _run_termination_cleanup(
+        self,
+        cleanup: Callable[[str, str, str], Awaitable[str | None]] | None,
+        *,
+        mark_complete: bool = True,
+    ) -> BaseException | None:
+        if cleanup is None:
+            return None
+        try:
+            execution_status = await cleanup(self.context_id, self.task_id, self.termination_reason or "terminated")
+        except Exception as exc:
+            return exc
+        async with self._condition:
+            if execution_status is not None:
+                self.execution_status = execution_status
+            if mark_complete:
+                self._termination_cleanup_complete = True
+                self._termination_cleanup_inflight = False
+        return None
+
+    async def _retry_termination_cleanup(self) -> None:
+        error = await self._run_termination_cleanup(self._termination_cleanup)
+        if error is not None:
+            await self._commit_blocked_backup_state("execution termination cleanup failed", error)
+            async with self._condition:
+                self._termination_cleanup_inflight = False
+            return
+        await self._perform_backup()
+
+    async def _retry_backup(self) -> None:
+        await self._perform_backup()
+
+    async def _perform_backup(self) -> None:
+        try:
+            await self._persist_external_operations()
+        except Exception as exc:
+            await self._commit_blocked_backup_state("external operation state could not be persisted", exc)
+            return
+        if self._backup_service is None or self.session_id is None:
+            async with self._condition:
+                self.backup = {"status": "disabled"}
+                self._backup_state_committed = False
+                self.release_ready = False
+                self.revision += 1
+                snapshot = self.snapshot()
+                snapshot["commitError"] = None
+            try:
+                await self._persist_snapshot(snapshot)
+            except Exception:
+                async with self._condition:
+                    self._commit_error = "state_commit_failed"
+                return
+            async with self._condition:
+                self._commit_error = None
+                self._backup_state_committed = True
+                self._maybe_mark_release_ready_locked()
+            return
+        try:
+            result = self._pending_staged_backup
+            if result is None:
+                result = await run_sync_fenced(
+                    self._backup_service.backup_session,
+                    self.cwd,
+                    self.session_id,
+                    reason=(
+                        BackupReason.DISCONNECT_TIMEOUT
+                        if self.termination_reason == "disconnect_timeout"
+                        else BackupReason.TERMINAL
+                    ),
+                    critical=True,
+                )
+            if result.enabled and result.staged_committed and not result.shared_committed:
+                wait_for_shared = getattr(self._backup_service, "wait_until_shared_committed", None)
+                if not callable(wait_for_shared) or result.generation is None or result.commit_id is None:
+                    raise RuntimeError("Staged backup cannot prove shared publication")
+                result = cast(
+                    BackupResult,
+                    await run_sync_fenced(
+                        wait_for_shared,
+                        self.cwd,
+                        self.session_id,
+                        generation=result.generation,
+                        commit_id=result.commit_id,
+                    ),
+                )
+            succeeded = (not result.enabled) or (result.succeeded and result.shared_committed)
+            self._pending_staged_backup = None if succeeded else result if result.staged_committed else None
+            backup = {
+                "status": "disabled" if not result.enabled else "shared_committed" if succeeded else "blocked",
+                "generation": result.generation,
+                "commitId": result.commit_id,
+                "error": result.error,
+            }
+        except Exception as exc:
+            succeeded = False
+            backup = {"status": "blocked", "error": str(exc)}
+        async with self._condition:
+            self.backup = backup
+            self._backup_state_committed = False
+            self.release_ready = False
+            self.revision += 1
+            snapshot = self.snapshot()
+            snapshot["commitError"] = None
+        try:
+            await self._persist_snapshot(snapshot)
+        except Exception:
+            async with self._condition:
+                self._commit_error = "state_commit_failed"
+            return
+        if succeeded:
+            async with self._condition:
+                self._commit_error = None
+                self._backup_state_committed = True
+                self._maybe_mark_release_ready_locked()
+        else:
+            async with self._condition:
+                self._commit_error = None
+                self._backup_state_committed = True
+
+    async def _commit_blocked_backup_state(self, message: str, exc: BaseException) -> None:
+        async with self._condition:
+            self.backup = {"status": "blocked", "error": f"{message}: {type(exc).__name__}"}
+            self._backup_state_committed = False
+            self.release_ready = False
+            self.revision += 1
+            snapshot = self.snapshot()
+            snapshot["commitError"] = None
+        try:
+            await self._persist_snapshot(snapshot)
+        except Exception:
+            async with self._condition:
+                self._commit_error = "state_commit_failed"
+            return
+        async with self._condition:
+            self._commit_error = None
+            self._backup_state_committed = True
+
+    async def _persist_external_operations(self) -> None:
+        if not self.external_operations or self.session_id is None:
+            return
+        async with self._operation_commit_lock:
+            document = {
+                "version": 1,
+                "contextId": self.context_id,
+                "taskId": self.task_id,
+                "executionId": self.execution_id,
+                "operations": [dict(operation) for operation in self.external_operations],
+            }
+            path = SessionStorage().session_dir(self.cwd, self.session_id) / "a2a" / "external-operations.json"
+            await run_sync_fenced(atomic_write_json, path, document)
+
+    async def _retry_backup_state_commit(self) -> None:
+        async with self._condition:
+            snapshot = self.snapshot()
+            snapshot["commitError"] = None
+            backup_complete = self.backup.get("status") in {"disabled", "shared_committed"}
+        try:
+            await self._persist_snapshot(snapshot)
+        except Exception:
+            async with self._condition:
+                self._commit_error = "state_commit_failed"
+            return
+        async with self._condition:
+            self._commit_error = None
+            self._backup_state_committed = True
+            if backup_complete:
+                self._maybe_mark_release_ready_locked()
+
+    async def _retry_external_operations_and_resume(self) -> None:
+        try:
+            await self._persist_external_operations()
+        except Exception:
+            async with self._condition:
+                if self.phase == "resuming":
+                    self._commit_error = "external_operation_commit_failed"
+            return
+        async with self._condition:
+            if self.phase != "resuming":
+                return
+            self.revision += 1
+            self._resume_barrier_revision = self.revision
+            revision = self.revision
+            target = self._running_commit_target_locked()
+        await self._finish_resume(revision, target)
+
+    async def _persist_snapshot(self, snapshot: dict[str, Any]) -> None:
+        revision = int(snapshot["revision"])
+        if self._persistence_path is None:
+            self.persisted_revision = max(self.persisted_revision, revision)
+            return
+        async with self._commit_lock:
+            if revision <= self.persisted_revision:
+                return
+            value = dict(snapshot)
+            value["persistedRevision"] = revision
+            await run_sync_fenced(atomic_write_json, self._persistence_path, value)
+            self.persisted_revision = revision
+
+    def _spawn(self, awaitable: Awaitable[Any], name: str) -> asyncio.Task[Any]:
+        task = asyncio.ensure_future(awaitable)
+        task.set_name(f"a2a-execution-{name}-{self.context_id}")
+        self._background_tasks.add(task)
+
+        def completed(done: asyncio.Task[Any]) -> None:
+            self._background_tasks.discard(done)
+            if not done.cancelled():
+                with suppress(BaseException):
+                    done.exception()
+
+        task.add_done_callback(completed)
+        return task
+
+
+class ExecutionControlService:
+    def __init__(self, *, persistence_root: Path | None, backup_service: Any | None) -> None:
+        self.server_instance_id = "instance-" + uuid.uuid4().hex
+        self._persistence_root = persistence_root
+        self._backup_service = backup_service
+        self._controls: dict[str, ExecutionController] = {}
+        self._context_start_locks: dict[str, asyncio.Lock] = {}
+        self._termination_cleanup: Callable[[str, str, str], Awaitable[str | None]] | None = None
+        self._on_resume: Callable[[str], None] | None = None
+
+    def set_resume_callback(self, callback: Callable[[str], None]) -> None:
+        self._on_resume = callback
+        for control in self._controls.values():
+            control._on_resume = callback
+
+    def set_termination_cleanup(
+        self,
+        cleanup: Callable[[str, str, str], Awaitable[str | None]],
+    ) -> None:
+        self._termination_cleanup = cleanup
+        for control in self._controls.values():
+            control._termination_cleanup = cleanup
+
+    async def begin_execution(
+        self,
+        *,
+        context_id: str,
+        task_id: str,
+        owner: str,
+        cwd: str,
+        continue_input_required: bool = False,
+    ) -> ExecutionController:
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("A2A execution requires an asyncio Task")
+        retired_control: ExecutionController | None = None
+        async with self._context_start_locks.setdefault(context_id, asyncio.Lock()):
+            control = self._controls.get(context_id)
+            if control is not None and control.owner != owner:
+                raise ExecutionControlNotFoundError("Execution was not found")
+            if control is not None and (
+                (
+                    control.task_id != task_id
+                    and control.phase in {"pausing", "pause_committing", "paused", "resuming", "terminating"}
+                )
+                or (control.phase in {"terminating", "terminated"} and not control.release_ready)
+            ):
+                raise ExecutionControlConflictError("Current execution must finish recovery before a new task starts")
+            reuse = bool(
+                control is not None
+                and control.task_id == task_id
+                and control.phase not in {"terminating", "terminated"}
+                and (
+                    control.stream_available
+                    or (continue_input_required and control.execution_status == "input-required")
+                    or control.phase != "running"
+                )
+            )
+            if (
+                not reuse
+                and control is not None
+                and control.phase == "running"
+                and not control.stream_available
+                and control.has_managed_work()
+            ):
+                await control.rollover_normal_execution(task_id=task_id, cwd=cwd)
+                reuse = True
+            if not reuse:
+                retired_control = control
+                path = None
+                if self._persistence_root is not None:
+                    path = self._persistence_root / "execution-control" / f"{context_id}.json"
+                control = ExecutionController(
+                    context_id=context_id,
+                    task_id=task_id,
+                    owner=owner,
+                    cwd=cwd,
+                    server_instance_id=self.server_instance_id,
+                    persistence_path=path,
+                    backup_service=self._backup_service,
+                    termination_cleanup=self._termination_cleanup,
+                    on_resume=self._on_resume,
+                )
+                self._controls[context_id] = control
+            assert control is not None
+            if retired_control is not None:
+                await retired_control.close()
+            await control.attach_task(task, mark_working=False)
+        return control
+
+    def get_for_context(self, context_id: str) -> ExecutionController | None:
+        return self._controls.get(context_id)
+
+    async def require(self, *, context_id: str, owner: str) -> ExecutionController:
+        control = self._controls.get(context_id)
+        if control is None or control.owner != owner:
+            raise ExecutionControlNotFoundError("Execution was not found")
+        return control
+
+    def snapshot_for_context(self, context_id: str) -> dict[str, Any] | None:
+        control = self._controls.get(context_id)
+        return control.snapshot() if control is not None else None
+
+    def has_active_work(self) -> bool:
+        active_phases = {"pausing", "pause_committing", "paused", "resuming", "terminating"}
+        return any(
+            control.has_managed_work()
+            or control.phase in active_phases
+            or (control.phase == "terminated" and not control.release_ready)
+            for control in self._controls.values()
+        )
+
+    async def close(self) -> None:
+        await asyncio.gather(*(control.close() for control in tuple(self._controls.values())), return_exceptions=True)
+
+
+def bind_execution_control(control: ExecutionController | None) -> Token[ExecutionController | None]:
+    return _CURRENT_CONTROL.set(control)
+
+
+def reset_execution_control(token: Token[ExecutionController | None]) -> None:
+    _CURRENT_CONTROL.reset(token)
+
+
+def clear_execution_participants() -> Token[tuple[str, ...]]:
+    return _CURRENT_PARTICIPANT_IDS.set(())
+
+
+def reset_execution_participants(token: Token[tuple[str, ...]]) -> None:
+    _CURRENT_PARTICIPANT_IDS.reset(token)
+
+
+def current_execution_control() -> ExecutionController | None:
+    return _CURRENT_CONTROL.get()
+
+
+def current_execution_termination_reason() -> str | None:
+    control = current_execution_control()
+    if control is None or control.phase not in {"terminating", "terminated"}:
+        return None
+    return control.termination_reason
+
+
+def register_execution_task(task: asyncio.Task[Any], *, kind: str) -> None:
+    control = current_execution_control()
+    if control is not None:
+        control.register_spawned_task(task, kind=kind)
+
+
+async def execution_checkpoint() -> None:
+    control = current_execution_control()
+    if control is not None:
+        await control.checkpoint()
+
+
+async def record_execution_external_operation(
+    *,
+    product: str,
+    action: str,
+    outcome: Literal["accepted", "unknown"],
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    region_id: str | None = None,
+    tool_use_id: str | None = None,
+) -> None:
+    control = current_execution_control()
+    if control is not None:
+        await control.record_external_operation(
+            product=product,
+            action=action,
+            outcome=outcome,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            region_id=region_id,
+            tool_use_id=tool_use_id,
+        )
+
+
+@asynccontextmanager
+async def execution_activity(
+    kind: str,
+    *,
+    check_gate: bool = True,
+    handoff_to_parent: bool = False,
+) -> AsyncIterator[ActivityHandle | None]:
+    control = current_execution_control()
+    if control is None:
+        yield None
+        return
+    handle = await control.begin_activity(
+        kind,
+        check_gate=check_gate,
+        handoff_to_parent=handoff_to_parent,
+    )
+    stack_token = _CURRENT_ACTIVITY_IDS.set((*_CURRENT_ACTIVITY_IDS.get(), handle.activity_id))
+    try:
+        yield handle
+    finally:
+        try:
+            _CURRENT_ACTIVITY_IDS.reset(stack_token)
+        except ValueError:
+            # Async-generator finalization may run in a different Context. Its
+            # token cannot reset that Context, but the activity must still end.
+            pass
+        finally:
+            await control.end_activity(handle.activity_id)
+
+
+@asynccontextmanager
+async def execution_non_advancing_wait() -> AsyncIterator[None]:
+    control = current_execution_control()
+    if control is None:
+        yield
+        return
+    waiter_id = await control.begin_non_advancing_wait()
+    try:
+        yield
+    finally:
+        await control.end_non_advancing_wait(waiter_id)
+
+
+async def run_with_execution_budget(awaitable: Awaitable[_T], timeout: float | None) -> _T:
+    """Wait for one existing Task while excluding descendant connection holds."""
+
+    if timeout is None:
+        return await awaitable
+    control = current_execution_control()
+    activity_ids = _CURRENT_ACTIVITY_IDS.get()
+    if control is None or not activity_ids:
+        return await asyncio.wait_for(awaitable, timeout=timeout)
+    activity_id = activity_ids[-1]
+    activity = control._activities.get(activity_id)
+    if activity is None:
+        return await asyncio.wait_for(awaitable, timeout=timeout)
+
+    task = asyncio.ensure_future(awaitable)
+    handle = ActivityHandle(control, activity_id)
+    remaining = float(timeout)
+    loop = asyncio.get_running_loop()
+    changed: asyncio.Task[bool] | None = None
+
+    async def cancel_and_drain_tool() -> None:
+        if not task.done():
+            task.cancel()
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+        if task.done() and not task.cancelled():
+            with suppress(BaseException):
+                task.result()
+
+    try:
+        while True:
+            if task.done():
+                return await task
+            if handle.blocked:
+                activity.budget_changed.clear()
+                if not handle.blocked:
+                    continue
+                changed = asyncio.create_task(activity.budget_changed.wait())
+                async with execution_non_advancing_wait():
+                    done, _ = await asyncio.wait({task, changed}, return_when=asyncio.FIRST_COMPLETED)
+                if changed not in done:
+                    changed.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await changed
+                continue
+            started = loop.time()
+            activity.budget_changed.clear()
+            if handle.blocked:
+                continue
+            changed = asyncio.create_task(activity.budget_changed.wait())
+            done, _ = await asyncio.wait({task, changed}, timeout=remaining, return_when=asyncio.FIRST_COMPLETED)
+            elapsed = loop.time() - started
+            remaining -= elapsed
+            if task in done:
+                changed.cancel()
+                with suppress(asyncio.CancelledError):
+                    await changed
+                return await task
+            if changed in done:
+                continue
+                changed.cancel()
+                with suppress(asyncio.CancelledError):
+                    await changed
+            await cancel_and_drain_tool()
+            raise asyncio.TimeoutError
+    except BaseException:
+        await cancel_and_drain_tool()
+        raise
+    finally:
+        if changed is not None and not changed.done():
+            changed.cancel()
+            with suppress(asyncio.CancelledError):
+                await changed

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -175,16 +175,6 @@ def _format_exception(exc: BaseException) -> str:
     return raw[:_ERROR_TEXT_MAX_CHARS]
 
 
-async def _drain_normal_turn_events(event_queue: Any) -> None:
-    """Finish SDK task-store updates before capturing the completed turn's backup."""
-    join_incoming = getattr(event_queue, "test_only_join_incoming_queue", None)
-    if callable(join_incoming):
-        await join_incoming()
-    join_consumer = getattr(getattr(event_queue, "queue", None), "join", None)
-    if callable(join_consumer):
-        await join_consumer()
-
-
 def _a2a_safe_mode_enabled() -> bool:
     return a2a_safe_mode_enabled()
 
@@ -1977,10 +1967,6 @@ class IacCodeA2AExecutor(AgentExecutor):
                             metadata={"iac_code": final_metadata},
                             session_id=ctx.session_id,
                         )
-                        # Earlier working events can still be queued in the SDK.
-                        # Drain them before persisting input-required, otherwise
-                        # their late saves can overwrite the backup's task state.
-                        await await_fenced(_drain_normal_turn_events(target_queue))
                         task.state = TASK_STATE_INPUT_REQUIRED
                         ctx.active_task_id = None
                         task.touch()

--- a/src/iac_code/a2a/executor.py
+++ b/src/iac_code/a2a/executor.py
@@ -19,7 +19,7 @@ from a2a.types import Message, Role, Task, TaskState, TaskStatus, TaskStatusUpda
 from a2a.utils.errors import InvalidParamsError
 from google.protobuf.json_format import MessageToDict, ParseDict
 
-from iac_code.a2a.backup import backup_session_async, run_sync_fenced
+from iac_code.a2a.backup import await_fenced, backup_session_async, run_sync_fenced
 from iac_code.a2a.events import (
     iac_code_session_metadata,
     make_text_part,
@@ -28,6 +28,15 @@ from iac_code.a2a.events import (
     publish_permission_input_received,
     publish_stream_event,
     with_iac_code_session_metadata,
+)
+from iac_code.a2a.execution_control import (
+    ExecutionControlService,
+    bind_execution_control,
+    clear_execution_participants,
+    current_execution_control,
+    current_execution_termination_reason,
+    reset_execution_control,
+    reset_execution_participants,
 )
 from iac_code.a2a.exposure import normalize_a2a_exposure_types
 from iac_code.a2a.input_required import (
@@ -52,7 +61,10 @@ from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTransl
 from iac_code.a2a.pipeline_executor import (
     RICH_CANDIDATE_PRESENTATION,
     IacCodeA2APipelineExecutor,
+    WaitingInputCancelResult,
+    cancel_waiting_input_task_from_sidecar,
     recoverable_task_id_from_sidecar,
+    terminal_task_state_from_sidecar,
 )
 from iac_code.a2a.pipeline_journal import A2APipelineJournal
 from iac_code.a2a.pipeline_paths import existing_a2a_pipeline_dir_for_session
@@ -161,6 +173,16 @@ def _format_exception(exc: BaseException) -> str:
     message = str(exc)
     raw = type(exc).__name__ if not message else f"{type(exc).__name__}: {message}"
     return raw[:_ERROR_TEXT_MAX_CHARS]
+
+
+async def _drain_normal_turn_events(event_queue: Any) -> None:
+    """Finish SDK task-store updates before capturing the completed turn's backup."""
+    join_incoming = getattr(event_queue, "test_only_join_incoming_queue", None)
+    if callable(join_incoming):
+        await join_incoming()
+    join_consumer = getattr(getattr(event_queue, "queue", None), "join", None)
+    if callable(join_consumer):
+        await join_consumer()
 
 
 def _a2a_safe_mode_enabled() -> bool:
@@ -845,23 +867,28 @@ async def _observe_cleanup_stream(
     *,
     publisher: PipelineA2AEventPublisher | None = None,
 ) -> AsyncIterator[Any]:
-    if ledger.load_failed():
-        async for event in events:
-            yield event
-        return
-    observer = CleanupObserver(ledger)
-    previous = (
-        _published_cleanup_resource_states(publisher, ledger)
-        if publisher is not None
-        else _cleanup_resource_states(ledger)
-    )
-    if publisher is not None:
-        previous = await _publish_cleanup_resource_changes(publisher, ledger, previous)
-    async for event in events:
-        observer.observe(event)
+    try:
+        if ledger.load_failed():
+            async for event in events:
+                yield event
+            return
+        observer = CleanupObserver(ledger)
+        previous = (
+            _published_cleanup_resource_states(publisher, ledger)
+            if publisher is not None
+            else _cleanup_resource_states(ledger)
+        )
         if publisher is not None:
             previous = await _publish_cleanup_resource_changes(publisher, ledger, previous)
-        yield event
+        async for event in events:
+            observer.observe(event)
+            if publisher is not None:
+                previous = await _publish_cleanup_resource_changes(publisher, ledger, previous)
+            yield event
+    finally:
+        close = getattr(events, "aclose", None)
+        if close is not None:
+            await close()
 
 
 def _cleanup_resource_state(resource: Any) -> tuple[Any, ...]:
@@ -1061,8 +1088,13 @@ async def _stream_a2a_normal_events(
             cleanup_ledger,
             publisher=cleanup_publisher,
         )
-        async for event in cleanup_stream:
-            yield event
+        try:
+            async for event in cleanup_stream:
+                yield event
+        finally:
+            close = getattr(cleanup_stream, "aclose", None)
+            if close is not None:
+                await close()
         if cleanup_ledger.pending_resources():
             if cleanup_only:
                 yield TextDeltaEvent(
@@ -1109,8 +1141,13 @@ async def _stream_a2a_normal_events(
             prompt_stream = runtime.agent_loop.run_streaming(prompt_to_run)
         if cleanup_ledger is not None:
             prompt_stream = _observe_cleanup_stream(prompt_stream, cleanup_ledger, publisher=cleanup_publisher)
-        async for event in prompt_stream:
-            yield event
+        try:
+            async for event in prompt_stream:
+                yield event
+        finally:
+            close = getattr(prompt_stream, "aclose", None)
+            if close is not None:
+                await close()
     if cleanup_ledger is not None and not cleanup_ledger.load_failed() and not cleanup_ledger.pending_resources():
         _mark_completed_cleanup_prompts(runtime=runtime, cwd=cwd, session_id=session_id, ledger=cleanup_ledger)
         _prune_completed_cleanup_prompt_from_runtime(runtime, cleanup_ledger)
@@ -1216,6 +1253,7 @@ class IacCodeA2AExecutor(AgentExecutor):
         permission_wait_policy: Any | None = None,
         thinking_exposure_types: Any = None,
         backup_service: Any | None = None,
+        execution_control_service: ExecutionControlService | None = None,
     ) -> None:
         self._task_store = task_store
         self._model = model
@@ -1234,6 +1272,10 @@ class IacCodeA2AExecutor(AgentExecutor):
         self._thinking_exposure_types = normalize_a2a_exposure_types(thinking_exposure_types)
         self._metadata_echo_redactor = A2AMetadataEchoRedactor()
         self._backup_service = backup_service or SessionBackupService()
+        self._execution_control_service = execution_control_service
+        if execution_control_service is not None:
+            execution_control_service.set_termination_cleanup(self._terminate_detached_execution)
+            execution_control_service.set_resume_callback(self._task_store.touch_context)
 
     async def resolve_sideband_permission(self, response: PermissionResponse) -> Message | None:
         if not await self._permission_input_registry.is_sideband_response(response):
@@ -1242,6 +1284,8 @@ class IacCodeA2AExecutor(AgentExecutor):
         return permission_ack_message(response, approved=approved)
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        execution_scope = bind_execution_control(None)
+        participant_scope = clear_execution_participants()
         metadata = getattr(context, "metadata", None) or getattr(getattr(context, "message", None), "metadata", None)
         permission_response = parse_permission_response(getattr(context, "message", None))
         context_id = (
@@ -1253,8 +1297,30 @@ class IacCodeA2AExecutor(AgentExecutor):
             context_id,
             self._resolve_telemetry_channel(metadata),
         )
-        with a2a_request_context(telemetry_channel=telemetry_channel):
-            await self._execute(context, event_queue, context_id=context_id)
+        try:
+            if permission_response is not None and self._execution_control_service is not None:
+                existing = self._execution_control_service.get_for_context(context_id)
+                owner = self._task_store.owner_for_context(getattr(context, "call_context", None))
+                current_task = asyncio.current_task()
+                if existing is not None and existing.owner == owner and current_task is not None:
+                    await existing.attach_task(current_task, mark_working=False)
+                    bind_execution_control(existing)
+            with a2a_request_context(telemetry_channel=telemetry_channel):
+                await self._execute(context, event_queue, context_id=context_id)
+        finally:
+            control = current_execution_control()
+            if control is not None:
+                execution_status = "unknown"
+                try:
+                    record = await self._task_store.get_task_record(control.task_id)
+                    execution_status = record.state
+                except ValueError:
+                    pass
+                current_task = asyncio.current_task()
+                if current_task is not None:
+                    await control.detach_task(current_task, execution_status=execution_status)
+            reset_execution_control(execution_scope)
+            reset_execution_participants(participant_scope)
 
     async def _execute(self, context: RequestContext, event_queue: EventQueue, *, context_id: str) -> None:
         requested_task_id = context.task_id or None
@@ -1466,6 +1532,17 @@ class IacCodeA2AExecutor(AgentExecutor):
                 owner=owner,
                 restore_interrupted=not pipeline_mode,
             )
+            if self._execution_control_service is not None:
+                control = await self._execution_control_service.begin_execution(
+                    context_id=context_id,
+                    task_id=task.task_id,
+                    owner=owner,
+                    cwd=cwd,
+                    continue_input_required=pipeline_mode and not route_pipeline_handoff_to_normal,
+                )
+                bind_execution_control(control)
+                await control.checkpoint()
+                await control.mark_execution_started()
             await publish_initial_task_if_missing()
             await self._task_store.ensure_task_not_expired(task.task_id)
         except InvalidParamsError:
@@ -1636,6 +1713,9 @@ class IacCodeA2AExecutor(AgentExecutor):
                     cwd=cwd,
                     runtime_factory=runtime_factory,
                 )
+                control = current_execution_control()
+                if control is not None:
+                    control.bind_session(ctx.session_id)
                 if not hasattr(ctx.runtime, "agent_loop"):
                     old_runtime = ctx.runtime
                     ctx.runtime = runtime_factory(ctx.session_id)
@@ -1655,6 +1735,10 @@ class IacCodeA2AExecutor(AgentExecutor):
                 )
                 await self._notify_terminal_task(task_id=task.task_id, context_id=task.context_id, state=task.state)
             self._metrics.record_task_canceled()
+            if current_execution_termination_reason() is not None:
+                # Let the SDK enqueue request completion after the canceled status.
+                # Re-raising here can strand its subscriber queue during shutdown.
+                return
             raise
         except Exception as exc:
             self._log_executor_exception("runtime setup", task_id=task_id, context_id=context_id)
@@ -1732,6 +1816,60 @@ class IacCodeA2AExecutor(AgentExecutor):
             task.active_task = asyncio.current_task()
             self._task_store.mirror_task(task)
             self._task_store.mirror_context(ctx)
+            normal_turn_finished = False
+
+            async def cancel_normal_turn(target_queue: EventQueue) -> None:
+                termination_reason = current_execution_termination_reason()
+                if termination_reason is not None and normal_turn_finished:
+                    task.state = TASK_STATE_INPUT_REQUIRED
+                    ctx.active_task_id = None
+                    task.touch()
+                    ctx.touch()
+                    self._task_store.mirror_task(task)
+                    self._task_store.mirror_context(ctx)
+                    control = current_execution_control()
+                    if control is not None:
+                        await control.mark_execution_status(task.state)
+                    await self._publish_status(
+                        target_queue,
+                        task_id=task_id,
+                        context_id=context_id,
+                        state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                        session_id=ctx.session_id,
+                    )
+                    await self._notify_terminal_task(task_id=task.task_id, context_id=task.context_id, state=task.state)
+                    self._metrics.record_turn_completed()
+                    return
+                task.state = TASK_STATE_CANCELED
+                ctx.active_task_id = None
+                task.touch()
+                ctx.touch()
+                self._task_store.mirror_task(task)
+                self._task_store.mirror_context(ctx)
+                await self._task_store.discard_context_runtime(context_id)
+                if termination_reason is None and await self._publish_backup_blocked_after_terminal_backup_failure(
+                    target_queue,
+                    task=task,
+                    ctx=ctx,
+                    cwd=cwd,
+                    task_id=task_id,
+                    context_id=context_id,
+                    reason=BackupReason.TERMINAL,
+                    blocked_terminal_state=TASK_STATE_CANCELED,
+                ):
+                    self._metrics.record_task_canceled()
+                    return
+                await self._publish_status(
+                    target_queue,
+                    task_id=task_id,
+                    context_id=context_id,
+                    state=TaskState.TASK_STATE_CANCELED,
+                    text=_("Task canceled."),
+                    session_id=ctx.session_id,
+                )
+                await self._notify_terminal_task(task_id=task.task_id, context_id=task.context_id, state=task.state)
+                self._metrics.record_task_canceled()
+
             try:
                 runtime = ctx.runtime
                 if runtime is None:
@@ -1807,7 +1945,10 @@ class IacCodeA2AExecutor(AgentExecutor):
                     detached_permission = None
 
                     async def finalize_normal_turn(target_queue: EventQueue) -> None:
-                        nonlocal final_assistant_text
+                        nonlocal final_assistant_text, normal_turn_finished
+                        # The AgentLoop has finished. Cancellation of its backup
+                        # must not reclassify the completed turn as canceled.
+                        normal_turn_finished = True
                         if current_assistant_text:
                             final_assistant_text = "".join(current_assistant_text)
                         await publish_mcp_warnings(
@@ -1836,12 +1977,23 @@ class IacCodeA2AExecutor(AgentExecutor):
                             metadata={"iac_code": final_metadata},
                             session_id=ctx.session_id,
                         )
+                        # Earlier working events can still be queued in the SDK.
+                        # Drain them before persisting input-required, otherwise
+                        # their late saves can overwrite the backup's task state.
+                        await await_fenced(_drain_normal_turn_events(target_queue))
                         task.state = TASK_STATE_INPUT_REQUIRED
                         ctx.active_task_id = None
                         task.touch()
                         ctx.touch()
                         self._task_store.mirror_task(task)
                         self._task_store.mirror_context(ctx)
+                        control = (
+                            self._execution_control_service.get_for_context(context_id)
+                            if self._execution_control_service is not None
+                            else current_execution_control()
+                        )
+                        if control is not None:
+                            await control.mark_execution_status(TASK_STATE_INPUT_REQUIRED)
                         await backup_session_async(
                             self._backup_service,
                             cwd,
@@ -1877,6 +2029,13 @@ class IacCodeA2AExecutor(AgentExecutor):
                         ctx.touch()
                         self._task_store.mirror_task(task)
                         self._task_store.mirror_context(ctx)
+                        control = (
+                            self._execution_control_service.get_for_context(context_id)
+                            if self._execution_control_service is not None
+                            else current_execution_control()
+                        )
+                        if control is not None:
+                            await control.mark_execution_status(TASK_STATE_INPUT_REQUIRED)
                         await self._notify_terminal_task(
                             task_id=task.task_id,
                             context_id=task.context_id,
@@ -1910,6 +2069,9 @@ class IacCodeA2AExecutor(AgentExecutor):
                             task.state = TASK_STATE_WORKING
                             self._task_store.mirror_task(task)
                             self._task_store.mirror_context(ctx)
+                            control = current_execution_control()
+                            if control is not None:
+                                await control.mark_execution_started()
                             with a2a_request_context(
                                 session_id=ctx.session_id,
                                 user_id=user_id,
@@ -1922,6 +2084,10 @@ class IacCodeA2AExecutor(AgentExecutor):
                                 await finalize_normal_turn(target_queue)
                             else:
                                 await mark_detached_input_required()
+                        except asyncio.CancelledError:
+                            await cancel_normal_turn(target_queue)
+                            if current_execution_termination_reason() is None:
+                                raise
                         finally:
                             task.active_task = None
                             ctx.active_task_id = None
@@ -1932,6 +2098,15 @@ class IacCodeA2AExecutor(AgentExecutor):
                             ctx.lock.release()
 
                     async def consume_normal_stream(target_queue: EventQueue) -> bool:
+                        try:
+                            return await consume_normal_stream_inner(target_queue)
+                        except BaseException:
+                            close = getattr(stream, "aclose", None)
+                            if close is not None:
+                                await close()
+                            raise
+
+                    async def consume_normal_stream_inner(target_queue: EventQueue) -> bool:
                         nonlocal current_assistant_text, final_assistant_text, detached_permission
                         async for event in stream:
                             if isinstance(event, MessageStartEvent):
@@ -2060,35 +2235,7 @@ class IacCodeA2AExecutor(AgentExecutor):
                 else:
                     await mark_detached_input_required()
             except asyncio.CancelledError:
-                task.state = TASK_STATE_CANCELED
-                ctx.active_task_id = None
-                task.touch()
-                ctx.touch()
-                self._task_store.mirror_task(task)
-                self._task_store.mirror_context(ctx)
-                await self._task_store.discard_context_runtime(context_id)
-                if await self._publish_backup_blocked_after_terminal_backup_failure(
-                    event_queue,
-                    task=task,
-                    ctx=ctx,
-                    cwd=cwd,
-                    task_id=task_id,
-                    context_id=context_id,
-                    reason=BackupReason.TERMINAL,
-                    blocked_terminal_state=TASK_STATE_CANCELED,
-                ):
-                    self._metrics.record_task_canceled()
-                    return
-                await self._publish_status(
-                    event_queue,
-                    task_id=task_id,
-                    context_id=context_id,
-                    state=TaskState.TASK_STATE_CANCELED,
-                    text=_("Task canceled."),
-                    session_id=ctx.session_id,
-                )
-                await self._notify_terminal_task(task_id=task.task_id, context_id=task.context_id, state=task.state)
-                self._metrics.record_task_canceled()
+                await cancel_normal_turn(event_queue)
             except Exception as exc:
                 if _is_retryable_executor_error(exc):
                     task.state = TASK_STATE_INPUT_REQUIRED
@@ -2166,6 +2313,110 @@ class IacCodeA2AExecutor(AgentExecutor):
                     logger.debug("flush_telemetry after task failed", exc_info=True)
         finally:
             lock.release()
+
+    async def _terminate_detached_execution(self, context_id: str, task_id: str, reason: str) -> str | None:
+        had_pending_permission = await self._permission_input_registry.has_pending_task(task_id)
+        if had_pending_permission:
+            await self._permission_input_registry.cancel_task(task_id)
+            await self._task_store.set_pending_permissions(task_id, [])
+            await self._task_store.discard_context_runtime(context_id, persist_context=False)
+
+        try:
+            task_record = await self._task_store.get_task_record(task_id)
+            context_record = await self._task_store.get_context_record(context_id)
+        except ValueError:
+            return None
+        control = (
+            self._execution_control_service.get_for_context(context_id)
+            if self._execution_control_service is not None
+            else current_execution_control()
+        )
+        if (control is not None and control.has_managed_work()) or await self._task_store.is_task_active(task_id):
+            return None
+        if task_record.state in {TASK_STATE_CANCELED, TASK_STATE_INPUT_REQUIRED}:
+            await run_sync_fenced(
+                self._finish_terminated_permission_restore,
+                cwd=context_record.cwd,
+                session_id=context_record.session_id,
+                context_id=context_id,
+                task_id=task_id,
+                canceled=task_record.state == TASK_STATE_CANCELED,
+            )
+        if task_record.state not in {TASK_STATE_INPUT_REQUIRED, TASK_STATE_CANCELED}:
+            if not await self._task_store.commit_inactive_execution_task(task_id=task_id, context_id=context_id):
+                raise RuntimeError("Execution task did not reach a terminal state")
+            return task_record.state
+        cancel_result = await run_sync_fenced(
+            cancel_waiting_input_task_from_sidecar,
+            cwd=context_record.cwd,
+            session_id=context_record.session_id,
+            context_id=context_id,
+            task_id=task_id,
+            reason=_("Task canceled while waiting for input."),
+            backup_service=self._backup_service,
+            task_store=self._task_store,
+            task_record=task_record,
+            context_record=context_record,
+            metrics=self._metrics,
+            source=reason,
+            allow_normal_handoff=False,
+        )
+        if cancel_result == WaitingInputCancelResult.NOT_OWNER:
+            terminal_state = await run_sync_fenced(
+                terminal_task_state_from_sidecar,
+                cwd=context_record.cwd,
+                session_id=context_record.session_id,
+                context_id=context_id,
+                task_id=task_id,
+            )
+            if (
+                terminal_state != TASK_STATE_CANCELED
+                and not had_pending_permission
+                and task_record.state != TASK_STATE_CANCELED
+            ):
+                if not await self._task_store.commit_inactive_execution_task(task_id=task_id, context_id=context_id):
+                    raise RuntimeError("Execution task did not reach a terminal state")
+                return task_record.state
+            await self._task_store.discard_context_runtime(context_id, persist_context=False)
+            committed = await self._task_store.cancel_inactive_input_required_task(
+                task_id=task_id,
+                context_id=context_id,
+            )
+            return TASK_STATE_CANCELED if committed else None
+        if cancel_result != WaitingInputCancelResult.CANCELED:
+            raise RuntimeError(f"Pipeline input termination failed: {cancel_result.value}")
+        await self._task_store.discard_context_runtime(context_id, persist_context=False)
+        await self._task_store.cancel_inactive_input_required_task(task_id=task_id, context_id=context_id)
+        return TASK_STATE_CANCELED
+
+    @staticmethod
+    def _finish_terminated_permission_restore(
+        *, cwd: str, session_id: str, context_id: str, task_id: str, canceled: bool
+    ) -> None:
+        """Seal a drained normal recovery before strict snapshots and final backup.
+
+        This also runs on termination retry: a failed OSS checkpoint write must
+        keep releaseReady false until the same recovery can be sealed.
+        """
+        store = PermissionWaitCheckpointStore(cwd, session_id)
+        for record in store.list_active():
+            if (
+                record.get("phase") != "RESTORING"
+                or record.get("permissionClass") != "normal"
+                or record.get("taskId") != task_id
+                or record.get("contextId") != context_id
+            ):
+                continue
+            decision = record["decision"]
+            if canceled:
+                store.cancel_restore(str(record["boundaryId"]), claim_id=str(decision["claimId"]))
+            else:
+                messages = SessionStorage().load(cwd, session_id)
+                store.resolve(
+                    str(record["boundaryId"]),
+                    result_digest=canonical_digest(messages[-1].to_dict()) if messages else "",
+                    ack={"decision": decision["value"], "accepted": True},
+                )
 
     async def _resume_persisted_permission(
         self,
@@ -2429,6 +2680,9 @@ class IacCodeA2AExecutor(AgentExecutor):
                 metrics=self._metrics,
             )
             record = store.mark_claim_backed_up(boundary_id, claim_id=claim_id)
+        task_record = await self._task_store.get_or_create_task(
+            task_id=response.task_id, context_id=response.context_id, restore_interrupted=False
+        )
         if not await self._permission_wait_coordinator.acquire_restore(boundary_id):
             await self._publish_permission_recovery_ack(
                 event_queue,
@@ -2444,30 +2698,42 @@ class IacCodeA2AExecutor(AgentExecutor):
             await self._permission_wait_coordinator.release_restore(boundary_id)
             raise InvalidParamsError(f"permission_resume_invalid: {exc}") from exc
 
-        await self._publish_status(
-            event_queue,
-            task_id=response.task_id,
-            context_id=response.context_id,
-            state=TaskState.TASK_STATE_WORKING,
-            metadata={
-                "iac_code": {
-                    "permissionRecovered": {
-                        "inputId": response.input_id,
-                        "toolUseId": response.tool_use_id,
-                    }
-                }
-            },
-            session_id=context_record.session_id,
-        )
-        await self._publish_permission_recovery_ack(
-            event_queue,
-            response=response,
-            decision=expected_value,
-            duplicate=False,
-            session_id=context_record.session_id,
-        )
+        normal_recovery = record.get("permissionClass") != "pipeline"
+        normal_turn_finished = False
+        normal_recovery_started = False
+        previous_task_state = task_record.state
         normal_final_assistant_text: str | None = None
         try:
+            if normal_recovery:
+                context_record = await self._task_store.activate_restored_task(task_record, context_record)
+                normal_recovery_started = True
+                self._task_store.mirror_task(task_record)
+                self._task_store.mirror_context(context_record)
+                control = current_execution_control()
+                if control is not None:
+                    await control.mark_execution_started()
+            await self._publish_status(
+                event_queue,
+                task_id=response.task_id,
+                context_id=response.context_id,
+                state=TaskState.TASK_STATE_WORKING,
+                metadata={
+                    "iac_code": {
+                        "permissionRecovered": {
+                            "inputId": response.input_id,
+                            "toolUseId": response.tool_use_id,
+                        }
+                    }
+                },
+                session_id=context_record.session_id,
+            )
+            await self._publish_permission_recovery_ack(
+                event_queue,
+                response=response,
+                decision=expected_value,
+                duplicate=False,
+                session_id=context_record.session_id,
+            )
             if record.get("permissionClass") == "pipeline":
                 task = await self._task_store.get_or_create_task(
                     task_id=response.task_id,
@@ -2551,9 +2817,55 @@ class IacCodeA2AExecutor(AgentExecutor):
                                 task.output_text.append(text_chunk)
                         if current_assistant_text:
                             normal_final_assistant_text = "".join(current_assistant_text)
+                        normal_turn_finished = True
                 finally:
                     if runtime is not None:
-                        await _close_runtime(runtime)
+                        await await_fenced(_close_runtime(runtime))
+            storage = SessionStorage()
+            persisted_messages = storage.load(context_record.cwd, context_record.session_id)
+            result_digest = canonical_digest(persisted_messages[-1].to_dict()) if persisted_messages else ""
+            store.resolve(
+                boundary_id,
+                result_digest=result_digest,
+                ack={"decision": expected_value, "accepted": True},
+            )
+            task = await self._task_store.get_or_create_task(
+                task_id=response.task_id,
+                context_id=response.context_id,
+            )
+            task.state = TASK_STATE_INPUT_REQUIRED
+            self._task_store.mirror_task(task)
+            if normal_final_assistant_text is not None:
+                await self._publish_status(
+                    event_queue,
+                    task_id=response.task_id,
+                    context_id=response.context_id,
+                    state=TaskState.TASK_STATE_WORKING,
+                    text=normal_final_assistant_text or None,
+                    metadata={"iac_code": {"assistantFinal": {"complete": True}}},
+                    session_id=context_record.session_id,
+                )
+                await backup_session_async(
+                    self._backup_service,
+                    context_record.cwd,
+                    context_record.session_id,
+                    reason=BackupReason.NORMAL_TURN_END,
+                    critical=False,
+                    metrics=self._metrics,
+                )
+                await self._publish_status(
+                    event_queue,
+                    task_id=response.task_id,
+                    context_id=response.context_id,
+                    state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                    session_id=context_record.session_id,
+                )
+                await self._notify_terminal_task(
+                    task_id=task.task_id,
+                    context_id=task.context_id,
+                    state=task.state,
+                )
+                self._metrics.record_turn_completed()
         except PermissionWaitSuspended:
             store.mark_suspended(boundary_id)
             await self._publish_status(
@@ -2569,6 +2881,41 @@ class IacCodeA2AExecutor(AgentExecutor):
                 session_id=context_record.session_id,
             )
             return True
+        except asyncio.CancelledError:
+            if not normal_recovery or current_execution_termination_reason() is None:
+                with contextlib.suppress(ValueError):
+                    store.reconcile_deadline(
+                        boundary_id,
+                        grace_seconds=self._permission_wait_policy.timeout_grace_seconds,
+                        live_owner=False,
+                    )
+                raise
+            # The controller commits the task/checkpoint and backs it up after
+            # this owner detaches. A completed turn keeps its result even when
+            # termination interrupts runtime close or final backup publication.
+            task_record.state = TASK_STATE_INPUT_REQUIRED if normal_turn_finished else TASK_STATE_CANCELED
+            task_record.touch()
+            self._task_store.mirror_task(task_record)
+            control = current_execution_control()
+            if control is not None:
+                await control.mark_execution_status(task_record.state)
+            await self._publish_status(
+                event_queue,
+                task_id=response.task_id,
+                context_id=response.context_id,
+                state=(
+                    TaskState.TASK_STATE_INPUT_REQUIRED if normal_turn_finished else TaskState.TASK_STATE_CANCELED
+                ),
+                session_id=context_record.session_id,
+            )
+            await self._notify_terminal_task(
+                task_id=response.task_id, context_id=response.context_id, state=task_record.state
+            )
+            if normal_turn_finished:
+                self._metrics.record_turn_completed()
+            else:
+                self._metrics.record_task_canceled()
+            return True
         except BaseException:
             with contextlib.suppress(ValueError):
                 store.reconcile_deadline(
@@ -2578,53 +2925,17 @@ class IacCodeA2AExecutor(AgentExecutor):
                 )
             raise
         finally:
+            if normal_recovery_started:
+                if task_record.state == TASK_STATE_WORKING and current_execution_termination_reason() is None:
+                    # Preserve the previous retryable wait on legacy errors or
+                    # cancellation; explicit execution termination seals it above.
+                    task_record.state = previous_task_state
+                    self._task_store.mirror_task(task_record)
+                task_record.active_task = None
+                context_record.active_task_id = None
+                context_record.touch()
+                self._task_store.mirror_context(context_record)
             await self._permission_wait_coordinator.release_restore(boundary_id)
-
-        storage = SessionStorage()
-        persisted_messages = storage.load(context_record.cwd, context_record.session_id)
-        result_digest = canonical_digest(persisted_messages[-1].to_dict()) if persisted_messages else ""
-        store.resolve(
-            boundary_id,
-            result_digest=result_digest,
-            ack={"decision": expected_value, "accepted": True},
-        )
-        task = await self._task_store.get_or_create_task(
-            task_id=response.task_id,
-            context_id=response.context_id,
-        )
-        task.state = TASK_STATE_INPUT_REQUIRED
-        self._task_store.mirror_task(task)
-        if normal_final_assistant_text is not None:
-            await self._publish_status(
-                event_queue,
-                task_id=response.task_id,
-                context_id=response.context_id,
-                state=TaskState.TASK_STATE_WORKING,
-                text=normal_final_assistant_text or None,
-                metadata={"iac_code": {"assistantFinal": {"complete": True}}},
-                session_id=context_record.session_id,
-            )
-            await backup_session_async(
-                self._backup_service,
-                context_record.cwd,
-                context_record.session_id,
-                reason=BackupReason.NORMAL_TURN_END,
-                critical=False,
-                metrics=self._metrics,
-            )
-            await self._publish_status(
-                event_queue,
-                task_id=response.task_id,
-                context_id=response.context_id,
-                state=TaskState.TASK_STATE_INPUT_REQUIRED,
-                session_id=context_record.session_id,
-            )
-            await self._notify_terminal_task(
-                task_id=task.task_id,
-                context_id=task.context_id,
-                state=task.state,
-            )
-            self._metrics.record_turn_completed()
         return True
 
     async def _rebuild_normal_permission_audit_event(

--- a/src/iac_code/a2a/input_required.py
+++ b/src/iac_code/a2a/input_required.py
@@ -13,6 +13,7 @@ from a2a.types import Message, Part, Role
 from a2a.utils.errors import InvalidParamsError
 from google.protobuf.json_format import MessageToDict
 
+from iac_code.a2a.execution_control import current_execution_control
 from iac_code.a2a.runtime_overrides import get_a2a_preferred_language
 from iac_code.i18n import translate_message
 from iac_code.services.permission_wait import (
@@ -1097,7 +1098,15 @@ class PermissionInputRegistry:
                 if asyncio.iscoroutine(result):
                     await result
 
-        coordinator.register_live(record=current, store=store, future=future, on_suspend=on_suspend)
+        control = current_execution_control()
+        coordinator.register_live(
+            record=current,
+            store=store,
+            future=future,
+            on_suspend=on_suspend,
+            run_suspension=control.run_permission_suspension if control is not None else None,
+            suspension_allowed=control.permission_suspension_allowed if control is not None else None,
+        )
         return current
 
     async def pending_for_response(self, response: PermissionResponse) -> PendingPermission:
@@ -1300,6 +1309,10 @@ class PermissionInputRegistry:
                 and pending.input_id not in excluded
             ]
 
+    async def has_pending_task(self, task_id: str) -> bool:
+        async with self._condition:
+            return any(pending.task_id == task_id for pending in self._pending.values())
+
     async def cancel_task(
         self,
         task_id: str,
@@ -1338,6 +1351,11 @@ class PermissionInputRegistry:
             )
             if not canceled:
                 await self.fail(pending)
+            callback = pending.suspend_callback
+            if callable(callback):
+                result = callback()
+                if asyncio.iscoroutine(result):
+                    await result
             await self.complete(pending)
         return token
 

--- a/src/iac_code/a2a/pipeline_executor.py
+++ b/src/iac_code/a2a/pipeline_executor.py
@@ -21,6 +21,11 @@ from google.protobuf.json_format import ParseDict
 from iac_code.a2a.artifacts import artifact_store_for_session
 from iac_code.a2a.backup import backup_session_async
 from iac_code.a2a.events import make_text_part, publish_mcp_warnings
+from iac_code.a2a.execution_control import (
+    current_execution_control,
+    current_execution_termination_reason,
+    execution_non_advancing_wait,
+)
 from iac_code.a2a.input_required import PendingPermission, staged_permission_backup_generation
 from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
 from iac_code.a2a.pipeline_flow_monitor import (
@@ -612,6 +617,30 @@ class IacCodeA2APipelineExecutor:
                     cwd=cwd,
                     runtime_factory=runtime_factory,
                 )
+                control = current_execution_control()
+                if control is not None:
+                    control.bind_session(ctx.session_id)
+        except asyncio.CancelledError:
+            # Context creation drains and closes an unfinished runtime before
+            # cancellation reaches here, even if no Pipeline exists yet.
+            task.active_task = None
+            task.state = TASK_STATE_CANCELED
+            self._task_store.mirror_task(task)
+            with contextlib.suppress(Exception):
+                await self._publish_status(
+                    event_queue,
+                    task_id=task_id,
+                    context_id=context_id,
+                    state=TaskState.TASK_STATE_CANCELED,
+                    text=_("Task canceled."),
+                )
+                await self._notify_terminal_task(task_id=task_id, context_id=context_id, state=task.state)
+            self._metrics.record_task_canceled()
+            if current_execution_termination_reason() is not None:
+                # The SDK must enqueue request completion after the canceled
+                # status; propagating cancellation can strand its subscriber.
+                return
+            raise
         except Exception as exc:
             await self._publish_exception_status(
                 event_queue,
@@ -975,12 +1004,27 @@ class IacCodeA2APipelineExecutor:
             except asyncio.CancelledError:
                 try:
                     task.state = TASK_STATE_CANCELED
-                    cancel_data = {"source": "executor", "reason": _("Task canceled.")}
+                    execution_termination_reason = current_execution_termination_reason()
+                    cancel_source = "execution_control" if execution_termination_reason is not None else "executor"
+                    cancel_reason = execution_termination_reason or _("Task canceled.")
+                    cancel_data = {"source": cancel_source, "reason": cancel_reason}
                     cancel_handoff_data = {"canceled": True, "reason": _("Task canceled.")}
 
                     async def publish_cancel_terminal() -> bool:
                         if pipeline is not None:
-                            await self._mark_user_aborted(pipeline)
+                            if execution_termination_reason is not None:
+                                mark_terminated = getattr(pipeline, "mark_execution_terminated", None)
+                                if callable(mark_terminated):
+                                    mark_terminated(execution_termination_reason)
+                            else:
+                                await self._mark_user_aborted(pipeline)
+                        if execution_termination_reason is not None:
+                            return await self._publish_pipeline_terminal_event(
+                                publisher,
+                                event_type="pipeline_canceled",
+                                status="canceled",
+                                data=cancel_data,
+                            )
                         cancel_transaction_result = _TerminalHandoffPublishResult(
                             attempted=False,
                             terminal_available=False,
@@ -1979,10 +2023,11 @@ class IacCodeA2APipelineExecutor:
                 next_event = asyncio.get_running_loop().create_future()
                 stream_requests.put_nowait(next_event)
                 restart_task = asyncio.create_task(restart_event.wait())
-                done, _pending = await asyncio.wait(
-                    {next_event, restart_task},
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
+                async with execution_non_advancing_wait():
+                    done, _pending = await asyncio.wait(
+                        {next_event, restart_task},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
 
                 if restart_task in done and runtime.restart_after_interrupt:
                     restart_event.clear()
@@ -4309,6 +4354,8 @@ def cancel_waiting_input_task_from_sidecar(
     task_record: Any | None = None,
     context_record: Any | None = None,
     metrics: Any | None = None,
+    source: str = "a2a_cancel",
+    allow_normal_handoff: bool = True,
 ) -> WaitingInputCancelResult:
     if reason is None:
         reason = _("Task canceled.")
@@ -4325,6 +4372,8 @@ def cancel_waiting_input_task_from_sidecar(
             task_record=task_record,
             context_record=context_record,
             metrics=metrics,
+            source=source,
+            allow_normal_handoff=allow_normal_handoff,
         )
 
 
@@ -4340,6 +4389,8 @@ def _cancel_waiting_input_task_from_sidecar_locked(
     task_record: Any | None = None,
     context_record: Any | None = None,
     metrics: Any | None = None,
+    source: str = "a2a_cancel",
+    allow_normal_handoff: bool = True,
 ) -> WaitingInputCancelResult:
     if waiting_input_task_id_from_sidecar(cwd=cwd, session_id=session_id, context_id=context_id) != task_id:
         return WaitingInputCancelResult.NOT_OWNER
@@ -4373,7 +4424,7 @@ def _cancel_waiting_input_task_from_sidecar_locked(
         "pipeline_canceled",
         "pipeline",
         status="canceled",
-        data={"source": "a2a_cancel", "reason": reason},
+        data={"source": source, "reason": reason},
     )
     high_water_sequence = max(
         [int(event.get("sequence") or 0) for event in events if isinstance(event, dict)]
@@ -4381,13 +4432,17 @@ def _cancel_waiting_input_task_from_sidecar_locked(
     )
     if int(envelope.get("sequence") or 0) <= high_water_sequence:
         envelope["sequence"] = high_water_sequence + 1
-    handoff_envelope = _waiting_input_cancel_handoff_event(
-        translator,
-        snapshot=snapshot,
-        cwd=cwd,
-        session_id=session_id,
-        pipeline_name=pipeline_name,
-        reason=reason,
+    handoff_envelope = (
+        _waiting_input_cancel_handoff_event(
+            translator,
+            snapshot=snapshot,
+            cwd=cwd,
+            session_id=session_id,
+            pipeline_name=pipeline_name,
+            reason=reason,
+        )
+        if allow_normal_handoff
+        else None
     )
     if handoff_envelope is not None and int(handoff_envelope.get("sequence") or 0) <= int(
         envelope.get("sequence") or 0

--- a/src/iac_code/a2a/pipeline_outbound.py
+++ b/src/iac_code/a2a/pipeline_outbound.py
@@ -10,7 +10,10 @@ from typing import Any
 
 from iac_code.a2a.pipeline_delta_coalescing import coalesce_pipeline_delta_envelopes_by_source
 from iac_code.a2a.pipeline_flow_monitor import PipelineA2AFlowItem
-from iac_code.a2a.pipeline_transport_delivery import pipeline_transport_delivery_required
+from iac_code.a2a.pipeline_transport_delivery import (
+    PipelineTransportDeliveryClosedError,
+    pipeline_transport_delivery_required,
+)
 from iac_code.types.stream_events import (
     PermissionRequestEvent,
     SubPipelineStreamEvent,
@@ -405,11 +408,14 @@ class PipelineA2AOutboundQueue:
             network_envelopes = coalesce_pipeline_delta_envelopes_by_source(persisted)
             if monitor is not None:
                 monitor.phase_started("a2a_internal_queue")
-            frame_count_result = await self._publisher.enqueue_persisted_batch(
-                network_envelopes,
-                wait_for_transport=True,
-                local_envelopes=persisted,
-            )
+            try:
+                frame_count_result = await self._publisher.enqueue_persisted_batch(
+                    network_envelopes,
+                    wait_for_transport=True,
+                    local_envelopes=persisted,
+                )
+            except PipelineTransportDeliveryClosedError:
+                frame_count_result = 0
             network_frames = (
                 int(frame_count_result) if isinstance(frame_count_result, int) else int(bool(network_envelopes))
             )
@@ -454,7 +460,26 @@ class PipelineA2AOutboundQueue:
             )
             if monitor is not None:
                 monitor.phase_started("a2a_internal_queue")
-            delivered = await self._publisher.enqueue_prepared_permission(prepared)
+            try:
+                delivered = await self._publisher.enqueue_prepared_permission(prepared)
+            except PipelineTransportDeliveryClosedError:
+                # The permission decision and its audit metadata are already durable.
+                # Losing the old subscription must not reverse that decision.
+                self._publisher.complete_prepared_permission(prepared, delivered=True)
+                if monitor is not None:
+                    envelope_count = len(prepared.envelopes)
+                    monitor.batch_completed(
+                        persisted_envelopes=envelope_count,
+                        wire_envelopes=envelope_count,
+                        network_frames=0,
+                    )
+                self._run_after_delivery(permission.item)
+                logger.debug(
+                    "A2A pipeline permission persisted after its transport closed approved=%s queued_ms=%.2f",
+                    approved,
+                    max(0.0, (asyncio.get_running_loop().time() - permission.item.enqueued_at) * 1_000),
+                )
+                return
             self._publisher.complete_prepared_permission(prepared, delivered=delivered)
             if monitor is not None:
                 envelope_count = len(prepared.envelopes)

--- a/src/iac_code/a2a/pipeline_recovery.py
+++ b/src/iac_code/a2a/pipeline_recovery.py
@@ -215,7 +215,13 @@ _SERVER_ONLY_SNAPSHOT_KEYS = ("seenEventIds",)
 _LEAN_ONLY_DISPLAY_KEYS = ("toolResults",)
 
 
-def client_pipeline_state(state: Mapping[str, Any], *, lean: bool = False) -> dict[str, Any]:
+def client_pipeline_state(
+    state: Mapping[str, Any],
+    *,
+    lean: bool = False,
+    include_snapshot: bool = True,
+    after_sequence: int | None = None,
+) -> dict[str, Any]:
     """去掉只服务端用得上的字段，得到面向客户端的恢复状态。
 
     磁盘快照与进程内状态都不受影响：这里只裁剪要发出去的那一份拷贝。
@@ -223,11 +229,25 @@ def client_pipeline_state(state: Mapping[str, Any], *, lean: bool = False) -> di
 
     ``lean=True`` 再去掉只有调试工具会读的 ``display`` 字段，供恢复界面
     （ROS 控制台经 bridge 拉取）少下载一大截；默认关闭，调试工具无需改动。
+    ``include_snapshot=False`` 只返回指定游标之后的事件和新的服务端高水位。
     """
 
     projected = dict(state)
     snapshot = projected.get("snapshot")
     if not isinstance(snapshot, Mapping):
+        return projected
+    if not include_snapshot:
+        if after_sequence is None:
+            raise ValueError("after_sequence is required when include_snapshot is False")
+        events = projected.get("events")
+        last_sequence = _int_value(snapshot.get("lastSequence"), 0)
+        if isinstance(events, list):
+            for event in events:
+                if isinstance(event, Mapping):
+                    last_sequence = max(last_sequence, _int_value(event.get("sequence"), 0))
+        projected.pop("snapshot", None)
+        projected["fromSequence"] = after_sequence
+        projected["lastSequence"] = last_sequence
         return projected
     trimmed = {key: value for key, value in snapshot.items() if key not in _SERVER_ONLY_SNAPSHOT_KEYS}
     if lean:

--- a/src/iac_code/a2a/pipeline_stream.py
+++ b/src/iac_code/a2a/pipeline_stream.py
@@ -19,6 +19,7 @@ from iac_code.a2a.events import (
     _emit_resolver_permission_audit,
     _extract_artifact_metadata,
 )
+from iac_code.a2a.execution_control import current_execution_control
 from iac_code.a2a.exposure import A2AExposureType, normalize_a2a_exposure_types
 from iac_code.a2a.input_required import PendingPermission, PermissionResponse
 from iac_code.a2a.pipeline_events import (
@@ -32,6 +33,7 @@ from iac_code.a2a.pipeline_outbound import OUTBOUND_HARD_MAX_BATCH_BYTES, OUTBOU
 from iac_code.a2a.pipeline_performance import a2a_extreme_performance_enabled
 from iac_code.a2a.pipeline_snapshot import SNAPSHOT_SCHEMA_VERSION, A2APipelineSnapshotStore, reduce_pipeline_events
 from iac_code.a2a.pipeline_transport_delivery import (
+    PipelineTransportDeliveryClosedError,
     discard_pipeline_transport_delivery,
     mark_pipeline_transport_delivery_enqueued,
     pipeline_transport_delivery_is_required,
@@ -1451,6 +1453,10 @@ class PipelineA2AEventPublisher:
             await self.event_queue.enqueue_event(event)
             mark_pipeline_transport_delivery_enqueued(event)
             await asyncio.shield(completion)
+        except PipelineTransportDeliveryClosedError:
+            if current_execution_control() is None:
+                raise
+            logger.debug("A2A pipeline event remains committed after its transport closed")
         finally:
             discard_pipeline_transport_delivery(event)
 

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -168,12 +168,13 @@ class A2ATaskStore(TaskStore):
                 and record.state
                 in {TASK_STATE_CANCELED, TASK_STATE_COMPLETED, TASK_STATE_FAILED, TASK_STATE_INPUT_REQUIRED}
                 and next_state in {TASK_STATE_SUBMITTED, TASK_STATE_WORKING}
+                and not active_finalization
                 and incoming_updated_at < record.updated_at
             )
-            if active_finalization or stale_state_projection:
+            if stale_state_projection:
                 # The SDK consumes executor events asynchronously. An event
-                # queued before active finalization or an older detached event
-                # must not roll either task projection back.
+                # older than a detached final state must not roll either task
+                # projection back.
                 return
             self._attach_context_metadata(task)
             self._attach_pending_permissions(task)
@@ -183,7 +184,10 @@ class A2ATaskStore(TaskStore):
                 self._remove_sdk_task_from_index(owner, task_id, previous.context_id)
             owner_tasks[task_id] = _copy_task(task)
             self._sdk_tasks_by_context.setdefault(owner, {}).setdefault(task.context_id, set()).add(task_id)
-            if preserve_terminal:
+            if preserve_terminal or active_finalization:
+                # During active finalization the SDK still needs the delayed
+                # nonterminal frame for stream ordering, but the durable record
+                # already describes the backup boundary and must stay final.
                 return
             # The SDK saves the full Task before yielding every streaming frame. Executors already
             # mirror task records explicitly at output/state durability boundaries, so repeated SDK

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -155,6 +155,14 @@ class A2ATaskStore(TaskStore):
                 assert record is not None
                 task = _copy_task(task)
                 task.status.state = TaskState.Value("TASK_STATE_" + record.state.upper().replace("-", "_"))
+            active_finalization = bool(
+                record is not None
+                and record.state
+                in {TASK_STATE_CANCELED, TASK_STATE_COMPLETED, TASK_STATE_FAILED, TASK_STATE_INPUT_REQUIRED}
+                and next_state in {TASK_STATE_SUBMITTED, TASK_STATE_WORKING}
+                and record.active_task is not None
+                and not record.active_task.done()
+            )
             stale_state_projection = bool(
                 record is not None
                 and record.state
@@ -162,10 +170,10 @@ class A2ATaskStore(TaskStore):
                 and next_state in {TASK_STATE_SUBMITTED, TASK_STATE_WORKING}
                 and incoming_updated_at < record.updated_at
             )
-            if stale_state_projection:
+            if active_finalization or stale_state_projection:
                 # The SDK consumes executor events asynchronously. An event
-                # queued before a newer executor mirror must not roll either
-                # the SDK-visible task or its durable record back.
+                # queued before active finalization or an older detached event
+                # must not roll either task projection back.
                 return
             self._attach_context_metadata(task)
             self._attach_pending_permissions(task)

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -20,7 +20,9 @@ from a2a.types import ListTasksRequest, ListTasksResponse, Message, Part, Role, 
 from a2a.utils.errors import InvalidParamsError
 from google.protobuf.json_format import MessageToDict, ParseDict
 
+from iac_code.a2a.backup import await_fenced, run_sync_fenced
 from iac_code.a2a.events import with_iac_code_session_metadata
+from iac_code.a2a.execution_control import current_execution_control, current_execution_termination_reason
 from iac_code.a2a.metrics import A2AMetrics, NoOpA2AMetrics
 from iac_code.a2a.persistence import A2AContextSnapshot, A2APersistenceStore, A2ATaskSnapshot
 from iac_code.a2a.types import (
@@ -75,14 +77,51 @@ class A2ATaskStore(TaskStore):
         self._discarded_context_runtime_tasks: set[asyncio.Task[Any]] = set()
         self._discarded_context_runtime_task_waiters: dict[asyncio.Task[Any], int] = {}
         self._reconciliation_locks: dict[str, asyncio.Lock] = {}
+        self._termination_commit_locks: dict[str, asyncio.Lock] = {}
         self._context_reconciliation_waiters: dict[str, set[str]] = {}
         self._context_execution_starts: dict[str, dict[str, asyncio.Task[Any]]] = {}
         self._owner_resolver = owner_resolver
         self._backup_service = backup_service or SessionBackupService()
         self._permission_wait_active_probe: Callable[[], bool] | None = None
+        self._execution_control_snapshot_provider: Callable[[str], dict[str, Any] | None] | None = None
+        self._execution_control_active_probe: Callable[[], bool] | None = None
 
     def set_permission_wait_active_probe(self, probe: Callable[[], bool] | None) -> None:
         self._permission_wait_active_probe = probe
+
+    def set_execution_control_provider(
+        self,
+        snapshot_provider: Callable[[str], dict[str, Any] | None] | None,
+        active_probe: Callable[[], bool] | None,
+    ) -> None:
+        self._execution_control_snapshot_provider = snapshot_provider
+        self._execution_control_active_probe = active_probe
+
+    def touch_context(self, context_id: str) -> None:
+        """Restart the idle interval after a connection hold, without storage I/O."""
+        record = self._contexts.get(context_id)
+        if record is not None:
+            record.touch()
+
+    def _execution_snapshot(self, context_id: str) -> dict[str, Any] | None:
+        if self._execution_control_snapshot_provider is not None:
+            return self._execution_control_snapshot_provider(context_id)
+        control = current_execution_control()
+        return control.snapshot() if control is not None and control.context_id == context_id else None
+
+    def _execution_is_terminating(self, context_id: str) -> bool:
+        control = self._execution_snapshot(context_id)
+        return bool(control and control["phase"] in {"terminating", "terminated"})
+
+    def _execution_retains_context(self, context_id: str) -> bool:
+        control = self._execution_snapshot(context_id)
+        return bool(
+            control
+            and (
+                control["phase"] in {"pausing", "pause_committing", "paused", "resuming", "terminating"}
+                or (control["phase"] == "terminated" and not control["releaseReady"])
+            )
+        )
 
     async def get(self, task_id: str, context: ServerCallContext | None = None) -> Task | None:
         owner = self._owner(context)
@@ -101,6 +140,19 @@ class A2ATaskStore(TaskStore):
         owner = self._owner(context)
         task_id = validate_protocol_id(task.id)
         async with self._mutation_lock:
+            record = self._tasks.get(task_id)
+            preserve_terminal = bool(
+                record is not None
+                and record.state
+                in {TASK_STATE_CANCELED, TASK_STATE_COMPLETED, TASK_STATE_FAILED, TASK_STATE_INPUT_REQUIRED}
+                and self._execution_is_terminating(task.context_id)
+            )
+            if preserve_terminal:
+                # Queued SDK working events must not undo the executor's final
+                # state while its immutable termination snapshot is committed.
+                assert record is not None
+                task = _copy_task(task)
+                task.status.state = TaskState.Value("TASK_STATE_" + record.state.upper().replace("-", "_"))
             self._attach_context_metadata(task)
             self._attach_pending_permissions(task)
             owner_tasks = self._sdk_tasks.setdefault(owner, {})
@@ -109,7 +161,8 @@ class A2ATaskStore(TaskStore):
                 self._remove_sdk_task_from_index(owner, task_id, previous.context_id)
             owner_tasks[task_id] = _copy_task(task)
             self._sdk_tasks_by_context.setdefault(owner, {}).setdefault(task.context_id, set()).add(task_id)
-            record = self._tasks.get(task_id)
+            if preserve_terminal:
+                return
             next_state = _task_state_from_sdk_task(task)
             # The SDK saves the full Task before yielding every streaming frame. Executors already
             # mirror task records explicitly at output/state durability boundaries, so repeated SDK
@@ -143,8 +196,15 @@ class A2ATaskStore(TaskStore):
             return
         metadata = MessageToDict(task.metadata, preserving_proto_field_name=False) if task.metadata.fields else {}
         metadata = with_iac_code_session_metadata(metadata, context.session_id)
-        if metadata is not None:
-            ParseDict(metadata, task.metadata)
+        if metadata is None:
+            metadata = {}
+        if self._execution_control_snapshot_provider is not None:
+            control = self._execution_control_snapshot_provider(task.context_id)
+            if control is not None:
+                iac_code = metadata.setdefault("iac_code", {})
+                if isinstance(iac_code, dict):
+                    iac_code["executionControl"] = control
+        ParseDict(metadata, task.metadata)
 
     def _attach_pending_permissions(self, task: Task) -> None:
         metadata = MessageToDict(task.metadata, preserving_proto_field_name=False) if task.metadata.fields else {}
@@ -364,6 +424,9 @@ class A2ATaskStore(TaskStore):
                 if create_task is None:
                     create_task = asyncio.create_task(asyncio.to_thread(runtime_factory, session_id))
                     self._context_runtime_tasks[context_id] = create_task
+            control = current_execution_control()
+            if control is not None and control.context_id == context_id:
+                control.bind_session(record.session_id)
             self._context_runtime_waiters[context_id] = self._context_runtime_waiters.get(context_id, 0) + 1
 
         if create_task is None:  # pragma: no cover - defensive guard for inconsistent state.
@@ -376,18 +439,31 @@ class A2ATaskStore(TaskStore):
                 remaining = self._decrement_context_runtime_waiter_locked(context_id)
                 if remaining == 0:
                     record = self._contexts.get(context_id)
-                    if record is not None and record.runtime is None:
+                    if record is not None and record.runtime is None and current_execution_termination_reason() is None:
                         self._contexts.pop(context_id, None)
                     if self._context_runtime_tasks.get(context_id) is create_task:
                         discard_task = self._context_runtime_tasks.pop(context_id, None)
                     if discard_task is not None:
                         self._mark_discarded_context_runtime_task_locked(discard_task, waiters=0)
             if discard_task is not None:
-                _close_runtime_task_when_done(
-                    discard_task,
-                    self._discarded_context_runtime_tasks,
-                    self._discarded_context_runtime_task_waiters,
-                )
+                if current_execution_termination_reason() is not None:
+                    # Keep the executor alive until bootstrap and runtime cleanup
+                    # finish. A canceled to_thread waiter does not stop its thread.
+                    async def drain_runtime() -> None:
+                        try:
+                            runtime = await asyncio.shield(discard_task)
+                            await _close_runtime(runtime)
+                        finally:
+                            self._discarded_context_runtime_tasks.discard(discard_task)
+                            self._discarded_context_runtime_task_waiters.pop(discard_task, None)
+
+                    await await_fenced(drain_runtime())
+                else:
+                    _close_runtime_task_when_done(
+                        discard_task,
+                        self._discarded_context_runtime_tasks,
+                        self._discarded_context_runtime_task_waiters,
+                    )
             raise
         except Exception:
             async with self._mutation_lock:
@@ -501,6 +577,19 @@ class A2ATaskStore(TaskStore):
 
         raise ValueError(_("A2A context not found"))
 
+    async def activate_restored_task(self, task: A2ATaskRecord, context: A2AContextRecord) -> A2AContextRecord:
+        """Attach a permission recovery to live records without creating a cached runtime."""
+        async with self._mutation_lock:
+            record = self._contexts.setdefault(context.context_id, context)
+            if record.lock is None:
+                record.lock = asyncio.Lock()
+            record.active_task_id = task.task_id
+            record.touch()
+            task.state = TASK_STATE_WORKING
+            task.active_task = asyncio.current_task()
+            task.touch()
+            return record
+
     async def get_context_runtime_path_directories(
         self,
         context_id: str,
@@ -513,7 +602,7 @@ class A2ATaskStore(TaskStore):
             runtime = record.runtime if record is not None else None
             return _runtime_path_directories(runtime)
 
-    async def discard_context_runtime(self, context_id: str) -> None:
+    async def discard_context_runtime(self, context_id: str, *, persist_context: bool = True) -> None:
         """Drop a cached runtime so the next turn rebuilds the context cleanly."""
         runtime: Any | None = None
         context_id = validate_protocol_id(context_id)
@@ -524,7 +613,18 @@ class A2ATaskStore(TaskStore):
             runtime = record.runtime
             record.runtime = None
             record.touch()
-            self._mirror_context(record)
+            # Runtime is memory-only. Termination commits the durable task and
+            # context together later, outside the global lock and event loop.
+            # Permission cancellation can also reach here through its suspend
+            # callback before the termination cleanup calls us directly.
+            control = (
+                self._execution_control_snapshot_provider(context_id)
+                if self._execution_control_snapshot_provider is not None
+                else None
+            )
+            terminating = control is not None and control.get("phase") in {"terminating", "terminated"}
+            if persist_context and not terminating:
+                self._mirror_context(record)
         await _close_runtime(runtime)
 
     def reconciliation_lock(self, context_id: str) -> asyncio.Lock:
@@ -856,6 +956,132 @@ class A2ATaskStore(TaskStore):
             record.active_task.cancel()
             return True
 
+    async def cancel_inactive_input_required_task(self, *, task_id: str, context_id: str) -> bool:
+        """Terminalize a detached input wait without overwriting a finished turn."""
+        return await self.commit_inactive_execution_task(task_id=task_id, context_id=context_id, cancel_wait=True)
+
+    async def commit_inactive_execution_task(
+        self, *, task_id: str, context_id: str, cancel_wait: bool = False
+    ) -> bool:
+        """Strictly commit an execution's final task/context snapshots off the event loop."""
+
+        task_id = validate_protocol_id(task_id)
+        context_id = validate_protocol_id(context_id)
+        allowed_states = {TASK_STATE_INPUT_REQUIRED, TASK_STATE_CANCELED}
+        if not cancel_wait:
+            allowed_states.update({TASK_STATE_COMPLETED, TASK_STATE_FAILED})
+        async with self._termination_commit_locks.setdefault(context_id, asyncio.Lock()):
+            async with self._mutation_lock:
+                record = self._tasks.get(task_id)
+                if (
+                    record is None
+                    or record.context_id != context_id
+                    or (record.active_task is not None and not record.active_task.done())
+                    or record.state not in allowed_states
+                ):
+                    return False
+                if cancel_wait:
+                    record.state = TASK_STATE_CANCELED
+                record.active_task = None
+                record.touch()
+                self._pending_permissions.pop(task_id, None)
+                context = self._contexts.get(context_id)
+                if context is not None and context.active_task_id == task_id:
+                    context.active_task_id = None
+                    context.touch()
+                for owner_tasks in self._sdk_tasks.values():
+                    task = owner_tasks.get(task_id)
+                    if task is None or task.context_id != context_id:
+                        continue
+                    if not cancel_wait:
+                        task.status.state = TaskState.Value("TASK_STATE_" + record.state.upper().replace("-", "_"))
+                        continue
+                    task.status.CopyFrom(
+                        TaskStatus(
+                            state=TaskState.Name(TaskState.TASK_STATE_CANCELED),
+                            message=Message(
+                                message_id=f"{task_id}-terminated",
+                                task_id=task_id,
+                                context_id=context_id,
+                                role=Role.ROLE_AGENT,
+                                parts=[Part(text=_("Task canceled."))],
+                            ),
+                        )
+                    )
+                    task.status.timestamp.GetCurrentTime()
+                    self._attach_context_metadata(task)
+                    self._attach_pending_permissions(task)
+                if context is None:
+                    raise OSError("A2A terminated context snapshot is unavailable")
+                task_snapshot = A2ATaskSnapshot(
+                    task_id=record.task_id,
+                    context_id=record.context_id,
+                    state=record.state,
+                    owner=record.owner,
+                    output_text=list(record.output_text),
+                    updated_at=record.updated_at,
+                    expected_permission_backup_generation=record.expected_permission_backup_generation,
+                )
+                context_snapshot = A2AContextSnapshot(
+                    context_id=context.context_id,
+                    session_id=context.session_id,
+                    cwd=context.cwd,
+                    telemetry_channel=context.telemetry_channel,
+                    active_task_id=context.active_task_id,
+                )
+                self._task_persistence_dirty.add(task_id)
+            await run_sync_fenced(self._persist_terminated_task_snapshots_strict, task_snapshot, context_snapshot)
+            async with self._mutation_lock:
+                if (
+                    self._tasks.get(task_id) is not record
+                    or self._contexts.get(context_id) is not context
+                    or record.updated_at != task_snapshot.updated_at
+                    or context.session_id != context_snapshot.session_id
+                    or context.cwd != context_snapshot.cwd
+                    or context.telemetry_channel != context_snapshot.telemetry_channel
+                    or record.state != task_snapshot.state
+                    or context.active_task_id is not None
+                ):
+                    raise OSError("A2A termination snapshot changed during commit; retry termination")
+                self._task_persistence_dirty.discard(task_id)
+            return True
+
+    def _persist_terminated_task_snapshots_strict(
+        self,
+        task_snapshot: A2ATaskSnapshot,
+        context_snapshot: A2AContextSnapshot,
+    ) -> None:
+        """Write detached snapshots in a worker; never access mutable task-store records."""
+
+        if self._persistence is not None:
+            self._persistence.save_task(task_snapshot)
+            persisted_task = self._persistence.load_task(task_snapshot.task_id)
+            if persisted_task is None or persisted_task.state != task_snapshot.state:
+                raise OSError("A2A terminated task snapshot verification failed")
+        session_paths = _session_paths_for_a2a_snapshot(context_snapshot)
+        if session_paths is None:
+            raise OSError("A2A terminated task session path is unavailable")
+        _write_session_snapshot(session_paths.session_dir, session_paths.a2a_task_path, asdict(task_snapshot))
+        persisted_session_task = json.loads(session_paths.a2a_task_path.read_text(encoding="utf-8"))
+        if (
+            persisted_session_task.get("task_id") != task_snapshot.task_id
+            or persisted_session_task.get("state") != task_snapshot.state
+        ):
+            raise OSError("A2A terminated session task snapshot verification failed")
+
+        if self._persistence is not None:
+            self._persistence.save_context(context_snapshot)
+            persisted_context = self._persistence.load_context(context_snapshot.context_id)
+            if persisted_context is None or persisted_context.active_task_id is not None:
+                raise OSError("A2A terminated context snapshot verification failed")
+        _write_session_snapshot(session_paths.session_dir, session_paths.a2a_context_path, asdict(context_snapshot))
+        persisted_session_context = json.loads(session_paths.a2a_context_path.read_text(encoding="utf-8"))
+        if (
+            persisted_session_context.get("context_id") != context_snapshot.context_id
+            or persisted_session_context.get("active_task_id") is not None
+        ):
+            raise OSError("A2A terminated session context snapshot verification failed")
+
     async def cancel_task_and_wait(self, task_id: str, *, timeout: float | None = None) -> bool:
         task_id = validate_protocol_id(task_id)
         async with self._mutation_lock:
@@ -923,6 +1149,7 @@ class A2ATaskStore(TaskStore):
                 or any(lock.locked() for lock in self._reconciliation_locks.values())
                 or any(count > 0 for count in self._context_runtime_waiters.values())
                 or any(not task.done() for task in self._discarded_context_runtime_tasks)
+                or bool(self._execution_control_active_probe and self._execution_control_active_probe())
                 or bool(self._permission_wait_active_probe and self._permission_wait_active_probe())
             )
 
@@ -954,8 +1181,18 @@ class A2ATaskStore(TaskStore):
                 and not self._context_execution_starts.get(context_id)
                 and context_id not in active_context_ids
                 and context_id not in reconciling_context_ids
+                and not self._execution_retains_context(context_id)
             ]
             for context_id in expired_context_ids:
+                # Closing an earlier runtime can yield while a later context
+                # accepts pause/resume. Recheck its hold and idle timestamp.
+                record = self._contexts.get(context_id)
+                if (
+                    record is None
+                    or now - record.last_active <= self._idle_timeout_seconds
+                    or self._execution_retains_context(context_id)
+                ):
+                    continue
                 record = self._contexts.pop(context_id, None)
                 if record is not None:
                     await _close_runtime(record.runtime)
@@ -1020,6 +1257,11 @@ class A2ATaskStore(TaskStore):
                 logger.exception("A2A cleanup loop failed")
 
     def _mirror_task(self, record: A2ATaskRecord, *, persist_shared_snapshot: bool = True) -> None:
+        if self._execution_is_terminating(record.context_id):
+            # Final snapshots are committed after all execution participants drain.
+            # This also covers SDK saves and executor finally blocks on slow OSS.
+            self._task_persistence_dirty.add(record.task_id)
+            return
         snapshot = A2ATaskSnapshot(
             task_id=record.task_id,
             context_id=record.context_id,
@@ -1049,6 +1291,8 @@ class A2ATaskStore(TaskStore):
         self._persist_context_snapshot(snapshot)
 
     def _persist_context_snapshot(self, snapshot: A2AContextSnapshot) -> None:
+        if self._execution_is_terminating(snapshot.context_id):
+            return
         if self._persistence is not None:
             try:
                 self._persistence.save_context(snapshot)

--- a/src/iac_code/a2a/task_store.py
+++ b/src/iac_code/a2a/task_store.py
@@ -141,6 +141,8 @@ class A2ATaskStore(TaskStore):
         task_id = validate_protocol_id(task.id)
         async with self._mutation_lock:
             record = self._tasks.get(task_id)
+            next_state = _task_state_from_sdk_task(task)
+            incoming_updated_at = _task_updated_at_from_sdk_task(task)
             preserve_terminal = bool(
                 record is not None
                 and record.state
@@ -153,6 +155,18 @@ class A2ATaskStore(TaskStore):
                 assert record is not None
                 task = _copy_task(task)
                 task.status.state = TaskState.Value("TASK_STATE_" + record.state.upper().replace("-", "_"))
+            stale_state_projection = bool(
+                record is not None
+                and record.state
+                in {TASK_STATE_CANCELED, TASK_STATE_COMPLETED, TASK_STATE_FAILED, TASK_STATE_INPUT_REQUIRED}
+                and next_state in {TASK_STATE_SUBMITTED, TASK_STATE_WORKING}
+                and incoming_updated_at < record.updated_at
+            )
+            if stale_state_projection:
+                # The SDK consumes executor events asynchronously. An event
+                # queued before a newer executor mirror must not roll either
+                # the SDK-visible task or its durable record back.
+                return
             self._attach_context_metadata(task)
             self._attach_pending_permissions(task)
             owner_tasks = self._sdk_tasks.setdefault(owner, {})
@@ -163,7 +177,6 @@ class A2ATaskStore(TaskStore):
             self._sdk_tasks_by_context.setdefault(owner, {}).setdefault(task.context_id, set()).add(task_id)
             if preserve_terminal:
                 return
-            next_state = _task_state_from_sdk_task(task)
             # The SDK saves the full Task before yielding every streaming frame. Executors already
             # mirror task records explicitly at output/state durability boundaries, so repeated SDK
             # saves with the same projected state only need the session-local mirror below.
@@ -179,14 +192,14 @@ class A2ATaskStore(TaskStore):
                     context_id=task.context_id,
                     state=next_state,
                     owner=owner,
-                    updated_at=_task_updated_at_from_sdk_task(task),
+                    updated_at=incoming_updated_at,
                 )
                 self._tasks[task_id] = record
                 self._metrics.record_task_created()
             else:
                 record.state = next_state
                 record.owner = owner
-                record.updated_at = _task_updated_at_from_sdk_task(task)
+                record.updated_at = incoming_updated_at
                 record.touch()
             self._mirror_task(record, persist_shared_snapshot=persist_shared_snapshot)
 

--- a/src/iac_code/a2a/transports/dispatcher.py
+++ b/src/iac_code/a2a/transports/dispatcher.py
@@ -290,6 +290,7 @@ class A2ARuntimeComponents:
     push_queue: Any | None = None
     runtime_registration: A2ARuntimeRegistration | None = None
     backup_staging_process: SessionBackupStagingProcess | None = None
+    execution_control_service: Any | None = None
 
     def start_background_services(self) -> None:
         if self.backup_staging_process is not None:
@@ -300,6 +301,8 @@ class A2ARuntimeComponents:
             self.runtime_registration.unregister()
             self.runtime_registration = None
         await self.task_store.stop_cleanup_loop()
+        if self.execution_control_service is not None:
+            await self.execution_control_service.close()
         executor = getattr(self.handler, "agent_executor", None)
         if executor is not None:
             artifact_store = getattr(executor, "artifact_store", None)
@@ -307,6 +310,11 @@ class A2ARuntimeComponents:
                 close = getattr(artifact_store, "aclose", None)
                 if close is not None:
                     await close()
+        detached_producers = tuple(getattr(self.handler, "_detached_message_producers", ()))
+        for producer in detached_producers:
+            producer.cancel()
+        if detached_producers:
+            await asyncio.gather(*detached_producers, return_exceptions=True)
         push_sender = getattr(self.handler, "_push_sender", None)
         if push_sender is not None:
             close = getattr(push_sender, "aclose", None)
@@ -379,6 +387,18 @@ def create_runtime_components(
 
         persistence = A2APersistenceStore(get_config_dir() / "a2a")
     task_store = A2ATaskStore(metrics=metrics, persistence=persistence, backup_service=backup_service)
+    from iac_code.a2a.execution_control import ExecutionControlService
+
+    execution_control_service = ExecutionControlService(
+        persistence_root=Path(persistence.root) if persistence is not None else None,
+        backup_service=backup_service,
+    )
+    set_execution_control_provider = getattr(task_store, "set_execution_control_provider", None)
+    if callable(set_execution_control_provider):
+        set_execution_control_provider(
+            execution_control_service.snapshot_for_context,
+            execution_control_service.has_active_work,
+        )
     if push_notifications:
         assert persistence is not None
         push_secret_keyring = A2APushSecretKeyring(Path(persistence.root) / "push_keys.json")
@@ -422,6 +442,7 @@ def create_runtime_components(
         permission_wait_policy=permission_wait_policy,
         thinking_exposure_types=thinking_exposure_types,
         backup_service=backup_service,
+        execution_control_service=execution_control_service,
     )
     card = build_agent_card(
         host=host,
@@ -470,6 +491,7 @@ def create_runtime_components(
         push_queue=push_queue_instance,
         runtime_registration=runtime_registration,
         backup_staging_process=backup_staging_process,
+        execution_control_service=execution_control_service,
     )
 
 
@@ -484,6 +506,7 @@ class IacCodeRequestHandler(DefaultRequestHandler):
         super().__init__(*args, **kwargs)
         self._backup_service = backup_service or SessionBackupService()
         self._metrics = metrics or NoOpA2AMetrics()
+        self._detached_message_producers: set[asyncio.Task[Any]] = set()
 
     async def on_get_task(self, params: GetTaskRequest, context):
         self._validate_extensions(context)
@@ -628,7 +651,12 @@ class IacCodeRequestHandler(DefaultRequestHandler):
             # The decision may already be committed. Let the same continuation
             # finish exactly once even if the response transport disappears.
             handed_off = True
-            asyncio.create_task(self._drain_inactive_permission_response(queue, producer, completed))
+            drain_task = asyncio.create_task(
+                self._drain_inactive_permission_response(queue, producer, completed),
+                name=f"a2a-detached-permission-producer-{task.id}",
+            )
+            self._detached_message_producers.add(drain_task)
+            drain_task.add_done_callback(self._detached_message_producers.discard)
             raise
         finally:
             if not handed_off and not producer.done():
@@ -648,6 +676,11 @@ class IacCodeRequestHandler(DefaultRequestHandler):
                 if value is completed:
                     break
             await producer
+        except asyncio.CancelledError:
+            if not producer.done():
+                producer.cancel()
+                await asyncio.gather(producer, return_exceptions=True)
+            raise
         except BaseException:
             logger.debug("Detached permission response continuation failed", exc_info=True)
 
@@ -705,7 +738,6 @@ class IacCodeRequestHandler(DefaultRequestHandler):
                         tapped_queue.task_done()
                     acknowledge_pipeline_transport_delivery(event)
             except (asyncio.CancelledError, GeneratorExit):
-                producer_task.cancel()
                 raise
             finally:
                 close_pipeline_transport_delivery_tracker(delivery_tracker)
@@ -713,7 +745,19 @@ class IacCodeRequestHandler(DefaultRequestHandler):
                 async with active_task._lock:
                     active_task._reference_count -= 1
                 await active_task._maybe_cleanup()
-                await self._cleanup_active_message_producer(producer_task, task.id)
+                if producer_task.done():
+                    await self._cleanup_active_message_producer(producer_task, task.id)
+                else:
+                    cleanup_task = asyncio.create_task(
+                        self._cleanup_active_message_producer(producer_task, task.id),
+                        name=f"a2a-detached-message-producer-{task.id}",
+                    )
+                    detached_producers = getattr(self, "_detached_message_producers", None)
+                    if detached_producers is None:
+                        detached_producers = set()
+                        self._detached_message_producers = detached_producers
+                    detached_producers.add(cleanup_task)
+                    cleanup_task.add_done_callback(detached_producers.discard)
 
     async def _hydrate_recoverable_pipeline_task_id(self, params: SendMessageRequest) -> None:
         if resolve_request_run_mode(params.message) is not RunMode.PIPELINE or not isinstance(

--- a/src/iac_code/agent/agent_loop.py
+++ b/src/iac_code/agent/agent_loop.py
@@ -9,13 +9,18 @@ import time
 import uuid
 from collections import deque
 from collections.abc import AsyncGenerator, Callable, Mapping
-from contextlib import suppress
+from contextlib import aclosing, suppress
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Literal, cast
 
 from loguru import logger
 
+from iac_code.a2a.execution_control import (
+    execution_activity,
+    execution_checkpoint,
+    execution_non_advancing_wait,
+)
 from iac_code.agent.message import (
     ContentBlock,
     RedactedThinkingBlock,
@@ -1020,22 +1025,25 @@ class AgentLoop:
                     )
                 memory_prefetch = self._start_memory_prefetch_for_turn(user_input)
                 try:
-                    async for event in self._run_streaming_inner(
-                        user_input,
-                        queued_input_provider=queued_input_provider,
-                        memory_prefetch=memory_prefetch,
-                    ):
-                        if _is_first_output_delta(event) and not first_token_received:
-                            first_token_received = True
-                            ttft_ns = int((time.monotonic() - interaction_started) * 1_000_000_000)
-                            entry_span.set_attribute(GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN, ttft_ns)
-                            entry_span.set_attribute(GenAiAttr.USER_TIME_TO_FIRST_TOKEN, ttft_ns)
-                        if isinstance(event, TextDeltaEvent):
-                            final_text_chunks.append(event.text)
-                        if isinstance(event, MessageEndEvent):
-                            final_stop_reason = event.stop_reason
-                            self._record_session_usage(event.usage, event.usage_attribution)
-                        yield event
+                    async with aclosing(
+                        self._run_streaming_inner(
+                            user_input,
+                            queued_input_provider=queued_input_provider,
+                            memory_prefetch=memory_prefetch,
+                        )
+                    ) as inner_stream:
+                        async for event in inner_stream:
+                            if _is_first_output_delta(event) and not first_token_received:
+                                first_token_received = True
+                                ttft_ns = int((time.monotonic() - interaction_started) * 1_000_000_000)
+                                entry_span.set_attribute(GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN, ttft_ns)
+                                entry_span.set_attribute(GenAiAttr.USER_TIME_TO_FIRST_TOKEN, ttft_ns)
+                            if isinstance(event, TextDeltaEvent):
+                                final_text_chunks.append(event.text)
+                            if isinstance(event, MessageEndEvent):
+                                final_stop_reason = event.stop_reason
+                                self._record_session_usage(event.usage, event.usage_attribution)
+                            yield event
                 except asyncio.CancelledError:
                     turn_cancelled = True
                     self._discard_memory_prefetch_for_turn(memory_prefetch)
@@ -1097,18 +1105,19 @@ class AgentLoop:
             try:
                 self._refresh_git_branch()
                 try:
-                    async for event in self._run_streaming_inner("", memory_prefetch=None):
-                        if _is_first_output_delta(event) and not first_token_received:
-                            first_token_received = True
-                            ttft_ns = int((time.monotonic() - interaction_started) * 1_000_000_000)
-                            entry_span.set_attribute(GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN, ttft_ns)
-                            entry_span.set_attribute(GenAiAttr.USER_TIME_TO_FIRST_TOKEN, ttft_ns)
-                        if isinstance(event, TextDeltaEvent):
-                            final_text_chunks.append(event.text)
-                        if isinstance(event, MessageEndEvent):
-                            final_stop_reason = event.stop_reason
-                            self._record_session_usage(event.usage, event.usage_attribution)
-                        yield event
+                    async with aclosing(self._run_streaming_inner("", memory_prefetch=None)) as inner_stream:
+                        async for event in inner_stream:
+                            if _is_first_output_delta(event) and not first_token_received:
+                                first_token_received = True
+                                ttft_ns = int((time.monotonic() - interaction_started) * 1_000_000_000)
+                                entry_span.set_attribute(GenAiAttr.RESPONSE_TIME_TO_FIRST_TOKEN, ttft_ns)
+                                entry_span.set_attribute(GenAiAttr.USER_TIME_TO_FIRST_TOKEN, ttft_ns)
+                            if isinstance(event, TextDeltaEvent):
+                                final_text_chunks.append(event.text)
+                            if isinstance(event, MessageEndEvent):
+                                final_stop_reason = event.stop_reason
+                                self._record_session_usage(event.usage, event.usage_attribution)
+                            yield event
                 except asyncio.CancelledError:
                     log_event(Events.SESSION_CANCELLED, {"stage": "in_query"})
                     raise
@@ -1411,9 +1420,11 @@ class AgentLoop:
                         },
                     )
                     yield permission_event
-                    outcome = await asyncio.shield(response_future)
+                    async with execution_non_advancing_wait():
+                        outcome = await asyncio.shield(response_future)
                     if outcome is PermissionWaitOutcome.SUSPEND:
                         raise PermissionWaitSuspended(permission_event.boundary_id)
+                    await execution_checkpoint()
                     automatic_deny = outcome is PermissionWaitOutcome.AUTOMATIC_DENY
                     state = "allow" if not automatic_deny and bool(outcome) else "deny"
                     source = "automatic" if automatic_deny else "user"
@@ -1491,7 +1502,8 @@ class AgentLoop:
 
         executed_by_id: dict[str, ToolResult] = {}
         if allowed_requests:
-            exec_task = asyncio.create_task(self._tool_executor.execute_batch(allowed_requests, context))
+            await execution_checkpoint()
+            exec_task = asyncio.create_task(self._execute_tool_batch_with_execution_control(allowed_requests, context))
 
             async def poll_recovered_event_queues() -> AsyncGenerator[StreamEvent, None]:
                 while not exec_task.done():
@@ -1513,9 +1525,10 @@ class AgentLoop:
                             yield cast(StreamEvent, item)
 
             try:
-                async for emitted_event in poll_recovered_event_queues():
-                    yield emitted_event
-                results = await exec_task
+                async with execution_non_advancing_wait():
+                    async for emitted_event in poll_recovered_event_queues():
+                        yield emitted_event
+                    results = await exec_task
             except asyncio.CancelledError:
                 if not exec_task.done():
                     exec_task.cancel()
@@ -1589,6 +1602,7 @@ class AgentLoop:
             if result.context_modifier is not None:
                 self._apply_context_modifier(result.context_modifier)
 
+        await execution_checkpoint()
         async for event in self.continue_streaming():
             yield event
 
@@ -1775,6 +1789,21 @@ class AgentLoop:
                     self._provider_requests_in_flight = max(0, self._provider_requests_in_flight - 1)
                     self._sync_pending_provider_context_if_idle()
 
+    async def _stream_provider_with_execution_control(self, **kwargs: Any) -> AsyncGenerator[StreamEvent, None]:
+        async with execution_activity("llm"):
+            async with aclosing(self._stream_provider(**kwargs)) as provider_stream:
+                async for event in provider_stream:
+                    yield event
+
+    async def _execute_tool_batch_with_execution_control(
+        self,
+        requests: list[ToolCallRequest],
+        context: ToolContext,
+    ) -> list[ToolResult]:
+        async with execution_activity("tool_batch", handoff_to_parent=True):
+            async with execution_non_advancing_wait():
+                return await self._tool_executor.execute_batch(requests, context)
+
     def _prepare_request_lease(
         self,
         request_manager: Any,
@@ -1787,9 +1816,7 @@ class AgentLoop:
         tools = list(self.tool_registry.list_tools())
         tool_definitions = self._get_tool_definitions(tools)
         begin_request = (
-            getattr(request_manager, "begin_request", None)
-            if hasattr(type(request_manager), "begin_request")
-            else None
+            getattr(request_manager, "begin_request", None) if hasattr(type(request_manager), "begin_request") else None
         )
         lease = begin_request(base_system_prompt, tool_definitions or None) if callable(begin_request) else None
         try:
@@ -1842,8 +1869,11 @@ class AgentLoop:
             # flight: an injected message cannot change that request, but it
             # can still be consumed by the next round.
             self._accepting_injected_user_messages = _turn < self._max_turns - 1
+            await execution_checkpoint()
             if self._pause_event is not None:
-                await self._pause_event.wait()
+                async with execution_non_advancing_wait():
+                    await self._pause_event.wait()
+                await execution_checkpoint()
             self._drain_pending_injections()
             self._current_turn_text = ""
 
@@ -1872,7 +1902,8 @@ class AgentLoop:
                 self._release_request_lease(request_manager, lease)
                 lease = None
                 yield CompactionEvent(phase="started")
-                compact_event = await self._auto_compact(request_manager)
+                async with execution_activity("llm"):
+                    compact_event = await self._auto_compact(request_manager)
                 yield compact_event if compact_event else CompactionEvent(phase="failed", reason="no_result")
                 lease, system_prompt, tool_definitions = self._prepare_request_lease(
                     request_manager,
@@ -1907,77 +1938,80 @@ class AgentLoop:
                 }
 
                 # Stream from provider
-                async for event in self._stream_provider(
-                    request_manager=request_manager,
-                    lease=lease,
-                    messages=provider_messages,
-                    system=system_prompt,
-                    tools=provider_tools,
-                    telemetry_messages=telemetry_messages,
-                ):
-                    if isinstance(event, ToolUseStartEvent):
-                        event = replace(
-                            event,
-                            metadata=self._tool_use_start_metadata(
-                                event.metadata,
-                                self.tool_registry.get(event.name),
-                            ),
-                        )
-                    if not (isinstance(event, ThinkingDeltaEvent) and event.is_metadata_only):
-                        yield event
+                async with aclosing(
+                    self._stream_provider_with_execution_control(
+                        request_manager=request_manager,
+                        lease=lease,
+                        messages=provider_messages,
+                        system=system_prompt,
+                        tools=provider_tools,
+                        telemetry_messages=telemetry_messages,
+                    )
+                ) as controlled_stream:
+                    async for event in controlled_stream:
+                        if isinstance(event, ToolUseStartEvent):
+                            event = replace(
+                                event,
+                                metadata=self._tool_use_start_metadata(
+                                    event.metadata,
+                                    self.tool_registry.get(event.name),
+                                ),
+                            )
+                        if not (isinstance(event, ThinkingDeltaEvent) and event.is_metadata_only):
+                            yield event
 
-                    # Collect data from events
-                    if isinstance(event, TextDeltaEvent):
-                        text_chunks.append(event.text)
-                        if self._pause_event is not None:
-                            self._current_turn_text += event.text
-                    elif isinstance(event, ThinkingDeltaEvent):
-                        thinking_block = thinking_blocks_by_index.setdefault(
-                            event.block_index,
-                            {
-                                "type": event.block_type,
-                                "text": "",
-                                "provider_metadata": {},
-                            },
-                        )
-                        thinking_block["type"] = event.block_type
-                        thinking_block["text"] += event.text
-                        if event.provider_metadata:
-                            for key, value in event.provider_metadata.items():
-                                if (
-                                    key == "signature"
-                                    and isinstance(value, str)
-                                    and isinstance(thinking_block["provider_metadata"].get(key), str)
-                                ):
-                                    thinking_block["provider_metadata"][key] += value
-                                else:
-                                    thinking_block["provider_metadata"][key] = value
-                    elif isinstance(event, ToolUseStartEvent):
-                        pending_tool_uses_by_id.setdefault(event.tool_use_id, {})
-                        pending_tool_uses_by_id[event.tool_use_id]["id"] = event.tool_use_id
-                        pending_tool_uses_by_id[event.tool_use_id]["name"] = event.name
-                        if event.provider_metadata:
-                            pending_tool_uses_by_id[event.tool_use_id]["provider_metadata"] = dict(
-                                event.provider_metadata
+                        # Collect data from events
+                        if isinstance(event, TextDeltaEvent):
+                            text_chunks.append(event.text)
+                            if self._pause_event is not None:
+                                self._current_turn_text += event.text
+                        elif isinstance(event, ThinkingDeltaEvent):
+                            thinking_block = thinking_blocks_by_index.setdefault(
+                                event.block_index,
+                                {
+                                    "type": event.block_type,
+                                    "text": "",
+                                    "provider_metadata": {},
+                                },
                             )
-                    elif isinstance(event, ToolUseEndEvent):
-                        pending_tool_uses_by_id.setdefault(event.tool_use_id, {})
-                        pending_tool_uses_by_id[event.tool_use_id]["id"] = event.tool_use_id
-                        pending_tool_uses_by_id[event.tool_use_id]["name"] = event.name
-                        pending_tool_uses_by_id[event.tool_use_id]["input"] = event.input
-                        if event.input_error:
-                            pending_tool_uses_by_id[event.tool_use_id]["input_error"] = event.input_error
-                        if event.provider_metadata:
-                            pending_tool_uses_by_id[event.tool_use_id]["provider_metadata"] = dict(
-                                event.provider_metadata
-                            )
-                    elif isinstance(event, TombstoneEvent):
-                        pending_tool_uses_by_id.clear()
-                        text_chunks.clear()
-                        thinking_blocks_by_index.clear()
-                    elif isinstance(event, MessageEndEvent):
-                        message_ended = True
-                        turn_stop_reason = event.stop_reason
+                            thinking_block["type"] = event.block_type
+                            thinking_block["text"] += event.text
+                            if event.provider_metadata:
+                                for key, value in event.provider_metadata.items():
+                                    if (
+                                        key == "signature"
+                                        and isinstance(value, str)
+                                        and isinstance(thinking_block["provider_metadata"].get(key), str)
+                                    ):
+                                        thinking_block["provider_metadata"][key] += value
+                                    else:
+                                        thinking_block["provider_metadata"][key] = value
+                        elif isinstance(event, ToolUseStartEvent):
+                            pending_tool_uses_by_id.setdefault(event.tool_use_id, {})
+                            pending_tool_uses_by_id[event.tool_use_id]["id"] = event.tool_use_id
+                            pending_tool_uses_by_id[event.tool_use_id]["name"] = event.name
+                            if event.provider_metadata:
+                                pending_tool_uses_by_id[event.tool_use_id]["provider_metadata"] = dict(
+                                    event.provider_metadata
+                                )
+                        elif isinstance(event, ToolUseEndEvent):
+                            pending_tool_uses_by_id.setdefault(event.tool_use_id, {})
+                            pending_tool_uses_by_id[event.tool_use_id]["id"] = event.tool_use_id
+                            pending_tool_uses_by_id[event.tool_use_id]["name"] = event.name
+                            pending_tool_uses_by_id[event.tool_use_id]["input"] = event.input
+                            if event.input_error:
+                                pending_tool_uses_by_id[event.tool_use_id]["input_error"] = event.input_error
+                            if event.provider_metadata:
+                                pending_tool_uses_by_id[event.tool_use_id]["provider_metadata"] = dict(
+                                    event.provider_metadata
+                                )
+                        elif isinstance(event, TombstoneEvent):
+                            pending_tool_uses_by_id.clear()
+                            text_chunks.clear()
+                            thinking_blocks_by_index.clear()
+                        elif isinstance(event, MessageEndEvent):
+                            message_ended = True
+                            turn_stop_reason = event.stop_reason
 
                 if not message_ended:
                     self._accepting_injected_user_messages = False
@@ -2042,12 +2076,14 @@ class AgentLoop:
                 # No tool calls -> end turn
                 if not completed_tools:
                     if self._pending_injections and _turn < self._max_turns - 1:
+                        await execution_checkpoint()
                         step_span.set_attribute(GenAiAttr.REACT_FINISH_REASON, "injected_message")
                         continue
                     self._accepting_injected_user_messages = False
                     step_span.set_attribute(GenAiAttr.REACT_FINISH_REASON, "stop")
                     break
 
+                await execution_checkpoint()
                 step_span.set_attribute(GenAiAttr.REACT_FINISH_REASON, "tool_calls")
 
                 # Execute tools (concurrent read-only, serial writes)
@@ -2294,13 +2330,15 @@ class AgentLoop:
                     )
                     yield permission_event
                     try:
-                        outcome = await asyncio.shield(response_future)
+                        async with execution_non_advancing_wait():
+                            outcome = await asyncio.shield(response_future)
                     except asyncio.CancelledError:
                         if not permission_event.resolution_owner_managed and not response_future.done():
                             response_future.set_result(False)
                         raise
                     if outcome is PermissionWaitOutcome.SUSPEND:
                         raise PermissionWaitSuspended(permission_event.boundary_id)
+                    await execution_checkpoint()
                     previous_permission_boundary_id = permission_event.boundary_id
                     automatic_deny = outcome is PermissionWaitOutcome.AUTOMATIC_DENY
                     approved = not automatic_deny and bool(outcome)
@@ -2385,12 +2423,13 @@ class AgentLoop:
                             )
                         async for event in self._submit_queued_inputs_after_tool_call(queued_input_provider):
                             yield event
+                        await execution_checkpoint()
                     continue
 
                 requests = allowed_requests
 
                 # Start tool execution
-                exec_task = asyncio.create_task(self._tool_executor.execute_batch(requests, context))
+                exec_task = asyncio.create_task(self._execute_tool_batch_with_execution_control(requests, context))
 
                 # Poll event queues while tools execute
                 async def poll_event_queues():
@@ -2431,21 +2470,29 @@ class AgentLoop:
                                     is_error=item.get("is_error", False),
                                 )
 
+                pending_cancellation: asyncio.CancelledError | None = None
                 try:
-                    async for sub_event in poll_event_queues():
-                        yield sub_event
+                    async with execution_non_advancing_wait():
+                        async for sub_event in poll_event_queues():
+                            yield sub_event
 
-                    results = await exec_task
-                    for request in requests:
-                        snapshot_id = request.snapshot_id
-                        if snapshot_id is not None and not PROCESS_RESOLVED_CONTRACT_STORE.is_pending(snapshot_id):
-                            self._owned_contract_snapshot_ids.discard(snapshot_id)
-                except asyncio.CancelledError:
+                        results = await exec_task
+                        for request in requests:
+                            snapshot_id = request.snapshot_id
+                            if snapshot_id is not None and not PROCESS_RESOLVED_CONTRACT_STORE.is_pending(snapshot_id):
+                                self._owned_contract_snapshot_ids.discard(snapshot_id)
+                except asyncio.CancelledError as cancellation:
                     if not exec_task.done():
                         exec_task.cancel()
                     with suppress(asyncio.CancelledError):
                         await exec_task
-                    raise
+                    if exec_task.cancelled():
+                        raise
+                    try:
+                        results = exec_task.result()
+                    except BaseException:
+                        raise cancellation
+                    pending_cancellation = cancellation
 
                 # Process results and yield ToolResultEvents.
                 terminal_step_result = False
@@ -2457,6 +2504,7 @@ class AgentLoop:
                     )
                     for request, result in denied_results
                 ]
+                tool_result_events: list[ToolResultEvent] = []
                 for result_index, (req, result) in enumerate(zip(requests, results)):
                     is_terminal_step_result = bool(
                         result.metadata
@@ -2492,13 +2540,15 @@ class AgentLoop:
                         tool_input=req.input,
                     )
 
-                    yield ToolResultEvent(
-                        tool_use_id=req.id,
-                        tool_name=req.name,
-                        result=processed.content,
-                        is_error=result.is_error,
-                        public_path_roots=public_path_roots,
-                        metadata=result_metadata,
+                    tool_result_events.append(
+                        ToolResultEvent(
+                            tool_use_id=req.id,
+                            tool_name=req.name,
+                            result=processed.content,
+                            is_error=result.is_error,
+                            public_path_roots=public_path_roots,
+                            metadata=result_metadata,
+                        )
                     )
 
                     tool_result_blocks.append(
@@ -2534,6 +2584,14 @@ class AgentLoop:
                             )
                     if result.context_modifier is not None:
                         self._apply_context_modifier(result.context_modifier)
+
+                if pending_cancellation is None:
+                    for tool_result_event in tool_result_events:
+                        yield tool_result_event
+
+                await execution_checkpoint()
+                if pending_cancellation is not None:
+                    raise pending_cancellation
 
                 async for event in self._submit_queued_inputs_after_tool_call(queued_input_provider):
                     yield event
@@ -2820,9 +2878,7 @@ class AgentLoop:
         cache_policy: str | None = None,
     ) -> Any:
         begin_request = (
-            getattr(request_manager, "begin_request", None)
-            if hasattr(type(request_manager), "begin_request")
-            else None
+            getattr(request_manager, "begin_request", None) if hasattr(type(request_manager), "begin_request") else None
         )
         lease = begin_request(system, tools) if callable(begin_request) else None
         effective_system = getattr(lease, "system_prompt", system)
@@ -3061,11 +3117,7 @@ class AgentLoop:
             # Compatibility for lightweight third-party/test managers that do
             # not implement ProviderManager's internal attribution contract.
             provider = self._get_runtime_provider_key()
-            model = (
-                self._provider_manager.get_model_name()
-                if hasattr(self._provider_manager, "get_model_name")
-                else ""
-            )
+            model = self._provider_manager.get_model_name() if hasattr(self._provider_manager, "get_model_name") else ""
         try:
             self._session_usage_store.append(
                 self._cwd,

--- a/src/iac_code/agent/agent_tool.py
+++ b/src/iac_code/agent/agent_tool.py
@@ -213,11 +213,14 @@ class AgentTool(Tool):
             return ToolResult.error(_("Unknown agent type: '{agent_type}'").format(agent_type=agent_type))
 
         if run_in_background and self._task_manager:
+            from iac_code.a2a.execution_control import register_execution_task
+
             task_id = self._task_manager.register(
                 description=tool_input.get("description", _("Sub-agent task")),
                 agent_type=agent_type,
             )
             background_task = asyncio.create_task(self._run_background(task_id, prompt, agent_type, context))
+            register_execution_task(background_task, kind="background_agent")
             self._task_manager.attach_task(task_id, background_task)
             background_task.add_done_callback(self._consume_background_task_exception)
             if event_queue is not None:

--- a/src/iac_code/pipeline/engine/pipeline_runner.py
+++ b/src/iac_code/pipeline/engine/pipeline_runner.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock
 
+from iac_code.a2a.backup import run_sync_fenced
+from iac_code.a2a.execution_control import execution_checkpoint, execution_non_advancing_wait
 from iac_code.agent.message import ContentBlock, Message, ToolResultBlock
 from iac_code.i18n import _
 from iac_code.pipeline.engine.cleanup import (
@@ -2089,7 +2091,7 @@ class PipelineRunner:
         return retry_count if isinstance(retry_count, int) and retry_count >= 0 else 0
 
     async def _backup_critical(self, reason: BackupReason, *, step_id: str | None = None) -> None:
-        result = await asyncio.to_thread(
+        result = await run_sync_fenced(
             self._backup_service.backup_session,
             self._cwd,
             self._session_id,
@@ -2395,6 +2397,35 @@ class PipelineRunner:
             )
 
         self._try_save_sidecar_sync("user_aborted", "save_user_aborted_sync", save, step_id=current_step or None)
+
+    def mark_execution_terminated(self, reason: str) -> None:
+        """Persist infrastructure cancellation without classifying it as a user abort."""
+
+        self._mark_active_attempt_failed_preserve_execution()
+        current_step = ""
+        if not self.state_machine.is_complete:
+            try:
+                current_step = self.state_machine.current_step.step_id
+            except (AttributeError, IndexError):
+                current_step = ""
+        if not self.session:
+            self._sidecar_status = "canceled"
+            return
+        session = self.session
+
+        def save() -> None:
+            session.save_canceled_sync(
+                current_step,
+                self._state_machine_snapshot_for_sidecar(),
+                self.context.to_snapshot(),
+                self._pipeline_identity,
+                reason=reason,
+                execution=dict(self._execution) if self._execution else None,
+                attempts=dict(self._attempts),
+                prerequisites=self._sidecar_prerequisites_metadata(),
+            )
+
+        self._try_save_sidecar_sync("canceled", "save_canceled_sync", save, step_id=current_step or None)
 
     async def _save_rollback(self, from_step: str, to_step: str, reason: str) -> None:
         if not self.session:
@@ -2851,6 +2882,7 @@ class PipelineRunner:
     ) -> AsyncGenerator[StreamEvent | PipelineEvent | StepResult, None]:
         """Start the pipeline from the first step."""
         pipeline_started_at = self._observability.now()
+        await execution_checkpoint()
         await self._start_mcp_reconnect_tasks()
         pipeline_input = normalize_pipeline_user_input(user_input)
         self._set_current_step_user_input(pipeline_input)
@@ -4258,6 +4290,7 @@ class PipelineRunner:
             terminal_pipeline_telemetry_emitted = True
 
         while not self.state_machine.is_complete:
+            await execution_checkpoint()
             step = self.state_machine.current_step
             step_user_message = first_step_user_input if is_first_step else None
             step_user_display_text = first_step_user_input_display_text if is_first_step else None
@@ -5454,7 +5487,8 @@ class PipelineRunner:
             done_count = initial_done_count
             total = len(candidates)
             while done_count < total:
-                event = await get_candidate_event()
+                async with execution_non_advancing_wait():
+                    event = await get_candidate_event()
                 if isinstance(event, PipelineStatePersistenceError):
                     yield self._persistence_failure_event(event)
                     return

--- a/src/iac_code/pipeline/engine/session.py
+++ b/src/iac_code/pipeline/engine/session.py
@@ -19,12 +19,13 @@ PipelineStatus = Literal[
     "waiting_input",
     "completed",
     "user_aborted",
+    "canceled",
     "failed",
     "discarded",
     "backup_blocked",
 ]
 RESUMABLE_STATUSES: set[PipelineStatus] = {"running", "waiting_input", "backup_blocked"}
-SKIP_RESTORE_STATUSES: set[PipelineStatus] = {"completed", "user_aborted", "failed", "discarded"}
+SKIP_RESTORE_STATUSES: set[PipelineStatus] = {"completed", "user_aborted", "canceled", "failed", "discarded"}
 
 _ALL_STATUSES = RESUMABLE_STATUSES | SKIP_RESTORE_STATUSES
 _EMPTY_IDENTITY = {
@@ -378,6 +379,32 @@ class PipelineSession:
         prerequisites: _MetadataValue = _PRESERVE_METADATA,
     ) -> None:
         self.save_user_aborted_sync(
+            step_id,
+            state_machine_snapshot,
+            context_snapshot,
+            identity,
+            reason=reason,
+            execution=execution,
+            attempts=attempts,
+            normal_handoff=normal_handoff,
+            prerequisites=prerequisites,
+        )
+
+    def save_canceled_sync(
+        self,
+        step_id: str,
+        state_machine_snapshot: dict,
+        context_snapshot: dict,
+        identity: PipelineIdentity | dict,
+        reason: str | None = None,
+        *,
+        execution: _MetadataValue = _PRESERVE_METADATA,
+        attempts: _MetadataValue = _PRESERVE_METADATA,
+        normal_handoff: _MetadataValue = _PRESERVE_METADATA,
+        prerequisites: _MetadataValue = _PRESERVE_METADATA,
+    ) -> None:
+        self._save_snapshot_sync(
+            "canceled",
             step_id,
             state_machine_snapshot,
             context_snapshot,

--- a/src/iac_code/pipeline/engine/show_diagram_tool.py
+++ b/src/iac_code/pipeline/engine/show_diagram_tool.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from loguru import logger
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.i18n import _
 from iac_code.pipeline.engine.architecture_graph import (
     ArchitectureMultiViewRenderResult,
@@ -133,7 +134,7 @@ class ShowArchitectureDiagramTool(Tool):
 
         # Rendering walks the whole template graph (pure CPU); keep it off the
         # shared event loop so web agent turns, SSE, and HTTP handlers stay responsive.
-        base_render_result = await asyncio.to_thread(render_ros_template_architecture_views, template_content)
+        base_render_result = await run_sync_fenced(render_ros_template_architecture_views, template_content)
         if mode == "facts":
             if context.event_queue is not None:
                 await context.event_queue.put(
@@ -168,7 +169,7 @@ class ShowArchitectureDiagramTool(Tool):
                 logger.exception("Failed to optimize architecture diagram with the LLM; keeping draft diagram")
             else:
                 if generated_semantic_plan:
-                    render_result = await asyncio.to_thread(
+                    render_result = await run_sync_fenced(
                         render_ros_template_architecture_views,
                         template_content,
                         semantic_plan=generated_semantic_plan,
@@ -191,10 +192,10 @@ class ShowArchitectureDiagramTool(Tool):
             )
 
         if semantic_plan is not None:
-            semantic_plan = await asyncio.to_thread(
+            semantic_plan = await run_sync_fenced(
                 repair_semantic_plan_locally, base_render_result.architecture_context, semantic_plan
             )
-            render_result = await asyncio.to_thread(
+            render_result = await run_sync_fenced(
                 render_ros_template_architecture_views, template_content, semantic_plan=semantic_plan
             )
         else:

--- a/src/iac_code/pipeline/engine/sub_pipeline_executor.py
+++ b/src/iac_code/pipeline/engine/sub_pipeline_executor.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from iac_code.a2a.execution_control import execution_checkpoint
 from iac_code.agent.message import ContentBlock, Message
 from iac_code.i18n import _
 from iac_code.pipeline.engine.context import PipelineContext
@@ -202,6 +203,7 @@ class SubPipelineExecutor:
 
         try:
             while not state_machine.is_complete:
+                await execution_checkpoint()
                 step = state_machine.current_step
 
                 if event_callback:

--- a/src/iac_code/pipeline/selling/tools/infraguard_scan_tool.py
+++ b/src/iac_code/pipeline/selling/tools/infraguard_scan_tool.py
@@ -13,6 +13,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.desktop.external_env import create_subprocess_exec, guarded_command, spawn_env
 from iac_code.i18n import _
 from iac_code.tools.base import Tool, ToolContext, ToolResult
@@ -46,12 +47,12 @@ async def _desktop_consumer_lease() -> tuple[Any | None, str | None]:
         # reader that would block repair in another Desktop channel.
         with suppress(Exception):
             await asyncio.shield(acquire)
-            await asyncio.to_thread(lease.__exit__, None, None, None)
+            await run_sync_fenced(lease.__exit__, None, None, None)
         raise
     except TimeoutError:
         return None, "installing"
     if lease.recovery_required():
-        await asyncio.to_thread(lease.__exit__, None, None, None)
+        await run_sync_fenced(lease.__exit__, None, None, None)
         return None, "recovery_required"
     return lease, None
 
@@ -100,7 +101,7 @@ async def _run_infraguard_with_desktop_lease(
         )
     finally:
         if lease is not None:
-            await asyncio.to_thread(lease.__exit__, None, None, None)
+            await run_sync_fenced(lease.__exit__, None, None, None)
 
 
 def _extract_findings(parsed: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/iac_code/services/permission_wait.py
+++ b/src/iac_code/services/permission_wait.py
@@ -574,6 +574,7 @@ class PermissionWaitCheckpointStore:
         grace_seconds: float,
         live_owner: bool,
         expected_generation: int | None = None,
+        allow_suspend: bool = True,
     ) -> dict[str, Any]:
         observed_at = now or utc_now()
 
@@ -596,7 +597,7 @@ class PermissionWaitCheckpointStore:
                 # configured request-versus-timeout race window.
                 grace_deadline = observed_at + timedelta(seconds=grace_seconds)
                 record["graceDeadlineAt"] = format_utc(grace_deadline)
-                if decision_status == "none" and grace_seconds == 0:
+                if decision_status == "none" and grace_seconds == 0 and allow_suspend:
                     record["phase"] = "SUSPENDING" if live_owner else "SUSPENDED"
                 else:
                     record["phase"] = "TIMEOUT_GRACE"
@@ -606,6 +607,7 @@ class PermissionWaitCheckpointStore:
             grace_deadline = parse_utc(record.get("graceDeadlineAt"))
             if (
                 phase == "TIMEOUT_GRACE"
+                and allow_suspend
                 and decision_status == "none"
                 and grace_deadline is not None
                 and observed_at >= grace_deadline
@@ -818,6 +820,24 @@ class PermissionWaitCheckpointStore:
 
         return self.transaction(boundary_id, mutate)
 
+    def cancel_restore(self, boundary_id: str, *, claim_id: str) -> dict[str, Any]:
+        """Seal a drained execution's recovery without undoing its permission decision."""
+
+        def mutate(record: dict[str, Any]) -> dict[str, Any] | None:
+            decision = record.get("decision")
+            if not claim_id or not isinstance(decision, dict) or decision.get("claimId") != claim_id:
+                raise ValueError("permission recovery claim changed")
+            if record.get("phase") == "CANCELED":
+                return None
+            if record.get("phase") != "RESTORING":
+                raise ValueError("permission recovery is not restoring")
+            record["phase"] = "CANCELED"
+            record["generation"] = int(record["generation"]) + 1
+            record["updatedAt"] = format_utc(utc_now())
+            return record
+
+        return self.transaction(boundary_id, mutate)
+
     def _record_path(self, boundary_id: str) -> Path:
         if not _BOUNDARY_ID.fullmatch(boundary_id):
             raise ValueError("invalid permission boundary id")
@@ -947,6 +967,8 @@ class _LiveOwner:
     timer: asyncio.Task[None] | None = None
     timer_retry: asyncio.TimerHandle | None = None
     on_suspend: Callable[[], Awaitable[None] | None] | None = None
+    run_suspension: Callable[[Callable[[], Awaitable[bool]]], Awaitable[bool | None]] | None = None
+    suspension_allowed: Callable[[], bool] | None = None
     owner_completed: asyncio.Event = field(default_factory=asyncio.Event)
 
 
@@ -997,6 +1019,8 @@ class PermissionWaitCoordinator:
         store: PermissionWaitCheckpointStore,
         future: asyncio.Future[bool | PermissionWaitOutcome],
         on_suspend: Callable[[], Awaitable[None] | None] | None = None,
+        run_suspension: Callable[[Callable[[], Awaitable[bool]]], Awaitable[bool | None]] | None = None,
+        suspension_allowed: Callable[[], bool] | None = None,
     ) -> None:
         boundary_id = str(record["boundaryId"])
         existing = self._owners.get(boundary_id)
@@ -1020,6 +1044,8 @@ class PermissionWaitCoordinator:
             store=store,
             permission_resolution_lock=asyncio.Lock(),
             on_suspend=on_suspend,
+            run_suspension=run_suspension,
+            suspension_allowed=suspension_allowed,
         )
         self._owners[boundary_id] = owner
         logger.info(
@@ -1174,6 +1200,7 @@ class PermissionWaitCoordinator:
                 grace_seconds=self.policy.timeout_grace_seconds,
                 live_owner=True,
                 expected_generation=owner.generation,
+                allow_suspend=owner.suspension_allowed is None or owner.suspension_allowed(),
             )
             owner.generation = int(reconciled["generation"])
             record, created = owner.store.claim_decision(
@@ -1233,15 +1260,28 @@ class PermissionWaitCoordinator:
         owner = self._owners.get(boundary_id)
         if owner is None:
             return False
+        if owner.run_suspension is not None:
+            return bool(await owner.run_suspension(lambda: self._suspend_owner(owner)))
+        return await self._suspend_owner(owner)
+
+    async def _suspend_owner(self, owner: _LiveOwner) -> bool:
+        boundary_id = owner.boundary_id
         callback = None
         async with owner.permission_resolution_lock:
+            if self._owners.get(boundary_id) is not owner or owner.future.done():
+                return False
             try:
-                record = owner.store.reconcile_deadline(
-                    boundary_id,
-                    grace_seconds=self.policy.timeout_grace_seconds,
-                    live_owner=True,
-                    expected_generation=owner.generation,
-                )
+                def reconcile() -> dict[str, Any]:
+                    return owner.store.reconcile_deadline(
+                        boundary_id,
+                        grace_seconds=self.policy.timeout_grace_seconds,
+                        live_owner=True,
+                        expected_generation=owner.generation,
+                    )
+
+                # A2A's guard fences cancellation until this worker and the
+                # suspension callback finish. Other surfaces retain their path.
+                record = await asyncio.to_thread(reconcile) if owner.run_suspension is not None else reconcile()
             except ValueError:
                 current = owner.store.load(boundary_id)
                 logger.warning(
@@ -1286,40 +1326,38 @@ class PermissionWaitCoordinator:
                 owner.boundary_id,
                 owner.generation,
             )
-            async with owner.permission_resolution_lock:
-                record = owner.store.reconcile_deadline(
-                    owner.boundary_id,
-                    grace_seconds=self.policy.timeout_grace_seconds,
-                    live_owner=True,
-                    expected_generation=owner.generation,
-                )
-                owner.generation = int(record["generation"])
-                if record.get("phase") == "SUSPENDING":
-                    grace_deadline = None
-                elif record.get("phase") != "TIMEOUT_GRACE":
-                    return
-                else:
+            if owner.run_suspension is None:
+                # Preserve the existing deadline/grace scheduling on surfaces
+                # that do not install A2A connection control.
+                async with owner.permission_resolution_lock:
+                    record = owner.store.reconcile_deadline(
+                        owner.boundary_id,
+                        grace_seconds=self.policy.timeout_grace_seconds,
+                        live_owner=True,
+                        expected_generation=owner.generation,
+                    )
+                    owner.generation = int(record["generation"])
+                    if record.get("phase") not in {"SUSPENDING", "TIMEOUT_GRACE"}:
+                        return
                     grace_deadline = parse_utc(record.get("graceDeadlineAt"))
-                logger.info(
-                    "Permission wait resident deadline reconciled boundary_id=%s generation=%s phase=%s",
-                    owner.boundary_id,
-                    owner.generation,
-                    record.get("phase"),
-                )
-            if grace_deadline is not None:
-                await asyncio.sleep(max(0.0, (grace_deadline - utc_now()).total_seconds()))
+                if grace_deadline is not None:
+                    await asyncio.sleep(max(0.0, (grace_deadline - utc_now()).total_seconds()))
             suspended = await self.suspend_now(owner.boundary_id)
             while not suspended:
+                if self._owners.get(owner.boundary_id) is not owner or owner.future.done():
+                    break
                 current = owner.store.load(owner.boundary_id)
                 decision = current.get("decision") if current is not None else None
                 if (
                     current is None
-                    or current.get("phase") != "TIMEOUT_GRACE"
+                    or current.get("phase") not in {"WAITING", "TIMEOUT_GRACE"}
                     or not isinstance(decision, Mapping)
                     or decision.get("status") != "none"
                 ):
                     break
-                grace_deadline = parse_utc(current.get("graceDeadlineAt"))
+                grace_deadline = parse_utc(
+                    current.get("residentDeadlineAt" if current.get("phase") == "WAITING" else "graceDeadlineAt")
+                )
                 if grace_deadline is None:
                     break
                 await asyncio.sleep(max(0.001, (grace_deadline - utc_now()).total_seconds()))

--- a/src/iac_code/services/session_backup.py
+++ b/src/iac_code/services/session_backup.py
@@ -60,6 +60,7 @@ class BackupReason(str, Enum):
     WAITING_INPUT = "waiting_input"
     TERMINAL = "terminal"
     HANDOFF_READY = "handoff_ready"
+    DISCONNECT_TIMEOUT = "disconnect_timeout"
 
 
 @dataclass(frozen=True)

--- a/src/iac_code/services/session_backup_staging.py
+++ b/src/iac_code/services/session_backup_staging.py
@@ -240,6 +240,50 @@ class StagedSessionBackupService(SessionBackupService):
             ) from None
         return failure_result
 
+    def wait_until_shared_committed(
+        self,
+        cwd: str,
+        session_id: str,
+        *,
+        generation: int,
+        commit_id: str,
+        timeout_seconds: float = 30.0,
+        poll_interval: float = 0.05,
+    ) -> BackupResult:
+        """Wait until the staging publisher exposes the exact commit in shared storage."""
+
+        source = self._source_for_backup(cwd, session_id)
+        backup_root = self._backup_root()
+        if source is None or backup_root is None:
+            return BackupResult(enabled=False)
+        destination = backup_root / "projects" / source.parent.name / session_id
+        deadline = time.monotonic() + max(timeout_seconds, 0.0)
+        while True:
+            state = self._read_state(destination, session_id=session_id, shared=True, missing_ok=True)
+            if state is not None and state.generation == generation and state.commit_id == commit_id:
+                return BackupResult(
+                    enabled=True,
+                    source=source,
+                    destination=destination,
+                    generation=generation,
+                    commit_id=commit_id,
+                    succeeded=True,
+                    shared_committed=True,
+                    staged_committed=True,
+                )
+            if time.monotonic() >= deadline:
+                return BackupResult(
+                    enabled=True,
+                    source=source,
+                    destination=destination,
+                    generation=generation,
+                    commit_id=commit_id,
+                    succeeded=False,
+                    error="Timed out waiting for the staged backup to reach shared storage.",
+                    staged_committed=True,
+                )
+            time.sleep(max(poll_interval, 0.01))
+
     def reconcile_session(
         self,
         cwd: str,

--- a/src/iac_code/tools/bash/bash_tool.py
+++ b/src/iac_code/tools/bash/bash_tool.py
@@ -6,6 +6,7 @@ import asyncio
 import sys
 from typing import TYPE_CHECKING, Any
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.desktop.external_env import (
     create_subprocess_exec,
     create_subprocess_shell,
@@ -61,7 +62,7 @@ class BashTool(Tool):
 
         try:
             if sys.platform == "win32":
-                info = await asyncio.to_thread(PlatformInfo.detect) if is_desktop_runtime() else PlatformInfo.detect()
+                info = await run_sync_fenced(PlatformInfo.detect) if is_desktop_runtime() else PlatformInfo.detect()
                 process = await create_subprocess_exec(
                     info.shell_path,
                     "-c",

--- a/src/iac_code/tools/cloud/aliyun/aliyun_api.py
+++ b/src/iac_code/tools/cloud/aliyun/aliyun_api.py
@@ -23,6 +23,7 @@ from alibabacloud_tea_openapi import models as open_api_models
 from alibabacloud_tea_openapi.client import Client as OpenApiClient
 from darabonba.runtime import RuntimeOptions
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.i18n import _
 from iac_code.services.cloud_credentials import CloudCredentials
 from iac_code.services.permissions.audit import fingerprint_text
@@ -2509,7 +2510,7 @@ class AliyunApi(BaseCloudApi):
                     else _authorized_materialization_path("template", authorized_read_paths)
                 )
                 try:
-                    template_bytes = await asyncio.to_thread(_read_body_file, resolved_template)
+                    template_bytes = await run_sync_fenced(_read_body_file, resolved_template)
                     params["TemplateBody"] = template_bytes.decode("utf-8")
                 except (OSError, UnicodeError) as error:
                     from iac_code.tools.cloud.aliyun.hooks.ros_validate import local_template_source_error
@@ -2525,7 +2526,7 @@ class AliyunApi(BaseCloudApi):
                     if trust_path == "internal"
                     else _authorized_materialization_path("body_file", authorized_read_paths)
                 )
-                materialized["body_file"] = await asyncio.to_thread(_read_body_file, resolved_body_file)
+                materialized["body_file"] = await run_sync_fenced(_read_body_file, resolved_body_file)
             region_id = materialized.get("region_id")
             if isinstance(region_id, str) and region_id:
                 for parameter in contract.parameters:
@@ -2835,7 +2836,7 @@ class AliyunApi(BaseCloudApi):
         if not endpoint:
             # Location-service discovery makes a blocking OpenAPI call; keep it off
             # the shared event loop (web agent turns, SSE, and HTTP handlers run on it).
-            endpoint = await asyncio.to_thread(self._discover_endpoint, product, region, credential)
+            endpoint = await run_sync_fenced(self._discover_endpoint, product, region, credential)
         if not endpoint:
             endpoint = self._get_endpoint_fallback(product, region)
         try:
@@ -2891,7 +2892,7 @@ class AliyunApi(BaseCloudApi):
         try:
             # The OpenAPI call is blocking network I/O; offload it so it never
             # starves the shared event loop. Telemetry/event emission stay on-loop.
-            result = await asyncio.to_thread(client.call_api, api_params, request, runtime)
+            result = await run_sync_fenced(client.call_api, api_params, request, runtime)
             body = result.get("body", result)
 
             self._last_action = action

--- a/src/iac_code/tools/cloud/aliyun/api_contract.py
+++ b/src/iac_code/tools/cloud/aliyun/api_contract.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import copy
 import hashlib
 import json
@@ -19,6 +18,7 @@ from urllib.parse import quote, urlencode
 import yaml
 from alibabacloud_openapi_util.client import Client as OpenApiUtil
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.tools.cloud.aliyun.api_identifiers import is_safe_api_version
 from iac_code.tools.cloud.aliyun.openmeta import (
     ApiMetadata,
@@ -1052,7 +1052,7 @@ class RequestBuilder:
                     raise ApiContractError("body_file_too_large")
                 body = body_file
             elif isinstance(body_file, str):
-                body = await asyncio.to_thread(_read_body_file, Path(body_file))
+                body = await run_sync_fenced(_read_body_file, Path(body_file))
             else:
                 raise ApiContractError("invalid_body_file")
             _validate_content_type(content_type, "byte", contract.consumes)

--- a/src/iac_code/tools/cloud/aliyun/openmeta.py
+++ b/src/iac_code/tools/cloud/aliyun/openmeta.py
@@ -23,6 +23,7 @@ from urllib.parse import quote
 import httpx
 import yaml
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.tools.cloud.aliyun.api_identifiers import is_safe_api_version
 from iac_code.tools.cloud.aliyun.user_agent import build_user_agent
 from iac_code.utils.async_lifecycle import await_task_to_completion
@@ -1560,7 +1561,7 @@ class OpenMetaClient:
                 return None, "temporarily_unavailable", str(current)
             try:
                 async with self._decode_semaphore:
-                    payload = await asyncio.to_thread(json.loads, b"".join(chunks))
+                    payload = await run_sync_fenced(json.loads, b"".join(chunks))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 return None, "temporarily_unavailable", str(current)
             if not isinstance(payload, Mapping | list):

--- a/src/iac_code/tools/cloud/aliyun/ros_stack.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_stack.py
@@ -11,6 +11,12 @@ from typing import Any, Literal
 
 from alibabacloud_ros20190910 import models as ros_models
 
+from iac_code.a2a.backup import await_fenced, run_sync_fenced, run_sync_fenced_with_cancel_completion
+from iac_code.a2a.execution_control import (
+    current_execution_control,
+    current_execution_termination_reason,
+    record_execution_external_operation,
+)
 from iac_code.i18n import _
 from iac_code.services.cloud_credentials import CloudCredentials
 from iac_code.services.telemetry import add_metric, log_event
@@ -33,6 +39,7 @@ from iac_code.tools.cloud.aliyun.template_source import (
 from iac_code.tools.cloud.base_stack import BaseCloudStack
 from iac_code.tools.cloud.types import ResourceStatus, StackStatus
 from iac_code.types.permissions import ToolPermissionContext
+from iac_code.types.stream_events import ResourceObservedEvent
 
 # Telemetry helpers
 _TERRAFORM_TRANSFORM_PREFIXES = ("Aliyun::Terraform-", "Aliyun::OpenTofu-")
@@ -84,6 +91,10 @@ _DELETE_TERMINAL_STATUSES = {
 }
 
 logger = logging.getLogger(__name__)
+
+
+def _deployment_cancellation_reason() -> str:
+    return current_execution_termination_reason() or "user_cancel"
 
 
 def _parse_template(template_body: str) -> dict | None:
@@ -521,7 +532,7 @@ class RosStack(BaseCloudStack):
                 "iac_kind": kind,
                 "region": context["region"],
                 "duration_ms": duration_ms,
-                "reason": "user_cancel",
+                "reason": _deployment_cancellation_reason(),
             },
         )
         self._add_metric_best_effort(Metrics.DEPLOYMENT_COUNT, 1, {"kind": kind, "outcome": "cancel"})
@@ -654,16 +665,21 @@ class RosStack(BaseCloudStack):
         try:
             client = self._get_client(region)
             if action == "CreateStack":
-                return await self._handle_create_stack(client, params, region)
+                return await self._handle_create_stack(client, params, region, tool_context=tool_context)
             elif action == "UpdateStack":
-                return await self._handle_update_stack(client, params, region)
+                return await self._handle_update_stack(client, params, region, tool_context=tool_context)
             elif action == "ContinueCreateStack":
                 _normalize_stack_parameters_for_sdk(params)
                 request = ros_models.ContinueCreateStackRequest().from_map(params)
-                response = await asyncio.to_thread(client.continue_create_stack, request)
+                response = await run_sync_fenced_with_cancel_completion(
+                    client.continue_create_stack,
+                    self._cancel_completion_recorder("ContinueCreateStack", params, region, tool_context),
+                    request,
+                )
+                await self._record_operation_result("ContinueCreateStack", params, region, tool_context, response, None)
                 return response.body.stack_id
             elif action == "DeleteStack":
-                return await self._handle_delete_stack(client, params, region)
+                return await self._handle_delete_stack(client, params, region, tool_context=tool_context)
         except Exception as error:
             # A dynamic credential is resolved when the client is built (a plain
             # ValueError) and again while the SDK signs the request (the same failure
@@ -673,7 +689,74 @@ class RosStack(BaseCloudStack):
             raise
         raise ValueError(f"Unsupported: {action}")
 
-    async def _handle_create_stack(self, client: Any, params: dict, region: str) -> str:
+    async def _record_operation_result(
+        self,
+        action: str,
+        params: dict[str, Any],
+        region: str,
+        tool_context: ToolContext | None,
+        response: Any | None,
+        error: BaseException | None,
+    ) -> None:
+        if current_execution_control() is None:
+            return
+        stack_id = str(params.get("StackId") or "")
+        if response is not None:
+            stack_id = str(getattr(getattr(response, "body", None), "stack_id", None) or stack_id)
+        await await_fenced(
+            record_execution_external_operation(
+                product="ros",
+                action=action,
+                outcome="accepted" if error is None else "unknown",
+                resource_type="stack",
+                resource_id=stack_id or None,
+                region_id=region or None,
+                tool_use_id=tool_context.tool_use_id if tool_context is not None else None,
+            )
+        )
+
+    def _cancel_completion_recorder(
+        self,
+        action: str,
+        params: dict[str, Any],
+        region: str,
+        tool_context: ToolContext | None,
+    ):
+        async def record(response: Any | None, error: BaseException | None) -> None:
+            await self._record_operation_result(action, params, region, tool_context, response, error)
+            stack_id = str(params.get("StackId") or "")
+            if response is not None:
+                stack_id = str(getattr(getattr(response, "body", None), "stack_id", None) or stack_id)
+            if (
+                error is None
+                and action == "CreateStack"
+                and stack_id
+                and tool_context is not None
+                and tool_context.event_queue is not None
+            ):
+                await tool_context.event_queue.put(
+                    ResourceObservedEvent(
+                        provider=self.provider_name,
+                        resource_type="stack",
+                        resource_id=stack_id,
+                        resource_name=str(params.get("StackName") or params.get("stack_name") or ""),
+                        region_id=region,
+                        action=action,
+                        tool_name=self.name,
+                        tool_use_id=tool_context.tool_use_id,
+                    )
+                )
+
+        return record
+
+    async def _handle_create_stack(
+        self,
+        client: Any,
+        params: dict,
+        region: str,
+        *,
+        tool_context: ToolContext | None = None,
+    ) -> str:
         """CreateStack with telemetry for template generation and deployment."""
         template_body = _template_body_for_telemetry(params)
 
@@ -756,7 +839,12 @@ class RosStack(BaseCloudStack):
         try:
             _normalize_stack_parameters_for_sdk(params)
             request = ros_models.CreateStackRequest().from_map(params)
-            response = await asyncio.to_thread(client.create_stack, request)
+            response = await run_sync_fenced_with_cancel_completion(
+                client.create_stack,
+                self._cancel_completion_recorder("CreateStack", params, region, tool_context),
+                request,
+            )
+            await self._record_operation_result("CreateStack", params, region, tool_context, response, None)
             stack_id = response.body.stack_id
             self._store_deployment_telemetry_context(
                 stack_id,
@@ -778,7 +866,7 @@ class RosStack(BaseCloudStack):
                     "iac_kind": kind,
                     "region": region,
                     "duration_ms": duration_ms,
-                    "reason": "user_cancel",
+                    "reason": _deployment_cancellation_reason(),
                 },
             )
             self._add_metric_best_effort(Metrics.DEPLOYMENT_COUNT, 1, {"kind": kind, "outcome": "cancel"})
@@ -832,7 +920,14 @@ class RosStack(BaseCloudStack):
             )
             raise
 
-    async def _handle_update_stack(self, client: Any, params: dict, region: str) -> str:
+    async def _handle_update_stack(
+        self,
+        client: Any,
+        params: dict,
+        region: str,
+        *,
+        tool_context: ToolContext | None = None,
+    ) -> str:
         """UpdateStack with telemetry for deployment events."""
         template_body = _template_body_for_telemetry(params)
 
@@ -866,7 +961,12 @@ class RosStack(BaseCloudStack):
         try:
             _normalize_stack_parameters_for_sdk(params)
             request = ros_models.UpdateStackRequest().from_map(params)
-            response = await asyncio.to_thread(client.update_stack, request)
+            response = await run_sync_fenced_with_cancel_completion(
+                client.update_stack,
+                self._cancel_completion_recorder("UpdateStack", params, region, tool_context),
+                request,
+            )
+            await self._record_operation_result("UpdateStack", params, region, tool_context, response, None)
             stack_id = response.body.stack_id
             self._store_deployment_telemetry_context(
                 stack_id,
@@ -888,7 +988,7 @@ class RosStack(BaseCloudStack):
                     "iac_kind": kind,
                     "region": region,
                     "duration_ms": duration_ms,
-                    "reason": "user_cancel",
+                    "reason": _deployment_cancellation_reason(),
                 },
             )
             self._add_metric_best_effort(Metrics.DEPLOYMENT_COUNT, 1, {"kind": kind, "outcome": "cancel"})
@@ -942,7 +1042,14 @@ class RosStack(BaseCloudStack):
             )
             raise
 
-    async def _handle_delete_stack(self, client: Any, params: dict, region: str) -> str:
+    async def _handle_delete_stack(
+        self,
+        client: Any,
+        params: dict,
+        region: str,
+        *,
+        tool_context: ToolContext | None = None,
+    ) -> str:
         """DeleteStack with request failure/cancellation telemetry, no started or terminal success event."""
         stack_id = params.get("StackId", "")
 
@@ -952,7 +1059,12 @@ class RosStack(BaseCloudStack):
         started = time.monotonic()
         try:
             request = ros_models.DeleteStackRequest().from_map(params)
-            await asyncio.to_thread(client.delete_stack, request)
+            response = await run_sync_fenced_with_cancel_completion(
+                client.delete_stack,
+                self._cancel_completion_recorder("DeleteStack", params, region, tool_context),
+                request,
+            )
+            await self._record_operation_result("DeleteStack", params, region, tool_context, response, None)
             return stack_id
         except (KeyboardInterrupt, asyncio.CancelledError):
             duration_ms = int((time.monotonic() - started) * 1000)
@@ -962,7 +1074,7 @@ class RosStack(BaseCloudStack):
                     "iac_kind": kind,
                     "region": region,
                     "duration_ms": duration_ms,
-                    "reason": "user_cancel",
+                    "reason": _deployment_cancellation_reason(),
                 },
             )
             self._add_metric_best_effort(Metrics.DEPLOYMENT_COUNT, 1, {"kind": kind, "outcome": "cancel"})
@@ -1021,7 +1133,7 @@ class RosStack(BaseCloudStack):
         )
         try:
             client = self._get_client(region)
-            response = await asyncio.to_thread(client.get_stack, request)
+            response = await run_sync_fenced(client.get_stack, request)
         except Exception as error:
             # Polling re-resolves the credential when the client is built and re-signs on
             # every round, so an IMDS failure can start here long after the stack
@@ -1044,7 +1156,7 @@ class RosStack(BaseCloudStack):
         request = ros_models.ListStackResourcesRequest(stack_id=stack_id, region_id=region)
         try:
             client = self._get_client(region)
-            response = await asyncio.to_thread(client.list_stack_resources, request)
+            response = await run_sync_fenced(client.list_stack_resources, request)
         except Exception as error:
             if message := public_ecs_credential_message(error, action="ListStackResources", region=region):
                 raise ValueError(message) from error

--- a/src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
+++ b/src/iac_code/tools/cloud/aliyun/ros_stack_instances.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from alibabacloud_ros20190910 import models as ros_models
 
+from iac_code.a2a.backup import await_fenced, run_sync_fenced, run_sync_fenced_with_cancel_completion
+from iac_code.a2a.execution_control import current_execution_control, record_execution_external_operation
 from iac_code.i18n import _
 from iac_code.services.cloud_credentials import CloudCredentials
 from iac_code.tools.base import Tool, ToolContext, ToolResult
@@ -136,31 +138,55 @@ class RosStackInstances(Tool):
         cred = credentials.get_provider("aliyun")
         return RosClientFactory.create(cred, region_id=region)
 
-    async def _initiate(self, client: Any, action: str, params: dict) -> str:
+    async def _initiate(self, client: Any, action: str, params: dict, *, context: ToolContext | None = None) -> str:
         """Start the stack instances operation and return the operation_id.
 
         Every SDK call is blocking network I/O, and signing a dynamic credential reads
         the instance metadata service on the calling thread, so it stays off the shared
         event loop (web agent turns, SSE, and HTTP handlers run on it).
         """
+
+        async def record_result(response: Any | None, error: BaseException | None) -> None:
+            if current_execution_control() is None:
+                return
+            operation_id = getattr(getattr(response, "body", None), "operation_id", None)
+            await await_fenced(
+                record_execution_external_operation(
+                    product="ros",
+                    action=action,
+                    outcome="accepted" if error is None else "unknown",
+                    resource_type="stack-group-operation",
+                    resource_id=str(operation_id) if operation_id else None,
+                    region_id=params.get("RegionId") or None,
+                    tool_use_id=context.tool_use_id if context is not None else None,
+                )
+            )
+
         if action == "CreateStackInstances":
             request = ros_models.CreateStackInstancesRequest().from_map(params)
-            response = await asyncio.to_thread(client.create_stack_instances, request)
-            return response.body.operation_id
+            response = await run_sync_fenced_with_cancel_completion(
+                client.create_stack_instances, record_result, request
+            )
         elif action == "UpdateStackInstances":
             request = ros_models.UpdateStackInstancesRequest().from_map(params)
-            response = await asyncio.to_thread(client.update_stack_instances, request)
-            return response.body.operation_id
+            response = await run_sync_fenced_with_cancel_completion(
+                client.update_stack_instances, record_result, request
+            )
         elif action == "DeleteStackInstances":
             request = ros_models.DeleteStackInstancesRequest().from_map(params)
-            response = await asyncio.to_thread(client.delete_stack_instances, request)
-            return response.body.operation_id
-        raise ValueError(f"Unsupported action: {action}")
+            response = await run_sync_fenced_with_cancel_completion(
+                client.delete_stack_instances, record_result, request
+            )
+        else:
+            raise ValueError(f"Unsupported action: {action}")
+        assert response is not None
+        await record_result(response, None)
+        return response.body.operation_id
 
     async def _get_operation_status(self, client: Any, operation_id: str, region: str) -> str:
         """Poll the current status of a stack group operation."""
         request = ros_models.GetStackGroupOperationRequest(operation_id=operation_id, region_id=region)
-        response = await asyncio.to_thread(client.get_stack_group_operation, request)
+        response = await run_sync_fenced(client.get_stack_group_operation, request)
         data = response.body.to_map()
         operation = data.get("StackGroupOperation") or {}
         return operation.get("Status") or data.get("Status", "RUNNING")
@@ -168,7 +194,7 @@ class RosStackInstances(Tool):
     async def _get_instances(self, client: Any, stack_group_name: str, region: str) -> list[InstanceStatus]:
         """Get the current list of stack instances for a stack group."""
         request = ros_models.ListStackInstancesRequest(stack_group_name=stack_group_name, region_id=region)
-        response = await asyncio.to_thread(client.list_stack_instances, request)
+        response = await run_sync_fenced(client.list_stack_instances, request)
         data = response.body.to_map()
         instances = []
         for item in data.get("StackInstances", []):
@@ -196,7 +222,7 @@ class RosStackInstances(Tool):
 
         try:
             client = self._get_client(region)
-            operation_id = await self._initiate(client, action, params)
+            operation_id = await self._initiate(client, action, params, context=context)
         except Exception as error:
             # A dynamic credential is resolved when the client is built (a plain
             # ValueError) and again while the SDK signs the request (the same failure

--- a/src/iac_code/tools/glob.py
+++ b/src/iac_code/tools/glob.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import fnmatch
 import os
 from pathlib import Path
 from typing import Any
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.i18n import _
 from iac_code.tools.base import Tool, ToolContext, ToolResult
 from iac_code.tools.path_safety import check_read_path, get_iac_code_application_root, resolve_read_path
@@ -237,7 +237,7 @@ class GlobTool(Tool):
 
         try:
             allowed_roots = _effective_allowed_roots(search_root, context)
-            matches = await asyncio.to_thread(_run_glob_execute, search_root, pattern, allowed_roots)
+            matches = await run_sync_fenced(_run_glob_execute, search_root, pattern, allowed_roots)
         except Exception as e:
             return ToolResult.error(f"Error during glob: {e}")
 
@@ -274,7 +274,7 @@ class GlobTool(Tool):
                     relative_read_directories=context.relative_read_directories,
                 )
                 allowed_roots = _effective_allowed_roots(search_root, context)
-                return await asyncio.to_thread(
+                return await run_sync_fenced(
                     _run_glob_permission_check,
                     search_root,
                     pattern,

--- a/src/iac_code/tools/grep.py
+++ b/src/iac_code/tools/grep.py
@@ -11,6 +11,7 @@ import sys
 from functools import lru_cache
 from typing import Any
 
+from iac_code.a2a.backup import run_sync_fenced
 from iac_code.desktop.external_env import create_subprocess_exec, guarded_command, spawn_env_kwargs
 from iac_code.i18n import _
 from iac_code.tools.base import Tool, ToolContext, ToolResult
@@ -358,7 +359,7 @@ class GrepTool(Tool):
             # Pure-Python fallback walks the tree and reads files synchronously;
             # offload it so it never starves the shared event loop.
             output = (
-                await asyncio.to_thread(
+                await run_sync_fenced(
                     _python_grep,
                     pattern,
                     path,

--- a/src/iac_code/tools/tool_executor.py
+++ b/src/iac_code/tools/tool_executor.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from iac_code.a2a.execution_control import execution_activity, run_with_execution_budget
 from iac_code.i18n import _
 from iac_code.services.telemetry import add_metric, log_event, start_span
 from iac_code.services.telemetry.config import should_capture_content_on_span
@@ -128,10 +129,11 @@ class ToolExecutor:
 
         try:
             with start_span(span_name, span_attrs) as span:
-                result = await asyncio.wait_for(
-                    tool.execute(tool_input=call.input, context=context),
-                    timeout=timeout,
-                )
+                async with execution_activity("tool", check_gate=False, handoff_to_parent=True):
+                    result = await run_with_execution_budget(
+                        tool.execute(tool_input=call.input, context=context),
+                        timeout=timeout,
+                    )
                 duration_ms = int((time.monotonic() - started) * 1000)
                 if should_capture_content_on_span():
                     span.set_attribute(GenAiAttr.TOOL_CALL_RESULT, serialize_tool_result(result, tool_name=call.name))

--- a/tests/a2a/test_agent_card.py
+++ b/tests/a2a/test_agent_card.py
@@ -1,6 +1,6 @@
 from a2a.server.routes.agent_card_routes import agent_card_to_dict
 
-from iac_code.a2a.agent_card import build_agent_card
+from iac_code.a2a.agent_card import IAC_CODE_EXECUTION_CONTROL_EXTENSION_URI, build_agent_card
 from iac_code.a2a.exposure import A2AExposureType
 from iac_code.a2a.pipeline_events import PIPELINE_EVENTS_EXTENSION_URI
 
@@ -85,6 +85,32 @@ def test_agent_card_advertises_pipeline_events_extension() -> None:
     extension = _extension_by_uri(data, PIPELINE_EVENTS_EXTENSION_URI)
     assert extension.get("required", False) is False
     assert extension["params"] == PIPELINE_EVENTS_EXTENSION_PARAMS
+
+
+def test_agent_card_advertises_execution_control_extension() -> None:
+    card = build_agent_card(host="127.0.0.1", port=41242, token_enabled=False)
+    data = agent_card_to_dict(card)
+
+    extension = _extension_by_uri(data, IAC_CODE_EXECUTION_CONTROL_EXTENSION_URI)
+    assert extension.get("required", False) is False
+    assert extension["params"]["pauseEndpoint"] == "/iac-code/execution/pause"
+    assert extension["params"]["sessionRecoveryEndpoint"] == "/iac-code/session/recovery"
+    assert extension["params"]["toolBatchDrainOnPause"] is True
+    assert extension["params"]["transportScope"] == "http"
+
+
+def test_agent_card_does_not_advertise_http_execution_control_on_non_http_only_transport() -> None:
+    card = build_agent_card(
+        host="127.0.0.1",
+        port=41242,
+        token_enabled=False,
+        supported_interfaces=[
+            {"url": "unix:///tmp/iac-code.sock", "protocolBinding": "unix", "protocolVersion": "1.0"},
+        ],
+    )
+    data = agent_card_to_dict(card)
+
+    assert _extensions_by_uri(data, IAC_CODE_EXECUTION_CONTROL_EXTENSION_URI) == []
 
 
 def test_agent_card_advertises_pipeline_event_batching_contract() -> None:

--- a/tests/a2a/test_app.py
+++ b/tests/a2a/test_app.py
@@ -37,6 +37,7 @@ from iac_code.a2a.app import (
     resolve_token,
     run_server,
 )
+from iac_code.a2a.execution_control import ExecutionController
 from iac_code.a2a.metrics import NoOpA2AMetrics
 from iac_code.a2a.persistence import A2AContextSnapshot, A2APersistenceStore, A2ATaskSnapshot
 from iac_code.a2a.pipeline_executor import recoverable_task_id_from_sidecar
@@ -419,6 +420,52 @@ def test_pipeline_state_endpoint_returns_recovery_state(tmp_path) -> None:
     data = response.json()
     assert data["snapshot"]["lastSequence"] == 1
     assert [event["eventId"] for event in data["events"]] == ["evt-2"]
+
+
+def test_pipeline_state_endpoint_can_return_delta_without_snapshot(tmp_path) -> None:
+    persistence_dir = tmp_path / "a2a"
+    persistence = A2APersistenceStore(persistence_dir)
+    persistence.save_context(A2AContextSnapshot(context_id="ctx-1", session_id="session-1", cwd=str(tmp_path)))
+    pipeline_dir = SessionStorage().session_dir(str(tmp_path), "session-1") / "pipeline"
+    journal = A2APipelineJournal(pipeline_dir)
+    journal.append(_pipeline_event(1, "evt-1"))
+    journal.append(_pipeline_event(2, "evt-2"))
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([_pipeline_event(1, "evt-1")]))
+    app = create_app(
+        host="127.0.0.1",
+        port=41242,
+        token=None,
+        model="qwen3.6-plus",
+        persistence_dir=persistence_dir,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/iac-code/pipeline/state?contextId=ctx-1&afterSequence=1&includeSnapshot=false"
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data) == {"events", "fromSequence", "lastSequence"}
+    assert data["fromSequence"] == 1
+    assert data["lastSequence"] == 2
+    assert [event["eventId"] for event in data["events"]] == ["evt-2"]
+
+
+def test_pipeline_state_endpoint_requires_cursor_when_snapshot_is_omitted(tmp_path) -> None:
+    app = create_app(
+        host="127.0.0.1",
+        port=41242,
+        token=None,
+        model="qwen3.6-plus",
+        persistence_dir=tmp_path / "a2a",
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/iac-code/pipeline/state?contextId=ctx-1&includeSnapshot=false")
+
+    assert response.status_code == 400
+    assert response.json() == {"error": "afterSequence must be a non-negative integer"}
 
 
 @pytest.mark.parametrize(("safe_mode", "expected_path"), [("1", "[PATH]"), ("0", "raw")])
@@ -3226,3 +3273,121 @@ def test_pipeline_state_endpoint_drops_tool_results_only_when_lean_is_requested(
     for response in (explicitly_full, unrecognized):
         display = response.json()["snapshot"]["display"]
         assert [item["toolUseId"] for item in display["toolResults"]] == ["call-1"]
+
+
+def test_execution_control_endpoints_pause_query_resume_and_recover(tmp_path) -> None:
+    persistence_dir = tmp_path / "a2a"
+    persistence = A2APersistenceStore(persistence_dir)
+    persistence.save_context(A2AContextSnapshot(context_id="ctx-1", session_id="session-1", cwd=str(tmp_path)))
+    persistence.save_task(
+        A2ATaskSnapshot(
+            task_id="task-1",
+            context_id="ctx-1",
+            state="input-required",
+            output_text=["finished turn"],
+        )
+    )
+    app = create_app(
+        host="127.0.0.1",
+        port=41242,
+        token=None,
+        model="qwen3.6-plus",
+        persistence_dir=persistence_dir,
+    )
+    components = app.state.a2a_components
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(tmp_path),
+        server_instance_id=components.execution_control_service.server_instance_id,
+        persistence_path=persistence_dir / "execution-control" / "ctx-1.json",
+        backup_service=None,
+        execution_id="exec-1",
+    )
+    control.bind_session("session-1")
+    control.execution_status = "input-required"
+    control.stream_available = False
+    components.execution_control_service._controls["ctx-1"] = control
+
+    pause_payload = {
+        "contextId": "ctx-1",
+        "taskId": "task-1",
+        "expectedExecutionId": "exec-1",
+        "requestId": "pause-request-1",
+        "connectionEpoch": 1,
+        "reason": "client_disconnected",
+        "reconnectTimeoutSeconds": 30,
+    }
+    with TestClient(app) as client:
+        pause = client.post("/iac-code/execution/pause", json=pause_payload)
+        assert pause.status_code == 202
+        pause_id = pause.json()["pauseId"]
+
+        state = client.get("/iac-code/execution/state?contextId=ctx-1&executionId=exec-1")
+        assert state.status_code == 200
+        assert state.json()["phase"] in {"pause_committing", "paused"}
+        assert state.json()["executionStatus"] == "input-required"
+        assert state.json()["streamAvailable"] is False
+
+        recovery = client.get("/iac-code/session/recovery?contextId=ctx-1&executionId=exec-1")
+        assert recovery.status_code == 200
+        assert recovery.json()["outputText"] == ["finished turn"]
+        assert recovery.json()["task"]["id"] == "task-1"
+
+        resumed = client.post(
+            "/iac-code/execution/resume",
+            json={
+                "contextId": "ctx-1",
+                "executionId": "exec-1",
+                "pauseId": pause_id,
+                "requestId": "resume-request-1",
+                "connectionEpoch": 2,
+            },
+        )
+        assert resumed.status_code == 202
+        assert resumed.json()["phase"] == "resuming"
+
+        stale = client.post(
+            "/iac-code/execution/pause",
+            json={**pause_payload, "requestId": "pause-request-2", "connectionEpoch": 1},
+        )
+        assert stale.status_code == 409
+
+        invalid_terminate = client.post(
+            "/iac-code/execution/terminate",
+            json={
+                "contextId": "ctx-1",
+                "expectedExecutionId": "exec-1",
+                "requestId": "terminate-request-invalid",
+                "connectionEpoch": 3,
+                "reason": [],
+            },
+        )
+        assert invalid_terminate.status_code == 400
+
+        late_timeout = client.post(
+            "/iac-code/execution/terminate",
+            json={
+                "contextId": "ctx-1",
+                "expectedExecutionId": "exec-1",
+                "pauseId": pause_id,
+                "requestId": "terminate-request-late-timeout",
+                "connectionEpoch": 3,
+                "reason": "disconnect_timeout",
+            },
+        )
+        assert late_timeout.status_code == 409
+
+        terminated = client.post(
+            "/iac-code/execution/terminate",
+            json={
+                "contextId": "ctx-1",
+                "expectedExecutionId": "exec-1",
+                "requestId": "terminate-request-1",
+                "connectionEpoch": 3,
+                "reason": "explicit_terminate",
+            },
+        )
+        assert terminated.status_code == 202
+        assert terminated.json()["phase"] == "terminating"

--- a/tests/a2a/test_client.py
+++ b/tests/a2a/test_client.py
@@ -102,6 +102,16 @@ class SessionRestoreHTTPClient(FakeHTTPClient):
         return FakeHTTPResponse(self.payload or {"status": self.status}, self.status_code)
 
 
+class ExecutionControlHTTPClient(FakeHTTPClient):
+    async def get(self, url: str, headers=None, params=None) -> FakeHTTPResponse:
+        self.requests.append(("GET", url, params, headers))
+        return FakeHTTPResponse({"phase": "paused", "contextId": "ctx-1"})
+
+    async def post(self, url: str, json: dict[str, object], headers=None) -> FakeHTTPResponse:
+        self.requests.append(("POST", url, json, headers))
+        return FakeHTTPResponse({"phase": "pausing", "contextId": "ctx-1"}, status_code=202)
+
+
 class HangingInputRequiredHTTPClient(FakeHTTPClient):
     def __init__(self) -> None:
         super().__init__()
@@ -149,6 +159,33 @@ async def test_get_pipeline_state_uses_read_only_http_extension_and_auth() -> No
         {"A2A-Version": "1.0", "Authorization": "Bearer secret"},
         {"taskId": "task-1", "afterSequence": 3},
     )
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_state_can_request_delta_without_snapshot() -> None:
+    http = PipelineStateHTTPClient()
+    client = A2AClient(http_client=http)
+
+    await client.get_pipeline_state(
+        "http://remote/",
+        task_id="task-1",
+        after_sequence=3,
+        include_snapshot=False,
+    )
+
+    assert http.pipeline_request == (
+        "http://remote/iac-code/pipeline/state",
+        {"A2A-Version": "1.0"},
+        {"taskId": "task-1", "afterSequence": 3, "includeSnapshot": "false"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_state_requires_cursor_when_snapshot_is_omitted() -> None:
+    client = A2AClient(http_client=PipelineStateHTTPClient())
+
+    with pytest.raises(ValueError, match="after_sequence is required"):
+        await client.get_pipeline_state("http://remote/", task_id="task-1", include_snapshot=False)
 
 
 @pytest.mark.asyncio
@@ -213,6 +250,101 @@ async def test_ensure_session_restored_surfaces_retryable_generation_fence() -> 
             session_id="session-1",
             task_id="task-1",
         )
+
+
+@pytest.mark.asyncio
+async def test_execution_control_client_uses_http_extensions_and_connection_identity() -> None:
+    http = ExecutionControlHTTPClient()
+    client = A2AClient(http_client=http, auth=A2AAuthConfig(bearer_token="secret"))
+
+    await client.pause_execution(
+        "http://remote/",
+        context_id="ctx-1",
+        task_id="task-1",
+        execution_id="exec-1",
+        request_id="pause-1",
+        connection_epoch=7,
+        reconnect_timeout_seconds=45,
+    )
+    await client.get_execution_state(
+        "http://remote/",
+        context_id="ctx-1",
+        execution_id="exec-1",
+        pause_id="pause-token-1",
+    )
+    await client.resume_execution(
+        "http://remote/",
+        context_id="ctx-1",
+        execution_id="exec-1",
+        pause_id="pause-token-1",
+        request_id="resume-1",
+        connection_epoch=8,
+    )
+    await client.terminate_execution(
+        "http://remote/",
+        context_id="ctx-1",
+        execution_id="exec-1",
+        request_id="terminate-1",
+        connection_epoch=9,
+        reason="disconnect_timeout",
+        pause_id="pause-token-1",
+    )
+    await client.get_session_recovery("http://remote/", context_id="ctx-1", execution_id="exec-1")
+
+    headers = {"A2A-Version": "1.0", "Authorization": "Bearer secret"}
+    assert http.requests == [
+        (
+            "POST",
+            "http://remote/iac-code/execution/pause",
+            {
+                "contextId": "ctx-1",
+                "taskId": "task-1",
+                "expectedExecutionId": "exec-1",
+                "requestId": "pause-1",
+                "connectionEpoch": 7,
+                "reason": "client_disconnected",
+                "reconnectTimeoutSeconds": 45,
+            },
+            headers,
+        ),
+        (
+            "GET",
+            "http://remote/iac-code/execution/state",
+            {"contextId": "ctx-1", "executionId": "exec-1", "pauseId": "pause-token-1"},
+            headers,
+        ),
+        (
+            "POST",
+            "http://remote/iac-code/execution/resume",
+            {
+                "contextId": "ctx-1",
+                "executionId": "exec-1",
+                "pauseId": "pause-token-1",
+                "requestId": "resume-1",
+                "connectionEpoch": 8,
+            },
+            headers,
+        ),
+        (
+            "POST",
+            "http://remote/iac-code/execution/terminate",
+            {
+                "contextId": "ctx-1",
+                "expectedExecutionId": "exec-1",
+                "requestId": "terminate-1",
+                "connectionEpoch": 9,
+                "reason": "disconnect_timeout",
+                "pauseId": "pause-token-1",
+            },
+            headers,
+        ),
+        (
+            "GET",
+            "http://remote/iac-code/session/recovery",
+            {"contextId": "ctx-1", "executionId": "exec-1"},
+            headers,
+        ),
+    ]
 
 
 def _base64url_uint(value: int) -> str:

--- a/tests/a2a/test_execution_control.py
+++ b/tests/a2a/test_execution_control.py
@@ -24,7 +24,7 @@ from iac_code.services.session_backup import BackupReason, BackupResult
 from iac_code.services.session_storage import SessionStorage
 
 
-async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: float = 20) -> None:
+async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: float = 5) -> None:
     async def wait() -> None:
         while control.phase != phase:
             await asyncio.sleep(0.005)
@@ -32,7 +32,7 @@ async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: 
     await asyncio.wait_for(wait(), timeout=timeout)
 
 
-async def _wait_for_condition(predicate, *, timeout: float = 20) -> None:
+async def _wait_for_condition(predicate, *, timeout: float = 5) -> None:
     async def wait() -> None:
         while not predicate():
             await asyncio.sleep(0.005)
@@ -1276,7 +1276,7 @@ async def test_new_execution_cannot_replace_another_owner_control(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_termination_cleanup_failure_is_retried_before_backup_release(tmp_path: Path) -> None:
+async def test_termination_cleanup_failure_is_retried_before_backup_release(tmp_path: Path, monkeypatch) -> None:
     calls = 0
 
     async def cleanup(context_id: str, task_id: str, reason: str) -> str:
@@ -1298,6 +1298,16 @@ async def test_termination_cleanup_failure_is_retried_before_backup_release(tmp_
         termination_cleanup=cleanup,
         execution_id="exec-1",
     )
+    blocked_committed = asyncio.Event()
+    allow_cleanup_failure_to_return = asyncio.Event()
+    commit_blocked = control._commit_blocked_backup_state
+
+    async def gated_commit_blocked(message: str, error: BaseException, **kwargs) -> None:
+        await commit_blocked(message, error, **kwargs)
+        blocked_committed.set()
+        await allow_cleanup_failure_to_return.wait()
+
+    monkeypatch.setattr(control, "_commit_blocked_backup_state", gated_commit_blocked)
     request = {
         "execution_id": "exec-1",
         "request_id": "terminate-request",
@@ -1305,10 +1315,12 @@ async def test_termination_cleanup_failure_is_retried_before_backup_release(tmp_
         "reason": "explicit_terminate",
     }
     await control.terminate(**request)
-    await _wait_for_condition(lambda: control.phase == "terminated" and control.backup["status"] == "blocked")
+    await asyncio.wait_for(blocked_committed.wait(), 3)
+    assert control.phase == "terminated" and control.backup["status"] == "blocked"
     assert control.release_ready is False
 
     await control.terminate(**request)
+    allow_cleanup_failure_to_return.set()
     await _wait_for_condition(lambda: control.release_ready)
     assert calls == 2
     assert control.execution_status == "canceled"

--- a/tests/a2a/test_execution_control.py
+++ b/tests/a2a/test_execution_control.py
@@ -24,7 +24,7 @@ from iac_code.services.session_backup import BackupReason, BackupResult
 from iac_code.services.session_storage import SessionStorage
 
 
-async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: float = 2) -> None:
+async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: float = 5) -> None:
     async def wait() -> None:
         while control.phase != phase:
             await asyncio.sleep(0.005)
@@ -32,7 +32,7 @@ async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: 
     await asyncio.wait_for(wait(), timeout=timeout)
 
 
-async def _wait_for_condition(predicate, *, timeout: float = 2) -> None:
+async def _wait_for_condition(predicate, *, timeout: float = 5) -> None:
     async def wait() -> None:
         while not predicate():
             await asyncio.sleep(0.005)

--- a/tests/a2a/test_execution_control.py
+++ b/tests/a2a/test_execution_control.py
@@ -1,0 +1,1366 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from iac_code.a2a.backup import run_sync_fenced, run_sync_fenced_with_cancel_completion
+from iac_code.a2a.execution_control import (
+    ExecutionControlConflictError,
+    ExecutionController,
+    ExecutionControlNotFoundError,
+    ExecutionControlService,
+    bind_execution_control,
+    execution_activity,
+    execution_checkpoint,
+    execution_non_advancing_wait,
+    reset_execution_control,
+    run_with_execution_budget,
+)
+from iac_code.services.session_backup import BackupReason, BackupResult
+from iac_code.services.session_storage import SessionStorage
+
+
+async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: float = 2) -> None:
+    async def wait() -> None:
+        while control.phase != phase:
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait(), timeout=timeout)
+
+
+async def _wait_for_condition(predicate, *, timeout: float = 2) -> None:
+    async def wait() -> None:
+        while not predicate():
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait(), timeout=timeout)
+
+
+def _controller(tmp_path: Path, *, backup_service=None) -> ExecutionController:
+    return ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=backup_service,
+        execution_id="exec-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_during_long_tool_does_not_wait_for_tool(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            await execution_checkpoint()
+            async with execution_activity("tool_batch"):
+                tool_started.set()
+                await release_tool.wait()
+            await execution_checkpoint()
+        finally:
+            await control.detach_task(current, execution_status="input-required")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    await tool_started.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    assert pause["phase"] == "pausing"
+    assert {item["kind"] for item in pause["blockers"]} == {"execution", "tool_batch"}
+
+    resumed = await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    assert resumed["phase"] == "resuming"
+    await _wait_for_phase(control, "running")
+    assert not worker_task.done()
+
+    release_tool.set()
+    await worker_task
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_resume_is_ordered_after_inflight_paused_commit(tmp_path: Path, monkeypatch) -> None:
+    control = _controller(tmp_path)
+    paused_write_started = threading.Event()
+    allow_paused_write = threading.Event()
+    from iac_code.a2a import execution_control as module
+
+    original_write = module.atomic_write_json
+
+    def delayed_write(path, value) -> None:
+        if value["phase"] == "paused":
+            paused_write_started.set()
+            assert allow_paused_write.wait(timeout=2)
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", delayed_write)
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    assert await asyncio.to_thread(paused_write_started.wait, 2)
+
+    resumed = await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    assert resumed["phase"] == "resuming"
+    with pytest.raises(ExecutionControlConflictError, match="resuming"):
+        await control.pause(
+            task_id="task-1",
+            expected_execution_id="exec-1",
+            request_id="new-pause-while-resuming",
+            connection_epoch=3,
+            reason="client_disconnected",
+            reconnect_timeout_seconds=10,
+        )
+    allow_paused_write.set()
+    await _wait_for_phase(control, "running")
+    await _wait_for_condition(
+        lambda: json.loads((tmp_path / "control.json").read_text(encoding="utf-8"))["phase"] == "running"
+    )
+    persisted = json.loads((tmp_path / "control.json").read_text(encoding="utf-8"))
+    assert persisted["revision"] == control.revision
+    assert persisted["phase"] == "running"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_external_operation_commit_cannot_strand_resume_barrier(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    control = _controller(tmp_path)
+    control.bind_session("session-1")
+    running_write_started = threading.Event()
+    allow_running_write = threading.Event()
+    from iac_code.a2a import execution_control as module
+
+    original_write = module.atomic_write_json
+
+    def delayed_write(path, value) -> None:
+        if value.get("phase") == "running" and not running_write_started.is_set():
+            running_write_started.set()
+            assert allow_running_write.wait(timeout=2)
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", delayed_write)
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    await _wait_for_phase(control, "paused")
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    assert await asyncio.to_thread(running_write_started.wait, 2)
+    resume_revision = control.revision
+
+    operation_commit = asyncio.create_task(
+        control.record_external_operation(
+            product="ros",
+            action="CreateStack",
+            outcome="accepted",
+            resource_type="stack",
+            resource_id="stack-late",
+            region_id="cn-hangzhou",
+        )
+    )
+    await _wait_for_condition(lambda: control.revision > resume_revision)
+    allow_running_write.set()
+    await operation_commit
+    await _wait_for_phase(control, "running")
+    await _wait_for_condition(
+        lambda: json.loads((tmp_path / "control.json").read_text(encoding="utf-8"))["phase"] == "running"
+    )
+    assert control.snapshot()["externalOperations"][0]["resourceId"] == "stack-late"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_immediate_resume_cannot_make_unscheduled_pause_commit_write_new_revision(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    control = _controller(tmp_path)
+    from iac_code.a2a import execution_control as module
+
+    writes: list[tuple[int, str]] = []
+    original_write = module.atomic_write_json
+
+    def record_write(path, value) -> None:
+        writes.append((value["revision"], value["phase"]))
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", record_write)
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    await _wait_for_phase(control, "running")
+    await _wait_for_condition(lambda: control.persisted_revision == control.revision)
+
+    persisted = json.loads((tmp_path / "control.json").read_text(encoding="utf-8"))
+    assert persisted["phase"] == "running"
+    assert (control.revision, "paused") not in writes
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_canceling_commit_wait_does_not_release_writer_lock_before_thread_finishes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    control = _controller(tmp_path)
+    paused_write_started = threading.Event()
+    allow_paused_write = threading.Event()
+    from iac_code.a2a import execution_control as module
+
+    original_write = module.atomic_write_json
+
+    def delayed_write(path, value) -> None:
+        if value["phase"] == "paused":
+            paused_write_started.set()
+            assert allow_paused_write.wait(timeout=2)
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", delayed_write)
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    assert await asyncio.to_thread(paused_write_started.wait, 2)
+    pause_commit = next(task for task in control._background_tasks if "pause-commit" in task.get_name())
+    pause_commit.cancel()
+
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    await asyncio.sleep(0.02)
+    assert control.phase == "resuming"
+
+    allow_paused_write.set()
+    await _wait_for_phase(control, "running")
+    await _wait_for_condition(lambda: control.persisted_revision == control.revision)
+    assert json.loads((tmp_path / "control.json").read_text(encoding="utf-8"))["phase"] == "running"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_participant_leaving_safe_wait_invalidates_inflight_pause_commit(tmp_path: Path, monkeypatch) -> None:
+    control = _controller(tmp_path)
+    paused_write_started = threading.Event()
+    allow_paused_write = threading.Event()
+    waiting = asyncio.Event()
+    leave_wait = asyncio.Event()
+    processing = asyncio.Event()
+    finish_processing = asyncio.Event()
+    from iac_code.a2a import execution_control as module
+
+    original_write = module.atomic_write_json
+
+    def delayed_write(path, value) -> None:
+        if value["phase"] == "paused" and not paused_write_started.is_set():
+            paused_write_started.set()
+            assert allow_paused_write.wait(timeout=2)
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", delayed_write)
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async with execution_non_advancing_wait():
+                waiting.set()
+                await leave_wait.wait()
+            processing.set()
+            await finish_processing.wait()
+            await execution_checkpoint()
+        finally:
+            await control.detach_task(current, execution_status="input-required")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    await waiting.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    assert await asyncio.to_thread(paused_write_started.wait, 2)
+
+    leave_wait.set()
+    await processing.wait()
+    assert control.phase == "pausing"
+    allow_paused_write.set()
+    await _wait_for_condition(
+        lambda: json.loads((tmp_path / "control.json").read_text(encoding="utf-8"))["phase"] == "pausing"
+    )
+
+    finish_processing.set()
+    await _wait_for_phase(control, "paused")
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    await worker_task
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_descendant_pause_does_not_consume_ancestor_tool_budget(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    descendant_at_checkpoint = asyncio.Event()
+
+    async def descendant() -> str:
+        descendant_at_checkpoint.set()
+        await execution_checkpoint()
+        await asyncio.sleep(0.01)
+        return "same-task-finished"
+
+    async def worker() -> str:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            await execution_checkpoint()
+            async with execution_activity("tool_batch"):
+                async with execution_activity("tool", check_gate=False):
+                    return await run_with_execution_budget(descendant(), timeout=0.05)
+        finally:
+            await control.detach_task(current, execution_status="input-required")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    await descendant_at_checkpoint.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    await _wait_for_phase(control, "paused")
+    await asyncio.sleep(0.1)
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    assert await worker_task == "same-task-finished"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_unblocked_parallel_descendant_keeps_ancestor_budget_running(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    child_at_checkpoint = asyncio.Event()
+    sibling_started = asyncio.Event()
+
+    async def paused_child() -> None:
+        child_at_checkpoint.set()
+        await execution_checkpoint()
+
+    async def running_sibling() -> None:
+        async with execution_activity("tool", check_gate=False):
+            sibling_started.set()
+            await asyncio.Event().wait()
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async with execution_activity("tool_batch"):
+                async with execution_activity("tool", check_gate=False):
+                    await run_with_execution_budget(
+                        asyncio.gather(paused_child(), running_sibling()),
+                        timeout=0.05,
+                    )
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    await child_at_checkpoint.wait()
+    await sibling_started.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(worker_task, timeout=0.5)
+
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    await _wait_for_phase(control, "running")
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_existing_business_wait_is_a_pause_safe_point(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    waiting = asyncio.Event()
+    release = asyncio.Event()
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async with execution_non_advancing_wait():
+                waiting.set()
+                await release.wait()
+        finally:
+            await control.detach_task(current, execution_status="input-required")
+            reset_execution_control(token)
+
+    task = asyncio.create_task(worker())
+    await waiting.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    await _wait_for_phase(control, "paused")
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    await _wait_for_phase(control, "running")
+    release.set()
+    await task
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_child_checkpoint_does_not_mark_its_running_parent_safe(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    child_ready = asyncio.Event()
+    let_child_checkpoint = asyncio.Event()
+    parent_processing_done = asyncio.Event()
+
+    async def child() -> None:
+        child_ready.set()
+        await let_child_checkpoint.wait()
+        await execution_checkpoint()
+
+    async def parent() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        child_task = asyncio.create_task(child())
+        try:
+            await child_ready.wait()
+            await parent_processing_done.wait()
+            await execution_checkpoint()
+            await child_task
+        finally:
+            if not child_task.done():
+                child_task.cancel()
+                await asyncio.gather(child_task, return_exceptions=True)
+            await control.detach_task(current, execution_status="input-required")
+            reset_execution_control(token)
+
+    parent_task = asyncio.create_task(parent())
+    await child_ready.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    let_child_checkpoint.set()
+    await _wait_for_condition(lambda: any(participant.safe for participant in control._participants.values()))
+    await asyncio.sleep(0.02)
+    assert control.phase == "pausing"
+
+    parent_processing_done.set()
+    await _wait_for_phase(control, "paused")
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=2,
+    )
+    await parent_task
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_cancels_local_execution_and_waits_for_shared_backup(tmp_path: Path) -> None:
+    class BackupService:
+        def __init__(self) -> None:
+            self.reasons: list[BackupReason] = []
+
+        def backup_session(self, cwd, session_id, *, reason, critical) -> BackupResult:
+            self.reasons.append(reason)
+            return BackupResult(
+                enabled=True,
+                generation=3,
+                commit_id="commit-3",
+                shared_committed=True,
+            )
+
+    backup = BackupService()
+    control = _controller(tmp_path, backup_service=backup)
+    control.bind_session("session-1")
+    started = asyncio.Event()
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async with execution_activity("tool_batch"):
+                started.set()
+                await asyncio.Event().wait()
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    await started.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    state = await control.terminate(
+        execution_id="exec-1",
+        request_id="request-terminate",
+        connection_epoch=2,
+        reason="disconnect_timeout",
+        pause_id=pause["pauseId"],
+    )
+    assert state["phase"] == "terminating"
+    await _wait_for_phase(control, "terminated")
+    await _wait_for_condition(lambda: control.release_ready)
+    assert worker_task.cancelled()
+    assert backup.reasons == [BackupReason.DISCONNECT_TIMEOUT]
+    assert control.snapshot()["backup"]["status"] == "shared_committed"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_does_not_finish_while_managed_sync_work_is_still_running(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    sync_started = threading.Event()
+    release_sync = threading.Event()
+
+    def blocking_sync_call() -> None:
+        sync_started.set()
+        release_sync.wait(timeout=2)
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async with execution_activity("tool_batch"):
+                await run_sync_fenced(blocking_sync_call)
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    assert await asyncio.to_thread(sync_started.wait, 2)
+    state = await control.terminate(
+        execution_id="exec-1",
+        request_id="request-terminate",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+    assert state["phase"] == "terminating"
+    await asyncio.sleep(0.02)
+    assert control.phase == "terminating"
+    assert control.release_ready is False
+
+    release_sync.set()
+    await _wait_for_phase(control, "terminated")
+    await _wait_for_condition(lambda: control.release_ready)
+    assert worker_task.done()
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_budget_wrapper_drains_fenced_tool_before_termination_finishes(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    sync_started = threading.Event()
+    release_sync = threading.Event()
+
+    def blocking_sync_call() -> None:
+        sync_started.set()
+        release_sync.wait(timeout=2)
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async with execution_activity("tool_batch"):
+                async with execution_activity("tool", check_gate=False):
+                    await run_with_execution_budget(run_sync_fenced(blocking_sync_call), timeout=30)
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    assert await asyncio.to_thread(sync_started.wait, 2)
+    await control.terminate(
+        execution_id="exec-1",
+        request_id="request-terminate",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+    await asyncio.sleep(0.02)
+    assert control.phase == "terminating"
+    assert control.release_ready is False
+    assert worker_task.done() is False
+
+    release_sync.set()
+    await _wait_for_condition(lambda: control.release_ready)
+    assert worker_task.done()
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_persists_sync_write_result_that_arrives_during_cancellation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    control = _controller(tmp_path)
+    control.bind_session("session-1")
+    sync_started = threading.Event()
+    release_sync = threading.Event()
+
+    def create_stack() -> str:
+        sync_started.set()
+        release_sync.wait(timeout=2)
+        return "stack-created-during-cancel"
+
+    async def record_result(result: str | None, error: BaseException | None) -> None:
+        await control.record_external_operation(
+            product="ros",
+            action="CreateStack",
+            outcome="accepted" if error is None else "unknown",
+            resource_type="stack",
+            resource_id=result,
+            region_id="cn-hangzhou",
+            tool_use_id="tool-1",
+        )
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async with execution_activity("tool_batch"):
+                await run_sync_fenced_with_cancel_completion(create_stack, record_result)
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    assert await asyncio.to_thread(sync_started.wait, 2)
+    await control.terminate(
+        execution_id="exec-1",
+        request_id="request-terminate",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+    await asyncio.sleep(0.02)
+    assert control.phase == "terminating"
+
+    release_sync.set()
+    await _wait_for_condition(lambda: control.release_ready)
+    assert worker_task.cancelled()
+    assert control.snapshot()["externalOperations"] == [
+        {
+            "product": "ros",
+            "action": "CreateStack",
+            "outcome": "accepted",
+            "resourceType": "stack",
+            "resourceId": "stack-created-during-cancel",
+            "regionId": "cn-hangzhou",
+            "toolUseId": "tool-1",
+        }
+    ]
+    operation_path = SessionStorage().session_dir(str(tmp_path), "session-1") / "a2a" / "external-operations.json"
+    document = json.loads(operation_path.read_text(encoding="utf-8"))
+    assert document["operations"][0]["resourceId"] == "stack-created-during-cancel"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_cancels_registered_background_participant_in_passive_wait(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    waiting = asyncio.Event()
+
+    async def background_participant() -> None:
+        token = bind_execution_control(control)
+        try:
+            async with execution_non_advancing_wait():
+                waiting.set()
+                await asyncio.Event().wait()
+        finally:
+            reset_execution_control(token)
+
+    participant = asyncio.create_task(background_participant())
+    await waiting.wait()
+    await control.terminate(
+        execution_id="exec-1",
+        request_id="request-terminate",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+    await _wait_for_phase(control, "terminated")
+    await _wait_for_condition(lambda: control.release_ready)
+    assert participant.cancelled()
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_staged_backup_does_not_release_until_shared_retry_succeeds(tmp_path: Path) -> None:
+    class StagedBackupService:
+        def __init__(self) -> None:
+            self.wait_calls = 0
+
+        def backup_session(self, cwd, session_id, *, reason, critical) -> BackupResult:
+            return BackupResult(
+                enabled=True,
+                generation=7,
+                commit_id="commit-7",
+                staged_committed=True,
+                shared_committed=False,
+            )
+
+        def wait_until_shared_committed(self, cwd, session_id, *, generation, commit_id) -> BackupResult:
+            self.wait_calls += 1
+            return BackupResult(
+                enabled=True,
+                generation=generation,
+                commit_id=commit_id,
+                succeeded=self.wait_calls > 1,
+                staged_committed=True,
+                shared_committed=self.wait_calls > 1,
+                error=None if self.wait_calls > 1 else "shared unavailable",
+            )
+
+    backup = StagedBackupService()
+    control = _controller(tmp_path, backup_service=backup)
+    control.bind_session("session-1")
+    request = {
+        "execution_id": "exec-1",
+        "request_id": "request-terminate",
+        "connection_epoch": 1,
+        "reason": "explicit_terminate",
+    }
+
+    await control.terminate(**request)
+    await _wait_for_condition(lambda: control.backup["status"] == "blocked")
+    assert control.phase == "terminated"
+    assert control.release_ready is False
+
+    await control.terminate(**request)
+    await _wait_for_condition(lambda: control.release_ready)
+    assert control.backup["status"] == "shared_committed"
+    assert backup.wait_calls == 2
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_external_terminate_retries_backup_after_automatic_deadline(tmp_path: Path) -> None:
+    class RetryBackupService:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def backup_session(self, cwd, session_id, *, reason, critical) -> BackupResult:
+            self.calls += 1
+            return BackupResult(
+                enabled=True,
+                generation=self.calls,
+                commit_id=f"commit-{self.calls}",
+                succeeded=self.calls > 1,
+                shared_committed=self.calls > 1,
+                error=None if self.calls > 1 else "shared unavailable",
+            )
+
+    backup = RetryBackupService()
+    control = _controller(tmp_path, backup_service=backup)
+    control.bind_session("session-1")
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    generation = control._pause_generation
+
+    await control._deadline(generation, pause["pauseId"], 0)
+    assert control.phase == "terminated"
+    assert control.backup["status"] == "blocked"
+    assert backup.calls == 1
+
+    await control.terminate(
+        execution_id="exec-1",
+        request_id="request-terminate-retry",
+        connection_epoch=2,
+        reason="disconnect_timeout",
+        pause_id=pause["pauseId"],
+    )
+    await _wait_for_condition(lambda: control.release_ready)
+    assert backup.calls == 2
+    assert control.backup["status"] == "shared_committed"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_late_disconnect_timeout_cannot_terminate_resumed_execution(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume",
+        connection_epoch=1,
+    )
+    await _wait_for_phase(control, "running")
+
+    with pytest.raises(ExecutionControlConflictError, match="no longer identifies"):
+        await control.terminate(
+            execution_id="exec-1",
+            request_id="late-timeout",
+            connection_epoch=1,
+            reason="disconnect_timeout",
+            pause_id=pause["pauseId"],
+        )
+    assert control.phase == "running"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_retry_can_recommit_successful_backup_state_without_rerunning_backup(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    control = _controller(tmp_path)
+    from iac_code.a2a import execution_control as module
+
+    failed_once = False
+    original_write = module.atomic_write_json
+
+    def fail_first_backup_state(path, value) -> None:
+        nonlocal failed_once
+        if not failed_once and value["phase"] == "terminated" and value["backup"]["status"] == "disabled":
+            failed_once = True
+            raise OSError("disk temporarily unavailable")
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", fail_first_backup_state)
+    request = {
+        "execution_id": "exec-1",
+        "request_id": "request-terminate",
+        "connection_epoch": 1,
+        "reason": "explicit_terminate",
+    }
+
+    await control.terminate(**request)
+    await _wait_for_condition(lambda: control.snapshot()["commitError"] == "state_commit_failed")
+    assert control.release_ready is False
+
+    await control.terminate(**request)
+    await _wait_for_condition(lambda: control.release_ready)
+    persisted = json.loads((tmp_path / "control.json").read_text(encoding="utf-8"))
+    assert persisted["releaseReady"] is True
+    assert persisted["commitError"] is None
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_idempotency_and_stale_connection_epoch(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=5,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    duplicate = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="request-pause",
+        connection_epoch=5,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    assert duplicate["pauseId"] == pause["pauseId"]
+
+    with pytest.raises(ExecutionControlConflictError, match="different content"):
+        await control.pause(
+            task_id="task-1",
+            expected_execution_id="exec-1",
+            request_id="request-pause",
+            connection_epoch=5,
+            reason="different",
+            reconnect_timeout_seconds=10,
+        )
+    with pytest.raises(ExecutionControlConflictError, match="stale"):
+        await control.resume(
+            execution_id="exec-1",
+            pause_id=pause["pauseId"],
+            request_id="request-resume",
+            connection_epoch=4,
+        )
+    pause_generation = control._pause_generation
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="request-resume-current",
+        connection_epoch=6,
+    )
+    await _wait_for_phase(control, "running")
+    await control._deadline(pause_generation, pause["pauseId"], 0)
+    assert control.phase == "running"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_new_normal_turn_gets_new_execution_identity_but_pipeline_continuation_reuses_it(tmp_path: Path) -> None:
+    service = ExecutionControlService(persistence_root=tmp_path, backup_service=None)
+
+    first = await service.begin_execution(context_id="ctx-1", task_id="task-1", owner="owner-1", cwd=str(tmp_path))
+    current = asyncio.current_task()
+    assert current is not None
+    pause = await first.pause(
+        task_id="task-1",
+        expected_execution_id=first.execution_id,
+        request_id="pause-old-turn",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=10,
+    )
+    await first.resume(
+        execution_id=first.execution_id,
+        pause_id=pause["pauseId"],
+        request_id="resume-old-turn",
+        connection_epoch=2,
+    )
+    await _wait_for_phase(first, "running")
+    await first.detach_task(current, execution_status="input-required")
+
+    pipeline_continuation = await service.begin_execution(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+        continue_input_required=True,
+    )
+    assert pipeline_continuation is first
+    await pipeline_continuation.detach_task(current, execution_status="input-required")
+
+    next_normal_turn = await service.begin_execution(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+    )
+    assert next_normal_turn is not first
+    assert next_normal_turn.execution_id != first.execution_id
+    assert all(task.done() for task in first._background_tasks)
+    await next_normal_turn.detach_task(current, execution_status="input-required")
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_new_normal_turn_retains_and_controls_previous_turn_background_agent(tmp_path: Path) -> None:
+    service = ExecutionControlService(persistence_root=tmp_path, backup_service=None)
+    control = await service.begin_execution(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+    )
+    token = bind_execution_control(control)
+    current = asyncio.current_task()
+    assert current is not None
+    background_started = asyncio.Event()
+
+    async def background_agent() -> None:
+        async with execution_activity("background_agent"):
+            background_started.set()
+            await asyncio.Event().wait()
+
+    background = asyncio.create_task(background_agent())
+    await background_started.wait()
+    old_execution_id = control.execution_id
+    await control.detach_task(current, execution_status="input-required")
+    assert service.has_active_work() is True
+
+    next_turn = await service.begin_execution(
+        context_id="ctx-1",
+        task_id="task-2",
+        owner="owner-1",
+        cwd=str(tmp_path),
+    )
+    assert next_turn is control
+    assert next_turn.execution_id != old_execution_id
+    assert next_turn.task_id == "task-2"
+    assert background.done() is False
+
+    await next_turn.detach_task(current, execution_status="input-required")
+    await next_turn.terminate(
+        execution_id=next_turn.execution_id,
+        request_id="terminate-next-turn",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+    await _wait_for_condition(lambda: next_turn.release_ready)
+    assert background.cancelled()
+    reset_execution_control(token)
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_paused_context_rejects_new_task_without_replacing_background_agent(tmp_path: Path) -> None:
+    service = ExecutionControlService(persistence_root=tmp_path, backup_service=None)
+    control = await service.begin_execution(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+    )
+    token = bind_execution_control(control)
+    current = asyncio.current_task()
+    assert current is not None
+    background_started = asyncio.Event()
+    enter_checkpoint = asyncio.Event()
+    background_resumed = asyncio.Event()
+    release_background = asyncio.Event()
+
+    async def background_agent() -> None:
+        async with execution_activity("background_agent"):
+            background_started.set()
+            await enter_checkpoint.wait()
+            await execution_checkpoint()
+            background_resumed.set()
+            await release_background.wait()
+
+    background = asyncio.create_task(background_agent())
+    await background_started.wait()
+    await control.detach_task(current, execution_status="normal-turn-ended")
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id=control.execution_id,
+        request_id="pause-background",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=30,
+    )
+    enter_checkpoint.set()
+    await _wait_for_phase(control, "paused")
+
+    with pytest.raises(ExecutionControlConflictError):
+        await service.begin_execution(
+            context_id="ctx-1",
+            task_id="task-2",
+            owner="owner-1",
+            cwd=str(tmp_path),
+        )
+    assert service.get_for_context("ctx-1") is control
+    assert background.done() is False
+
+    await control.resume(
+        execution_id=control.execution_id,
+        pause_id=pause["pauseId"],
+        request_id="resume-background",
+        connection_epoch=2,
+    )
+    await asyncio.wait_for(background_resumed.wait(), timeout=2)
+    release_background.set()
+    await background
+    reset_execution_control(token)
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_finished_tool_hands_safety_back_to_parent_until_result_checkpoint(tmp_path: Path) -> None:
+    control = _controller(tmp_path)
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+    result_recorded = asyncio.Event()
+    allow_result_checkpoint = asyncio.Event()
+
+    async def tool_batch() -> str:
+        async with execution_activity("tool_batch", handoff_to_parent=True):
+            async with execution_non_advancing_wait():
+                async with execution_activity("tool", check_gate=False, handoff_to_parent=True):
+                    tool_started.set()
+                    await release_tool.wait()
+                    return "durable-result"
+
+    async def worker() -> None:
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            child = asyncio.create_task(tool_batch())
+            async with execution_non_advancing_wait():
+                assert await child == "durable-result"
+            result_recorded.set()
+            await allow_result_checkpoint.wait()
+            await execution_checkpoint()
+        finally:
+            await control.detach_task(current, execution_status="input-required")
+            reset_execution_control(token)
+
+    worker_task = asyncio.create_task(worker())
+    await tool_started.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="pause-tool-result",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=30,
+    )
+    assert control.phase == "pausing"
+    release_tool.set()
+    await asyncio.wait_for(result_recorded.wait(), timeout=2)
+    await asyncio.sleep(0.02)
+    assert control.phase == "pausing"
+
+    allow_result_checkpoint.set()
+    await _wait_for_phase(control, "paused")
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="resume-tool-result",
+        connection_epoch=2,
+    )
+    await worker_task
+    await control.close()
+
+
+def test_backup_blocked_terminated_execution_still_counts_as_active_work(tmp_path: Path) -> None:
+    service = ExecutionControlService(persistence_root=tmp_path, backup_service=None)
+    control = _controller(tmp_path)
+    service._controls["ctx-1"] = control
+
+    control.phase = "terminated"
+    control.release_ready = False
+    assert service.has_active_work() is True
+
+    control.release_ready = True
+    assert service.has_active_work() is False
+
+
+@pytest.mark.asyncio
+async def test_new_execution_cannot_replace_another_owner_control(tmp_path: Path) -> None:
+    service = ExecutionControlService(persistence_root=tmp_path, backup_service=None)
+    first = await service.begin_execution(context_id="ctx-1", task_id="task-1", owner="owner-1", cwd=str(tmp_path))
+    current = asyncio.current_task()
+    assert current is not None
+    await first.detach_task(current, execution_status="input-required")
+
+    with pytest.raises(ExecutionControlNotFoundError):
+        await service.begin_execution(
+            context_id="ctx-1",
+            task_id="different-task",
+            owner="owner-2",
+            cwd=str(tmp_path),
+        )
+    assert service.get_for_context("ctx-1") is first
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_termination_cleanup_failure_is_retried_before_backup_release(tmp_path: Path) -> None:
+    calls = 0
+
+    async def cleanup(context_id: str, task_id: str, reason: str) -> str:
+        nonlocal calls
+        calls += 1
+        assert (context_id, task_id, reason) == ("ctx-1", "task-1", "explicit_terminate")
+        if calls == 1:
+            raise RuntimeError("cleanup temporarily failed")
+        return "canceled"
+
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=None,
+        termination_cleanup=cleanup,
+        execution_id="exec-1",
+    )
+    request = {
+        "execution_id": "exec-1",
+        "request_id": "terminate-request",
+        "connection_epoch": 1,
+        "reason": "explicit_terminate",
+    }
+    await control.terminate(**request)
+    await _wait_for_condition(lambda: control.phase == "terminated" and control.backup["status"] == "blocked")
+    assert control.release_ready is False
+
+    await control.terminate(**request)
+    await _wait_for_condition(lambda: control.release_ready)
+    assert calls == 2
+    assert control.execution_status == "canceled"
+    assert control.backup["status"] == "disabled"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_termination_cleanup_rechecks_state_after_active_worker_drains(tmp_path: Path) -> None:
+    worker_state = "working"
+    observed_states: list[str] = []
+
+    async def cleanup(_context_id: str, _task_id: str, _reason: str) -> str | None:
+        observed_states.append(worker_state)
+        return "canceled" if worker_state == "canceled" else None
+
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=None,
+        termination_cleanup=cleanup,
+        execution_id="exec-1",
+    )
+
+    async def worker() -> None:
+        nonlocal worker_state
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            worker_state = "canceled"
+            raise
+        finally:
+            await control.detach_task(current, execution_status=worker_state)
+
+    active = asyncio.create_task(worker())
+    await _wait_for_condition(control.has_managed_work)
+    await control.terminate(
+        execution_id="exec-1",
+        request_id="terminate-active-worker",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+    await _wait_for_condition(lambda: control.release_ready)
+
+    assert active.cancelled()
+    assert observed_states == ["working", "canceled"]
+    assert control.execution_status == "canceled"
+    await control.close()

--- a/tests/a2a/test_execution_control.py
+++ b/tests/a2a/test_execution_control.py
@@ -24,7 +24,7 @@ from iac_code.services.session_backup import BackupReason, BackupResult
 from iac_code.services.session_storage import SessionStorage
 
 
-async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: float = 5) -> None:
+async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: float = 20) -> None:
     async def wait() -> None:
         while control.phase != phase:
             await asyncio.sleep(0.005)
@@ -32,7 +32,7 @@ async def _wait_for_phase(control: ExecutionController, phase: str, *, timeout: 
     await asyncio.wait_for(wait(), timeout=timeout)
 
 
-async def _wait_for_condition(predicate, *, timeout: float = 5) -> None:
+async def _wait_for_condition(predicate, *, timeout: float = 20) -> None:
     async def wait() -> None:
         while not predicate():
             await asyncio.sleep(0.005)

--- a/tests/a2a/test_execution_control_regressions.py
+++ b/tests/a2a/test_execution_control_regressions.py
@@ -42,7 +42,7 @@ def isolate_backup_environment(monkeypatch):
     monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_TMP_DIR", raising=False)
 
 
-async def wait_until(predicate, timeout=20):
+async def wait_until(predicate, timeout=10):
     async def wait():
         while not predicate():
             await asyncio.sleep(0.005)

--- a/tests/a2a/test_execution_control_regressions.py
+++ b/tests/a2a/test_execution_control_regressions.py
@@ -42,7 +42,7 @@ def isolate_backup_environment(monkeypatch):
     monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_TMP_DIR", raising=False)
 
 
-async def wait_until(predicate, timeout=10):
+async def wait_until(predicate, timeout=20):
     async def wait():
         while not predicate():
             await asyncio.sleep(0.005)

--- a/tests/a2a/test_execution_control_regressions.py
+++ b/tests/a2a/test_execution_control_regressions.py
@@ -42,7 +42,7 @@ def isolate_backup_environment(monkeypatch):
     monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_TMP_DIR", raising=False)
 
 
-async def wait_until(predicate, timeout=5):
+async def wait_until(predicate, timeout=10):
     async def wait():
         while not predicate():
             await asyncio.sleep(0.005)

--- a/tests/a2a/test_execution_control_regressions.py
+++ b/tests/a2a/test_execution_control_regressions.py
@@ -1,0 +1,838 @@
+"""Production-path regressions for execution control, cancellation, and slow storage."""
+
+import asyncio
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from a2a.types import Task, TaskState, TaskStatus
+from starlette.testclient import TestClient
+
+from iac_code.a2a.app import create_app
+from iac_code.a2a.execution_control import (
+    ExecutionController,
+    ExecutionControlService,
+    bind_execution_control,
+    execution_activity,
+    reset_execution_control,
+)
+from iac_code.a2a.executor import IacCodeA2AExecutor
+from iac_code.a2a.persistence import A2APersistenceStore
+from iac_code.a2a.pipeline_executor import _cancel_task_safely, _drive_stream_events
+from iac_code.a2a.task_store import A2ATaskStore
+from iac_code.agent.agent_loop import AgentLoop
+from iac_code.services.session_backup import BackupReason, SessionBackupService
+from iac_code.services.session_backup_staging import SessionBackupStagingWorker, StagedSessionBackupService
+from iac_code.services.session_storage import SessionStorage
+from iac_code.tools.base import ToolContext, ToolRegistry
+from iac_code.tools.cloud.aliyun.ros_stack import RosStack
+from iac_code.tools.cloud.aliyun.ros_stack_instances import RosStackInstances
+from iac_code.types.stream_events import MessageEndEvent, TextDeltaEvent, Usage
+
+from .fakes import FakeAgentLoop, FakeEventQueue, FakeRequestContext, FakeRuntime
+
+
+@pytest.fixture(autouse=True)
+def isolate_backup_environment(monkeypatch):
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_DIR", raising=False)
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_TMP_DIR", raising=False)
+
+
+async def wait_until(predicate, timeout=5):
+    async def wait():
+        while not predicate():
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait(), timeout)
+
+
+def controller(tmp_path, backup=None):
+    return ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(tmp_path),
+        server_instance_id="test",
+        persistence_path=tmp_path / "control.json",
+        backup_service=backup,
+    )
+
+
+@pytest.mark.asyncio
+async def test_slow_termination_commit_keeps_event_loop_and_other_contexts_available(tmp_path, monkeypatch):
+    store = A2ATaskStore(persistence=A2APersistenceStore(tmp_path / "a2a"))
+    await store.get_or_create_context(context_id="ctx-1", cwd=str(tmp_path), runtime_factory=lambda _: object())
+    record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    record.state = "input-required"
+    started, release, finished = threading.Event(), threading.Event(), threading.Event()
+    original = store._persist_terminated_task_snapshots_strict
+
+    def blocked_write(*args):
+        started.set()
+        try:
+            assert release.wait(3)
+            original(*args)
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(store, "_persist_terminated_task_snapshots_strict", blocked_write)
+    commit = asyncio.create_task(store.cancel_inactive_input_required_task(task_id="task-1", context_id="ctx-1"))
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        await asyncio.wait_for(store.get_or_create_task(task_id="task-2", context_id="ctx-2"), 1)
+        assert not finished.is_set()
+        assert not commit.done()
+    finally:
+        release.set()
+        await commit
+    assert store._persistence.load_task("task-1").state == "canceled"
+    await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("staged", [False, True])
+@pytest.mark.parametrize("mode", ["normal", "pipeline"])
+async def test_terminate_waits_for_bootstrap_and_cleanup_then_backs_up(tmp_path, monkeypatch, staged, mode):
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("IAC_CODE_MODE", mode)
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(shared))
+    backup = StagedSessionBackupService(tmp_path / "staging") if staged else SessionBackupService()
+    service = ExecutionControlService(persistence_root=tmp_path / "a2a", backup_service=backup)
+    store = A2ATaskStore(backup_service=backup)
+    executor = IacCodeA2AExecutor(
+        task_store=store, model="test", backup_service=backup, execution_control_service=service
+    )
+    started, release = threading.Event(), threading.Event()
+    closing, close_release, closed = asyncio.Event(), asyncio.Event(), asyncio.Event()
+
+    async def close():
+        closing.set()
+        await close_release.wait()
+        closed.set()
+
+    def factory(options):
+        started.set()
+        assert release.wait(5)
+        return FakeRuntime(agent_loop=FakeAgentLoop([]), session_id=options.session_id, aclose=close)
+
+    monkeypatch.setattr("iac_code.a2a.executor.create_agent_runtime", factory)
+    monkeypatch.setattr("iac_code.a2a.pipeline_executor.create_agent_runtime", factory)
+    worker = SessionBackupStagingWorker(tmp_path / "staging", shared)
+
+    async def publish():
+        while True:
+            await asyncio.to_thread(worker.run_once)
+            await asyncio.sleep(0.01)
+
+    publisher = asyncio.create_task(publish()) if staged else None
+    execution = asyncio.create_task(
+        executor.execute(FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}), FakeEventQueue())
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        control = service.get_for_context("ctx-1")
+        assert control.session_id is not None
+        await control.terminate(
+            execution_id=control.execution_id, request_id="terminate", connection_epoch=1, reason="explicit_terminate"
+        )
+        await asyncio.sleep(0.03)
+        assert control.phase == "terminating"
+        assert not control.release_ready
+        assert not execution.done()
+        release.set()
+        await asyncio.wait_for(closing.wait(), 2)
+        assert not control.release_ready
+        execution.cancel()  # Repeated cancellation must not abandon runtime cleanup.
+        await asyncio.sleep(0.01)
+        assert not execution.done()
+        close_release.set()
+        with suppress(asyncio.CancelledError):
+            await execution
+        await wait_until(lambda: control.release_ready)
+        assert closed.is_set()
+        assert control.backup["status"] == "shared_committed"
+        snapshots = list(shared.rglob("a2a/task.json"))
+        assert len(snapshots) == 1
+        assert json.loads(snapshots[0].read_text(encoding="utf-8"))["state"] == "canceled"
+    finally:
+        release.set()
+        close_release.set()
+        await asyncio.gather(execution, return_exceptions=True)
+        await service.close()
+        if publisher:
+            publisher.cancel()
+            await asyncio.gather(publisher, return_exceptions=True)
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["CreateStack", "UpdateStack", "ContinueCreateStack", "DeleteStack"])
+async def test_ros_successful_submission_survives_polling_termination_and_backup(tmp_path, monkeypatch, action):
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(shared))
+    backup = SessionBackupService()
+    SessionStorage().ensure_v2_session_dir_for_new_session(str(tmp_path), "session-1")
+    backup.initialize_session(str(tmp_path), "session-1")
+    control = controller(tmp_path, backup)
+    control.bind_session("session-1")
+    tool = RosStack(allow_pipeline_deployment_actions=True)
+    tool.poll_interval = 3600
+    calls = []
+
+    def submit(_request):
+        calls.append(action)
+        return SimpleNamespace(body=SimpleNamespace(stack_id="stack-accepted"))
+
+    client = SimpleNamespace(
+        create_stack=submit, update_stack=submit, continue_create_stack=submit, delete_stack=submit
+    )
+    monkeypatch.setattr(tool, "_get_client", lambda _: client)
+    monkeypatch.setattr(tool, "_log_event_best_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(tool, "_add_metric_best_effort", lambda *a, **kw: None)
+    monkeypatch.setattr("iac_code.tools.cloud.aliyun.api_hooks.run_hooks", lambda *a, **kw: None)
+    polling = asyncio.Event()
+    original_wait = tool.wait_for_stack_operation
+
+    async def wait(*args, **kwargs):
+        polling.set()
+        return await original_wait(*args, **kwargs)
+
+    monkeypatch.setattr(tool, "wait_for_stack_operation", wait)
+
+    async def execute():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        await control.attach_task(current)
+        try:
+            await tool.execute(
+                tool_input={
+                    "action": action,
+                    "region_id": "cn-hangzhou",
+                    "params": {
+                        "StackName": "test",
+                        "StackId": "stack-accepted",
+                        "TemplateBody": '{"ROSTemplateFormatVersion":"2015-09-01","Resources":{}}',
+                    },
+                },
+                context=ToolContext(cwd=str(tmp_path), tool_use_id="call-1", event_queue=asyncio.Queue()),
+            )
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    execution = asyncio.create_task(execute())
+    try:
+        await asyncio.wait_for(polling.wait(), 3)
+        await control.terminate(
+            execution_id=control.execution_id, request_id="terminate", connection_epoch=1, reason="explicit_terminate"
+        )
+        await wait_until(lambda: control.release_ready)
+        assert execution.cancelled()
+        assert calls == [action]
+        assert control.external_operations[0]["resourceId"] == "stack-accepted"
+        paths = list(shared.rglob("external-operations.json"))
+        assert len(paths) == 1
+        assert json.loads(paths[0].read_text(encoding="utf-8"))["operations"] == control.external_operations
+    finally:
+        execution.cancel()
+        await asyncio.gather(execution, return_exceptions=True)
+        await control.close()
+
+
+@pytest.mark.asyncio
+async def test_activity_finalization_in_another_context_releases_without_error(tmp_path):
+    control = controller(tmp_path)
+
+    async def stream():
+        async with execution_activity("llm"):
+            yield "first"
+
+    async def start():
+        token = bind_execution_control(control)
+        try:
+            events = stream()
+            assert await anext(events) == "first"
+            return events
+        finally:
+            reset_execution_control(token)
+
+    events = await asyncio.create_task(start())
+    try:
+        assert control.has_managed_work()
+        await events.aclose()
+        assert not control.has_managed_work()
+    finally:
+        await control.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("continuation", [False, True])
+async def test_legacy_stream_cancel_releases_llm_activity_in_consuming_context(tmp_path, continuation):
+    closed = asyncio.Event()
+
+    class Provider:
+        def get_model_name(self):
+            return "test"
+
+        async def stream(self, **kwargs):
+            try:
+                yield TextDeltaEvent(text="first")
+                yield MessageEndEvent(stop_reason="stop", usage=Usage())
+            finally:
+                closed.set()
+
+    agent = AgentLoop(provider_manager=Provider(), system_prompt="test", tool_registry=ToolRegistry())
+    control = controller(tmp_path)
+    service = ExecutionControlService(persistence_root=None, backup_service=None)
+    service._controls["ctx-1"] = control
+    store = A2ATaskStore()
+    store.set_execution_control_provider(service.snapshot_for_context, service.has_active_work)
+    requests = asyncio.Queue()
+
+    async def drive():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        await control.attach_task(current)
+        try:
+            stream = agent.continue_streaming() if continuation else agent.run_streaming("hello")
+            await _drive_stream_events(stream, requests)
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    driver = asyncio.create_task(drive())
+    try:
+        while True:
+            completion = asyncio.get_running_loop().create_future()
+            await requests.put(completion)
+            event = await asyncio.wait_for(completion, 2)
+            if isinstance(event, TextDeltaEvent):
+                break
+        await _cancel_task_safely(driver)
+        assert driver.cancelled()
+        assert closed.is_set()
+        assert not control.has_managed_work()
+        assert not await store.has_active_work()
+    finally:
+        await _cancel_task_safely(driver)
+        await service.close()
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+async def test_normal_executor_cancel_during_publication_closes_real_agent_stream(tmp_path, monkeypatch):
+    from iac_code.a2a import executor as module
+
+    closed, publishing = asyncio.Event(), asyncio.Event()
+
+    class Provider:
+        def get_model_name(self):
+            return "test"
+
+        async def stream(self, **kwargs):
+            try:
+                yield TextDeltaEvent(text="first")
+                yield MessageEndEvent(stop_reason="stop", usage=Usage())
+            finally:
+                closed.set()
+
+    def factory(options):
+        agent = AgentLoop(
+            provider_manager=Provider(),
+            system_prompt="test",
+            tool_registry=ToolRegistry(),
+            cwd=options.cwd,
+            session_id=options.session_id,
+        )
+        return FakeRuntime(agent_loop=agent, session_id=options.session_id)
+
+    original_publish = module.publish_stream_event
+
+    async def publish(*args, **kwargs):
+        if isinstance(kwargs.get("event"), TextDeltaEvent):
+            publishing.set()
+            await asyncio.Event().wait()
+        return await original_publish(*args, **kwargs)
+
+    monkeypatch.setattr(module, "create_agent_runtime", factory)
+    monkeypatch.setattr(module, "publish_stream_event", publish)
+    service = ExecutionControlService(persistence_root=None, backup_service=None)
+    store = A2ATaskStore()
+    store.set_execution_control_provider(service.snapshot_for_context, service.has_active_work)
+    executor = IacCodeA2AExecutor(task_store=store, model="test", execution_control_service=service)
+    execution = asyncio.create_task(
+        executor.execute(FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}), FakeEventQueue())
+    )
+    try:
+        await asyncio.wait_for(publishing.wait(), 2)
+        # The existing cancel route, without pause/resume/terminate.
+        assert await store.cancel_task("task-1")
+        await execution
+        assert closed.is_set()
+        assert not service.get_for_context("ctx-1").has_managed_work()
+        assert not await store.has_active_work()
+    finally:
+        execution.cancel()
+        await asyncio.gather(execution, return_exceptions=True)
+        await service.close()
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+async def test_ros_result_commit_drains_repeated_cancellation(tmp_path, monkeypatch):
+    from iac_code.a2a import execution_control as module
+
+    control = controller(tmp_path)
+    control.bind_session("session-1")
+    started, release = threading.Event(), threading.Event()
+    original_write = module.atomic_write_json
+
+    def blocked_write(path, value):
+        if path.name == "external-operations.json":
+            started.set()
+            assert release.wait(3)
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", blocked_write)
+
+    async def record():
+        token = bind_execution_control(control)
+        try:
+            await RosStack()._record_operation_result(
+                "CreateStack",
+                {},
+                "cn-hangzhou",
+                ToolContext(tool_use_id="call-1"),
+                SimpleNamespace(body=SimpleNamespace(stack_id="stack-accepted")),
+                None,
+            )
+        finally:
+            reset_execution_control(token)
+
+    task = asyncio.create_task(record())
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        for _ in range(2):
+            task.cancel()
+            await asyncio.sleep(0.01)
+            assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        path = SessionStorage().session_dir(str(tmp_path), "session-1") / "a2a" / "external-operations.json"
+        assert json.loads(path.read_text(encoding="utf-8"))["operations"][0]["resourceId"] == "stack-accepted"
+    finally:
+        release.set()
+        await asyncio.gather(task, return_exceptions=True)
+        await control.close()
+
+
+@pytest.mark.asyncio
+async def test_slow_rollover_only_serializes_its_own_context(tmp_path, monkeypatch):
+    from iac_code.a2a import execution_control as module
+
+    service = ExecutionControlService(persistence_root=tmp_path, backup_service=None)
+    first = await service.begin_execution(context_id="ctx-1", task_id="task-1", owner="", cwd=str(tmp_path))
+    background = asyncio.create_task(asyncio.Event().wait())
+    first.register_spawned_task(background, kind="background_agent")
+    await first.detach_task(asyncio.current_task(), execution_status="normal-turn-ended")
+    started, release = threading.Event(), threading.Event()
+    original_write = module.atomic_write_json
+
+    def blocked_write(path, value):
+        if value.get("contextId") == "ctx-1":
+            started.set()
+            assert release.wait(3)
+        original_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", blocked_write)
+
+    async def begin(context, task):
+        result = await service.begin_execution(context_id=context, task_id=task, owner="", cwd=str(tmp_path))
+        await result.detach_task(asyncio.current_task(), execution_status="normal-turn-ended")
+        return result
+
+    rollover = asyncio.create_task(begin("ctx-1", "task-2"))
+    same_context = None
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        same_context = asyncio.create_task(begin("ctx-1", "task-3"))
+        other = await asyncio.wait_for(begin("ctx-2", "task-other"), 1)
+        assert other is not first
+        assert not rollover.done()
+        assert not same_context.done()
+    finally:
+        release.set()
+        await rollover
+        if same_context:
+            await same_context
+        background.cancel()
+        await asyncio.gather(background, return_exceptions=True)
+        await service.close()
+
+
+async def publish_staged_backups(worker):
+    while True:
+        await asyncio.to_thread(worker.run_once)
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_write", [False, True])
+async def test_permission_termination_context_write_is_off_loop_and_gates_release(tmp_path, monkeypatch, fail_write):
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(shared))
+    backup = StagedSessionBackupService(tmp_path / "staging")
+    service = ExecutionControlService(persistence_root=tmp_path / "a2a", backup_service=backup)
+    store = A2ATaskStore(persistence=A2APersistenceStore(tmp_path / "a2a"), backup_service=backup)
+    executor = IacCodeA2AExecutor(
+        task_store=store, model="test", backup_service=backup, execution_control_service=service
+    )
+    closed = asyncio.Event()
+
+    async def close():
+        closed.set()
+
+    ctx = await store.get_or_create_context(
+        context_id="ctx-1", cwd=str(tmp_path), runtime_factory=lambda _: SimpleNamespace(aclose=close)
+    )
+    record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    record.state = "input-required"
+    control = controller(tmp_path, backup)
+    control.bind_session(ctx.session_id)
+    control._termination_cleanup = executor._terminate_detached_execution
+    service._controls["ctx-1"] = control
+    store.set_execution_control_provider(service.snapshot_for_context, service.has_active_work)
+
+    async def cancel_permission(_task_id):
+        # A real pending permission's suspend callback also discards runtime,
+        # before _terminate_detached_execution can do its own cleanup.
+        await store.discard_context_runtime("ctx-1")
+
+    executor._permission_input_registry = SimpleNamespace(
+        has_pending_task=AsyncMock(return_value=True), cancel_task=cancel_permission
+    )
+    started, release = threading.Event(), threading.Event()
+    original_write = store._persistence.save_context
+    loop_thread = threading.get_ident()
+    writes = []
+
+    def gated_write(snapshot):
+        if snapshot.context_id == "ctx-1":
+            writes.append((threading.get_ident() == loop_thread, store._mutation_lock.locked()))
+            started.set()
+            assert release.wait(5)
+            if fail_write:
+                raise OSError("injected context write failure")
+        original_write(snapshot)
+
+    monkeypatch.setattr(store._persistence, "save_context", gated_write)
+    publisher = asyncio.create_task(publish_staged_backups(SessionBackupStagingWorker(tmp_path / "staging", shared)))
+    try:
+        await control.terminate(
+            execution_id=control.execution_id, request_id="terminate", connection_epoch=1, reason="explicit_terminate"
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        assert closed.is_set()
+        assert control.phase == "terminating" and not control.release_ready
+        await asyncio.wait_for(
+            store.get_or_create_context(context_id="ctx-2", cwd=str(tmp_path), runtime_factory=lambda _: object()), 1
+        )
+        assert writes == [(False, False)]
+        release.set()
+        if fail_write:
+            await wait_until(lambda: control.backup["status"] == "blocked")
+            assert not control.release_ready
+            fail_write = False
+            await control.terminate(
+                execution_id=control.execution_id, request_id="retry", connection_epoch=2, reason="explicit_terminate"
+            )
+        await wait_until(lambda: control.release_ready)
+        assert all(on_loop is False and locked is False for on_loop, locked in writes)
+        assert store._persistence.load_task("task-1").state == "canceled"
+        assert store._persistence.load_context("ctx-1").active_task_id is None
+        snapshot = next(shared.rglob("a2a/task.json"))
+        assert json.loads(snapshot.read_text(encoding="utf-8"))["state"] == "canceled"
+    finally:
+        release.set()
+        await service.close()
+        publisher.cancel()
+        await asyncio.gather(publisher, return_exceptions=True)
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["CreateStackInstances", "UpdateStackInstances", "DeleteStackInstances"])
+@pytest.mark.parametrize("inflight", [False, True])
+async def test_stack_instances_id_survives_termination_and_staged_backup(tmp_path, monkeypatch, action, inflight):
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(shared))
+    backup = StagedSessionBackupService(tmp_path / "staging")
+    SessionStorage().ensure_v2_session_dir_for_new_session(str(tmp_path), "session-1")
+    backup.initialize_session(str(tmp_path), "session-1")
+    control = controller(tmp_path, backup)
+    control.bind_session("session-1")
+    tool = RosStackInstances()
+    monkeypatch.setattr(RosStackInstances, "poll_interval", 3600)
+    started, release = threading.Event(), threading.Event()
+    calls = []
+
+    def submit(_request):
+        calls.append(action)
+        started.set()
+        assert release.wait(5)
+        return SimpleNamespace(body=SimpleNamespace(operation_id="operation-accepted"))
+
+    client = SimpleNamespace(
+        create_stack_instances=submit, update_stack_instances=submit, delete_stack_instances=submit
+    )
+    monkeypatch.setattr(tool, "_get_client", lambda _: client)
+    if not inflight:
+        release.set()
+
+    async def execute():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        await control.attach_task(current)
+        try:
+            await tool.execute(
+                tool_input={"action": action, "region_id": "cn-hangzhou", "params": {"StackGroupName": "test"}},
+                context=ToolContext(cwd=str(tmp_path), tool_use_id="call-1"),
+            )
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    execution = asyncio.create_task(execute())
+    publisher = asyncio.create_task(publish_staged_backups(SessionBackupStagingWorker(tmp_path / "staging", shared)))
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        if not inflight:
+            await wait_until(lambda: bool(control.external_operations))
+        await control.terminate(
+            execution_id=control.execution_id, request_id="terminate", connection_epoch=1, reason="explicit_terminate"
+        )
+        if inflight:
+            await asyncio.sleep(0.03)
+            assert control.phase == "terminating" and not control.release_ready
+            assert not execution.done()
+        release.set()
+        await wait_until(lambda: control.release_ready)
+        assert execution.cancelled()
+        assert calls == [action]
+        assert control.external_operations == [
+            {
+                "product": "ros",
+                "action": action,
+                "outcome": "accepted",
+                "resourceType": "stack-group-operation",
+                "resourceId": "operation-accepted",
+                "regionId": "cn-hangzhou",
+                "toolUseId": "call-1",
+            }
+        ]
+        snapshot = next(shared.rglob("external-operations.json"))
+        assert json.loads(snapshot.read_text(encoding="utf-8"))["operations"] == control.external_operations
+    finally:
+        release.set()
+        execution.cancel()
+        await asyncio.gather(execution, return_exceptions=True)
+        await control.close()
+        publisher.cancel()
+        await asyncio.gather(publisher, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("staged", [False, True])
+@pytest.mark.parametrize("termination", ["explicit", "timeout", "legacy"])
+async def test_finished_normal_turn_keeps_result_during_slow_backup(tmp_path, monkeypatch, staged, termination):
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("IAC_CODE_MODE", "normal")
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(shared))
+    backup = StagedSessionBackupService(tmp_path / "staging") if staged else SessionBackupService()
+    service = ExecutionControlService(persistence_root=tmp_path / "a2a", backup_service=backup)
+    store = A2ATaskStore(backup_service=backup)
+    executor = IacCodeA2AExecutor(
+        task_store=store, model="test", backup_service=backup, execution_control_service=service
+    )
+    monkeypatch.setattr(
+        "iac_code.a2a.executor.create_agent_runtime",
+        lambda options: FakeRuntime(
+            agent_loop=FakeAgentLoop([TextDeltaEvent(text="finished result")]), session_id=options.session_id
+        ),
+    )
+    started, release = threading.Event(), threading.Event()
+    original_backup = backup.backup_session
+
+    def gated_backup(*args, **kwargs):
+        if kwargs.get("reason") == BackupReason.NORMAL_TURN_END:
+            started.set()
+            assert release.wait(5)
+        return original_backup(*args, **kwargs)
+
+    monkeypatch.setattr(backup, "backup_session", gated_backup)
+    publisher = (
+        asyncio.create_task(publish_staged_backups(SessionBackupStagingWorker(tmp_path / "staging", shared)))
+        if staged
+        else None
+    )
+    queue = FakeEventQueue()
+    execution = asyncio.create_task(
+        executor.execute(FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}), queue)
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        record = await store.get_task_record("task-1")
+        assert record.state == "input-required"
+        control = service.get_for_context("ctx-1")
+        if termination == "legacy":
+            assert await store.cancel_task("task-1")
+        elif termination == "explicit":
+            await control.terminate(
+                execution_id=control.execution_id,
+                request_id="terminate",
+                connection_epoch=1,
+                reason="explicit_terminate",
+            )
+        else:
+            await control.pause(
+                task_id="task-1",
+                expected_execution_id=control.execution_id,
+                request_id="pause",
+                connection_epoch=1,
+                reason="client_disconnected",
+                reconnect_timeout_seconds=1,
+            )
+            await wait_until(lambda: control.phase == "terminating")
+        assert not control.release_ready
+        release.set()
+        await asyncio.wait_for(execution, 3)
+        expected = "canceled" if termination == "legacy" else "input-required"
+        if termination != "legacy":
+            await wait_until(lambda: control.release_ready)
+            assert control.execution_status == expected
+        record = await store.get_task_record("task-1")
+        assert record.state == expected
+        assert record.output_text == ["finished result"]
+        # Legacy cancel only stages its noncritical backup; it has no
+        # execution-control releaseReady barrier for shared publication.
+        await wait_until(
+            lambda: any(
+                json.loads(snapshot.read_text(encoding="utf-8"))["state"] == expected
+                for snapshot in shared.rglob("a2a/task.json")
+            )
+        )
+    finally:
+        release.set()
+        execution.cancel()
+        await asyncio.gather(execution, return_exceptions=True)
+        await service.close()
+        if publisher:
+            publisher.cancel()
+            await asyncio.gather(publisher, return_exceptions=True)
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.parametrize("change", ["none", "rollover", "replacement"])
+def test_recovery_revalidates_execution_after_history_read(tmp_path, monkeypatch, change):
+    app = create_app(host="127.0.0.1", port=41242, token=None, model="test", persistence_dir=tmp_path / "a2a")
+    components = app.state.a2a_components
+    service, store = components.execution_control_service, components.task_store
+    started, release = threading.Event(), threading.Event()
+
+    def load(*_args):
+        started.set()
+        assert release.wait(5)
+        return []
+
+    monkeypatch.setattr(SessionStorage, "load", load)
+
+    async def begin(task_id):
+        await store.get_or_create_context(context_id="ctx-1", cwd=str(tmp_path), runtime_factory=lambda _: object())
+        record = await store.get_or_create_task(task_id=task_id, context_id="ctx-1")
+        record.state = "input-required"
+        record.output_text = [task_id]
+        await store.save(
+            Task(id=task_id, context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_INPUT_REQUIRED))
+        )
+        control = await service.begin_execution(context_id="ctx-1", task_id=task_id, owner="", cwd=str(tmp_path))
+        if task_id == "task-1" and change == "rollover":
+            control.register_spawned_task(asyncio.create_task(asyncio.Event().wait()), kind="background_agent")
+        await control.detach_task(asyncio.current_task(), execution_status="normal-turn-ended")
+        return control.execution_id
+
+    with TestClient(app) as client, ThreadPoolExecutor(max_workers=1) as pool:
+        old_execution_id = client.portal.call(begin, "task-1")
+        request = pool.submit(
+            client.get, "/iac-code/session/recovery", params={"contextId": "ctx-1", "executionId": old_execution_id}
+        )
+        try:
+            assert started.wait(2)
+            if change != "none":
+                assert client.portal.call(begin, "task-2") != old_execution_id
+            release.set()
+            response = request.result(timeout=3)
+            if change != "none":
+                assert response.status_code == 409
+            else:
+                assert response.status_code == 200
+                data = response.json()
+                assert data["executionId"] == data["executionControl"]["executionId"] == old_execution_id
+                assert data["taskId"] == data["task"]["id"] == "task-1"
+        finally:
+            release.set()
+            request.result(timeout=3)
+
+
+@pytest.mark.parametrize("timeout", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_pause_timeout_leaves_http_control_usable(tmp_path, timeout):
+    app = create_app(host="127.0.0.1", port=41242, token=None, model="test", persistence_dir=tmp_path / "a2a")
+    control = controller(tmp_path)
+    app.state.a2a_components.execution_control_service._controls["ctx-1"] = control
+    before = control.snapshot()
+    payload = {
+        "contextId": "ctx-1",
+        "taskId": "task-1",
+        "expectedExecutionId": control.execution_id,
+        "requestId": "pause",
+        "connectionEpoch": 1,
+        "reason": "client_disconnected",
+        "reconnectTimeoutSeconds": timeout,
+    }
+    with TestClient(app) as client:
+        invalid = client.post(
+            "/iac-code/execution/pause", content=json.dumps(payload), headers={"Content-Type": "application/json"}
+        )
+        assert invalid.status_code == 400
+        assert control.snapshot() == before
+        assert client.get("/iac-code/execution/state?contextId=ctx-1").status_code == 200
+        payload["reconnectTimeoutSeconds"] = 30
+        assert client.post("/iac-code/execution/pause", json=payload).status_code in {200, 202}
+        assert client.post(
+            "/iac-code/execution/resume",
+            json={
+                "contextId": "ctx-1",
+                "executionId": control.execution_id,
+                "pauseId": control.pause_id,
+                "requestId": "resume",
+                "connectionEpoch": 2,
+            },
+        ).status_code in {200, 202}
+        assert client.post(
+            "/iac-code/execution/terminate",
+            json={
+                "contextId": "ctx-1",
+                "expectedExecutionId": control.execution_id,
+                "requestId": "terminate",
+                "connectionEpoch": 3,
+            },
+        ).status_code in {200, 202}

--- a/tests/a2a/test_execution_control_review_regressions.py
+++ b/tests/a2a/test_execution_control_review_regressions.py
@@ -1,0 +1,417 @@
+"""Permission continuations, slow terminal storage, and connection-hold retention."""
+
+import asyncio
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+from a2a.types import Message as A2AMessage
+from a2a.types import Part, Role, Task, TaskState, TaskStatus
+
+from iac_code.a2a.execution_control import (
+    ExecutionController,
+    ExecutionControlService,
+    bind_execution_control,
+    reset_execution_control,
+)
+from iac_code.a2a.executor import IacCodeA2AExecutor
+from iac_code.a2a.input_required import PERMISSION_QUERY_PREFIX
+from iac_code.a2a.persistence import A2APersistenceStore
+from iac_code.a2a.task_store import A2ATaskStore
+from iac_code.agent.agent_loop import AgentLoop
+from iac_code.agent.message import Message, ToolUseBlock
+from iac_code.services.permission_wait import canonical_digest
+from iac_code.services.session_backup import BackupReason, SessionBackupService
+from iac_code.services.session_backup_staging import SessionBackupStagingWorker, StagedSessionBackupService
+from iac_code.tools.base import ToolRegistry
+from iac_code.types.stream_events import MessageEndEvent, PermissionRequestEvent, TextDeltaEvent, Usage
+from tests.agent.test_agent_loop_permissions import WriteTool
+
+from .fakes import FakeEventQueue, FakeRequestContext, FakeRuntime
+from .test_execution_control_regressions import publish_staged_backups, wait_until
+
+
+@pytest.fixture(autouse=True)
+def isolated_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("IAC_CODE_MODE", "normal")
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_DIR", raising=False)
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_TMP_DIR", raising=False)
+
+
+def make_executor(tmp_path, backup):
+    store = A2ATaskStore(persistence=A2APersistenceStore(tmp_path / "a2a"), backup_service=backup)
+    service = ExecutionControlService(persistence_root=tmp_path / "a2a", backup_service=backup)
+    store.set_execution_control_provider(service.snapshot_for_context, service.has_active_work)
+    executor = IacCodeA2AExecutor(
+        task_store=store, model="test", backup_service=backup, execution_control_service=service
+    )
+    return executor, store, service
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("staged", [False, True])
+@pytest.mark.parametrize("finished", [False, True])
+async def test_permission_continuation_termination_commits_actual_result(tmp_path, monkeypatch, staged, finished):
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(shared))
+    backup = StagedSessionBackupService(tmp_path / "staging") if staged else SessionBackupService()
+    executor, store, service = make_executor(tmp_path, backup)
+    started = asyncio.Event()
+    backup_started, release_backup = threading.Event(), threading.Event()
+    future = asyncio.get_running_loop().create_future()
+
+    class PermissionLoop:
+        async def run_streaming(self, _prompt):
+            yield PermissionRequestEvent(
+                tool_name="bash",
+                tool_input={"cmd": "pwd"},
+                tool_use_id="tool-1",
+                response_future=future,
+                continuation_frame={
+                    "assistantMessageRef": "session.jsonl:0",
+                    "assistantMessageDigest": "a" * 64,
+                    "orderedToolUseIds": ["tool-1"],
+                    "currentIndex": 0,
+                    "decisions": [{"toolUseId": "tool-1", "state": "pending", "source": None, "deniedResult": None}],
+                },
+            )
+            started.set()
+            if not finished:
+                await asyncio.Event().wait()
+            yield TextDeltaEvent(text="finished continuation")
+
+    monkeypatch.setattr(
+        "iac_code.a2a.executor.create_agent_runtime",
+        lambda options: FakeRuntime(agent_loop=PermissionLoop(), session_id=options.session_id),
+    )
+    monkeypatch.setattr("iac_code.a2a.input_required.emit_permission_boundary_audit", lambda *_args, **_kwargs: True)
+    original_backup = backup.backup_session
+
+    def gated_backup(*args, **kwargs):
+        if kwargs.get("reason") == BackupReason.NORMAL_TURN_END:
+            backup_started.set()
+            assert release_backup.wait(5)
+        return original_backup(*args, **kwargs)
+
+    monkeypatch.setattr(backup, "backup_session", gated_backup)
+    publisher = (
+        asyncio.create_task(publish_staged_backups(SessionBackupStagingWorker(tmp_path / "staging", shared)))
+        if staged
+        else None
+    )
+    continuation = None
+    try:
+        metadata = {"iac_code": {"cwd": str(tmp_path)}}
+        await executor.execute(FakeRequestContext(metadata=metadata), FakeEventQueue())
+        pending = next(iter(executor._permission_input_registry._pending.values()))
+        response = {
+            "schemaVersion": 1,
+            "kind": "permission",
+            "requestTaskId": pending.task_id,
+            "contextId": pending.context_id,
+            "inputId": pending.input_id,
+            "toolUseId": "tool-1",
+            "decision": "allow_once",
+        }
+        context = FakeRequestContext(metadata=metadata)
+        context.message = A2AMessage(
+            message_id="reply",
+            context_id=pending.context_id,
+            role=Role.ROLE_USER,
+            parts=[Part(text=PERMISSION_QUERY_PREFIX + " " + json.dumps(response))],
+        )
+        queue = FakeEventQueue()
+        continuation = asyncio.create_task(executor.execute(context, queue))
+        await asyncio.wait_for(started.wait(), 3)
+        if finished:
+            assert await asyncio.to_thread(backup_started.wait, 3)
+        control = service.get_for_context("ctx-1")
+        await control.terminate(
+            execution_id=control.execution_id, request_id="terminate", connection_epoch=1, reason="explicit_terminate"
+        )
+        release_backup.set()
+        await wait_until(lambda: control.release_ready)
+        await continuation
+        expected = "input-required" if finished else "canceled"
+        assert control.execution_status == expected
+        assert (await store.get_task_record("task-1")).state == expected
+        assert store._persistence.load_task("task-1").state == expected
+        assert json.loads(next(shared.rglob("a2a/task.json")).read_text(encoding="utf-8"))["state"] == expected
+        assert store._persistence.load_context("ctx-1").active_task_id is None
+        assert queue.events[-1].status.state == (
+            TaskState.TASK_STATE_INPUT_REQUIRED if finished else TaskState.TASK_STATE_CANCELED
+        )
+    finally:
+        release_backup.set()
+        if continuation is not None:
+            continuation.cancel()
+            await asyncio.gather(continuation, return_exceptions=True)
+        await service.close()
+        if publisher is not None:
+            publisher.cancel()
+            await asyncio.gather(publisher, return_exceptions=True)
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+async def test_recovered_permission_batch_waits_for_connection_resume(tmp_path):
+    control = ExecutionController(
+        context_id="ctx",
+        task_id="task",
+        owner="",
+        cwd=str(tmp_path),
+        server_instance_id="test",
+        persistence_path=None,
+        backup_service=None,
+    )
+    paused = await control.pause(
+        task_id="task",
+        expected_execution_id=control.execution_id,
+        request_id="pause",
+        connection_epoch=1,
+        reason="disconnect",
+        reconnect_timeout_seconds=60,
+    )
+    await wait_until(lambda: control.phase == "paused")
+    executions = []
+
+    class RecordingTool(WriteTool):
+        async def execute(self, **kwargs):
+            executions.append(control.phase)
+            return await super().execute(**kwargs)
+
+    class Provider:
+        def get_model_name(self):
+            return "fake"
+
+        async def stream(self, *_args, **_kwargs):
+            yield MessageEndEvent(stop_reason="end_turn", usage=Usage())
+
+    registry = ToolRegistry()
+    registry.register(RecordingTool())
+    assistant = Message(role="assistant", content=[ToolUseBlock(id="tool-1", name="write_test", input={"value": "ok"})])
+    loop = AgentLoop(
+        provider_manager=Provider(),
+        system_prompt="test",
+        tool_registry=registry,
+        max_turns=1,
+        resume_messages=[assistant],
+        cwd=str(tmp_path),
+    )
+    checkpoint = {
+        "toolUseId": "tool-1",
+        "payloadDigest": canonical_digest({"name": "write_test", "input": {"value": "ok"}}),
+        "decision": {"status": "claimed", "value": "allow_once", "claimId": "claim-1"},
+        "continuationFrame": {
+            "assistantMessageRef": "session.jsonl:0",
+            "assistantMessageDigest": canonical_digest([block.model_dump(mode="json") for block in assistant.content]),
+            "orderedToolUseIds": ["tool-1"],
+            "currentIndex": 0,
+            "decisions": [{"toolUseId": "tool-1", "state": "pending", "source": None, "deniedResult": None}],
+        },
+    }
+    attached = asyncio.Event()
+
+    async def consume():
+        token = bind_execution_control(control)
+        await control.attach_task(asyncio.current_task(), mark_working=False)
+        attached.set()
+        try:
+            async for _event in loop.resume_permission_boundary(checkpoint):
+                pass
+        finally:
+            await control.detach_task(asyncio.current_task(), execution_status="input-required")
+            reset_execution_control(token)
+
+    task = asyncio.create_task(consume())
+    try:
+        await attached.wait()
+        await asyncio.sleep(0.1)
+        assert executions == []
+        assert not task.done()
+        await control.resume(
+            execution_id=control.execution_id, pause_id=paused["pauseId"], request_id="resume", connection_epoch=2
+        )
+        await asyncio.wait_for(task, 3)
+        assert executions == ["running"]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        await control.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_write", [False, True])
+async def test_active_termination_commits_off_loop_and_blocks_release_on_failure(tmp_path, monkeypatch, fail_write):
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(tmp_path / "shared"))
+    backup = StagedSessionBackupService(tmp_path / "staging")
+    executor, store, service = make_executor(tmp_path, backup)
+    running = asyncio.Event()
+
+    class Loop:
+        async def run_streaming(self, _prompt):
+            running.set()
+            await asyncio.Event().wait()
+            yield TextDeltaEvent(text="unreachable")
+
+    monkeypatch.setattr(
+        "iac_code.a2a.executor.create_agent_runtime",
+        lambda options: FakeRuntime(agent_loop=Loop(), session_id=options.session_id),
+    )
+    original = store._persistence.save_task
+    started, release = threading.Event(), threading.Event()
+    loop_thread = threading.get_ident()
+    writes = []
+
+    def gated_save(snapshot):
+        control = service.get_for_context(snapshot.context_id)
+        if snapshot.task_id == "task-1" and control and control.phase in {"terminating", "terminated"}:
+            writes.append((threading.get_ident() == loop_thread, store._mutation_lock.locked()))
+            started.set()
+            assert release.wait(5)
+            if fail_write:
+                raise OSError("injected terminal storage failure")
+        original(snapshot)
+
+    monkeypatch.setattr(store._persistence, "save_task", gated_save)
+    publisher = asyncio.create_task(
+        publish_staged_backups(SessionBackupStagingWorker(tmp_path / "staging", tmp_path / "shared"))
+    )
+    task = asyncio.create_task(
+        executor.execute(FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}), FakeEventQueue())
+    )
+    try:
+        await asyncio.wait_for(running.wait(), 3)
+        control = service.get_for_context("ctx-1")
+        await control.terminate(
+            execution_id=control.execution_id, request_id="terminate", connection_epoch=1, reason="explicit_terminate"
+        )
+        assert await asyncio.to_thread(started.wait, 3)
+        assert writes == [(False, False)]
+        assert not control.release_ready
+        await asyncio.wait_for(
+            store.get_or_create_context(context_id="ctx-2", cwd=str(tmp_path), runtime_factory=lambda _: object()), 1
+        )
+        # A previously queued SDK event may arrive while the final write is in flight.
+        await store.save(Task(id="task-1", context_id="ctx-1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)))
+        assert (await store.get_task_record("task-1")).state == "canceled"
+        release.set()
+        if fail_write:
+            await wait_until(lambda: control.backup["status"] == "blocked")
+            assert not control.release_ready
+            fail_write = False
+            await control.terminate(
+                execution_id=control.execution_id, request_id="retry", connection_epoch=2, reason="explicit_terminate"
+            )
+        await wait_until(lambda: control.release_ready)
+        assert all(write == (False, False) for write in writes)
+        assert store._persistence.load_task("task-1").state == "canceled"
+        assert (await store.get("task-1")).status.state == TaskState.TASK_STATE_CANCELED
+        assert (
+            json.loads(next((tmp_path / "shared").rglob("a2a/task.json")).read_text(encoding="utf-8"))["state"]
+            == "canceled"
+        )
+    finally:
+        release.set()
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        await service.close()
+        publisher.cancel()
+        await asyncio.gather(publisher, return_exceptions=True)
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+async def test_pause_retains_only_its_context_and_resume_restarts_idle_interval(tmp_path):
+    executor, store, service = make_executor(tmp_path, SessionBackupService())
+    closed = []
+
+    async def close():
+        closed.append(True)
+
+    ctx = await store.get_or_create_context(
+        context_id="ctx-1", cwd=str(tmp_path), runtime_factory=lambda _: SimpleNamespace(aclose=close)
+    )
+    other = await store.get_or_create_context(context_id="ctx-2", cwd=str(tmp_path), runtime_factory=lambda _: object())
+    record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    record.state = "input-required"
+    control = await service.begin_execution(context_id="ctx-1", task_id="task-1", owner="", cwd=str(tmp_path))
+    await control.detach_task(asyncio.current_task(), execution_status="input-required")
+    ctx.last_active = other.last_active = time.monotonic() - 3601
+    try:
+        paused = await control.pause(
+            task_id="task-1",
+            expected_execution_id=control.execution_id,
+            request_id="pause",
+            connection_epoch=1,
+            reason="disconnect",
+            reconnect_timeout_seconds=300,
+        )
+        await wait_until(lambda: control.phase == "paused")
+        await store.cleanup_once()
+        assert closed == []
+        assert not record.expired
+        assert "ctx-1" in store._contexts and "ctx-2" not in store._contexts
+        await control.resume(
+            execution_id=control.execution_id, pause_id=paused["pauseId"], request_id="resume", connection_epoch=2
+        )
+        await wait_until(lambda: control.phase == "running")
+        await store.cleanup_once()
+        assert "ctx-1" in store._contexts
+        assert time.monotonic() - ctx.last_active < 2
+        await store.cleanup_once(now_offset_seconds=3601)
+        assert closed == [True]
+        assert record.expired
+    finally:
+        await service.close()
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resume_during_cleanup", [False, True])
+async def test_cleanup_rechecks_hold_after_closing_another_runtime(tmp_path, resume_during_cleanup):
+    _executor, store, service = make_executor(tmp_path, SessionBackupService())
+    closing, release = asyncio.Event(), asyncio.Event()
+
+    async def slow_close():
+        closing.set()
+        await release.wait()
+
+    first = await store.get_or_create_context(
+        context_id="ctx-first", cwd=str(tmp_path), runtime_factory=lambda _: SimpleNamespace(aclose=slow_close)
+    )
+    held = await store.get_or_create_context(
+        context_id="ctx-held", cwd=str(tmp_path), runtime_factory=lambda _: object()
+    )
+    control = await service.begin_execution(context_id="ctx-held", task_id="task", owner="", cwd=str(tmp_path))
+    await control.detach_task(asyncio.current_task(), execution_status="input-required")
+    first.last_active = held.last_active = time.monotonic() - 3601
+    cleanup = asyncio.create_task(store.cleanup_once())
+    try:
+        await asyncio.wait_for(closing.wait(), 1)
+        paused = await control.pause(
+            task_id="task",
+            expected_execution_id=control.execution_id,
+            request_id="pause",
+            connection_epoch=1,
+            reason="disconnect",
+            reconnect_timeout_seconds=300,
+        )
+        await wait_until(lambda: control.phase == "paused")
+        if resume_during_cleanup:
+            await control.resume(
+                execution_id=control.execution_id, pause_id=paused["pauseId"], request_id="resume", connection_epoch=2
+            )
+            await wait_until(lambda: control.phase == "running")
+        release.set()
+        await asyncio.wait_for(cleanup, 1)
+        assert store._contexts.get("ctx-held") is held
+        assert "ctx-first" not in store._contexts
+    finally:
+        release.set()
+        await cleanup
+        await service.close()
+        await store.stop_cleanup_loop()

--- a/tests/a2a/test_input_required.py
+++ b/tests/a2a/test_input_required.py
@@ -23,7 +23,7 @@ from iac_code.a2a.input_required import (
 )
 from iac_code.a2a.pipeline_events import PipelineA2AContext, PipelineEventTranslator
 from iac_code.a2a.pipeline_journal import A2APipelineJournal
-from iac_code.a2a.pipeline_snapshot import A2APipelineSnapshotStore
+from iac_code.a2a.pipeline_snapshot import A2APipelineSnapshotStore, reduce_pipeline_events
 from iac_code.a2a.pipeline_stream import PipelineA2AEventPublisher, _unified_input_projection
 from iac_code.a2a.runtime_overrides import a2a_request_context
 from iac_code.a2a.task_store import A2ATaskStore
@@ -40,6 +40,127 @@ from iac_code.types.permissions import PermissionAuditMetadata, PermissionResult
 from iac_code.types.stream_events import PermissionRequestEvent, SubPipelineStreamEvent
 
 from .fakes import FakeEventQueue, pending_future
+
+
+@pytest.mark.asyncio
+async def test_cancel_durable_detached_permission_runs_suspend_callback() -> None:
+    registry = PermissionInputRegistry()
+    future = pending_future()
+    request = PermissionRequestEvent(
+        tool_name="bash",
+        tool_input={"cmd": "true"},
+        tool_use_id="tool-1",
+        response_future=future,
+    )
+    pending = await registry.register(request, task_id="task-1", context_id="ctx-1", scope="normal")
+    pending.boundary_id = "boundary-1"
+    suspended = asyncio.Event()
+
+    class Coordinator:
+        async def cancel_live(self, boundary_id: str) -> bool:
+            assert boundary_id == "boundary-1"
+            future.cancel()
+            return True
+
+        def unregister_live(self, boundary_id: str) -> None:
+            assert boundary_id == "boundary-1"
+
+    async def suspend() -> None:
+        pending.continuation = None
+        suspended.set()
+
+    pending.continuation = object()
+    pending.suspend_callback = suspend
+    registry.set_permission_wait_coordinator(Coordinator())
+
+    assert await registry.has_pending_task("task-1") is True
+    await registry.cancel_task("task-1")
+
+    assert suspended.is_set()
+    assert pending.continuation is None
+    assert pending.state == "completed"
+    assert await registry.has_pending_task("task-1") is False
+
+
+@pytest.mark.asyncio
+async def test_terminate_detached_pipeline_permission_cancels_sidecar_without_handoff(tmp_path) -> None:
+    from iac_code.a2a.pipeline_paths import a2a_pipeline_dir_for_session
+
+    class DisabledBackup:
+        def initialize_session(self, *_args, **_kwargs):
+            return None
+
+        def backup_session(self, *_args, **_kwargs):
+            return BackupResult(enabled=False)
+
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    store = A2ATaskStore(backup_service=DisabledBackup())
+    context = await store.get_or_create_context(
+        context_id="ctx-1",
+        cwd=str(cwd),
+        runtime_factory=lambda _session_id: object(),
+    )
+    context.active_task_id = "task-1"
+    store.mirror_context(context)
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    task.state = "input-required"
+    store.mirror_task(task)
+    pipeline_dir = a2a_pipeline_dir_for_session(cwd=str(cwd), session_id=context.session_id)
+    pending_input = {
+        "schemaVersion": "1.0",
+        "extensionUri": "urn:iac-code:a2a:pipeline-events:v1",
+        "eventId": "evt-permission",
+        "sequence": 1,
+        "createdAt": "2026-09-10T10:00:00Z",
+        "eventType": "input_required",
+        "scope": "step",
+        "pipelineRunId": "ctx-1",
+        "taskId": "task-1",
+        "contextId": "ctx-1",
+        "pipelineName": "selling",
+        "status": "input_required",
+        "step": {"runId": "step-1", "id": "confirm_and_select", "attempt": 1},
+        "input": {"inputId": "permission-1", "kind": "permission", "prompt": "Allow?"},
+    }
+    journal = A2APipelineJournal(pipeline_dir)
+    journal.append(pending_input)
+    A2APipelineSnapshotStore(pipeline_dir).save(reduce_pipeline_events([pending_input]))
+
+    registry = PermissionInputRegistry()
+    future = pending_future()
+    request = PermissionRequestEvent(
+        tool_name="bash",
+        tool_input={"cmd": "true"},
+        tool_use_id="tool-1",
+        response_future=future,
+    )
+    pending = await registry.register(request, task_id="task-1", context_id="ctx-1", scope="pipeline")
+    suspended = asyncio.Event()
+
+    async def suspend() -> None:
+        pending.continuation = None
+        suspended.set()
+
+    pending.continuation = object()
+    pending.suspend_callback = suspend
+    executor = IacCodeA2AExecutor(
+        task_store=store,
+        model="fake-model",
+        permission_input_registry=registry,
+        backup_service=DisabledBackup(),
+    )
+
+    result = await executor._terminate_detached_execution("ctx-1", "task-1", "disconnect_timeout")
+
+    assert result == "canceled"
+    assert suspended.is_set()
+    assert (await store.get_task_record("task-1")).state == "canceled"
+    snapshot = A2APipelineSnapshotStore(pipeline_dir).load()
+    assert snapshot is not None and snapshot["status"] == "canceled"
+    event_types = [event["eventType"] for event in journal.read_all()]
+    assert "pipeline_canceled" in event_types
+    assert "pipeline_handoff_ready" not in event_types
 
 
 @pytest.fixture(autouse=True)

--- a/tests/a2a/test_permission_execution_control.py
+++ b/tests/a2a/test_permission_execution_control.py
@@ -1,0 +1,497 @@
+"""Connection holds and termination across durable permission recovery."""
+
+import asyncio
+import json
+import threading
+from datetime import timedelta
+
+import pytest
+from a2a.types import Message as A2AMessage
+from a2a.types import Part, Role, TaskState
+
+from iac_code.a2a.execution_control import ExecutionController, execution_checkpoint
+from iac_code.a2a.executor import IacCodeA2AExecutor
+from iac_code.a2a.input_required import PERMISSION_QUERY_PREFIX
+from iac_code.agent.message import Message
+from iac_code.services.permission_wait import (
+    PermissionWaitCheckpointStore,
+    PermissionWaitCoordinator,
+    PermissionWaitPolicy,
+    build_permission_checkpoint,
+    format_utc,
+    utc_now,
+)
+from iac_code.services.session_backup import BackupReason, SessionBackupService
+from iac_code.services.session_backup_staging import SessionBackupStagingWorker, StagedSessionBackupService
+from iac_code.services.session_storage import SessionStorage
+from iac_code.types.stream_events import PermissionRequestEvent, PermissionWaitOutcome, TextDeltaEvent
+
+from .fakes import FakeEventQueue, FakeRequestContext, FakeRuntime
+from .test_execution_control_regressions import publish_staged_backups, wait_until
+from .test_execution_control_review_regressions import make_executor
+
+
+@pytest.fixture(autouse=True)
+def isolated_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("IAC_CODE_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("IAC_CODE_MODE", "normal")
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_DIR", raising=False)
+    monkeypatch.delenv("IAC_CODE_CONFIG_BACKUP_TMP_DIR", raising=False)
+
+
+def continuation_frame():
+    return {
+        "assistantMessageRef": "session.jsonl:0",
+        "assistantMessageDigest": "a" * 64,
+        "orderedToolUseIds": ["tool-1"],
+        "currentIndex": 0,
+        "decisions": [{"toolUseId": "tool-1", "state": "pending", "source": None, "deniedResult": None}],
+    }
+
+
+def permission_reply(tmp_path, *, input_id="input-1"):
+    response = {
+        "schemaVersion": 1,
+        "kind": "permission",
+        "requestTaskId": "task-1",
+        "contextId": "ctx-1",
+        "inputId": input_id,
+        "toolUseId": "tool-1",
+        "decision": "allow_once",
+    }
+    request = FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}})
+    request.message = A2AMessage(
+        message_id="reply",
+        context_id="ctx-1",
+        role=Role.ROLE_USER,
+        parts=[Part(text=PERMISSION_QUERY_PREFIX + " " + json.dumps(response))],
+    )
+    return request
+
+
+def checkpoint_record(session_id, *, policy=None, permission_class="normal"):
+    frame = continuation_frame()
+    if permission_class == "pipeline":
+        frame["assistantMessageRef"] = "pipeline/transcripts/transcript-1/session.jsonl:0"
+    return build_permission_checkpoint(
+        session_id=session_id,
+        task_id="task-1",
+        context_id="ctx-1",
+        input_id="input-1",
+        tool_use_id="tool-1",
+        tool_name="bash",
+        tool_input={"cmd": "pwd"},
+        permission_class=permission_class,
+        continuation_frame=frame,
+        policy=policy or PermissionWaitPolicy(),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("staged", [False, True])
+@pytest.mark.parametrize(
+    ("finished", "fail_checkpoint", "close_gate"),
+    [(False, False, False), (False, True, False), (True, False, False), (True, False, True)],
+)
+async def test_persisted_recovery_termination_seals_checkpoint_and_backup(
+    tmp_path, monkeypatch, staged, finished, fail_checkpoint, close_gate
+):
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("IAC_CODE_CONFIG_BACKUP_DIR", str(shared))
+    backup = StagedSessionBackupService(tmp_path / "staging") if staged else SessionBackupService()
+    executor, store, service = make_executor(tmp_path, backup)
+    ctx = await store.get_or_create_context(
+        context_id="ctx-1", cwd=str(tmp_path), runtime_factory=lambda sid: FakeRuntime(session_id=sid)
+    )
+    SessionStorage().append(str(tmp_path), ctx.session_id, Message(role="user", content="test permission"))
+    task = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    task.state = "input-required"
+    store.mirror_task(task)
+    checkpoints = PermissionWaitCheckpointStore(str(tmp_path), ctx.session_id)
+    checkpoint = checkpoints.create(checkpoint_record(ctx.session_id))
+    boundary_id = checkpoint["boundaryId"]
+    checkpoints.mark_suspended(boundary_id)
+    claimed, _ = checkpoints.claim_decision(boundary_id, value="allow_once", source="user")
+    claim_id = claimed["decision"]["claimId"]
+    checkpoints.run_claim_audit_once(boundary_id, claim_id=claim_id, audit=lambda _: True)
+    checkpoints.mark_claim_backed_up(boundary_id, claim_id=claim_id)
+    control = await service.begin_execution(context_id="ctx-1", task_id="task-1", owner="", cwd=str(tmp_path))
+    control.bind_session(ctx.session_id)
+    await control.detach_task(asyncio.current_task(), execution_status="input-required")
+    started = asyncio.Event()
+    backup_started, release_backup = threading.Event(), threading.Event()
+    closed = []
+    close_started, release_close = asyncio.Event(), asyncio.Event()
+    original_cancel_restore = PermissionWaitCheckpointStore.cancel_restore
+    failed = False
+
+    def flaky_cancel_restore(self, *args, **kwargs):
+        nonlocal failed
+        if fail_checkpoint and not failed:
+            failed = True
+            raise OSError("simulated checkpoint write failure")
+        return original_cancel_restore(self, *args, **kwargs)
+
+    monkeypatch.setattr(PermissionWaitCheckpointStore, "cancel_restore", flaky_cancel_restore)
+
+    class RecoveryLoop:
+        async def resume_permission_boundary(self, _checkpoint):
+            started.set()
+            if not finished:
+                await asyncio.Event().wait()
+            yield TextDeltaEvent(text="recovered result")
+
+    async def close():
+        close_started.set()
+        if close_gate:
+            await release_close.wait()
+        closed.append(True)
+
+    monkeypatch.setattr(
+        "iac_code.a2a.executor.create_agent_runtime",
+        lambda options: FakeRuntime(
+            session_id=options.session_id,
+            agent_loop=RecoveryLoop(),
+            aclose=close,
+        ),
+    )
+    original_backup = backup.backup_session
+
+    def gated_backup(*args, **kwargs):
+        if kwargs.get("reason") == BackupReason.NORMAL_TURN_END:
+            backup_started.set()
+            assert release_backup.wait(5)
+        return original_backup(*args, **kwargs)
+
+    monkeypatch.setattr(backup, "backup_session", gated_backup)
+    publisher = (
+        asyncio.create_task(publish_staged_backups(SessionBackupStagingWorker(tmp_path / "staging", shared)))
+        if staged
+        else None
+    )
+    queue = FakeEventQueue()
+    recovery = asyncio.create_task(executor.execute(permission_reply(tmp_path), queue))
+    try:
+        await asyncio.wait_for(started.wait(), 3)
+        assert task.active_task is recovery
+        assert ctx.active_task_id == "task-1"
+        if close_gate:
+            await asyncio.wait_for(close_started.wait(), 3)
+        elif finished:
+            assert await asyncio.to_thread(backup_started.wait, 3)
+        else:
+            assert task.state == control.execution_status == "working"
+        await control.terminate(
+            execution_id=control.execution_id, request_id="terminate", connection_epoch=1, reason="explicit_terminate"
+        )
+        assert not control.release_ready
+        release_backup.set()
+        release_close.set()
+        if fail_checkpoint:
+            await wait_until(lambda: control.backup["status"] == "blocked")
+            assert not control.release_ready
+            assert checkpoints.load(boundary_id)["phase"] == "RESTORING"
+            await control.terminate(
+                execution_id=control.execution_id, request_id="retry", connection_epoch=2, reason="explicit_terminate"
+            )
+        await wait_until(lambda: control.release_ready)
+        await recovery
+        expected = "input-required" if finished else "canceled"
+        assert task.state == control.execution_status == expected
+        assert task.active_task is None and ctx.active_task_id is None
+        assert closed == [True]
+        assert queue.events[-1].status.state == (
+            TaskState.TASK_STATE_INPUT_REQUIRED if finished else TaskState.TASK_STATE_CANCELED
+        )
+        assert store._persistence.load_task("task-1").state == expected
+        shared_task = json.loads(next(shared.rglob("a2a/task.json")).read_text(encoding="utf-8"))
+        assert shared_task["state"] == expected
+        final_checkpoint = checkpoints.load(boundary_id)
+        assert final_checkpoint["phase"] == ("RESOLVED" if finished else "CANCELED")
+        assert final_checkpoint["decision"]["claimId"] == claim_id
+        shared_checkpoint = next(shared.rglob(boundary_id + ".json"))
+        assert json.loads(shared_checkpoint.read_text(encoding="utf-8"))["phase"] == final_checkpoint["phase"]
+    finally:
+        release_backup.set()
+        release_close.set()
+        recovery.cancel()
+        await asyncio.gather(recovery, return_exceptions=True)
+        await service.close()
+        if publisher is not None:
+            publisher.cancel()
+            await asyncio.gather(publisher, return_exceptions=True)
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["resume", "terminate", "approve_resume"])
+async def test_normal_permission_resident_timer_keeps_paused_runtime(tmp_path, monkeypatch, action):
+    backup = SessionBackupService()
+    _, store, service = make_executor(tmp_path, backup)
+    executor = IacCodeA2AExecutor(
+        task_store=store,
+        model="test",
+        backup_service=backup,
+        execution_control_service=service,
+        permission_wait_policy=PermissionWaitPolicy(resident_timeout_seconds=0.2, timeout_grace_seconds=0),
+    )
+    future = asyncio.get_running_loop().create_future()
+    ran = asyncio.Event()
+    closed = []
+
+    class PermissionLoop:
+        async def run_streaming(self, _prompt):
+            yield PermissionRequestEvent(
+                tool_name="bash",
+                tool_input={"cmd": "pwd"},
+                tool_use_id="tool-1",
+                response_future=future,
+                continuation_frame=continuation_frame(),
+            )
+            await execution_checkpoint()
+            ran.set()
+            yield TextDeltaEvent(text="approved")
+
+    async def close():
+        closed.append(True)
+
+    monkeypatch.setattr(
+        "iac_code.a2a.executor.create_agent_runtime",
+        lambda options: FakeRuntime(
+            session_id=options.session_id,
+            agent_loop=PermissionLoop(),
+            aclose=close,
+        ),
+    )
+    monkeypatch.setattr("iac_code.a2a.input_required.emit_permission_boundary_audit", lambda *args, **kwargs: True)
+    response_task = None
+    try:
+        await executor.execute(FakeRequestContext(metadata={"iac_code": {"cwd": str(tmp_path)}}), FakeEventQueue())
+        pending = next(iter(executor._permission_input_registry._pending.values()))
+        control = service.get_for_context("ctx-1")
+        paused = await control.pause(
+            task_id="task-1",
+            expected_execution_id=control.execution_id,
+            request_id="pause",
+            connection_epoch=1,
+            reason="disconnect",
+            reconnect_timeout_seconds=60,
+        )
+        await wait_until(lambda: control.phase == "paused")
+        await asyncio.sleep(0.3)
+        assert not closed and not future.done() and pending.continuation is not None
+        assert control.phase == "paused"
+        if action == "terminate":
+            await control.terminate(
+                execution_id=control.execution_id,
+                request_id="terminate",
+                connection_epoch=2,
+                reason="explicit_terminate",
+            )
+            await wait_until(lambda: control.release_ready)
+            assert closed == [True] and not ran.is_set()
+            assert not executor._permission_wait_coordinator.has_live_owners()
+            return
+        if action == "approve_resume":
+            response_task = asyncio.create_task(
+                executor.execute(
+                    permission_reply(tmp_path, input_id=pending.input_id),
+                    FakeEventQueue(),
+                )
+            )
+            await wait_until(future.done)
+            assert not ran.is_set() and not closed
+        await control.resume(
+            execution_id=control.execution_id,
+            pause_id=paused["pauseId"],
+            request_id="resume",
+            connection_epoch=2,
+        )
+        if response_task is not None:
+            await asyncio.wait_for(response_task, 3)
+            assert ran.is_set() and not closed
+        else:
+            await wait_until(lambda: bool(closed))
+            assert closed == [True] and not ran.is_set()
+    finally:
+        if response_task is not None:
+            response_task.cancel()
+            await asyncio.gather(response_task, return_exceptions=True)
+        await service.close()
+        await store.stop_cleanup_loop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permission_class", ["normal", "pipeline"])
+@pytest.mark.parametrize("terminate", [False, True])
+async def test_permission_cleanup_claim_blocks_pause_until_slow_write_finishes(
+    tmp_path, monkeypatch, permission_class, terminate
+):
+    storage = SessionStorage()
+    storage.ensure_v2_session_dir_for_new_session(str(tmp_path), "session-1")
+    checkpoints = PermissionWaitCheckpointStore(str(tmp_path), "session-1")
+    policy = PermissionWaitPolicy(timeout_grace_seconds=0)
+    record = checkpoint_record("session-1", policy=policy, permission_class=permission_class)
+    record["residentDeadlineAt"] = format_utc(utc_now() - timedelta(seconds=1))
+    record = checkpoints.create(record)
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(tmp_path),
+        server_instance_id="test",
+        persistence_path=None,
+        backup_service=None,
+    )
+    coordinator = PermissionWaitCoordinator(policy)
+    future = asyncio.get_running_loop().create_future()
+    cleanup_calls = []
+
+    async def on_suspend():
+        cleanup_calls.append(True)
+        coordinator.unregister_live(record["boundaryId"])
+
+    coordinator.register_live(
+        record=record,
+        store=checkpoints,
+        future=future,
+        on_suspend=on_suspend,
+        run_suspension=control.run_permission_suspension,
+        suspension_allowed=control.permission_suspension_allowed,
+    )
+    started, release = threading.Event(), threading.Event()
+    original_reconcile = checkpoints.reconcile_deadline
+
+    def gated_reconcile(*args, **kwargs):
+        started.set()
+        assert release.wait(5)
+        return original_reconcile(*args, **kwargs)
+
+    monkeypatch.setattr(checkpoints, "reconcile_deadline", gated_reconcile)
+    suspension = asyncio.create_task(coordinator.suspend_now(record["boundaryId"]))
+    try:
+        assert await asyncio.to_thread(started.wait, 3)
+        await asyncio.wait_for(
+            control.pause(
+                task_id="task-1",
+                expected_execution_id=control.execution_id,
+                request_id="pause",
+                connection_epoch=1,
+                reason="disconnect",
+                reconnect_timeout_seconds=60,
+            ),
+            0.5,
+        )
+        assert control.phase == "pausing" and not future.done()
+        if terminate:
+            await control.terminate(
+                execution_id=control.execution_id,
+                request_id="terminate",
+                connection_epoch=2,
+                reason="explicit_terminate",
+            )
+            # Let the termination driver cancel the waiter while its worker is still gated.
+            await asyncio.sleep(0)
+            assert not control.release_ready
+        release.set()
+        if terminate:
+            result = await asyncio.gather(suspension, return_exceptions=True)
+            assert isinstance(result[0], asyncio.CancelledError)
+            await wait_until(lambda: control.release_ready)
+        else:
+            assert await suspension
+            await wait_until(lambda: control.phase == "paused")
+        assert future.result() is PermissionWaitOutcome.SUSPEND
+        assert cleanup_calls == [True]
+        assert not control.has_managed_work()
+    finally:
+        release.set()
+        suspension.cancel()
+        await asyncio.gather(suspension, return_exceptions=True)
+        coordinator.unregister_live(record["boundaryId"])
+        await control.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permission_class", ["normal", "pipeline"])
+async def test_permission_resident_timer_waits_for_hold_before_signaling_suspend(tmp_path, permission_class):
+    storage = SessionStorage()
+    storage.ensure_v2_session_dir_for_new_session(str(tmp_path), "session-1")
+    checkpoints = PermissionWaitCheckpointStore(str(tmp_path), "session-1")
+    policy = PermissionWaitPolicy(resident_timeout_seconds=0.05, timeout_grace_seconds=0)
+    record = checkpoints.create(checkpoint_record("session-1", policy=policy, permission_class=permission_class))
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(tmp_path),
+        server_instance_id="test",
+        persistence_path=None,
+        backup_service=None,
+    )
+    coordinator = PermissionWaitCoordinator(policy)
+    future = asyncio.get_running_loop().create_future()
+    closed = []
+
+    async def on_suspend():
+        closed.append(True)
+        coordinator.unregister_live(record["boundaryId"])
+
+    coordinator.register_live(
+        record=record,
+        store=checkpoints,
+        future=future,
+        on_suspend=on_suspend,
+        run_suspension=control.run_permission_suspension,
+        suspension_allowed=control.permission_suspension_allowed,
+    )
+    try:
+        paused = await control.pause(
+            task_id="task-1",
+            expected_execution_id=control.execution_id,
+            request_id="pause",
+            connection_epoch=1,
+            reason="disconnect",
+            reconnect_timeout_seconds=60,
+        )
+        await wait_until(lambda: control.phase == "paused")
+        await asyncio.sleep(0.1)
+        assert not future.done() and not closed
+        assert checkpoints.load(record["boundaryId"])["phase"] == "WAITING"
+        await control.resume(
+            execution_id=control.execution_id,
+            pause_id=paused["pauseId"],
+            request_id="resume",
+            connection_epoch=2,
+        )
+        assert await asyncio.wait_for(future, 3) is PermissionWaitOutcome.SUSPEND
+        await wait_until(lambda: not control.has_managed_work())
+        assert closed == [True]
+        assert not coordinator.has_live_owners()
+    finally:
+        coordinator.unregister_live(record["boundaryId"])
+        await control.close()
+
+
+def test_execution_termination_seals_only_its_claimed_restore(tmp_path):
+    storage = SessionStorage()
+    storage.ensure_v2_session_dir_for_new_session(str(tmp_path), "session-1")
+    checkpoints = PermissionWaitCheckpointStore(str(tmp_path), "session-1")
+    record = checkpoints.create(checkpoint_record("session-1"))
+    boundary_id = record["boundaryId"]
+    checkpoints.mark_suspended(boundary_id)
+    claimed, _ = checkpoints.claim_decision(boundary_id, value="allow_once", source="user")
+    claim_id = claimed["decision"]["claimId"]
+    with pytest.raises(ValueError, match="not restoring"):
+        checkpoints.cancel_restore(boundary_id, claim_id=claim_id)
+    checkpoints.begin_restore(boundary_id)
+    with pytest.raises(ValueError, match="already claimed"):
+        checkpoints.cancel(boundary_id)
+    with pytest.raises(ValueError, match="claim changed"):
+        checkpoints.cancel_restore(boundary_id, claim_id="another-claim")
+    canceled = checkpoints.cancel_restore(boundary_id, claim_id=claim_id)
+    assert canceled["phase"] == "CANCELED"
+    assert canceled["decision"] == claimed["decision"]
+    assert checkpoints.cancel_restore(boundary_id, claim_id=claim_id) == canceled
+    with pytest.raises(ValueError, match="not recoverable"):
+        checkpoints.begin_restore(boundary_id)

--- a/tests/a2a/test_permission_execution_control.py
+++ b/tests/a2a/test_permission_execution_control.py
@@ -233,7 +233,7 @@ async def test_normal_permission_resident_timer_keeps_paused_runtime(tmp_path, m
         model="test",
         backup_service=backup,
         execution_control_service=service,
-        permission_wait_policy=PermissionWaitPolicy(resident_timeout_seconds=0.2, timeout_grace_seconds=0),
+        permission_wait_policy=PermissionWaitPolicy(resident_timeout_seconds=1.0, timeout_grace_seconds=0),
     )
     future = asyncio.get_running_loop().create_future()
     ran = asyncio.Event()
@@ -278,7 +278,7 @@ async def test_normal_permission_resident_timer_keeps_paused_runtime(tmp_path, m
             reconnect_timeout_seconds=60,
         )
         await wait_until(lambda: control.phase == "paused")
-        await asyncio.sleep(0.3)
+        await asyncio.sleep(1.1)
         assert not closed and not future.done() and pending.continuation is not None
         assert control.phase == "paused"
         if action == "terminate":

--- a/tests/a2a/test_pipeline_executor.py
+++ b/tests/a2a/test_pipeline_executor.py
@@ -8918,9 +8918,11 @@ def test_waiting_input_task_id_from_sidecar_accepts_candidate_selection(tmp_path
     assert waiting_input_task_id_from_sidecar(cwd=str(cwd), session_id=session_id, context_id=context_id) == "task-1"
 
 
+@pytest.mark.parametrize("allow_normal_handoff", [True, False])
 def test_cancel_waiting_input_sidecar_appends_cancel_handoff_as_durable_group(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    allow_normal_handoff: bool,
 ) -> None:
     from iac_code.a2a.pipeline_executor import (
         WaitingInputCancelResult,
@@ -8971,19 +8973,17 @@ def test_cancel_waiting_input_sidecar_appends_cancel_handoff_as_durable_group(
         context_id=context_id,
         task_id="task-1",
         reason="user canceled",
+        allow_normal_handoff=allow_normal_handoff,
     )
 
     assert canceled == WaitingInputCancelResult.CANCELED
-    assert append_many_calls[-2:] == [
-        (["pipeline_canceled", "pipeline_handoff_ready"], True),
-        (["backup_committed", "backup_committed"], True),
-    ]
+    terminal_events = ["pipeline_canceled", "pipeline_handoff_ready"] if allow_normal_handoff else ["pipeline_canceled"]
+    committed_events = ["backup_committed"] * len(terminal_events)
+    assert append_many_calls[-2:] == [(terminal_events, True), (committed_events, True)]
     events = A2APipelineJournal(pipeline_dir).read_all()
-    assert [event["eventType"] for event in events[-4:]] == [
-        "pipeline_canceled",
-        "pipeline_handoff_ready",
-        "backup_committed",
-        "backup_committed",
+    assert [event["eventType"] for event in events[-2 * len(terminal_events) :]] == [
+        *terminal_events,
+        *committed_events,
     ]
     assert (
         terminal_task_state_from_sidecar(

--- a/tests/a2a/test_pipeline_outbound.py
+++ b/tests/a2a/test_pipeline_outbound.py
@@ -9,6 +9,7 @@ import pytest
 
 import iac_code.a2a.pipeline_outbound as pipeline_outbound_module
 from iac_code.a2a.pipeline_outbound import PipelineA2AOutboundQueue, _estimated_event_size
+from iac_code.a2a.pipeline_transport_delivery import PipelineTransportDeliveryClosedError
 from iac_code.types.stream_events import (
     PermissionRequestEvent,
     SubPipelineStreamEvent,
@@ -167,6 +168,43 @@ async def test_publish_batch_forwards_uncoalesced_envelopes_to_local_web_sink() 
     local_frame = publisher.local_envelope_frames[1]
     assert local_frame is not None
     assert [envelope["data"]["text"] for envelope in local_frame] == ["A1", "B1", "A2"]
+
+
+@pytest.mark.asyncio
+async def test_persisted_batch_survives_transport_closure() -> None:
+    publisher = RecordingPublisher()
+    publisher.send_error = PipelineTransportDeliveryClosedError("subscriber disconnected")
+    outbound = PipelineA2AOutboundQueue(publisher, max_batch_delay_seconds=10)
+
+    await outbound.start()
+    await outbound.submit(TextDeltaEvent(text="persist while offline"))
+    await asyncio.wait_for(publisher.first_send_started.wait(), timeout=0.2)
+    await outbound.close()
+
+    assert [event.text for event in publisher.persisted_events] == ["persist while offline"]
+
+
+@pytest.mark.asyncio
+async def test_persisted_permission_decision_survives_transport_closure() -> None:
+    publisher = RecordingPublisher()
+    publisher.send_error = PipelineTransportDeliveryClosedError("subscriber disconnected")
+    outbound = PipelineA2AOutboundQueue(publisher, max_batch_delay_seconds=10)
+    response = asyncio.get_running_loop().create_future()
+
+    await outbound.start()
+    await outbound.submit(
+        PermissionRequestEvent(
+            tool_name="write_file",
+            tool_input={},
+            tool_use_id="permission-offline",
+            response_future=response,
+        ),
+        auto_approve_permissions=True,
+    )
+    await outbound.close()
+
+    assert response.result() is True
+    assert [event.tool_use_id for event in publisher.persisted_events] == ["permission-offline"]
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_pipeline_stream.py
+++ b/tests/a2a/test_pipeline_stream.py
@@ -14,6 +14,7 @@ from google.protobuf.json_format import MessageToDict
 import iac_code.a2a.pipeline_stream as pipeline_stream
 from iac_code.a2a.artifacts import A2AArtifactStore
 from iac_code.a2a.events import _METADATA_MAX_CHARS
+from iac_code.a2a.execution_control import ExecutionController, bind_execution_control, reset_execution_control
 from iac_code.a2a.exposure import A2AExposureType
 from iac_code.a2a.input_required import PermissionInputRegistry
 from iac_code.a2a.metrics import NoOpA2AMetrics
@@ -995,6 +996,33 @@ async def test_inherited_closed_transport_tracker_rejects_later_publication(tmp_
     with pytest.raises(PipelineTransportDeliveryClosedError):
         await publication
     assert queue.events == []
+
+
+@pytest.mark.asyncio
+async def test_controlled_execution_keeps_committed_event_when_inherited_transport_is_closed(tmp_path: Path) -> None:
+    publisher, queue = _publisher(tmp_path)
+    tracker = create_pipeline_transport_delivery_tracker()
+    close_pipeline_transport_delivery_tracker(tracker)
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="owner-1",
+        cwd=str(tmp_path),
+        server_instance_id="instance-1",
+        persistence_path=None,
+        backup_service=None,
+    )
+    token = bind_execution_control(control)
+    try:
+        with bind_pipeline_transport_delivery_tracker(tracker), pipeline_transport_delivery_required():
+            returned = await publisher.publish(TextDeltaEvent(text="persisted-offline"))
+    finally:
+        reset_execution_control(token)
+        await control.close()
+
+    assert returned == "persisted-offline"
+    assert queue.events == []
+    assert publisher.journal.read_all_repairing_tail()[-1]["data"]["text"] == "persisted-offline"
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -838,6 +838,35 @@ async def test_task_id_cannot_move_between_contexts() -> None:
 
 
 @pytest.mark.asyncio
+async def test_late_sdk_working_event_does_not_overwrite_final_executor_state(tmp_path) -> None:
+    persistence = A2APersistenceStore(tmp_path)
+    store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=10))
+    record = await store.get_task_record("task-1")
+    record.state = "input-required"
+    record.updated_at = 20
+    store._mirror_task(record)
+
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=15))
+
+    assert record.state == "input-required"
+    assert persistence.load_task("task-1").state == "input-required"
+
+
+@pytest.mark.asyncio
+async def test_stale_sdk_state_does_not_replace_newer_sdk_visible_state() -> None:
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=10))
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_INPUT_REQUIRED, updated_at=20))
+
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=15))
+
+    task = await store.get("task-1")
+    assert task is not None
+    assert task.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_task_rejects_persisted_context_mismatch_after_restart(tmp_path) -> None:
     persistence = A2APersistenceStore(tmp_path)
     persistence.save_task(A2ATaskSnapshot(task_id="task-1", context_id="ctx-a", state="working"))

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -1277,6 +1277,33 @@ async def test_save_clears_consumed_input_metadata_when_task_leaves_input_requir
 
 
 @pytest.mark.asyncio
+async def test_save_attaches_current_execution_control_metadata() -> None:
+    store = A2ATaskStore(metrics=NoOpA2AMetrics())
+    await store.get_or_create_context(context_id="ctx-1", cwd="/tmp", runtime_factory=lambda _sid: object())
+    store.set_execution_control_provider(
+        lambda context_id: {
+            "contextId": context_id,
+            "executionId": "exec-1",
+            "phase": "pausing",
+            "revision": 2,
+        },
+        lambda: True,
+    )
+
+    await store.save(sdk_task("task-1", context_id="ctx-1", state=TaskState.TASK_STATE_WORKING))
+
+    saved = await store.get("task-1")
+    assert saved is not None
+    metadata = MessageToDict(saved.metadata, preserving_proto_field_name=False)
+    assert metadata["iac_code"]["executionControl"] == {
+        "contextId": "ctx-1",
+        "executionId": "exec-1",
+        "phase": "pausing",
+        "revision": 2.0,
+    }
+
+
+@pytest.mark.asyncio
 async def test_save_retries_failed_shared_task_snapshot_when_sdk_state_is_unchanged(tmp_path) -> None:
     persistence = FlakyTaskPersistence(tmp_path / "a2a")
     store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
@@ -1385,6 +1412,69 @@ async def test_task_store_mirrors_task_and_context_to_persistence(tmp_path) -> N
 
     assert persistence.load_context("ctx-1").session_id == context.session_id
     assert persistence.load_task("task-1").context_id == task.context_id
+
+
+@pytest.mark.asyncio
+async def test_cancel_inactive_input_required_task_updates_internal_and_sdk_state(tmp_path) -> None:
+    persistence = A2APersistenceStore(tmp_path / "a2a")
+    store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
+    context = await store.get_or_create_context(
+        context_id="ctx-1",
+        cwd=str(tmp_path),
+        runtime_factory=lambda _session_id: object(),
+    )
+    context.active_task_id = "task-1"
+    store.mirror_context(context)
+    await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_INPUT_REQUIRED))
+
+    assert await store.cancel_inactive_input_required_task(task_id="task-1", context_id="ctx-1") is True
+
+    record = await store.get_task_record("task-1")
+    task = await store.get("task-1")
+    refreshed_context = await store.get_context_record("ctx-1")
+    assert record.state == "canceled"
+    assert task is not None and task.status.state == TaskState.TASK_STATE_CANCELED
+    assert refreshed_context.active_task_id is None
+    assert persistence.load_task("task-1").state == "canceled"
+
+    assert await store.cancel_inactive_input_required_task(task_id="task-1", context_id="ctx-1") is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_inactive_input_required_task_retries_strict_session_snapshot(tmp_path, monkeypatch) -> None:
+    from iac_code.a2a import task_store as task_store_module
+
+    persistence = A2APersistenceStore(tmp_path / "a2a")
+    store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
+    context = await store.get_or_create_context(
+        context_id="ctx-1",
+        cwd=str(tmp_path),
+        runtime_factory=lambda _session_id: object(),
+    )
+    context.active_task_id = "task-1"
+    store.mirror_context(context)
+    await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_INPUT_REQUIRED))
+    original_write = task_store_module._write_session_snapshot
+    failed = False
+
+    def fail_first_canceled_task_snapshot(session_dir, path, data):
+        nonlocal failed
+        if path.name == "task.json" and data.get("state") == "canceled" and not failed:
+            failed = True
+            raise OSError("temporary session snapshot failure")
+        original_write(session_dir, path, data)
+
+    monkeypatch.setattr(task_store_module, "_write_session_snapshot", fail_first_canceled_task_snapshot)
+
+    with pytest.raises(OSError, match="temporary session snapshot failure"):
+        await store.cancel_inactive_input_required_task(task_id="task-1", context_id="ctx-1")
+    session_task_path = SessionStorage().session_dir(str(tmp_path), context.session_id) / "a2a" / "task.json"
+    assert json.loads(session_task_path.read_text(encoding="utf-8"))["state"] == "input-required"
+
+    assert await store.cancel_inactive_input_required_task(task_id="task-1", context_id="ctx-1") is True
+    assert json.loads(session_task_path.read_text(encoding="utf-8"))["state"] == "canceled"
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -841,8 +841,7 @@ async def test_task_id_cannot_move_between_contexts() -> None:
 async def test_late_sdk_working_event_does_not_overwrite_active_executor_finalization(tmp_path) -> None:
     persistence = A2APersistenceStore(tmp_path)
     store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
-    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=10))
-    record = await store.get_task_record("task-1")
+    record = await store.get_or_create_task(task_id="task-1", context_id="ctx-1")
     record.state = "input-required"
     record.updated_at = 20
     record.active_task = asyncio.current_task()
@@ -852,6 +851,9 @@ async def test_late_sdk_working_event_does_not_overwrite_active_executor_finaliz
 
     assert record.state == "input-required"
     assert persistence.load_task("task-1").state == "input-required"
+    task = await store.get("task-1")
+    assert task is not None
+    assert task.status.state == TaskState.TASK_STATE_WORKING
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_task_store.py
+++ b/tests/a2a/test_task_store.py
@@ -838,16 +838,17 @@ async def test_task_id_cannot_move_between_contexts() -> None:
 
 
 @pytest.mark.asyncio
-async def test_late_sdk_working_event_does_not_overwrite_final_executor_state(tmp_path) -> None:
+async def test_late_sdk_working_event_does_not_overwrite_active_executor_finalization(tmp_path) -> None:
     persistence = A2APersistenceStore(tmp_path)
     store = A2ATaskStore(metrics=NoOpA2AMetrics(), persistence=persistence)
     await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=10))
     record = await store.get_task_record("task-1")
     record.state = "input-required"
     record.updated_at = 20
+    record.active_task = asyncio.current_task()
     store._mirror_task(record)
 
-    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=15))
+    await store.save(sdk_task("task-1", state=TaskState.TASK_STATE_WORKING, updated_at=30))
 
     assert record.state == "input-required"
     assert persistence.load_task("task-1").state == "input-required"

--- a/tests/a2a/test_transport_dispatcher.py
+++ b/tests/a2a/test_transport_dispatcher.py
@@ -1414,7 +1414,7 @@ async def _collect_async(iterator):
 
 
 @pytest.mark.asyncio
-async def test_active_message_stream_cancellation_cancels_producer() -> None:
+async def test_active_message_stream_cancellation_detaches_producer() -> None:
     producer_cancelled = asyncio.Event()
 
     class FakeAgentExecutor:
@@ -1480,7 +1480,12 @@ async def test_active_message_stream_cancellation_cancels_producer() -> None:
 
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(stream_task, timeout=_STREAM_TEST_TIMEOUT)
-    assert producer_cancelled.is_set()
+    assert not producer_cancelled.is_set()
+    cleanup_tasks = tuple(handler._detached_message_producers)
+    assert len(cleanup_tasks) == 1
+    cleanup_tasks[0].cancel()
+    await asyncio.wait_for(producer_cancelled.wait(), timeout=_STREAM_TEST_TIMEOUT)
+    await asyncio.gather(*cleanup_tasks, return_exceptions=True)
     assert active_task._reference_count == 0
 
 

--- a/tests/a2a_e2e/test_execution_control_scenarios.py
+++ b/tests/a2a_e2e/test_execution_control_scenarios.py
@@ -32,15 +32,8 @@ CASES = (
     ("recovery-during-normal-rollover", "normal"),
 )
 
-IS_WINDOWS = sys.platform == "win32"
-SCENARIO_TIMEOUT_SECONDS = 40 if IS_WINDOWS else 20
-OVERALL_TIMEOUT_SECONDS = 50 if IS_WINDOWS else 25
-PROCESS_TIMEOUT_SECONDS = 60 if IS_WINDOWS else 35
-TEST_TIMEOUT_SECONDS = 65 if IS_WINDOWS else 30
-
-
 @pytest.mark.integration
-@pytest.mark.timeout(TEST_TIMEOUT_SECONDS)
+@pytest.mark.timeout(40)
 @pytest.mark.parametrize(("scenario", "mode"), CASES, ids=["{}-{}".format(*case) for case in CASES])
 def test_execution_control_scenario(tmp_path: Path, scenario: str, mode: str) -> None:
     repo_root = Path(__file__).resolve().parents[2]
@@ -57,14 +50,14 @@ def test_execution_control_scenario(tmp_path: Path, scenario: str, mode: str) ->
             "--mode",
             mode,
             "--timeout",
-            str(SCENARIO_TIMEOUT_SECONDS),
+            "20",
             "--overall-timeout",
-            str(OVERALL_TIMEOUT_SECONDS),
+            "25",
         ],
         cwd=repo_root,
         text=True,
         capture_output=True,
-        timeout=PROCESS_TIMEOUT_SECONDS,
+        timeout=35,
         check=False,
     )
     summary_path = run_dir / "summary.json"
@@ -77,7 +70,7 @@ def test_execution_control_scenario(tmp_path: Path, scenario: str, mode: str) ->
         (run_dir / "runner-error.txt").read_text(encoding="utf-8") if (run_dir / "runner-error.txt").exists() else "",
     )
     assert summary is not None and summary["status"] == "passed"
-    assert 0 < summary["elapsedSeconds"] < PROCESS_TIMEOUT_SECONDS
+    assert 0 < summary["elapsedSeconds"] < 35
     assert summary["server"]["returnCode"] is not None
     assert summary["server"]["forcedKill"] is False
     for artifact in (

--- a/tests/a2a_e2e/test_execution_control_scenarios.py
+++ b/tests/a2a_e2e/test_execution_control_scenarios.py
@@ -32,8 +32,15 @@ CASES = (
     ("recovery-during-normal-rollover", "normal"),
 )
 
+IS_WINDOWS = sys.platform == "win32"
+SCENARIO_TIMEOUT_SECONDS = 40 if IS_WINDOWS else 20
+OVERALL_TIMEOUT_SECONDS = 50 if IS_WINDOWS else 25
+PROCESS_TIMEOUT_SECONDS = 60 if IS_WINDOWS else 35
+TEST_TIMEOUT_SECONDS = 65 if IS_WINDOWS else 30
+
 
 @pytest.mark.integration
+@pytest.mark.timeout(TEST_TIMEOUT_SECONDS)
 @pytest.mark.parametrize(("scenario", "mode"), CASES, ids=["{}-{}".format(*case) for case in CASES])
 def test_execution_control_scenario(tmp_path: Path, scenario: str, mode: str) -> None:
     repo_root = Path(__file__).resolve().parents[2]
@@ -50,14 +57,14 @@ def test_execution_control_scenario(tmp_path: Path, scenario: str, mode: str) ->
             "--mode",
             mode,
             "--timeout",
-            "20",
+            str(SCENARIO_TIMEOUT_SECONDS),
             "--overall-timeout",
-            "25",
+            str(OVERALL_TIMEOUT_SECONDS),
         ],
         cwd=repo_root,
         text=True,
         capture_output=True,
-        timeout=35,
+        timeout=PROCESS_TIMEOUT_SECONDS,
         check=False,
     )
     summary_path = run_dir / "summary.json"
@@ -70,7 +77,7 @@ def test_execution_control_scenario(tmp_path: Path, scenario: str, mode: str) ->
         (run_dir / "runner-error.txt").read_text(encoding="utf-8") if (run_dir / "runner-error.txt").exists() else "",
     )
     assert summary is not None and summary["status"] == "passed"
-    assert 0 < summary["elapsedSeconds"] < 35
+    assert 0 < summary["elapsedSeconds"] < PROCESS_TIMEOUT_SECONDS
     assert summary["server"]["returnCode"] is not None
     assert summary["server"]["forcedKill"] is False
     for artifact in (

--- a/tests/a2a_e2e/test_execution_control_scenarios.py
+++ b/tests/a2a_e2e/test_execution_control_scenarios.py
@@ -1,0 +1,101 @@
+"""Deterministic process E2E matrix for A2A pause, resume, and termination."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CASES = (
+    ("warm-resume-pausing", "normal"),
+    ("warm-resume-pausing", "pipeline"),
+    ("warm-resume-paused", "normal"),
+    ("warm-resume-paused", "pipeline"),
+    ("disconnect-timeout-after-operation-id", "normal"),
+    ("disconnect-timeout-after-operation-id", "pipeline"),
+    ("disconnect-timeout-inflight-sync-call", "pipeline"),
+    ("disconnect-timeout-backup-blocked", "pipeline"),
+    ("natural-completion-while-pausing", "normal"),
+    ("slow-termination-storage", "normal"),
+    ("terminate-during-bootstrap", "normal"),
+    ("terminate-during-bootstrap", "pipeline"),
+    ("terminate-during-bootstrap-disconnected", "normal"),
+    ("terminate-during-bootstrap-disconnected", "pipeline"),
+    ("disconnect-timeout-during-turn-backup", "normal"),
+    ("legacy-cancel-idle", "pipeline"),
+    ("slow-rollover-storage", "normal"),
+    ("stack-instances-timeout-after-operation-id", "normal"),
+    ("stack-instances-terminate-inflight", "normal"),
+    ("recovery-during-normal-rollover", "normal"),
+)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(("scenario", "mode"), CASES, ids=["{}-{}".format(*case) for case in CASES])
+def test_execution_control_scenario(tmp_path: Path, scenario: str, mode: str) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    run_dir = tmp_path / "{}-{}".format(scenario, mode)
+    runner = repo_root / "scripts" / "a2a" / "e2e" / "execution_control" / "run_execution_control_scenarios.py"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--run-dir",
+            str(run_dir),
+            "--scenario",
+            scenario,
+            "--mode",
+            mode,
+            "--timeout",
+            "20",
+            "--overall-timeout",
+            "25",
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        timeout=35,
+        check=False,
+    )
+    summary_path = run_dir / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8")) if summary_path.exists() else None
+    assert completed.returncode == 0, "scenario failed: {}\nstdout:\n{}\nstderr:\n{}\nserver:\n{}\nrunner:\n{}".format(
+        summary,
+        completed.stdout,
+        completed.stderr,
+        (run_dir / "server.log").read_text(encoding="utf-8") if (run_dir / "server.log").exists() else "",
+        (run_dir / "runner-error.txt").read_text(encoding="utf-8") if (run_dir / "runner-error.txt").exists() else "",
+    )
+    assert summary is not None and summary["status"] == "passed"
+    assert 0 < summary["elapsedSeconds"] < 35
+    assert summary["server"]["returnCode"] is not None
+    assert summary["server"]["forcedKill"] is False
+    for artifact in (
+        "agent-card.json",
+        "backup-audit.json",
+        "control-requests.json",
+        "execution-state-timeline.json",
+        "initial.events.jsonl",
+        "provider-lifecycle.jsonl",
+        "requests.jsonl",
+        "server-lifecycle.json",
+        "server.log",
+        "stream-summaries.json",
+        "tool-lifecycle.jsonl",
+    ):
+        assert (run_dir / artifact).exists(), artifact
+    for stream in summary["streams"]:
+        assert (run_dir / "{}.events.jsonl".format(stream["name"])).exists()
+    provider_calls = [
+        json.loads(line)
+        for line in (run_dir / "provider-lifecycle.jsonl").read_text(encoding="utf-8").splitlines()
+        if '"provider.called"' in line
+    ]
+    if scenario.startswith("terminate-during-bootstrap"):
+        assert not provider_calls
+    else:
+        assert provider_calls
+    assert all("messageCount" in call and "messageSummary" in call for call in provider_calls)

--- a/tests/agent/test_agent_loop_pause.py
+++ b/tests/agent/test_agent_loop_pause.py
@@ -200,3 +200,384 @@ class TestPauseEventGatesTurnTextAccumulation:
         assert loop._current_turn_text == "alphabeta", (
             f"pipeline-mode AgentLoop must keep accumulating, got {loop._current_turn_text!r}"
         )
+
+
+@pytest.mark.asyncio
+async def test_execution_control_allows_committed_final_answer_to_finish_during_pause(tmp_path):
+    from iac_code.a2a.execution_control import ExecutionController, bind_execution_control, reset_execution_control
+    from iac_code.types.stream_events import MessageEndEvent, TextDeltaEvent, Usage
+
+    provider_started = asyncio.Event()
+    release_provider = asyncio.Event()
+
+    class Provider:
+        def get_model_name(self):
+            return "fake-model"
+
+        async def stream(self, **_kwargs):
+            provider_started.set()
+            yield TextDeltaEvent(text="complete response")
+            await release_provider.wait()
+            yield MessageEndEvent(stop_reason="stop", usage=Usage())
+
+    loop = _make_loop(Provider())
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(tmp_path),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=None,
+        execution_id="exec-1",
+    )
+
+    async def consume():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            return [event async for event in loop.run_streaming("hello")]
+        finally:
+            await control.detach_task(current, execution_status="normal-turn-ended")
+            reset_execution_control(token)
+
+    execution = asyncio.create_task(consume())
+    await provider_started.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="pause-request",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=30,
+    )
+    assert pause["phase"] == "pausing"
+    release_provider.set()
+
+    await asyncio.wait_for(execution, timeout=2)
+    assert loop.context_manager.get_context_messages()[-1].to_dict()["content"][0]["text"] == "complete response"
+
+    async def wait_until_paused():
+        while control.phase != "paused":
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait_until_paused(), timeout=2)
+    assert control.phase == "paused"
+    assert control.execution_status == "normal-turn-ended"
+    assert control.stream_available is False
+
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="resume-request",
+        connection_epoch=2,
+    )
+
+    async def wait_until_running():
+        while control.phase != "running":
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait_until_running(), timeout=2)
+    assert control.phase == "running"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_execution_control_pauses_only_after_finished_tool_result_is_persisted(tmp_path):
+    from iac_code.a2a.execution_control import ExecutionController, bind_execution_control, reset_execution_control
+    from iac_code.agent.agent_loop import AgentLoop
+    from iac_code.services.session_storage import SessionStorage
+    from iac_code.tools.base import Tool, ToolContext, ToolRegistry, ToolResult
+    from iac_code.types.stream_events import (
+        MessageEndEvent,
+        MessageStartEvent,
+        ToolResultEvent,
+        ToolUseEndEvent,
+        ToolUseStartEvent,
+        Usage,
+    )
+
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    class SlowReadTool(Tool):
+        @property
+        def name(self):
+            return "slow_read"
+
+        @property
+        def description(self):
+            return "Return a durable result after being released."
+
+        @property
+        def input_schema(self):
+            return {"type": "object", "additionalProperties": False}
+
+        def is_read_only(self, input=None):
+            return True
+
+        async def execute(self, *, tool_input: dict, context: ToolContext) -> ToolResult:
+            tool_started.set()
+            await release_tool.wait()
+            return ToolResult.success("DURABLE_RESULT")
+
+    class Provider:
+        def get_model_name(self):
+            return "fake-model"
+
+        async def stream(self, **_kwargs):
+            yield MessageStartEvent(message_id="message-1")
+            yield ToolUseStartEvent(tool_use_id="tool-1", name="slow_read")
+            yield ToolUseEndEvent(tool_use_id="tool-1", name="slow_read", input={})
+            yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    storage = SessionStorage(projects_dir=tmp_path / "projects")
+    registry = ToolRegistry()
+    registry.register(SlowReadTool())
+    loop = AgentLoop(
+        provider_manager=Provider(),
+        system_prompt="test",
+        tool_registry=registry,
+        max_turns=1,
+        session_storage=storage,
+        session_id="session-1",
+        cwd=str(cwd),
+    )
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(cwd),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=None,
+        execution_id="exec-1",
+    )
+    emitted_events = []
+
+    async def consume():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async for event in loop.run_streaming("use the tool"):
+                emitted_events.append(event)
+        finally:
+            await control.detach_task(current, execution_status="normal-turn-ended")
+            reset_execution_control(token)
+
+    execution = asyncio.create_task(consume())
+    await tool_started.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="pause-during-tool",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=30,
+    )
+    assert pause["phase"] == "pausing"
+    release_tool.set()
+
+    async def wait_until_paused():
+        while control.phase != "paused":
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait_until_paused(), timeout=2)
+    assert execution.done() is False
+    assert any(isinstance(event, ToolResultEvent) and event.result == "DURABLE_RESULT" for event in emitted_events)
+    persisted = storage.load(str(cwd), "session-1")
+    assert persisted[-1].to_dict()["content"][0]["content"] == "DURABLE_RESULT"
+
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="resume-after-tool",
+        connection_epoch=2,
+    )
+    await execution
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_drains_already_finished_tool_result_before_release_ready(tmp_path):
+    from iac_code.a2a.execution_control import ExecutionController, bind_execution_control, reset_execution_control
+    from iac_code.agent.agent_loop import AgentLoop
+    from iac_code.services.session_storage import SessionStorage
+    from iac_code.tools.base import ToolRegistry, ToolResult
+    from iac_code.types.stream_events import (
+        MessageEndEvent,
+        MessageStartEvent,
+        ToolUseEndEvent,
+        ToolUseStartEvent,
+        Usage,
+    )
+
+    class Provider:
+        def get_model_name(self):
+            return "fake-model"
+
+        async def stream(self, **_kwargs):
+            yield MessageStartEvent(message_id="message-1")
+            yield ToolUseStartEvent(tool_use_id="tool-1", name="finished_tool")
+            yield ToolUseEndEvent(tool_use_id="tool-1", name="finished_tool", input={})
+            yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    storage = SessionStorage(projects_dir=tmp_path / "projects")
+    loop = AgentLoop(
+        provider_manager=Provider(),
+        system_prompt="test",
+        tool_registry=ToolRegistry(),
+        max_turns=1,
+        session_storage=storage,
+        session_id="session-1",
+        cwd=str(cwd),
+    )
+    tool_result_ready = asyncio.Event()
+
+    async def execute_batch(_requests, _context):
+        tool_result_ready.set()
+        return [ToolResult.success("RESULT_BEFORE_TERMINATE")]
+
+    loop._tool_executor.execute_batch = execute_batch
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(cwd),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=None,
+        execution_id="exec-1",
+    )
+
+    async def consume():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async for _event in loop.run_streaming("use the tool"):
+                pass
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    execution = asyncio.create_task(consume())
+    await tool_result_ready.wait()
+    await asyncio.sleep(0)
+    await control.terminate(
+        execution_id="exec-1",
+        request_id="terminate-after-result",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await execution
+
+    async def wait_until_release_ready():
+        while not control.release_ready:
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait_until_release_ready(), timeout=2)
+    persisted = storage.load(str(cwd), "session-1")
+    assert persisted[-1].to_dict()["content"][0]["content"] == "RESULT_BEFORE_TERMINATE"
+    await control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_during_tool_result_publication_keeps_persisted_result(tmp_path):
+    from iac_code.a2a.execution_control import ExecutionController, bind_execution_control, reset_execution_control
+    from iac_code.agent.agent_loop import AgentLoop
+    from iac_code.services.session_storage import SessionStorage
+    from iac_code.tools.base import ToolRegistry, ToolResult
+    from iac_code.types.stream_events import (
+        MessageEndEvent,
+        MessageStartEvent,
+        ToolResultEvent,
+        ToolUseEndEvent,
+        ToolUseStartEvent,
+        Usage,
+    )
+
+    class Provider:
+        def get_model_name(self):
+            return "fake-model"
+
+        async def stream(self, **_kwargs):
+            yield MessageStartEvent(message_id="message-1")
+            yield ToolUseStartEvent(tool_use_id="tool-1", name="finished_tool")
+            yield ToolUseEndEvent(tool_use_id="tool-1", name="finished_tool", input={})
+            yield MessageEndEvent(stop_reason="tool_use", usage=Usage())
+
+    cwd = tmp_path / "workspace"
+    cwd.mkdir()
+    storage = SessionStorage(projects_dir=tmp_path / "projects")
+    loop = AgentLoop(
+        provider_manager=Provider(),
+        system_prompt="test",
+        tool_registry=ToolRegistry(),
+        max_turns=1,
+        session_storage=storage,
+        session_id="session-1",
+        cwd=str(cwd),
+    )
+
+    async def execute_batch(_requests, _context):
+        return [ToolResult.success("RESULT_BEFORE_PUBLICATION")]
+
+    loop._tool_executor.execute_batch = execute_batch
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(cwd),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=None,
+        execution_id="exec-1",
+    )
+    publication_started = asyncio.Event()
+    publication_blocked = asyncio.Event()
+
+    async def consume():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        try:
+            async for event in loop.run_streaming("use the tool"):
+                if isinstance(event, ToolResultEvent):
+                    publication_started.set()
+                    await publication_blocked.wait()
+        finally:
+            await control.detach_task(current, execution_status="canceled")
+            reset_execution_control(token)
+
+    execution = asyncio.create_task(consume())
+    await asyncio.wait_for(publication_started.wait(), timeout=2)
+    await control.terminate(
+        execution_id="exec-1",
+        request_id="terminate-during-publication",
+        connection_epoch=1,
+        reason="explicit_terminate",
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await execution
+
+    async def wait_until_release_ready():
+        while not control.release_ready:
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait_until_release_ready(), timeout=2)
+    persisted = storage.load(str(cwd), "session-1")
+    assert persisted[-1].to_dict()["content"][0]["content"] == "RESULT_BEFORE_PUBLICATION"
+    await control.close()

--- a/tests/agent/test_agent_tool.py
+++ b/tests/agent/test_agent_tool.py
@@ -253,6 +253,83 @@ class TestAgentToolExecution:
             assert "task_id" in result.content
             assert len(tm.list_all()) == 1
 
+    async def test_background_execution_is_registered_before_first_schedule(self, tmp_path):
+        from iac_code.a2a.execution_control import (
+            ExecutionControlService,
+            bind_execution_control,
+            reset_execution_control,
+        )
+
+        service = ExecutionControlService(persistence_root=tmp_path, backup_service=None)
+        control = await service.begin_execution(
+            context_id="ctx-1",
+            task_id="task-1",
+            owner="owner-1",
+            cwd=str(tmp_path),
+        )
+        token = bind_execution_control(control)
+        task_manager = TaskManager()
+        tool = AgentTool(task_manager=task_manager)
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_run_sub_agent(**_kwargs):
+            started.set()
+            await release.wait()
+            return "done", AgentProgress()
+
+        run_patch = patch("iac_code.agent.agent_tool.run_sub_agent", side_effect=fake_run_sub_agent)
+        run_patch.start()
+        try:
+            result = await tool.execute(
+                tool_input={"prompt": "task", "description": "bg", "run_in_background": True},
+                context=ToolContext(cwd=str(tmp_path)),
+            )
+            background = task_manager.list_all()[0].background_task
+            assert result.is_error is False
+            assert background is not None
+            assert started.is_set() is False
+            assert control.has_managed_work() is True
+
+            current = asyncio.current_task()
+            assert current is not None
+            await control.detach_task(current, execution_status="normal-turn-ended")
+            next_turn = await service.begin_execution(
+                context_id="ctx-1",
+                task_id="task-2",
+                owner="owner-1",
+                cwd=str(tmp_path),
+            )
+            assert next_turn is control
+            await next_turn.detach_task(current, execution_status="working")
+            pause = await next_turn.pause(
+                task_id="task-2",
+                expected_execution_id=next_turn.execution_id,
+                request_id="pause-background-before-first-schedule",
+                connection_epoch=1,
+                reason="client_disconnected",
+                reconnect_timeout_seconds=30,
+            )
+            assert pause["phase"] == "pausing"
+            await next_turn.terminate(
+                execution_id=next_turn.execution_id,
+                request_id="terminate-background-before-first-schedule",
+                connection_epoch=2,
+                reason="explicit_terminate",
+            )
+
+            async def wait_until_released():
+                while not next_turn.release_ready:
+                    await asyncio.sleep(0.005)
+
+            await asyncio.wait_for(wait_until_released(), timeout=2)
+            assert background.cancelled()
+        finally:
+            release.set()
+            run_patch.stop()
+            reset_execution_control(token)
+            await service.close()
+
     async def test_background_execution_closes_context_event_queue(self):
         tm = TaskManager()
         tool = AgentTool(task_manager=tm)

--- a/tests/pipeline/engine/test_pipeline_observability.py
+++ b/tests/pipeline/engine/test_pipeline_observability.py
@@ -1395,6 +1395,15 @@ def test_mark_user_aborted_emits_user_aborted_terminal_telemetry(runner):
     )
 
 
+def test_mark_execution_terminated_is_not_reported_as_user_abort(runner):
+    runner._observability.pipeline_user_aborted = MagicMock()
+
+    runner.mark_execution_terminated("disconnect_timeout")
+
+    assert runner.sidecar_status == "canceled"
+    runner._observability.pipeline_user_aborted.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_runner_does_not_emit_terminal_telemetry_when_pause_stream_closes_after_input_required(runner):
     runner.state_machine.current_step.auto_advance = False

--- a/tests/pipeline/engine/test_pipeline_runner_pause.py
+++ b/tests/pipeline/engine/test_pipeline_runner_pause.py
@@ -151,7 +151,6 @@ class TestPauseEventEndToEnd:
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
-
     @pytest.mark.asyncio
     async def test_pause_then_resume_releases_existing_loop(self, pipeline_runner):
         """Resuming after pause sets the event and any AgentLoop parked on it wakes up."""
@@ -185,3 +184,63 @@ class TestPauseEventEndToEnd:
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
+
+
+@pytest.mark.asyncio
+async def test_execution_control_blocks_pipeline_before_starting_first_step(pipeline_runner, tmp_path):
+    from iac_code.a2a.execution_control import ExecutionController, bind_execution_control, reset_execution_control
+
+    control = ExecutionController(
+        context_id="ctx-1",
+        task_id="task-1",
+        owner="",
+        cwd=str(tmp_path),
+        server_instance_id="instance-1",
+        persistence_path=tmp_path / "control.json",
+        backup_service=None,
+        execution_id="exec-1",
+    )
+    attached = asyncio.Event()
+    start_pipeline = asyncio.Event()
+
+    async def consume_first_event():
+        token = bind_execution_control(control)
+        current = asyncio.current_task()
+        assert current is not None
+        await control.attach_task(current)
+        attached.set()
+        try:
+            await start_pipeline.wait()
+            async for event in pipeline_runner.run("hello"):
+                return event
+        finally:
+            await control.detach_task(current, execution_status="input-required")
+            reset_execution_control(token)
+
+    execution = asyncio.create_task(consume_first_event())
+    await attached.wait()
+    pause = await control.pause(
+        task_id="task-1",
+        expected_execution_id="exec-1",
+        request_id="pause-request",
+        connection_epoch=1,
+        reason="client_disconnected",
+        reconnect_timeout_seconds=30,
+    )
+    start_pipeline.set()
+    async def wait_until_paused():
+        while control.phase != "paused":
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(wait_until_paused(), timeout=2)
+    assert pipeline_runner._session_storage.meta_entries == []
+
+    await control.resume(
+        execution_id="exec-1",
+        pause_id=pause["pauseId"],
+        request_id="resume-request",
+        connection_epoch=2,
+    )
+    event = await asyncio.wait_for(execution, timeout=2)
+    assert event.type.value == "pipeline_started"
+    await control.close()

--- a/tests/pipeline/engine/test_session.py
+++ b/tests/pipeline/engine/test_session.py
@@ -327,13 +327,15 @@ class TestRestore:
         assert "status=None" in caplog.text
         assert str(session.session_dir) in caplog.text
 
-    @pytest.mark.parametrize("status", ["completed", "user_aborted", "failed", "discarded"])
+    @pytest.mark.parametrize("status", ["completed", "user_aborted", "canceled", "failed", "discarded"])
     def test_terminal_status_restore_does_not_log_warning(self, session, caplog, status):
         sm_snap = {"current_index": 0, "rollback_count": 0, "interrupt_rollback_count": 0, "step_statuses": {}}
         if status == "completed":
             session.save_completed_sync("intent", sm_snap, {}, _identity(), reason="done")
         elif status == "user_aborted":
             session.save_user_aborted_sync("intent", sm_snap, {}, _identity(), reason="ctrl-c")
+        elif status == "canceled":
+            session.save_canceled_sync("intent", sm_snap, {}, _identity(), reason="disconnect_timeout")
         elif status == "failed":
             session.save_failed_sync("intent", sm_snap, {}, _identity(), reason="step failed")
         else:

--- a/tests/services/test_session_backup_staging.py
+++ b/tests/services/test_session_backup_staging.py
@@ -92,6 +92,29 @@ def test_staged_backup_creates_immutable_versions_without_writing_final_root(
     assert not backup_root.exists()
 
 
+def test_wait_until_shared_committed_verifies_exact_staged_commit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service, session_dir, staging_root, backup_root = _create_staged_service(monkeypatch, tmp_path)
+    (session_dir / "session.jsonl").write_text("final\n", encoding="utf-8")
+    staged = service.backup_session("/repo", "s1", reason=BackupReason.DISCONNECT_TIMEOUT, critical=True)
+    assert staged.generation is not None and staged.commit_id is not None
+
+    SessionBackupStagingWorker(staging_root, backup_root).run_once()
+    shared = service.wait_until_shared_committed(
+        "/repo",
+        "s1",
+        generation=staged.generation,
+        commit_id=staged.commit_id,
+        timeout_seconds=0.1,
+    )
+
+    assert shared.shared_committed is True
+    assert shared.generation == staged.generation
+    assert shared.commit_id == staged.commit_id
+
+
 def test_regular_backup_service_ignores_staging_environment(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/tools/cloud/aliyun/test_ros_stack.py
+++ b/tests/tools/cloud/aliyun/test_ros_stack.py
@@ -657,6 +657,35 @@ class TestRosStackExecute:
             for name, value, attrs in metrics
         )
 
+    def test_execution_control_timeout_is_not_reported_as_user_cancel(self, tool: RosStack) -> None:
+        tool._store_deployment_telemetry_context(
+            "stack-123",
+            action="CreateStack",
+            iac_kind="ros",
+            region="cn-hangzhou",
+            started_at=0,
+            resource_count_total=1,
+            resource_types=["ALIYUN::ECS::Instance"],
+            resource_type_counts=[1],
+            terraform_providers=[],
+        )
+        events: list[tuple[str, dict]] = []
+
+        with (
+            patch(
+                "iac_code.tools.cloud.aliyun.ros_stack.current_execution_termination_reason",
+                return_value="disconnect_timeout",
+            ),
+            patch(
+                "iac_code.tools.cloud.aliyun.ros_stack.log_event",
+                side_effect=lambda event_name, metadata=None: events.append((event_name, metadata or {})),
+            ),
+        ):
+            tool.on_polling_cancelled("CreateStack", {}, "cn-hangzhou", "stack-123", 5)
+
+        cancelled = [metadata for event_name, metadata in events if event_name == Events.DEPLOYMENT_CANCELLED]
+        assert cancelled[0]["reason"] == "disconnect_timeout"
+
     @pytest.mark.asyncio
     async def test_create_stack_template_generated_telemetry_failure_does_not_prevent_api_call(
         self, tool: RosStack, mock_credentials


### PR DESCRIPTION
## Problem

When a sandbox connection drops during a normal or Pipeline A2A execution, the sandbox controller needs to stop the AgentLoop at a safe boundary, reconnect without duplicating execution, or end the execution after the reconnect timeout. Long-running tools must be allowed to finish while pause/resume/terminate requests remain race-safe.

## Changes

- Add asynchronous pause, state query, resume, and terminate APIs for normal and Pipeline A2A executions.
- Define execution state transitions and safe checkpoints around AgentLoop, Pipeline, permission waits, and long-running tool calls.
- Add execution identity and connection epoch checks so stale or duplicate controller requests cannot mutate a newer execution.
- Support timeout termination with staged session backup, including backup-mode completion behavior.
- Add Pipeline cursor recovery with `includeSnapshot=false` for clients that already retain `afterSequence`.
- Add client helpers, agent-card capabilities, persistence, transport wiring, focused tests, and 20 process E2E scenarios.

## Validation

- `uv run pytest -q tests/a2a/test_pipeline_recovery.py tests/a2a/test_client.py tests/a2a/test_app.py` (153 passed)
- `make lint`
- 20 execution-control process E2E scenarios
- `scripts/a2a/e2e/README.zh-CN.md` scenario1 and scenario1-performance-backup
